### PR TITLE
Add dynamic bug-report fixture

### DIFF
--- a/examples/bug-reports/bug-report.fixture.tsx
+++ b/examples/bug-reports/bug-report.fixture.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from "react"
+import { AutoroutingPipelineDebugger } from "lib/testing/AutoroutingPipelineDebugger"
+import { SimpleRouteJson } from "lib/types"
+
+export default () => {
+  const params = new URLSearchParams(window.location.search)
+  const bugReportId = params.get("bug_report_id")
+  const [srj, setSrj] = useState<SimpleRouteJson | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!bugReportId) return
+    const url =
+      "https://api.tscircuit.com/autorouting/bug_reports/get?autorouting_bug_report_id=" +
+      bugReportId +
+      "&download=true"
+    fetch(url)
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.ok && data.autorouting_bug_report) {
+          setSrj(data.autorouting_bug_report.simple_route_json)
+        } else {
+          setError("Bug report not found")
+        }
+      })
+      .catch((err) => {
+        console.error(err)
+        setError("Failed to load bug report")
+      })
+  }, [bugReportId])
+
+  if (!bugReportId) {
+    return <div className="p-4">No bug_report_id specified in URL.</div>
+  }
+  if (error) {
+    return <div className="p-4 text-red-500">{error}</div>
+  }
+  if (!srj) {
+    return <div className="p-4">Loading bug report...</div>
+  }
+  return <AutoroutingPipelineDebugger srj={srj} />
+}


### PR DESCRIPTION
## Summary
- allow dynamic loading of bug report data from the URL query
- fetch bug report JSON and render in `AutoroutingPipelineDebugger`

## Testing
- `bun test` *(fails: core3 - 0402 columns)*

------
https://chatgpt.com/codex/tasks/task_b_684605607dd4832e9d3cf9c2c8db3efa