### PR TITLE
Add test for unsolved high density node

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
         "circuit-to-svg": "^0.0.110",
         "clsx": "^2.1.1",
         "flatbush": "^4.4.0",
-        "graphics-debug": "^0.0.44",
+        "graphics-debug": "^0.0.46",
         "rbush": "^4.0.1",
         "react": "18",
         "react-cosmos": "^6.2.3",
@@ -775,7 +775,7 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
-    "graphics-debug": ["graphics-debug@0.0.44", "", { "dependencies": { "@types/react-router-dom": "^5.3.3", "polished": "^4.3.1", "pretty": "^2.0.0", "react-router-dom": "^6.28.0", "react-supergrid": "^1.0.10", "svgson": "^5.3.1", "transformation-matrix": "^2.16.1", "use-mouse-matrix-transform": "^1.3.0" }, "peerDependencies": { "bun-match-svg": "^0.0.9", "looks-same": "^9.0.1", "typescript": "^5.0.0" }, "bin": { "graphics-debug": "dist/cli/cli.js", "gd": "dist/cli/cli.js" } }, "sha512-18TgFTC21oG/w8h3V1Gdx/bv4NDXpvV959+n4WlRPpmS3L1V73tnCdjlasa3rWsyVZiHGX5B+QWs1C6d5ysC2A=="],
+    "graphics-debug": ["graphics-debug@0.0.46", "", { "dependencies": { "@types/react-router-dom": "^5.3.3", "polished": "^4.3.1", "pretty": "^2.0.0", "react-router-dom": "^6.28.0", "react-supergrid": "^1.0.10", "svgson": "^5.3.1", "transformation-matrix": "^2.16.1", "use-mouse-matrix-transform": "^1.3.0" }, "peerDependencies": { "bun-match-svg": "^0.0.9", "looks-same": "^9.0.1", "typescript": "^5.0.0" }, "bin": { "graphics-debug": "dist/cli/cli.js", "gd": "dist/cli/cli.js" } }, "sha512-K26v6dN1uNQJiTA6ieQYOxmChEIxEtT1XMWnTgOQmVHLREmqZKKssbVsz8vyqFTRHnd3CiFxaaHAQco81PmUxw=="],
 
     "has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
 

--- a/examples/assets/cn670-nodeWithPortPoints.json
+++ b/examples/assets/cn670-nodeWithPortPoints.json
@@ -1,0 +1,130 @@
+{
+  "nodeId": "cn670",
+  "capacityMeshNode": {
+    "capacityMeshNodeId": "cn670",
+    "center": {
+      "x": 12.0390625,
+      "y": 5.569687500000001
+    },
+    "width": 1.046875,
+    "height": 1.046875,
+    "layer": "top",
+    "availableZ": [0, 1],
+    "_depth": 5,
+    "_parent": {
+      "capacityMeshNodeId": "cn668",
+      "center": {
+        "x": 11.515625,
+        "y": 6.093125000000001
+      },
+      "width": 2.09375,
+      "height": 2.09375,
+      "layer": "top",
+      "availableZ": [0, 1],
+      "_depth": 4,
+      "_parent": {
+        "capacityMeshNodeId": "cn499",
+        "center": {
+          "x": 10.46875,
+          "y": 5.046250000000001
+        },
+        "width": 4.1875,
+        "height": 4.1875,
+        "layer": "top",
+        "availableZ": [0, 1],
+        "_depth": 3,
+        "_parent": {
+          "capacityMeshNodeId": "cn6",
+          "center": {
+            "x": 12.5625,
+            "y": 2.9525000000000006
+          },
+          "width": 8.375,
+          "height": 8.375,
+          "layer": "top",
+          "availableZ": [0, 1],
+          "_depth": 2,
+          "_parent": {
+            "capacityMeshNodeId": "cn4",
+            "center": {
+              "x": 8.375,
+              "y": 7.140000000000001
+            },
+            "width": 16.75,
+            "height": 16.75,
+            "layer": "top",
+            "availableZ": [0, 1],
+            "_depth": 1,
+            "_parent": {
+              "capacityMeshNodeId": "cn0",
+              "center": {
+                "x": 0,
+                "y": -1.2349999999999994
+              },
+              "width": 33.5,
+              "height": 33.5,
+              "layer": "top",
+              "availableZ": [0, 1],
+              "_depth": 0,
+              "_containsTarget": true,
+              "_containsObstacle": true,
+              "_completelyInsideObstacle": false
+            },
+            "_containsObstacle": true,
+            "_targetConnectionName": "source_trace_14",
+            "_containsTarget": true,
+            "_completelyInsideObstacle": false
+          },
+          "_containsObstacle": true,
+          "_targetConnectionName": "source_trace_14",
+          "_containsTarget": true,
+          "_completelyInsideObstacle": false
+        },
+        "_containsObstacle": true,
+        "_targetConnectionName": "source_trace_10",
+        "_containsTarget": true,
+        "_completelyInsideObstacle": false
+      },
+      "_containsObstacle": true,
+      "_targetConnectionName": "source_trace_11",
+      "_containsTarget": true,
+      "_completelyInsideObstacle": false
+    },
+    "_containsObstacle": false
+  },
+  "nodeWithPortPoints": {
+    "capacityMeshNodeId": "cn670",
+    "portPoints": [
+      {
+        "x": 12.0390625,
+        "y": 5.046250000000001,
+        "z": 0,
+        "connectionName": "source_trace_12"
+      },
+      {
+        "x": 12.0390625,
+        "y": 6.093125000000001,
+        "z": 0,
+        "connectionName": "source_trace_12"
+      },
+      {
+        "x": 11.515625,
+        "y": 5.110083841463414,
+        "z": 1,
+        "connectionName": "source_trace_11"
+      },
+      {
+        "x": 11.515625,
+        "y": 5.569687500000001,
+        "z": 0,
+        "connectionName": "source_trace_11"
+      }
+    ],
+    "center": {
+      "x": 12.0390625,
+      "y": 5.569687500000001
+    },
+    "width": 1.046875,
+    "height": 1.046875
+  }
+}

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "circuit-to-svg": "^0.0.110",
     "clsx": "^2.1.1",
     "flatbush": "^4.4.0",
-    "graphics-debug": "^0.0.44",
+    "graphics-debug": "^0.0.46",
     "rbush": "^4.0.1",
     "react": "18",
     "react-cosmos": "^6.2.3",

--- a/tests/bugs/cn670-not-routing.test.ts
+++ b/tests/bugs/cn670-not-routing.test.ts
@@ -1,0 +1,14 @@
+import { test, expect } from "bun:test"
+import { HyperSingleIntraNodeSolver } from "lib/solvers/HyperHighDensitySolver/HyperSingleIntraNodeSolver"
+import cn670 from "../../examples/assets/cn670-nodeWithPortPoints.json"
+import "graphics-debug/matcher"
+
+const nodeWithPortPoints = (cn670 as any).nodeWithPortPoints
+
+test.skip("cn670 routes successfully", () => {
+  const solver = new HyperSingleIntraNodeSolver({ nodeWithPortPoints })
+  solver.solve()
+  expect(solver.solved).toBe(true)
+  expect(solver.error).toBe(null)
+  expect(solver.visualize()).toMatchGraphicsSvg(import.meta.path)
+})


### PR DESCRIPTION
## Summary
- add cn670 fixture for high density capacity node
- add skipped test showing cn670 fails to route
- update graphics-debug to latest version

## Testing
- `bun test tests/bugs/cn670-not-routing.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_6852d9553860832ea7532b04131b032a