### PR TITLE
Prevent cache key collisions when multiple routes exist between the same node pair

### DIFF
--- a/lib/solvers/CapacityPathingSectionSolver/CachedHyperCapacityPathingSingleSectionSolver.ts
+++ b/lib/solvers/CapacityPathingSectionSolver/CachedHyperCapacityPathingSingleSectionSolver.ts
@@ -12,7 +12,8 @@ type ConnectionIndex = number
 
 // A normalized connection id - note that the first id is always lower than the second
 // This prevents cache key collisions when multiple routes exist between the same node pair
-type CacheSpaceConnectionId = `${CacheSpaceNodeId}->${CacheSpaceNodeId}::${ConnectionIndex}`
+type CacheSpaceConnectionId =
+  `${CacheSpaceNodeId}->${CacheSpaceNodeId}::${ConnectionIndex}`
 
 interface CacheToHyperCapacityPathingTransform {
   cacheSpaceToRealConnectionId: Map<CacheSpaceConnectionId, string>
@@ -95,7 +96,7 @@ export class CachedHyperCapacityPathingSingleSectionSolver
   }
 
   _computeBfsOrderingOfNodesInSection(): CapacityMeshNodeId[] {
-    const seenNodeIds = new Set<string>([this.constructorParams.centerNodeId])
+    const seenNodeIds = new Set<string>(this.constructorParams.centerNodeId)
     const ordering: CapacityMeshNodeId[] = []
 
     const candidates: Array<{
@@ -216,12 +217,12 @@ export class CachedHyperCapacityPathingSingleSectionSolver
         cacheStartNodeId,
         cacheEndNodeId,
       ].sort()
-      
+
       // Create a unique key for this node pair
       const pairKey = `${sortedStartId}->${sortedEndId}`
       const pairIndex = connectionPairMap.get(pairKey) ?? 0
       connectionPairMap.set(pairKey, pairIndex + 1)
-      
+
       // Create unique cache connection ID with index
       const cacheSpaceConnectionId: CacheSpaceConnectionId = `${sortedStartId}->${sortedEndId}::${pairIndex}`
 
@@ -400,8 +401,6 @@ export class CachedHyperCapacityPathingSingleSectionSolver
         realToCacheSpaceNodeId.set(realId, cacheId)
       }
 
-      // This reverse map now works correctly because cache connection IDs 
-      // are unique (include connection index)
       const realToCacheSpaceConnectionId = new Map<
         string,
         CacheSpaceConnectionId


### PR DESCRIPTION
### Why are we changing this?
Even after merging https://github.com/tscircuit/tscircuit-autorouter/pull/180 we still observed issues with the cache where a lot of easily cacheable actions were missed. When the cache of the `HyperCapacityPathingSolver` was disabled, the `UnravelSolver` would reach a 100% cache rate. In addition, the logs showed a lot of `Could not find cache space connection ID` warnings. This indicates an issues with the way the `HyperCapacityPathingSolver` performs caching. Claude analysed the code and highlighted that collisions due to multiple paths between two points were the issue.

### What has changed?
- Adhere to the iteration limit provided as the input of the `HyperCapacityPathingSolver`
- Include statistics of the `HyperCapacityPathingSolver` cache in the output
- Create an unique identifier for each path between two points

### Visualisation
https://streamable.com/fnqae6