### PR TITLE
Enable closed form high density routing again

### DIFF
--- a/examples/assets/cn7890-nodeWithPortPoints.json
+++ b/examples/assets/cn7890-nodeWithPortPoints.json
@@ -1,0 +1,205 @@
+{
+  "nodeId": "cn7890",
+  "capacityMeshNode": {
+    "capacityMeshNodeId": "cn7890",
+    "center": {
+      "x": 66.796875,
+      "y": -18.359375
+    },
+    "width": 0.78125,
+    "height": 0.78125,
+    "layer": "top",
+    "availableZ": [
+      0,
+      1
+    ],
+    "_depth": 8,
+    "_parent": {
+      "capacityMeshNodeId": "cn7753",
+      "center": {
+        "x": 66.40625,
+        "y": -17.96875
+      },
+      "width": 1.5625,
+      "height": 1.5625,
+      "layer": "top",
+      "availableZ": [
+        0,
+        1
+      ],
+      "_depth": 7,
+      "_parent": {
+        "capacityMeshNodeId": "cn7590",
+        "center": {
+          "x": 67.1875,
+          "y": -17.1875
+        },
+        "width": 3.125,
+        "height": 3.125,
+        "layer": "top",
+        "availableZ": [
+          0,
+          1
+        ],
+        "_depth": 6,
+        "_parent": {
+          "capacityMeshNodeId": "cn7451",
+          "center": {
+            "x": 65.625,
+            "y": -15.625
+          },
+          "width": 6.25,
+          "height": 6.25,
+          "layer": "top",
+          "availableZ": [
+            0,
+            1
+          ],
+          "_depth": 5,
+          "_parent": {
+            "capacityMeshNodeId": "cn6198",
+            "center": {
+              "x": 68.75,
+              "y": -18.75
+            },
+            "width": 12.5,
+            "height": 12.5,
+            "layer": "top",
+            "availableZ": [
+              0,
+              1
+            ],
+            "_depth": 4,
+            "_parent": {
+              "capacityMeshNodeId": "cn6195",
+              "center": {
+                "x": 62.5,
+                "y": -12.5
+              },
+              "width": 25,
+              "height": 25,
+              "layer": "top",
+              "availableZ": [
+                0,
+                1
+              ],
+              "_depth": 3,
+              "_parent": {
+                "capacityMeshNodeId": "cn6192",
+                "center": {
+                  "x": 75,
+                  "y": -25
+                },
+                "width": 50,
+                "height": 50,
+                "layer": "top",
+                "availableZ": [
+                  0,
+                  1
+                ],
+                "_depth": 2,
+                "_parent": {
+                  "capacityMeshNodeId": "cn2",
+                  "center": {
+                    "x": 50,
+                    "y": -50
+                  },
+                  "width": 100,
+                  "height": 100,
+                  "layer": "top",
+                  "availableZ": [
+                    0,
+                    1
+                  ],
+                  "_depth": 1,
+                  "_parent": {
+                    "capacityMeshNodeId": "cn0",
+                    "center": {
+                      "x": 0,
+                      "y": 0
+                    },
+                    "width": 200,
+                    "height": 200,
+                    "layer": "top",
+                    "availableZ": [
+                      0,
+                      1
+                    ],
+                    "_depth": 0,
+                    "_containsTarget": true,
+                    "_containsObstacle": true,
+                    "_completelyInsideObstacle": false
+                  },
+                  "_containsObstacle": true,
+                  "_targetConnectionName": "source_net_5_mst0",
+                  "_containsTarget": true,
+                  "_completelyInsideObstacle": false
+                },
+                "_containsObstacle": true,
+                "_targetConnectionName": "source_net_5_mst0",
+                "_containsTarget": true,
+                "_completelyInsideObstacle": false
+              },
+              "_containsObstacle": true,
+              "_targetConnectionName": "source_net_5_mst0",
+              "_containsTarget": true,
+              "_completelyInsideObstacle": false
+            },
+            "_containsObstacle": true,
+            "_targetConnectionName": "source_net_5_mst2",
+            "_containsTarget": true,
+            "_completelyInsideObstacle": false
+          },
+          "_containsObstacle": true,
+          "_targetConnectionName": "source_net_5_mst2",
+          "_containsTarget": true,
+          "_completelyInsideObstacle": false
+        },
+        "_containsObstacle": true,
+        "_targetConnectionName": "source_net_5_mst0",
+        "_containsTarget": true,
+        "_completelyInsideObstacle": false
+      },
+      "_containsObstacle": true,
+      "_targetConnectionName": "source_net_4_mst0",
+      "_containsTarget": true,
+      "_completelyInsideObstacle": false
+    },
+    "_containsObstacle": false
+  },
+  "nodeWithPortPoints": {
+    "capacityMeshNodeId": "cn7890",
+    "portPoints": [
+      {
+        "x": 66.9921875,
+        "y": -17.96875,
+        "z": 0,
+        "connectionName": "source_trace_168"
+      },
+      {
+        "x": 66.796875,
+        "y": -18.75,
+        "z": 1,
+        "connectionName": "source_trace_168"
+      },
+      {
+        "x": 66.6015625,
+        "y": -17.96875,
+        "z": 0,
+        "connectionName": "source_net_4_mst0"
+      },
+      {
+        "x": 67.1875,
+        "y": -18.359375,
+        "z": 0,
+        "connectionName": "source_net_4_mst0"
+      }
+    ],
+    "center": {
+      "x": 66.796875,
+      "y": -18.359375
+    },
+    "width": 0.78125,
+    "height": 0.78125
+  }
+}

--- a/examples/highdensity/highdensity80.fixture.tsx
+++ b/examples/highdensity/highdensity80.fixture.tsx
@@ -1,0 +1,8 @@
+import cn7890 from "examples/assets/cn7890-nodeWithPortPoints.json"
+import { HyperHighDensityDebugger } from "lib/testing/HyperHighDensityDebugger"
+
+export default () => {
+  return (
+    <HyperHighDensityDebugger nodeWithPortPoints={cn7890.nodeWithPortPoints} />
+  )
+}

--- a/lib/solvers/HighDensitySolver/TwoRouteHighDensitySolver/SingleTransitionCrossingRouteSolver.ts
+++ b/lib/solvers/HighDensitySolver/TwoRouteHighDensitySolver/SingleTransitionCrossingRouteSolver.ts
@@ -171,7 +171,6 @@ export class SingleTransitionCrossingRouteSolver extends BaseSolver {
     const C = flatRoute.B
 
     const turnDirection = computeTurnDirection(A, B, C, this.bounds)
-    // const turnDirection = computeTurnDirection(A, B, C, this.bounds)
     const sideTraversal = calculateTraversalPercentages(
       A,
       B,
@@ -179,8 +178,6 @@ export class SingleTransitionCrossingRouteSolver extends BaseSolver {
       this.bounds,
       turnDirection,
     )
-
-    // console.log({ sideTraversal, turnDirection })
 
     const viaBounds = {
       minX:
@@ -291,13 +288,6 @@ export class SingleTransitionCrossingRouteSolver extends BaseSolver {
       }
 
       return middle(effectiveA, effectiveB)
-    }
-
-    const traceBounds = {
-      maxX: this.bounds.maxX - this.obstacleMargin - this.traceThickness / 2,
-      maxY: this.bounds.maxY - this.obstacleMargin - this.traceThickness / 2,
-      minX: this.bounds.minX + this.obstacleMargin + this.traceThickness / 2,
-      minY: this.bounds.minY + this.obstacleMargin + this.traceThickness / 2,
     }
 
     const minDistFromViaToTrace =

--- a/lib/solvers/HyperHighDensitySolver/HyperSingleIntraNodeSolver.ts
+++ b/lib/solvers/HyperHighDensitySolver/HyperSingleIntraNodeSolver.ts
@@ -33,12 +33,12 @@ export class HyperSingleIntraNodeSolver extends HyperParameterSupervisorSolver<
 
   getCombinationDefs() {
     return [
-      // ["closedFormTwoTrace"],
       ["multiHeadPolyLine"],
       ["majorCombinations", "orderings6", "cellSizeFactor"],
       ["noVias"],
       ["orderings50"],
       ["flipTraceAlignmentDirection", "orderings6"],
+      ["closedFormTwoTrace"],
     ]
   }
 


### PR DESCRIPTION
### What has changed?
- Added fixture of https://github.com/tscircuit/tscircuit-autorouter/issues/178
- Enabled closed form high density routing again

### Visualisation
<img width="671" alt="Screenshot 2025-07-07 at 23 01 52" src="https://github.com/user-attachments/assets/20ce6a0a-421d-4b78-a5aa-f222e9ea0e17" />

https://capacity-node-autorouter-git-closed-form-crossing-tscircuit.vercel.app/renderer.html?fixtureId=%7B%22path%22%3A%22examples%2Fbug-reports%2Fbug-report.fixture.tsx%22%7D&locked=true&bug_report_id=2807d7a9-517f-4824-831f-ff6b2d2d299a

Fixes https://github.com/tscircuit/tscircuit-autorouter/issues/178