### PR TITLE
Improved handling of the `ViaPossibilitiesSolver` part of the `MultiHeadSolver`

### DIFF
--- a/lib/solvers/HighDensitySolver/MultiHeadPolyLineIntraNodeSolver/MultiHeadPolyLineIntraNodeSolver3_ViaPossibilitiesSolverIntegration.ts
+++ b/lib/solvers/HighDensitySolver/MultiHeadPolyLineIntraNodeSolver/MultiHeadPolyLineIntraNodeSolver3_ViaPossibilitiesSolverIntegration.ts
@@ -48,9 +48,6 @@ export class MultiHeadPolyLineIntraNodeSolver3 extends MultiHeadPolyLineIntraNod
     viaSolver.solve()
 
     if (viaSolver.failed || !viaSolver.solved) {
-      console.error(
-        viaSolver.error ?? "ViaPossibilitiesSolver2 failed to find a solution.",
-      )
       return null
     }
 

--- a/lib/solvers/HighDensitySolver/MultiHeadPolyLineIntraNodeSolver/MultiHeadPolyLineIntraNodeSolver3_ViaPossibilitiesSolverIntegration.ts
+++ b/lib/solvers/HighDensitySolver/MultiHeadPolyLineIntraNodeSolver/MultiHeadPolyLineIntraNodeSolver3_ViaPossibilitiesSolverIntegration.ts
@@ -48,10 +48,9 @@ export class MultiHeadPolyLineIntraNodeSolver3 extends MultiHeadPolyLineIntraNod
     viaSolver.solve()
 
     if (viaSolver.failed || !viaSolver.solved) {
-      this.failed = true
-      this.error =
-        viaSolver.error ?? "ViaPossibilitiesSolver2 failed to find a solution."
-      console.error(this.error)
+      console.error(
+        viaSolver.error ?? "ViaPossibilitiesSolver2 failed to find a solution.",
+      )
       return null
     }
 

--- a/lib/solvers/ViaPossibilitiesSolver/ViaPossibilitiesSolver2.ts
+++ b/lib/solvers/ViaPossibilitiesSolver/ViaPossibilitiesSolver2.ts
@@ -66,6 +66,7 @@ export class ViaPossibilitiesSolver2 extends BaseSolver {
   currentHead: Point3
   currentConnectionName: ConnectionName
   currentPath: Point3[]
+  currentViaCount: number
 
   constructor({
     nodeWithPortPoints,
@@ -146,6 +147,7 @@ export class ViaPossibilitiesSolver2 extends BaseSolver {
     const start = this.portPairMap.get(this.currentConnectionName)!.start
     this.currentHead = this._padByNewHeadWallBuffer(start)
     this.currentPath = [start, this.currentHead]
+    this.currentViaCount = 0
     this.placeholderPaths.delete(this.currentConnectionName) // Delete placeholder when we start processing
   }
 
@@ -238,6 +240,16 @@ export class ViaPossibilitiesSolver2 extends BaseSolver {
 
     const needsZChange = this.currentHead.z !== targetEnd.z
 
+    if (closestIntersection || needsZChange) {
+      this.currentViaCount++
+
+      // Check if adding this via would exceed the limit
+      if (this.currentViaCount >= this.maxViaCount) {
+        this.failed = true
+        return
+      }
+    }
+
     if (closestIntersection) {
       // --- Intersection Found ---
       let viaXY: Point
@@ -317,6 +329,7 @@ export class ViaPossibilitiesSolver2 extends BaseSolver {
         const { start } = this.portPairMap.get(this.currentConnectionName)!
         this.currentHead = this._padByNewHeadWallBuffer(start)
         this.currentPath = [start, this.currentHead]
+        this.currentViaCount = 0
         this.placeholderPaths.delete(this.currentConnectionName) // Remove placeholder
       }
     }

--- a/lib/solvers/ViaPossibilitiesSolver/ViaPossibilitiesSolver2.ts
+++ b/lib/solvers/ViaPossibilitiesSolver/ViaPossibilitiesSolver2.ts
@@ -99,8 +99,6 @@ export class ViaPossibilitiesSolver2 extends BaseSolver {
     }
 
     // Generate placeholder paths
-    const nodeCenterX = (this.bounds.minX + this.bounds.maxX) / 2
-    const nodeCenterY = (this.bounds.minY + this.bounds.maxY) / 2
     for (const [connectionName, { start, end }] of this.portPairMap.entries()) {
       if (start.z === end.z) {
         const isVertical = Math.abs(start.x - end.x) < 1e-9 // Use tolerance for float comparison
@@ -245,7 +243,7 @@ export class ViaPossibilitiesSolver2 extends BaseSolver {
       let viaXY: Point
       const distToIntersection = closestIntersection.dist
 
-      if (distToIntersection < this.VIA_INTERSECTION_BUFFER_DISTANCE) {
+      if (distToIntersection <= this.VIA_INTERSECTION_BUFFER_DISTANCE + 1e-6) {
         // If intersection is too close, place via at midpoint
         viaXY = midpoint(this.currentHead, closestIntersection.point)
       } else {


### PR DESCRIPTION
### Why are we changing this?
We've observed that the MultiHeadSolver failed after a single iteration. This was caused by the `ViaPossibilitiesSolver2` not finding a solution within the iteration limit. This pull request introduces a couple of fixes for the same problem.

### What has changed?
- The entire MultiHeadSolver no longer fails directly when a single iteration of the `ViaPossibilitiesSolver2` doesn't find a solution
- The `ViaPossibilitiesSolver2` could not find a solution because it iteratively added a via just slightly closer to the target. By adding a floating point tolerance this is no longer the case
- Limit the search to a maximum number of vias for a single trace within a node

Fixes https://github.com/tscircuit/tscircuit-autorouter/issues/191

### Visualisation
[Highdensity fixture 79](https://capacity-node-autorouter-git-via-possibilities-tscircuit.vercel.app/?fixtureId=%7B%22path%22%3A%22examples%2Fhighdensity%2Fhighdensity79.fixture.tsx%22%7D) can now be solved while this was not previously the case
<img width="671" alt="Screenshot 2025-07-08 at 00 09 35" src="https://github.com/user-attachments/assets/1d134f0b-18aa-4958-8da5-3d51649e90df" />

