### PR TITLE
Add 4-layer routing test

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
         "@types/react-dom": "^19.0.3",
         "@vercel/node": "^5.1.7",
         "@vitejs/plugin-react": "^4.3.4",
-        "bun-match-svg": "^0.0.9",
+        "bun-match-svg": "^0.0.12",
         "circuit-json-to-connectivity-map": "^0.0.19",
         "circuit-to-svg": "^0.0.110",
         "clsx": "^2.1.1",
@@ -487,7 +487,7 @@
 
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
-    "bun-match-svg": ["bun-match-svg@0.0.9", "", { "dependencies": { "looks-same": "^9.0.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "bin": { "bun-match-svg": "cli.ts" } }, "sha512-WISE8cUd3ztIEbYRymuxs+l4qwRviHIhyRQHmDz26vnhKON9g+Ur+2L3pfJrffpGiYWGF/jtWoWmYRQiaimTxg=="],
+    "bun-match-svg": ["bun-match-svg@0.0.12", "", { "dependencies": { "looks-same": "^9.0.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "bin": { "bun-match-svg": "cli.ts" } }, "sha512-qjQtTwRvuqGDe8xza1OEm3OMA4bUEuFDl4i4y1vH9GwdEegqB9x1/H5+AjoRwQUcMmt5kP9bfPdplkBWxmlfWg=="],
 
     "bun-types": ["bun-types@1.2.16", "", { "dependencies": { "@types/node": "*" } }, "sha512-ciXLrHV4PXax9vHvUrkvun9VPVGOVwbbbBF/Ev1cXz12lyEZMoJpIJABOfPcN9gDJRaiKF9MVbSygLg4NXu3/A=="],
 

--- a/lib/solvers/HighDensitySolver/IntraNodeSolver.ts
+++ b/lib/solvers/HighDensitySolver/IntraNodeSolver.ts
@@ -192,7 +192,7 @@ export class IntraNodeRouteSolver extends BaseSolver {
             )
           : this.solvedRoutes,
         futureConnections: this.unsolvedConnections,
-        layerCount: 2,
+        layerCount: this.nodeWithPortPoints.availableZ?.length ?? 2,
         hyperParameters: this.hyperParameters,
         connMap: this.connMap,
       })

--- a/lib/solvers/HighDensitySolver/SingleHighDensityRouteSolver.ts
+++ b/lib/solvers/HighDensitySolver/SingleHighDensityRouteSolver.ts
@@ -282,7 +282,7 @@ export class SingleHighDensityRouteSolver extends BaseSolver {
   computeG(node: Node) {
     return (
       (node.parent?.g ?? 0) +
-      (node.z === 0 ? 0 : this.viaPenaltyDistance) +
+      (node.parent && node.z !== node.parent.z ? this.viaPenaltyDistance : 0) +
       distance(node, node.parent!)
     )
   }
@@ -342,26 +342,23 @@ export class SingleHighDensityRouteSolver extends BaseSolver {
       }
     }
 
-    const viaNeighbor = {
-      ...node,
-      parent: node,
-      z: node.z === 0 ? this.layerCount - 1 : 0,
-    }
-
-    if (
-      !this.exploredNodes.has(this.getNodeKey(viaNeighbor)) &&
-      !this.isNodeTooCloseToObstacle(
-        viaNeighbor,
-        this.viaDiameter / 2 + this.obstacleMargin / 2,
-        true,
-      ) &&
-      !this.isNodeTooCloseToEdge(viaNeighbor, true)
-    ) {
-      viaNeighbor.g = this.computeG(viaNeighbor)
-      viaNeighbor.h = this.computeH(viaNeighbor)
-      viaNeighbor.f = this.computeF(viaNeighbor.g, viaNeighbor.h)
-
-      neighbors.push(viaNeighbor)
+    for (let z = 0; z < this.layerCount; z++) {
+      if (z === node.z) continue
+      const viaNeighbor = { ...node, parent: node, z }
+      if (
+        !this.exploredNodes.has(this.getNodeKey(viaNeighbor)) &&
+        !this.isNodeTooCloseToObstacle(
+          viaNeighbor,
+          this.viaDiameter / 2 + this.obstacleMargin / 2,
+          true,
+        ) &&
+        !this.isNodeTooCloseToEdge(viaNeighbor, true)
+      ) {
+        viaNeighbor.g = this.computeG(viaNeighbor)
+        viaNeighbor.h = this.computeH(viaNeighbor)
+        viaNeighbor.f = this.computeF(viaNeighbor.g, viaNeighbor.h)
+        neighbors.push(viaNeighbor)
+      }
     }
 
     return neighbors

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@types/react-dom": "^19.0.3",
     "@vercel/node": "^5.1.7",
     "@vitejs/plugin-react": "^4.3.4",
-    "bun-match-svg": "^0.0.9",
+    "bun-match-svg": "^0.0.12",
     "circuit-json-to-connectivity-map": "^0.0.19",
     "circuit-to-svg": "^0.0.110",
     "clsx": "^2.1.1",

--- a/tests/__snapshots__/e2e-4layer.snap.svg
+++ b/tests/__snapshots__/e2e-4layer.snap.svg
@@ -1,0 +1,84 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg">
+  <g>
+    <circle data-type="point" data-label="conn1 (top)" data-x="2" data-y="2" cx="112.59259259259261" cy="527.4074074074074" r="3" fill="hsl(0, 100%, 50%)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="conn1 (inner1)" data-x="8" data-y="2" cx="527.4074074074074" cy="527.4074074074074" r="3" fill="hsl(0, 100%, 50%)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="conn2 (top)" data-x="2" data-y="8" cx="112.59259259259261" cy="112.59259259259261" r="3" fill="hsl(170, 100%, 50%)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="conn2 (bottom)" data-x="8" data-y="8" cx="527.4074074074074" cy="112.59259259259261" r="3" fill="hsl(170, 100%, 50%)" />
+  </g>
+  <polyline data-points="8,8 6.440074121521245,8" data-type="line" points="527.4074074074074,112.59259259259261 419.56068000640704,112.59259259259261" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="10.370370370370368" />
+  <polyline data-points="6.440074121521245,8 5.920098828694992,8.519975292826253" data-type="line" points="419.56068000640704,112.59259259259261 383.6117708727402,76.6436834589258" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="10.370370370370368" />
+  <polyline data-points="5.920098828694992,8.519975292826253 5,8.75" data-type="line" points="383.6117708727402,76.6436834589258 320,60.74074074074076" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="10.370370370370368" />
+  <polyline data-points="5,8.75 2.75,8.75" data-type="line" points="320,60.74074074074076 164.44444444444446,60.74074074074076" fill="none" stroke="rgba(255,0,0,0.5)" stroke-width="10.370370370370368" />
+  <polyline data-points="2.75,8.75 2,8" data-type="line" points="164.44444444444446,60.74074074074076 112.59259259259261,112.59259259259261" fill="none" stroke="rgba(255,0,0,0.5)" stroke-width="10.370370370370368" />
+  <polyline data-points="8,2 7.021427705118342,2" data-type="line" points="527.4074074074074,527.4074074074074 459.7530265267001,527.4074074074074" fill="none" stroke="rgba(0,128,0,0.5)" stroke-width="10.370370370370368" />
+  <polyline data-points="7.021427705118342,2 6.292855410236683,1.2714277051183414" data-type="line" points="459.7530265267001,527.4074074074074 409.38259626327687,577.7778376708306" fill="none" stroke="rgba(0,128,0,0.5)" stroke-width="10.370370370370368" />
+  <polyline data-points="6.292855410236683,1.2714277051183414 6.25,1.25" data-type="line" points="409.38259626327687,577.7778376708306 406.41975308641975,579.2592592592592" fill="none" stroke="rgba(0,128,0,0.5)" stroke-width="10.370370370370368" />
+  <polyline data-points="6.25,1.25 2.75,1.25" data-type="line" points="406.41975308641975,579.2592592592592 164.44444444444446,579.2592592592592" fill="none" stroke="rgba(255,0,0,0.5)" stroke-width="10.370370370370368" />
+  <polyline data-points="2.75,1.25 2,2" data-type="line" points="164.44444444444446,579.2592592592592 112.59259259259261,527.4074074074074" fill="none" stroke="rgba(255,0,0,0.5)" stroke-width="10.370370370370368" />
+  <rect data-type="rect" data-label="" data-x="5" data-y="5" x="285.4320987654321" y="285.4320987654321" width="69.1358024691358" height="69.1358024691358" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.014464285714285716" />
+  <circle data-type="circle" data-label="" data-x="5" data-y="8.75" cx="320" cy="60.74074074074076" r="20.740740740740737" fill="blue" stroke="none" stroke-width="0.014464285714285716" />
+  <circle data-type="circle" data-label="" data-x="6.25" data-y="1.25" cx="406.41975308641975" cy="579.2592592592592" r="20.740740740740737" fill="blue" stroke="none" stroke-width="0.014464285714285716" />
+  <g id="crosshair" style="display: none">
+    <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
+    <line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5" /><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text>
+  </g>
+  <script>
+    <![CDATA[
+    document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+      const svg = e.currentTarget;
+      const rect = svg.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const crosshair = svg.getElementById('crosshair');
+      const h = svg.getElementById('crosshair-h');
+      const v = svg.getElementById('crosshair-v');
+      const coords = svg.getElementById('coordinates');
+
+      crosshair.style.display = 'block';
+      h.setAttribute('x1', '0');
+      h.setAttribute('x2', '640');
+      h.setAttribute('y1', y);
+      h.setAttribute('y2', y);
+      v.setAttribute('x1', x);
+      v.setAttribute('x2', x);
+      v.setAttribute('y1', '0');
+      v.setAttribute('y2', '640');
+
+      // Calculate real coordinates using inverse transformation
+      const matrix = {
+        "a": 69.1358024691358,
+        "c": 0,
+        "e": -25.679012345678984,
+        "b": 0,
+        "d": -69.1358024691358,
+        "f": 665.679012345679
+      };
+      // Manually invert and apply the affine transform
+      // Since we only use translate and scale, we can directly compute:
+      // x' = (x - tx) / sx
+      // y' = (y - ty) / sy
+      const sx = matrix.a;
+      const sy = matrix.d;
+      const tx = matrix.e;
+      const ty = matrix.f;
+      const realPoint = {
+        x: (x - tx) / sx,
+        y: (y - ty) / sy // Flip y back since we used negative scale
+      }
+
+      coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+      coords.setAttribute('x', (x + 5).toString());
+      coords.setAttribute('y', (y - 5).toString());
+    });
+    document.currentScript.parentElement.addEventListener('mouseleave', () => {
+      document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+    });
+    ]]>
+  </script>
+</svg>

--- a/tests/e2e-4layer.test.ts
+++ b/tests/e2e-4layer.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "bun:test"
+import { CapacityMeshSolver } from "../lib"
+import type { SimpleRouteJson } from "../lib/types"
+import srj from "./fixtures/simple-4layer.json"
+import { convertSrjToGraphicsObject } from "./fixtures/convertSrjToGraphicsObject"
+
+test("should solve 4 layer board", async () => {
+  const solver = new CapacityMeshSolver(srj as SimpleRouteJson)
+  await solver.solve()
+  const result = solver.getOutputSimpleRouteJson()
+  expect(convertSrjToGraphicsObject(result)).toMatchGraphicsSvg(
+    import.meta.path,
+  )
+})

--- a/tests/fixtures/convertSrjToGraphicsObject.ts
+++ b/tests/fixtures/convertSrjToGraphicsObject.ts
@@ -10,7 +10,7 @@ export const convertSrjToGraphicsObject = (srj: SimpleRouteJson) => {
   const points: Point[] = []
 
   const colorMap: Record<string, string> = getColorMap(srj)
-  const layerCount = 2
+  const layerCount = srj.layerCount ?? 2
 
   // Add points for each connection's pointsToConnect
   if (srj.connections) {
@@ -45,7 +45,7 @@ export const convertSrjToGraphicsObject = (srj: SimpleRouteJson) => {
             radius: 0.3, // 0.6 via diameter
             fill: "blue",
             stroke: "none",
-            layer: "z0,1",
+            layer: `z${mapLayerNameToZ(routePoint.from_layer!, layerCount)},${mapLayerNameToZ(routePoint.to_layer!, layerCount)}`,
           })
         } else if (
           routePoint.route_type === "wire" &&

--- a/tests/fixtures/simple-4layer.json
+++ b/tests/fixtures/simple-4layer.json
@@ -1,0 +1,31 @@
+{
+  "layerCount": 4,
+  "minTraceWidth": 0.15,
+  "obstacles": [
+    {
+      "type": "rect",
+      "layers": ["top"],
+      "center": { "x": 5, "y": 5 },
+      "width": 1,
+      "height": 1,
+      "connectedTo": []
+    }
+  ],
+  "connections": [
+    {
+      "name": "conn1",
+      "pointsToConnect": [
+        { "x": 2, "y": 2, "layer": "top" },
+        { "x": 8, "y": 2, "layer": "inner1" }
+      ]
+    },
+    {
+      "name": "conn2",
+      "pointsToConnect": [
+        { "x": 2, "y": 8, "layer": "top" },
+        { "x": 8, "y": 8, "layer": "bottom" }
+      ]
+    }
+  ],
+  "bounds": { "minX": 0, "maxX": 10, "minY": 0, "maxY": 10 }
+}


### PR DESCRIPTION
## Summary
- update graphics conversion helper to respect srj.layerCount
- support multilayer vias and costs in high density solver
- pass layer count from node details in IntraNodeSolver
- add simple 4‑layer routing fixture and test
- update bun-match-svg

## Testing
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/e2e-4layer.test.ts`
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/e2e2.test.ts`
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/e2e1.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_6872bb1d05c0832eaba3e018c81a02b8