### PR TITLE
Add 4-layer e2e routing test

### DIFF
--- a/lib/data-structures/ObstacleTree.ts
+++ b/lib/data-structures/ObstacleTree.ts
@@ -20,7 +20,10 @@ export class ObstacleSpatialHashIndex {
     obstacles: Obstacle[] = [],
   ) {
     if (implementation === "flatbush") {
-      this.idx = new FlatbushIndex<Obstacle>(obstacles.length)
+      this.idx =
+        obstacles.length === 0
+          ? new RbushIndex<Obstacle>()
+          : new FlatbushIndex<Obstacle>(obstacles.length)
     } else if (implementation === "rbush") {
       this.idx = new RbushIndex<Obstacle>()
     } else {
@@ -50,7 +53,8 @@ export class ObstacleSpatialHashIndex {
 
     // bulk-load initial obstacles
     obstacles.forEach((o) => this.insert(o))
-    if (implementation === "flatbush") this.idx.finish?.()
+    if (implementation === "flatbush" && obstacles.length > 0)
+      this.idx.finish?.()
   }
 
   insert(o: Obstacle) {

--- a/tests/__snapshots__/e2e3_4layer.snap.svg
+++ b/tests/__snapshots__/e2e3_4layer.snap.svg
@@ -1,0 +1,91 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg">
+  <g>
+    <circle data-type="point" data-label="conn1 (top)" data-x="1" data-y="1" cx="80.42780748663102" cy="559.572192513369" r="3" fill="hsl(0, 100%, 50%)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="conn1 (bottom)" data-x="9" data-y="9" cx="559.5721925133689" cy="80.42780748663108" r="3" fill="hsl(0, 100%, 50%)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="conn2 (top)" data-x="1" data-y="9" cx="80.42780748663102" cy="80.42780748663108" r="3" fill="hsl(170, 100%, 50%)" />
+  </g>
+  <g>
+    <circle data-type="point" data-label="conn2 (bottom)" data-x="9" data-y="1" cx="559.5721925133689" cy="559.572192513369" r="3" fill="hsl(170, 100%, 50%)" />
+  </g>
+  <polyline data-points="9,1 8.311030865739976,1" data-type="line" points="559.5721925133689,559.572192513369 518.307730996191,559.572192513369" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="8.983957219251336" />
+  <polyline data-points="8.311030865739976,1 8.081374487653303,0.7703436219133257" data-type="line" points="518.307730996191,559.572192513369 504.55291049046514,573.3270130190949" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="8.983957219251336" />
+  <polyline data-points="8.081374487653303,0.7703436219133257 7.5,0.625" data-type="line" points="504.55291049046514,573.3270130190949 469.7326203208556,582.0320855614974" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="8.983957219251336" />
+  <polyline data-points="7.5,0.625 6.884500404985178,0.625" data-type="line" points="469.7326203208556,582.0320855614974 432.86847345365766,582.0320855614974" fill="none" stroke="rgba(0,128,0,0.5)" stroke-width="8.983957219251336" />
+  <polyline data-points="6.884500404985178,0.625 6.274866237606011,1.2346341673791674" data-type="line" points="432.86847345365766,582.0320855614974 396.35562492613536,545.5192370339751" fill="none" stroke="rgba(0,128,0,0.5)" stroke-width="8.983957219251336" />
+  <polyline data-points="6.274866237606011,1.2346341673791674 6.25,1.25" data-type="line" points="396.35562492613536,545.5192370339751 394.86631016042776,544.5989304812834" fill="none" stroke="rgba(0,128,0,0.5)" stroke-width="8.983957219251336" />
+  <polyline data-points="6.25,1.25 6.25,3.75" data-type="line" points="394.86631016042776,544.5989304812834 394.86631016042776,394.8663101604279" fill="none" stroke="rgba(255,0,0,0.5)" stroke-width="8.983957219251336" />
+  <polyline data-points="6.25,3.75 1,9" data-type="line" points="394.86631016042776,394.8663101604279 80.42780748663102,80.42780748663108" fill="none" stroke="rgba(255,0,0,0.5)" stroke-width="8.983957219251336" />
+  <polyline data-points="9,9 8.311030865739976,9" data-type="line" points="559.5721925133689,80.42780748663108 518.307730996191,80.42780748663108" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="8.983957219251336" />
+  <polyline data-points="8.311030865739976,9 8.081374487653303,9.229656378086673" data-type="line" points="518.307730996191,80.42780748663108 504.55291049046514,66.6729869809052" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="8.983957219251336" />
+  <polyline data-points="8.081374487653303,9.229656378086673 7.5,9.375" data-type="line" points="504.55291049046514,66.6729869809052 469.7326203208556,57.96791443850282" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="8.983957219251336" />
+  <polyline data-points="7.5,9.375 7.5,6.89001267021096" data-type="line" points="469.7326203208556,57.96791443850282 469.7326203208556,206.80138017987844" fill="none" stroke="rgba(0,128,0,0.5)" stroke-width="8.983957219251336" />
+  <polyline data-points="7.5,6.89001267021096 3.6953065834901446,3.0853192537011047" data-type="line" points="469.7326203208556,206.80138017987844 241.85793441224394,434.6760660884901" fill="none" stroke="rgba(0,128,0,0.5)" stroke-width="8.983957219251336" />
+  <polyline data-points="3.6953065834901446,3.0853192537011047 3.6,2.9000000000000004" data-type="line" points="241.85793441224394,434.6760660884901 236.14973262032086,445.77540106951875" fill="none" stroke="rgba(0,128,0,0.5)" stroke-width="8.983957219251336" />
+  <polyline data-points="3.6,2.9000000000000004 2.9000000000000004,2.9000000000000004" data-type="line" points="236.14973262032086,445.77540106951875 194.2245989304813,445.77540106951875" fill="none" stroke="rgba(255,0,0,0.5)" stroke-width="8.983957219251336" />
+  <polyline data-points="2.9000000000000004,2.9000000000000004 1,1" data-type="line" points="194.2245989304813,445.77540106951875 80.42780748663102,559.572192513369" fill="none" stroke="rgba(255,0,0,0.5)" stroke-width="8.983957219251336" />
+  <circle data-type="circle" data-label="" data-x="7.5" data-y="0.625" cx="469.7326203208556" cy="582.0320855614974" r="17.96791443850267" fill="blue" stroke="none" stroke-width="0.016696428571428574" />
+  <circle data-type="circle" data-label="" data-x="6.25" data-y="1.25" cx="394.86631016042776" cy="544.5989304812834" r="17.96791443850267" fill="blue" stroke="none" stroke-width="0.016696428571428574" />
+  <circle data-type="circle" data-label="" data-x="7.5" data-y="9.375" cx="469.7326203208556" cy="57.96791443850282" r="17.96791443850267" fill="blue" stroke="none" stroke-width="0.016696428571428574" />
+  <circle data-type="circle" data-label="" data-x="3.6" data-y="2.9000000000000004" cx="236.14973262032086" cy="445.77540106951875" r="17.96791443850267" fill="blue" stroke="none" stroke-width="0.016696428571428574" />
+  <g id="crosshair" style="display: none">
+    <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
+    <line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5" /><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text>
+  </g>
+  <script>
+    <![CDATA[
+    document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+      const svg = e.currentTarget;
+      const rect = svg.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const crosshair = svg.getElementById('crosshair');
+      const h = svg.getElementById('crosshair-h');
+      const v = svg.getElementById('crosshair-v');
+      const coords = svg.getElementById('coordinates');
+
+      crosshair.style.display = 'block';
+      h.setAttribute('x1', '0');
+      h.setAttribute('x2', '640');
+      h.setAttribute('y1', y);
+      h.setAttribute('y2', y);
+      v.setAttribute('x1', x);
+      v.setAttribute('x2', x);
+      v.setAttribute('y1', '0');
+      v.setAttribute('y2', '640');
+
+      // Calculate real coordinates using inverse transformation
+      const matrix = {
+        "a": 59.89304812834224,
+        "c": 0,
+        "e": 20.534759358288795,
+        "b": 0,
+        "d": -59.89304812834224,
+        "f": 619.4652406417113
+      };
+      // Manually invert and apply the affine transform
+      // Since we only use translate and scale, we can directly compute:
+      // x' = (x - tx) / sx
+      // y' = (y - ty) / sy
+      const sx = matrix.a;
+      const sy = matrix.d;
+      const tx = matrix.e;
+      const ty = matrix.f;
+      const realPoint = {
+        x: (x - tx) / sx,
+        y: (y - ty) / sy // Flip y back since we used negative scale
+      }
+
+      coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+      coords.setAttribute('x', (x + 5).toString());
+      coords.setAttribute('y', (y - 5).toString());
+    });
+    document.currentScript.parentElement.addEventListener('mouseleave', () => {
+      document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+    });
+    ]]>
+  </script>
+</svg>

--- a/tests/core3.test.tsx
+++ b/tests/core3.test.tsx
@@ -47,4 +47,4 @@ test("core3 - 0402 columns", async () => {
   expect(convertCircuitJsonToPcbSvg(circuitJson)).toMatchSvgSnapshot(
     import.meta.path,
   )
-})
+}, 20_000)

--- a/tests/e2e3_4layer.test.ts
+++ b/tests/e2e3_4layer.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test"
+import { CapacityMeshSolver } from "../lib"
+import type { SimpleRouteJson } from "lib/types"
+import { convertSrjToGraphicsObject } from "./fixtures/convertSrjToGraphicsObject"
+
+test("routes a simple 4-layer board", () => {
+  const srj: SimpleRouteJson = {
+    layerCount: 4,
+    minTraceWidth: 0.15,
+    obstacles: [],
+    connections: [
+      {
+        name: "conn1",
+        pointsToConnect: [
+          { x: 1, y: 1, layer: "top" },
+          { x: 9, y: 9, layer: "bottom" },
+        ],
+      },
+      {
+        name: "conn2",
+        pointsToConnect: [
+          { x: 1, y: 9, layer: "top" },
+          { x: 9, y: 1, layer: "bottom" },
+        ],
+      },
+    ],
+    bounds: { minX: 0, maxX: 10, minY: 0, maxY: 10 },
+  }
+
+  const solver = new CapacityMeshSolver(srj)
+  solver.solve()
+  const result = solver.getOutputSimpleRouteJson()
+
+  expect(convertSrjToGraphicsObject(result)).toMatchGraphicsSvg(
+    import.meta.path,
+  )
+})

--- a/tests/fixtures/convertSrjToGraphicsObject.ts
+++ b/tests/fixtures/convertSrjToGraphicsObject.ts
@@ -10,7 +10,7 @@ export const convertSrjToGraphicsObject = (srj: SimpleRouteJson) => {
   const points: Point[] = []
 
   const colorMap: Record<string, string> = getColorMap(srj)
-  const layerCount = 2
+  const layerCount = srj.layerCount ?? 2
 
   // Add points for each connection's pointsToConnect
   if (srj.connections) {
@@ -66,7 +66,9 @@ export const convertSrjToGraphicsObject = (srj: SimpleRouteJson) => {
                 bottom: "blue",
                 inner1: "green",
                 inner2: "yellow",
-              }[routePoint.layer]!,
+                inner3: "purple",
+                inner4: "orange",
+              }[routePoint.layer] ?? "black",
               0.5,
             ),
             // For some reason this is too small, likely a graphics-debug bug


### PR DESCRIPTION
## Summary
- allow ObstacleTree to handle zero obstacles when using flatbush
- respect `layerCount` in `convertSrjToGraphicsObject`
- give core3 test more time
- add an end-to-end test for 4‑layer routing

## Testing
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/e2e3_4layer.test.ts`
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/core3.test.tsx`
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests`

------
https://chatgpt.com/codex/tasks/task_b_6872bb1d05c0832eaba3e018c81a02b8