### PR TITLE
Fix flatbush index when obstacle list is empty

### DIFF
--- a/lib/data-structures/FlatbushIndex.ts
+++ b/lib/data-structures/FlatbushIndex.ts
@@ -5,9 +5,11 @@ export class FlatbushIndex<T> implements ISpatialIndex<T> {
   private index: Flatbush
   private items: T[] = []
   private currentIndex = 0
+  private capacity: number
 
   constructor(numItems: number) {
-    this.index = new Flatbush(numItems)
+    this.capacity = Math.max(1, numItems)
+    this.index = new Flatbush(this.capacity)
   }
 
   insert(item: T, minX: number, minY: number, maxX: number, maxY: number) {
@@ -30,6 +32,7 @@ export class FlatbushIndex<T> implements ISpatialIndex<T> {
 
   clear() {
     this.items = []
-    this.index = new Flatbush(0)
+    this.currentIndex = 0
+    this.index = new Flatbush(this.capacity)
   }
 }

--- a/lib/data-structures/ObstacleTree.ts
+++ b/lib/data-structures/ObstacleTree.ts
@@ -20,7 +20,13 @@ export class ObstacleSpatialHashIndex {
     obstacles: Obstacle[] = [],
   ) {
     if (implementation === "flatbush") {
-      this.idx = new FlatbushIndex<Obstacle>(obstacles.length)
+      if (obstacles.length === 0) {
+        // use rbush for empty data to avoid Flatbush limitations
+        this.idx = new RbushIndex<Obstacle>()
+        implementation = "rbush"
+      } else {
+        this.idx = new FlatbushIndex<Obstacle>(obstacles.length)
+      }
     } else if (implementation === "rbush") {
       this.idx = new RbushIndex<Obstacle>()
     } else {
@@ -50,7 +56,8 @@ export class ObstacleSpatialHashIndex {
 
     // bulk-load initial obstacles
     obstacles.forEach((o) => this.insert(o))
-    if (implementation === "flatbush") this.idx.finish?.()
+    if (implementation === "flatbush" && obstacles.length > 0)
+      this.idx.finish?.()
   }
 
   insert(o: Obstacle) {

--- a/tests/bugs/flatbush-zero-obstacles.test.ts
+++ b/tests/bugs/flatbush-zero-obstacles.test.ts
@@ -1,0 +1,8 @@
+import { test, expect } from "bun:test"
+import { ObstacleSpatialHashIndex } from "../../lib/data-structures/ObstacleTree"
+
+test("flatbush index handles zero obstacles", () => {
+  const idx = new ObstacleSpatialHashIndex("flatbush", [])
+  const result = idx.searchArea(0, 0, 1, 1)
+  expect(result.length).toBe(0)
+})


### PR DESCRIPTION
## Summary
- avoid creating flatbush index with numItems 0 by falling back to rbush for empty inputs
- store capacity in `FlatbushIndex` and reuse it on clear
- skip `finish()` when no items
- add regression test for empty obstacle list

## Testing
- `bun test tests/bugs/flatbush-zero-obstacles.test.ts`
- `bun run format`

------
https://chatgpt.com/codex/tasks/task_b_688d3f6559bc832e842acd20f99a7977