### PR TITLE
chore: add bug report fixture 3-fe4a17

### DIFF
--- a/examples/bug-reports/bugreport3-fe4a17/bugreport3-fe4a17.fixture.tsx
+++ b/examples/bug-reports/bugreport3-fe4a17/bugreport3-fe4a17.fixture.tsx
@@ -1,0 +1,7 @@
+// @ts-nocheck
+import { AutoroutingPipelineDebugger } from "lib/testing/AutoroutingPipelineDebugger"
+import bugReportJson from "./bugreport3-fe4a17.json"
+
+export default () => {
+  return <AutoroutingPipelineDebugger srj={bugReportJson.simple_route_json} />
+}

--- a/examples/bug-reports/bugreport3-fe4a17/bugreport3-fe4a17.json
+++ b/examples/bug-reports/bugreport3-fe4a17/bugreport3-fe4a17.json
@@ -1,0 +1,986 @@
+{
+  "autorouting_bug_report_id": "fe4a172b-07ce-4cd1-a6c7-69c5c05a24c9",
+  "reporter_account_id": "9f398687-69d0-4ef4-a48c-bb6dc990e7df",
+  "package_id": null,
+  "title": "<board#12297 />",
+  "simple_route_json": {
+    "bounds": {
+      "maxX": 6.35,
+      "maxY": 13.97,
+      "minX": -6.35,
+      "minY": -13.97
+    },
+    "obstacles": [
+      {
+        "type": "rect",
+        "width": 0.6649974,
+        "center": {
+          "x": -1.1574779999999691,
+          "y": 1.249934000000053
+        },
+        "height": 0.2800096,
+        "layers": ["top"],
+        "connectedTo": [
+          "pcb_smtpad_0",
+          "connectivity_net99",
+          "source_port_1",
+          "pcb_smtpad_0",
+          "pcb_port_1"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 0.6649974,
+        "center": {
+          "x": -1.1574779999999691,
+          "y": 0.750061999999957
+        },
+        "height": 0.2800096,
+        "layers": ["top"],
+        "connectedTo": [
+          "pcb_smtpad_1",
+          "connectivity_net100",
+          "source_port_2",
+          "pcb_smtpad_1",
+          "pcb_port_2"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 0.6649974,
+        "center": {
+          "x": -1.1574779999999691,
+          "y": 0.24993599999993413
+        },
+        "height": 0.2800096,
+        "layers": ["top"],
+        "connectedTo": [
+          "pcb_smtpad_2",
+          "connectivity_net101",
+          "source_port_3",
+          "pcb_smtpad_2",
+          "pcb_port_3"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 0.6649974,
+        "center": {
+          "x": -1.1574779999999691,
+          "y": -0.2499359999998206
+        },
+        "height": 0.2800096,
+        "layers": ["top"],
+        "connectedTo": [
+          "pcb_smtpad_3",
+          "connectivity_net102",
+          "source_port_4",
+          "pcb_smtpad_3",
+          "pcb_port_4"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 0.6649974,
+        "center": {
+          "x": -1.1574779999999691,
+          "y": -0.7500619999999573
+        },
+        "height": 0.2800096,
+        "layers": ["top"],
+        "connectedTo": [
+          "pcb_smtpad_4",
+          "connectivity_net103",
+          "source_port_5",
+          "pcb_smtpad_4",
+          "pcb_port_5"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 0.6649974,
+        "center": {
+          "x": -1.1574779999999691,
+          "y": -1.2499339999999393
+        },
+        "height": 0.2800096,
+        "layers": ["top"],
+        "connectedTo": [
+          "pcb_smtpad_5",
+          "connectivity_net104",
+          "source_port_6",
+          "pcb_smtpad_5",
+          "pcb_port_6"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 0.2800096,
+        "center": {
+          "x": -0.2499359999999341,
+          "y": -1.6576039999998784
+        },
+        "height": 0.6649974,
+        "layers": ["top"],
+        "connectedTo": [
+          "pcb_smtpad_6",
+          "connectivity_net12",
+          "source_trace_4",
+          "source_port_7",
+          "source_trace_2",
+          "source_port_18",
+          "source_net_1",
+          "pcb_smtpad_6",
+          "pcb_port_7",
+          "pcb_smtpad_18",
+          "pcb_port_18"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 0.2800096,
+        "center": {
+          "x": 0.249936000000048,
+          "y": -1.6576039999998784
+        },
+        "height": 0.6649974,
+        "layers": ["top"],
+        "connectedTo": [
+          "pcb_smtpad_7",
+          "connectivity_net105",
+          "source_port_8",
+          "pcb_smtpad_7",
+          "pcb_port_8"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 0.6649974,
+        "center": {
+          "x": 1.1574779999999691,
+          "y": -1.2499339999999393
+        },
+        "height": 0.2800096,
+        "layers": ["top"],
+        "connectedTo": [
+          "pcb_smtpad_8",
+          "connectivity_net106",
+          "source_port_9",
+          "pcb_smtpad_8",
+          "pcb_port_9"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 0.6649974,
+        "center": {
+          "x": 1.1574779999999691,
+          "y": -0.750061999999957
+        },
+        "height": 0.2800096,
+        "layers": ["top"],
+        "connectedTo": [
+          "pcb_smtpad_9",
+          "connectivity_net107",
+          "source_port_10",
+          "pcb_smtpad_9",
+          "pcb_port_10"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 0.6649974,
+        "center": {
+          "x": 1.1574779999999691,
+          "y": -0.24993599999982044
+        },
+        "height": 0.2800096,
+        "layers": ["top"],
+        "connectedTo": [
+          "pcb_smtpad_10",
+          "connectivity_net108",
+          "source_port_11",
+          "pcb_smtpad_10",
+          "pcb_port_11"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 0.6649974,
+        "center": {
+          "x": 1.1574779999999691,
+          "y": 0.2499359999999343
+        },
+        "height": 0.2800096,
+        "layers": ["top"],
+        "connectedTo": [
+          "pcb_smtpad_11",
+          "connectivity_net109",
+          "source_port_12",
+          "pcb_smtpad_11",
+          "pcb_port_12"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 0.6649974,
+        "center": {
+          "x": 1.1574779999999691,
+          "y": 0.7500619999999573
+        },
+        "height": 0.2800096,
+        "layers": ["top"],
+        "connectedTo": [
+          "pcb_smtpad_12",
+          "connectivity_net110",
+          "source_port_13",
+          "pcb_smtpad_12",
+          "pcb_port_13"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 0.6649974,
+        "center": {
+          "x": 1.1574779999999691,
+          "y": 1.249934000000053
+        },
+        "height": 0.2800096,
+        "layers": ["top"],
+        "connectedTo": [
+          "pcb_smtpad_13",
+          "connectivity_net111",
+          "source_port_14",
+          "pcb_smtpad_13",
+          "pcb_port_14"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 0.2800096,
+        "center": {
+          "x": 0.2499360000000478,
+          "y": 1.6576039999998784
+        },
+        "height": 0.6649974,
+        "layers": ["top"],
+        "connectedTo": [
+          "pcb_smtpad_14",
+          "connectivity_net0",
+          "source_trace_0",
+          "source_port_15",
+          "source_port_16",
+          "pcb_smtpad_14",
+          "pcb_port_15",
+          "pcb_smtpad_16",
+          "pcb_port_16"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 0.2800096,
+        "center": {
+          "x": -0.24993599999993432,
+          "y": 1.6576039999998784
+        },
+        "height": 0.6649974,
+        "layers": ["top"],
+        "connectedTo": [
+          "pcb_smtpad_15",
+          "connectivity_net98",
+          "source_port_0",
+          "pcb_smtpad_15",
+          "pcb_port_0"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 0.9999979999999999,
+        "center": {
+          "x": 0,
+          "y": 0
+        },
+        "height": 1.9999959999999999,
+        "layers": ["top"],
+        "connectedTo": [
+          "pcb_smtpad_16",
+          "connectivity_net0",
+          "source_trace_0",
+          "source_port_15",
+          "source_port_16",
+          "pcb_smtpad_14",
+          "pcb_port_15",
+          "pcb_smtpad_16",
+          "pcb_port_16"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1.1,
+        "center": {
+          "x": 0.85,
+          "y": 4.1850000000000005
+        },
+        "height": 0.275,
+        "layers": ["top"],
+        "connectedTo": [
+          "pcb_smtpad_17",
+          "connectivity_net3",
+          "source_trace_1",
+          "source_port_17",
+          "source_net_0",
+          "pcb_smtpad_17",
+          "pcb_port_17"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1.1,
+        "center": {
+          "x": 0.85,
+          "y": 3.935
+        },
+        "height": 0.275,
+        "layers": ["top"],
+        "connectedTo": [
+          "pcb_smtpad_17",
+          "connectivity_net3",
+          "source_trace_1",
+          "source_port_17",
+          "source_net_0",
+          "pcb_smtpad_17",
+          "pcb_port_17"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1.1,
+        "center": {
+          "x": 0.85,
+          "y": 3.685
+        },
+        "height": 0.275,
+        "layers": ["top"],
+        "connectedTo": [
+          "pcb_smtpad_17",
+          "connectivity_net3",
+          "source_trace_1",
+          "source_port_17",
+          "source_net_0",
+          "pcb_smtpad_17",
+          "pcb_port_17"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1.1,
+        "center": {
+          "x": 0.85,
+          "y": 3.435
+        },
+        "height": 0.275,
+        "layers": ["top"],
+        "connectedTo": [
+          "pcb_smtpad_17",
+          "connectivity_net3",
+          "source_trace_1",
+          "source_port_17",
+          "source_net_0",
+          "pcb_smtpad_17",
+          "pcb_port_17"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1.1,
+        "center": {
+          "x": -0.85,
+          "y": 4.1850000000000005
+        },
+        "height": 0.275,
+        "layers": ["top"],
+        "connectedTo": [
+          "pcb_smtpad_18",
+          "connectivity_net12",
+          "source_trace_4",
+          "source_port_7",
+          "source_trace_2",
+          "source_port_18",
+          "source_net_1",
+          "pcb_smtpad_6",
+          "pcb_port_7",
+          "pcb_smtpad_18",
+          "pcb_port_18"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1.1,
+        "center": {
+          "x": -0.85,
+          "y": 3.935
+        },
+        "height": 0.275,
+        "layers": ["top"],
+        "connectedTo": [
+          "pcb_smtpad_18",
+          "connectivity_net12",
+          "source_trace_4",
+          "source_port_7",
+          "source_trace_2",
+          "source_port_18",
+          "source_net_1",
+          "pcb_smtpad_6",
+          "pcb_port_7",
+          "pcb_smtpad_18",
+          "pcb_port_18"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1.1,
+        "center": {
+          "x": -0.85,
+          "y": 3.685
+        },
+        "height": 0.275,
+        "layers": ["top"],
+        "connectedTo": [
+          "pcb_smtpad_18",
+          "connectivity_net12",
+          "source_trace_4",
+          "source_port_7",
+          "source_trace_2",
+          "source_port_18",
+          "source_net_1",
+          "pcb_smtpad_6",
+          "pcb_port_7",
+          "pcb_smtpad_18",
+          "pcb_port_18"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1.1,
+        "center": {
+          "x": -0.85,
+          "y": 3.435
+        },
+        "height": 0.275,
+        "layers": ["top"],
+        "connectedTo": [
+          "pcb_smtpad_18",
+          "connectivity_net12",
+          "source_trace_4",
+          "source_port_7",
+          "source_trace_2",
+          "source_port_18",
+          "source_net_1",
+          "pcb_smtpad_6",
+          "pcb_port_7",
+          "pcb_smtpad_18",
+          "pcb_port_18"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1.1,
+        "center": {
+          "x": -0.85,
+          "y": -6.35
+        },
+        "height": 1,
+        "layers": ["top"],
+        "connectedTo": [
+          "pcb_smtpad_19",
+          "connectivity_net9",
+          "source_trace_3",
+          "source_port_19",
+          "source_port_32",
+          "pcb_smtpad_19",
+          "pcb_port_19",
+          "pcb_plated_hole_11",
+          "pcb_port_32"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1.1,
+        "center": {
+          "x": 0.85,
+          "y": -6.35
+        },
+        "height": 1,
+        "layers": ["top"],
+        "connectedTo": [
+          "pcb_smtpad_20",
+          "connectivity_net112",
+          "source_port_20",
+          "pcb_smtpad_20",
+          "pcb_port_20"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1.27,
+        "center": {
+          "x": 0,
+          "y": 7.219
+        },
+        "height": 0.635,
+        "layers": ["top"],
+        "connectedTo": [
+          "pcb_smtpad_21",
+          "connectivity_net131",
+          "source_port_40",
+          "pcb_smtpad_21",
+          "pcb_port_40"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1.27,
+        "center": {
+          "x": 4.898587196589413e-17,
+          "y": 8.019
+        },
+        "height": 0.635,
+        "layers": ["top"],
+        "connectedTo": [
+          "pcb_smtpad_22",
+          "connectivity_net132",
+          "source_port_41",
+          "pcb_smtpad_22",
+          "pcb_port_41"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 5.079999999999999,
+          "y": 12.5
+        },
+        "height": 1.88,
+        "layers": ["top", "inner1", "inner2", "bottom"],
+        "connectedTo": [
+          "pcb_plated_hole_0",
+          "connectivity_net123",
+          "source_port_31",
+          "pcb_plated_hole_0",
+          "pcb_port_31"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 5.079999999999999,
+          "y": 10
+        },
+        "height": 1.88,
+        "layers": ["top", "inner1", "inner2", "bottom"],
+        "connectedTo": [
+          "pcb_plated_hole_1",
+          "connectivity_net122",
+          "source_port_30",
+          "pcb_plated_hole_1",
+          "pcb_port_30"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 5.079999999999999,
+          "y": 7.5
+        },
+        "height": 1.88,
+        "layers": ["top", "inner1", "inner2", "bottom"],
+        "connectedTo": [
+          "pcb_plated_hole_2",
+          "connectivity_net121",
+          "source_port_29",
+          "pcb_plated_hole_2",
+          "pcb_port_29"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 5.08,
+          "y": 5
+        },
+        "height": 1.88,
+        "layers": ["top", "inner1", "inner2", "bottom"],
+        "connectedTo": [
+          "pcb_plated_hole_3",
+          "connectivity_net120",
+          "source_port_28",
+          "pcb_plated_hole_3",
+          "pcb_port_28"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 5.08,
+          "y": 2.5
+        },
+        "height": 1.88,
+        "layers": ["top", "inner1", "inner2", "bottom"],
+        "connectedTo": [
+          "pcb_plated_hole_4",
+          "connectivity_net119",
+          "source_port_27",
+          "pcb_plated_hole_4",
+          "pcb_port_27"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 5.08,
+          "y": 0
+        },
+        "height": 1.88,
+        "layers": ["top", "inner1", "inner2", "bottom"],
+        "connectedTo": [
+          "pcb_plated_hole_5",
+          "connectivity_net118",
+          "source_port_26",
+          "pcb_plated_hole_5",
+          "pcb_port_26"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 5.08,
+          "y": -2.5
+        },
+        "height": 1.88,
+        "layers": ["top", "inner1", "inner2", "bottom"],
+        "connectedTo": [
+          "pcb_plated_hole_6",
+          "connectivity_net117",
+          "source_port_25",
+          "pcb_plated_hole_6",
+          "pcb_port_25"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 5.08,
+          "y": -5
+        },
+        "height": 1.88,
+        "layers": ["top", "inner1", "inner2", "bottom"],
+        "connectedTo": [
+          "pcb_plated_hole_7",
+          "connectivity_net116",
+          "source_port_24",
+          "pcb_plated_hole_7",
+          "pcb_port_24"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 5.080000000000001,
+          "y": -7.5
+        },
+        "height": 1.88,
+        "layers": ["top", "inner1", "inner2", "bottom"],
+        "connectedTo": [
+          "pcb_plated_hole_8",
+          "connectivity_net115",
+          "source_port_23",
+          "pcb_plated_hole_8",
+          "pcb_port_23"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 5.080000000000001,
+          "y": -10
+        },
+        "height": 1.88,
+        "layers": ["top", "inner1", "inner2", "bottom"],
+        "connectedTo": [
+          "pcb_plated_hole_9",
+          "connectivity_net114",
+          "source_port_22",
+          "pcb_plated_hole_9",
+          "pcb_port_22"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 5.080000000000001,
+          "y": -12.5
+        },
+        "height": 1.88,
+        "layers": ["top", "inner1", "inner2", "bottom"],
+        "connectedTo": [
+          "pcb_plated_hole_10",
+          "connectivity_net113",
+          "source_port_21",
+          "pcb_plated_hole_10",
+          "pcb_port_21"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": -5.080000000000001,
+          "y": -8.75
+        },
+        "height": 1.88,
+        "layers": ["top", "inner1", "inner2", "bottom"],
+        "connectedTo": [
+          "pcb_plated_hole_11",
+          "connectivity_net9",
+          "source_trace_3",
+          "source_port_19",
+          "source_port_32",
+          "pcb_smtpad_19",
+          "pcb_port_19",
+          "pcb_plated_hole_11",
+          "pcb_port_32"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": -5.08,
+          "y": -6.25
+        },
+        "height": 1.88,
+        "layers": ["top", "inner1", "inner2", "bottom"],
+        "connectedTo": [
+          "pcb_plated_hole_12",
+          "connectivity_net124",
+          "source_port_33",
+          "pcb_plated_hole_12",
+          "pcb_port_33"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": -5.08,
+          "y": -3.75
+        },
+        "height": 1.88,
+        "layers": ["top", "inner1", "inner2", "bottom"],
+        "connectedTo": [
+          "pcb_plated_hole_13",
+          "connectivity_net125",
+          "source_port_34",
+          "pcb_plated_hole_13",
+          "pcb_port_34"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": -5.08,
+          "y": -1.25
+        },
+        "height": 1.88,
+        "layers": ["top", "inner1", "inner2", "bottom"],
+        "connectedTo": [
+          "pcb_plated_hole_14",
+          "connectivity_net126",
+          "source_port_35",
+          "pcb_plated_hole_14",
+          "pcb_port_35"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": -5.08,
+          "y": 1.25
+        },
+        "height": 1.88,
+        "layers": ["top", "inner1", "inner2", "bottom"],
+        "connectedTo": [
+          "pcb_plated_hole_15",
+          "connectivity_net127",
+          "source_port_36",
+          "pcb_plated_hole_15",
+          "pcb_port_36"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": -5.08,
+          "y": 3.75
+        },
+        "height": 1.88,
+        "layers": ["top", "inner1", "inner2", "bottom"],
+        "connectedTo": [
+          "pcb_plated_hole_16",
+          "connectivity_net128",
+          "source_port_37",
+          "pcb_plated_hole_16",
+          "pcb_port_37"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": -5.08,
+          "y": 6.25
+        },
+        "height": 1.88,
+        "layers": ["top", "inner1", "inner2", "bottom"],
+        "connectedTo": [
+          "pcb_plated_hole_17",
+          "connectivity_net129",
+          "source_port_38",
+          "pcb_plated_hole_17",
+          "pcb_port_38"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": -5.079999999999999,
+          "y": 8.75
+        },
+        "height": 1.88,
+        "layers": ["top", "inner1", "inner2", "bottom"],
+        "connectedTo": [
+          "pcb_plated_hole_18",
+          "connectivity_net130",
+          "source_port_39",
+          "pcb_plated_hole_18",
+          "pcb_port_39"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 3.302,
+        "center": {
+          "x": 0,
+          "y": 11.43
+        },
+        "height": 3.302,
+        "layers": ["top", "inner1", "inner2", "bottom"],
+        "connectedTo": []
+      },
+      {
+        "type": "rect",
+        "width": 3.302,
+        "center": {
+          "x": 0,
+          "y": -11.43
+        },
+        "height": 3.302,
+        "layers": ["top", "inner1", "inner2", "bottom"],
+        "connectedTo": []
+      }
+    ],
+    "layerCount": 2,
+    "connections": [
+      {
+        "name": "source_trace_0",
+        "pointsToConnect": [
+          {
+            "x": 0.2499360000000478,
+            "y": 1.6576039999998784,
+            "layer": "top",
+            "pointId": "pcb_port_15",
+            "pcb_port_id": "pcb_port_15"
+          },
+          {
+            "x": 0,
+            "y": 0,
+            "layer": "top",
+            "pointId": "pcb_port_16",
+            "pcb_port_id": "pcb_port_16"
+          }
+        ],
+        "source_trace_id": "source_trace_0"
+      },
+      {
+        "name": "source_trace_3",
+        "pointsToConnect": [
+          {
+            "x": -0.85,
+            "y": -6.35,
+            "layer": "top",
+            "pointId": "pcb_port_19",
+            "pcb_port_id": "pcb_port_19"
+          },
+          {
+            "x": -5.080000000000001,
+            "y": -8.75,
+            "layer": "top",
+            "pointId": "pcb_port_32",
+            "pcb_port_id": "pcb_port_32"
+          }
+        ],
+        "source_trace_id": "source_trace_3"
+      },
+      {
+        "name": "source_net_0",
+        "pointsToConnect": [
+          {
+            "x": 0.85,
+            "y": 3.81,
+            "layer": "top",
+            "pointId": "pcb_port_17",
+            "pcb_port_id": "pcb_port_17"
+          }
+        ]
+      },
+      {
+        "name": "source_net_1",
+        "pointsToConnect": [
+          {
+            "x": -0.85,
+            "y": 3.81,
+            "layer": "top",
+            "pointId": "pcb_port_18",
+            "pcb_port_id": "pcb_port_18"
+          },
+          {
+            "x": -0.2499359999999341,
+            "y": -1.6576039999998784,
+            "layer": "top",
+            "pointId": "pcb_port_7",
+            "pcb_port_id": "pcb_port_7"
+          }
+        ]
+      }
+    ],
+    "minTraceWidth": 0.15
+  },
+  "circuit_json": null,
+  "subcircuit_id": null,
+  "created_at": "2025-08-18T23:22:48.077Z"
+}


### PR DESCRIPTION
## Summary
- add downloaded autorouting bug report fixture for fe4a172b-07ce-4cd1-a6c7-69c5c05a24c9

## Testing
- `bun test tests/bugs/flatbush-zero-obstacles.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68a3b6e1ee78832eb3a2b1594a7eae43