### PR TITLE
Introduce outline SRJ fixture for capacity mesh tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ interface SimpleRouteJson {
   obstacles: Obstacle[]
   connections: Array<SimpleRouteConnection>
   bounds: { minX: number; maxX: number; minY: number; maxY: number }
+  outline?: Array<{ x: number; y: number }>
   traces?: SimplifiedPcbTraces // Optional for input
 }
 

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
         "@tscircuit/checks": "^0.0.75",
         "@tscircuit/circuit-json-util": "^0.0.46",
         "@tscircuit/core": "^0.0.337",
-        "@tscircuit/math-utils": "^0.0.23",
+        "@tscircuit/math-utils": "^0.0.27",
         "@types/bun": "^1.2.16",
         "@types/fast-json-stable-stringify": "^2.1.2",
         "@types/object-hash": "^3.0.6",
@@ -336,7 +336,7 @@
 
     "@tscircuit/manual-edit-events": ["@tscircuit/manual-edit-events@0.0.6", "", { "dependencies": { "zod": "^3.23.8" } }, "sha512-PLgy+/Dsw1YcnNVNqfieNGTNIaRKRJ70Jt2LcSMljwaBOtsiOwtdzj24xCYO9XzJUZc7opKytShMlx863PehTQ=="],
 
-    "@tscircuit/math-utils": ["@tscircuit/math-utils@0.0.23", "", { "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-8iNr/seND7t9lpk/IfmofvuS0bLD2C5Vc81mkThzKmqGNlqodInregw74KggWKZtX3Ejz9w6YtgZPqDUdwDQlw=="],
+    "@tscircuit/math-utils": ["@tscircuit/math-utils@0.0.27", "", { "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-gmmlUVvFtSTu9mBMQJv61U1KnwszZxSjxKKcYlkrmw9u9+SDPdXusjqgg05vziYiuYIRodoKr98+n13t3c9oSA=="],
 
     "@tscircuit/mm": ["@tscircuit/mm@0.0.8", "", { "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-nl7nxE7AhARbKuobflI0LUzoir7+wJyvwfPw6bzA/O0Q3YTcH3vBkU/Of+V/fp6ht+AofiCXj7YAH9E446138Q=="],
 

--- a/lib/types/srj-types.ts
+++ b/lib/types/srj-types.ts
@@ -6,6 +6,7 @@ export interface SimpleRouteJson {
   obstacles: Obstacle[]
   connections: Array<SimpleRouteConnection>
   bounds: { minX: number; maxX: number; minY: number; maxY: number }
+  outline?: Array<{ x: number; y: number }>
   traces?: SimplifiedPcbTraces
 }
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@tscircuit/checks": "^0.0.75",
     "@tscircuit/circuit-json-util": "^0.0.46",
     "@tscircuit/core": "^0.0.337",
-    "@tscircuit/math-utils": "^0.0.23",
+    "@tscircuit/math-utils": "^0.0.27",
     "@types/bun": "^1.2.16",
     "@types/fast-json-stable-stringify": "^2.1.2",
     "@types/object-hash": "^3.0.6",

--- a/tests/capacity-mesh-outline.fixture.tsx
+++ b/tests/capacity-mesh-outline.fixture.tsx
@@ -1,4 +1,4 @@
-import type { SimpleRouteJson } from "../../lib/types"
+import type { SimpleRouteJson } from "../lib/types"
 
 export const squareOutline: Array<{ x: number; y: number }> = [
   { x: 1, y: 1 },

--- a/tests/capacity-mesh-outline.test.ts
+++ b/tests/capacity-mesh-outline.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import type { CapacityMeshNode } from "../lib/types"
 import { CapacityMeshNodeSolver } from "../lib/solvers/CapacityMeshSolver/CapacityMeshNodeSolver1"
 import { CapacityMeshNodeSolver2_NodeUnderObstacle } from "../lib/solvers/CapacityMeshSolver/CapacityMeshNodeSolver2_NodesUnderObstacles"
-import { createSimpleRouteJsonWithOutline } from "./fixtures/simple-route-json-with-outline"
+import { createSimpleRouteJsonWithOutline } from "./capacity-mesh-outline.fixture"
 
 const baseSrj = createSimpleRouteJsonWithOutline()
 

--- a/tests/capacity-mesh-outline.test.ts
+++ b/tests/capacity-mesh-outline.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test"
+import type { CapacityMeshNode } from "../lib/types"
+import { CapacityMeshNodeSolver } from "../lib/solvers/CapacityMeshSolver/CapacityMeshNodeSolver1"
+import { CapacityMeshNodeSolver2_NodeUnderObstacle } from "../lib/solvers/CapacityMeshSolver/CapacityMeshNodeSolver2_NodesUnderObstacles"
+import { createSimpleRouteJsonWithOutline } from "./fixtures/simple-route-json-with-outline"
+
+const baseSrj = createSimpleRouteJsonWithOutline()
+
+const createNode = (
+  id: string,
+  center: { x: number; y: number },
+  size: number,
+): CapacityMeshNode => ({
+  capacityMeshNodeId: id,
+  center,
+  width: size,
+  height: size,
+  layer: "top",
+  availableZ: [0, 1],
+})
+
+describe("Capacity mesh node solvers with outline", () => {
+  test("treat outline exterior as obstacle", () => {
+    const solver = new CapacityMeshNodeSolver(baseSrj)
+
+    const insideNode = createNode("inside", { x: 5, y: 5 }, 2)
+    expect(solver.doesNodeOverlapObstacle(insideNode)).toBe(false)
+
+    const partialNode = createNode("partial", { x: 1, y: 5 }, 2)
+    expect(solver.doesNodeOverlapObstacle(partialNode)).toBe(true)
+    expect(solver.isNodeCompletelyInsideObstacle(partialNode)).toBe(false)
+
+    const outsideNode = createNode("outside", { x: 0, y: 5 }, 1)
+    expect(solver.doesNodeOverlapObstacle(outsideNode)).toBe(true)
+    expect(solver.isNodeCompletelyInsideObstacle(outsideNode)).toBe(true)
+  })
+
+  test("node under obstacle solver respects outline boundaries", () => {
+    const solver = new CapacityMeshNodeSolver2_NodeUnderObstacle(baseSrj)
+
+    const insideNode = createNode("inside", { x: 5, y: 5 }, 2)
+    expect(solver.isNodeCompletelyOutsideBounds(insideNode)).toBe(false)
+    expect(solver.isNodePartiallyOutsideBounds(insideNode)).toBe(false)
+
+    const partialNode = createNode("partial", { x: 1, y: 5 }, 2)
+    expect(solver.isNodeCompletelyOutsideBounds(partialNode)).toBe(false)
+    expect(solver.isNodePartiallyOutsideBounds(partialNode)).toBe(true)
+
+    const outsideNode = createNode("outside", { x: 0, y: 5 }, 1)
+    expect(solver.isNodeCompletelyOutsideBounds(outsideNode)).toBe(true)
+    expect(solver.isNodePartiallyOutsideBounds(outsideNode)).toBe(true)
+  })
+})

--- a/tests/fixtures/simple-route-json-with-outline.ts
+++ b/tests/fixtures/simple-route-json-with-outline.ts
@@ -1,0 +1,27 @@
+import type { SimpleRouteJson } from "../../lib/types"
+
+export const squareOutline: Array<{ x: number; y: number }> = [
+  { x: 1, y: 1 },
+  { x: 9, y: 1 },
+  { x: 9, y: 9 },
+  { x: 1, y: 9 },
+]
+
+const baseSimpleRouteJsonWithOutline: SimpleRouteJson = {
+  layerCount: 2,
+  minTraceWidth: 0.25,
+  obstacles: [],
+  connections: [],
+  bounds: { minX: 0, maxX: 10, minY: 0, maxY: 10 },
+  outline: squareOutline,
+}
+
+export const createSimpleRouteJsonWithOutline = (
+  overrides: Partial<SimpleRouteJson> = {},
+): SimpleRouteJson => ({
+  ...baseSimpleRouteJsonWithOutline,
+  ...overrides,
+  outline: overrides.outline ?? baseSimpleRouteJsonWithOutline.outline,
+})
+
+export const simpleRouteJsonWithOutline = createSimpleRouteJsonWithOutline()


### PR DESCRIPTION
## Summary
- add an optional `outline` polygon to `SimpleRouteJson` typings and docs
- treat areas outside the outline as obstacles in the capacity mesh node solvers via the new math-utils helpers
- cover the outline behaviour with targeted unit tests and update `@tscircuit/math-utils`
- introduce a reusable `createSimpleRouteJsonWithOutline` fixture and update outline tests to consume it

## Testing
- bunx tsc --noEmit
- bun test tests/capacity-mesh-outline.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68df129d3e34832ea1b68b577d8d5476