### PR TITLE
Show problem outline in initial visualization

### DIFF
--- a/lib/solvers/AutoroutingPipelineSolver.ts
+++ b/lib/solvers/AutoroutingPipelineSolver.ts
@@ -477,6 +477,43 @@ export class AutoroutingPipelineSolver extends BaseSolver {
       this.multiSimplifiedPathSolver1?.visualize()
     const simplifiedPathSolverViz2 =
       this.multiSimplifiedPathSolver2?.visualize()
+    const problemOutline = this.srj.outline
+    const problemLines: Line[] = []
+
+    problemLines.push({
+      points: [
+        // Add five points representing the bounds of the PCB
+        {
+          x: this.srj.bounds?.minX ?? -50,
+          y: this.srj.bounds?.minY ?? -50,
+        },
+        { x: this.srj.bounds?.maxX ?? 50, y: this.srj.bounds?.minY ?? -50 },
+        { x: this.srj.bounds?.maxX ?? 50, y: this.srj.bounds?.maxY ?? 50 },
+        { x: this.srj.bounds?.minX ?? -50, y: this.srj.bounds?.maxY ?? 50 },
+        {
+          x: this.srj.bounds?.minX ?? -50,
+          y: this.srj.bounds?.minY ?? -50,
+        }, // Close the rectangle
+      ],
+      strokeColor: "rgba(255,0,0,0.25)",
+    })
+
+    if (problemOutline && problemOutline.length >= 2) {
+      const outlinePoints = problemOutline.map(
+        (point: { x: number; y: number }) => ({
+          x: point.x,
+          y: point.y,
+        }),
+      )
+
+      outlinePoints.push({ ...outlinePoints[0]! })
+
+      problemLines.push({
+        points: outlinePoints,
+        strokeColor: "rgba(0, 136, 255, 0.95)",
+      })
+    }
+
     const problemViz = {
       points: [
         ...this.srj.connections.flatMap((c) =>
@@ -497,25 +534,7 @@ export class AutoroutingPipelineSolver extends BaseSolver {
           label: o.layers?.join(", "),
         })),
       ],
-      lines: [
-        {
-          points: [
-            // Add five points representing the bounds of the PCB
-            {
-              x: this.srj.bounds?.minX ?? -50,
-              y: this.srj.bounds?.minY ?? -50,
-            },
-            { x: this.srj.bounds?.maxX ?? 50, y: this.srj.bounds?.minY ?? -50 },
-            { x: this.srj.bounds?.maxX ?? 50, y: this.srj.bounds?.maxY ?? 50 },
-            { x: this.srj.bounds?.minX ?? -50, y: this.srj.bounds?.maxY ?? 50 },
-            {
-              x: this.srj.bounds?.minX ?? -50,
-              y: this.srj.bounds?.minY ?? -50,
-            }, // Close the rectangle
-          ],
-          strokeColor: "rgba(255,0,0,0.25)",
-        },
-      ],
+      lines: problemLines,
     } as GraphicsObject
     const visualizations = [
       problemViz,

--- a/lib/solvers/CapacityMeshSolver/CapacityMeshNodeSolver1.ts
+++ b/lib/solvers/CapacityMeshSolver/CapacityMeshNodeSolver1.ts
@@ -471,17 +471,18 @@ export class CapacityMeshNodeSolver extends BaseSolver {
 
     // Draw outline polygon if provided
     if (this.outlinePolygon && this.outlinePolygon.length >= 2) {
-      const outlinePoints = this.outlinePolygon.map((point) => ({
-        x: point.x,
-        y: point.y,
-      }))
+      const outlinePoints = this.outlinePolygon.map(
+        (point: { x: number; y: number }) => ({
+          x: point.x,
+          y: point.y,
+        }),
+      )
 
       outlinePoints.push({ ...outlinePoints[0]! })
 
       graphics.lines!.push({
         points: outlinePoints,
         strokeColor: "rgba(0, 136, 255, 0.95)",
-        strokeWidth: 0.35,
         label: "outline",
       })
 


### PR DESCRIPTION
## Summary
- draw the PCB outline in the initial problem visualization so it is visible before solving starts
- reuse that outline polygon when available while keeping the existing bounds box visualization
- remove the explicit stroke width from the capacity mesh outline visualization and add point typing to satisfy linting

## Testing
- bunx tsc --noEmit *(fails: @tscircuit/math-utils missing Polygon/isRect* exports)*
- bun run format


------
https://chatgpt.com/codex/tasks/task_b_68df58b83c94832eb497b45b892ee06b