### PR TITLE
Add script to scaffold bug report fixtures and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Want to understand how the autorouter works? Check out a stage-by-stage breakdow
 ## How to file a bug report
 
 1. You should have [created a bug report via the tscircuit errors tab](https://docs.tscircuit.com/contributing/report-autorouter-bugs)
-2. Run `bun run bug-report <bug-report-url>`
-3. This will download the bug report and create a debugging fixture file in the `examples/bug-reports` directory, you can then find the bug report in the server (via `bun run start`)
+2. Run `bun run bug-report <bug-report-url>` to download the report and create a debugging fixture file in the `examples/bug-reports` directory, you can then find the bug report in the server (via `bun run start`)
+3. Or run `bun run bug-report-with-test <bug-report-url>` to download the report, create the fixture, and scaffold a matching snapshot test under `tests/bugs`
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "format:check": "biome format .",
     "vercel-build": "cosmos-export",
     "repomix:lib": "repomix --ignore 'testing/**,**/TwoRouteHighDensitySolver/**,**/RouteStitchingSolver/**,solvers/CapacitySegmentPointOptimizer/CapacitySegmentPointOptimizer.ts' lib",
-    "bug-report": "bun run scripts/download-bug-report.ts"
+    "bug-report": "bun run scripts/download-bug-report.ts",
+    "bug-report-with-test": "bun run scripts/create-bug-report-test.ts"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/scripts/create-bug-report-test.ts
+++ b/scripts/create-bug-report-test.ts
@@ -1,0 +1,101 @@
+#! /usr/bin/env bun
+
+import fs from "node:fs"
+import path from "node:path"
+
+const bugReportArg = process.argv[2]
+
+if (!bugReportArg) {
+  console.error("Please provide a bug report URL or UUID as an argument")
+  process.exit(1)
+}
+
+let uuid: string
+if (bugReportArg.includes("autorouting_bug_report_id=")) {
+  const match = bugReportArg.match(/autorouting_bug_report_id=([^&]+)/)
+  if (!match) {
+    console.error("Could not extract UUID from URL")
+    process.exit(1)
+  }
+  uuid = match[1]
+} else if (
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+    bugReportArg,
+  )
+) {
+  uuid = bugReportArg
+} else {
+  console.error("Invalid bug report URL or UUID")
+  process.exit(1)
+}
+
+const downloadUrl = `https://api.tscircuit.com/autorouting/bug_reports/get?autorouting_bug_report_id=${uuid}&download=true`
+
+const bugReportsDir = path.join("examples", "bug-reports")
+if (!fs.existsSync(bugReportsDir)) {
+  fs.mkdirSync(bugReportsDir, { recursive: true })
+}
+
+let highestNum = 0
+const existingDirs = fs.readdirSync(bugReportsDir)
+for (const dir of existingDirs) {
+  const match = dir.match(/^bugreport(\d+)/)
+  if (match) {
+    const num = parseInt(match[1], 10)
+    if (num > highestNum) {
+      highestNum = num
+    }
+  }
+}
+
+const newBugReportNum = highestNum + 1
+const shortUuid = uuid.substring(0, 6)
+const dirName = `bugreport${newBugReportNum}-${shortUuid}`
+const dirPath = path.join(bugReportsDir, dirName)
+const jsonFileName = `${dirName}.json`
+const jsonFilePath = path.join(dirPath, jsonFileName)
+const fixtureFileName = `${dirName}.fixture.tsx`
+const fixtureFilePath = path.join(dirPath, fixtureFileName)
+const testFileName = `${dirName}.test.ts`
+const testsBugsDir = path.join("tests", "bugs")
+const testFilePath = path.join(testsBugsDir, testFileName)
+
+fs.mkdirSync(dirPath, { recursive: true })
+if (!fs.existsSync(testsBugsDir)) {
+  fs.mkdirSync(testsBugsDir, { recursive: true })
+}
+
+console.log(`Downloading bug report from ${downloadUrl}...`)
+let bugReportJson: unknown
+try {
+  const response = await fetch(downloadUrl)
+  const data = await response.json()
+  bugReportJson = data.autorouting_bug_report
+  if (
+    !bugReportJson ||
+    typeof bugReportJson !== "object" ||
+    !("simple_route_json" in (bugReportJson as Record<string, unknown>))
+  ) {
+    console.error("Downloaded bug report did not include simple_route_json")
+    process.exit(1)
+  }
+  fs.writeFileSync(jsonFilePath, JSON.stringify(bugReportJson, null, 2))
+  console.log(`\nBug report saved to ${jsonFilePath}`)
+} catch (error) {
+  console.error("Failed to download bug report:", error)
+  process.exit(1)
+}
+
+const fixtureTemplate = `// @ts-nocheck\nimport { AutoroutingPipelineDebugger } from "lib/testing/AutoroutingPipelineDebugger"\nimport bugReportJson from "./${jsonFileName}"\n\nexport default () => {\n  return <AutoroutingPipelineDebugger srj={bugReportJson.simple_route_json} />\n}\n`
+
+fs.writeFileSync(fixtureFilePath, fixtureTemplate)
+console.log(`Fixture file created at ${fixtureFilePath}`)
+
+const testTemplate = `import { beforeAll, describe, expect, test } from "bun:test"\nimport { CapacityMeshSolver } from "lib"\nimport { convertToCircuitJson } from "lib/testing/utils/convertToCircuitJson"\nimport { checkEachPcbTraceNonOverlapping } from "@tscircuit/checks"\nimport { convertCircuitJsonToPcbSvg } from "circuit-to-svg"\nimport bugReport from "../../examples/bug-reports/${dirName}/${jsonFileName}" assert { type: "json" }\nimport type { SimpleRouteJson } from "lib/types"\n\nconst srj = bugReport.simple_route_json as SimpleRouteJson\n\ndescribe("bug report ${dirName}", () => {\n  let solver: CapacityMeshSolver\n  let circuitJson: ReturnType<typeof convertToCircuitJson>\n  let pcbSvg: string\n\n  beforeAll(() => {\n    solver = new CapacityMeshSolver(srj)\n    solver.solve()\n\n    if (solver.failed || !solver.solved) {\n      throw new Error(\`Solver failed: \${solver.error ?? "unknown"}\`)\n    }\n\n    const srjWithPointPairs = solver.srjWithPointPairs\n    if (!srjWithPointPairs) {\n      throw new Error("Solver did not produce point pairs SRJ")\n    }\n\n    const simplifiedTraces = solver.getOutputSimplifiedPcbTraces()\n\n    circuitJson = convertToCircuitJson(\n      srjWithPointPairs,\n      simplifiedTraces,\n      srj.minTraceWidth,\n    )\n\n    pcbSvg = convertCircuitJsonToPcbSvg(circuitJson)\n  })\n\n  test("matches expected PCB snapshot", () => {\n    expect(pcbSvg).toMatchSvgSnapshot(import.meta.path)\n  })\n\n  test("produces routes without DRC violations", () => {\n    const errors = checkEachPcbTraceNonOverlapping(circuitJson)\n    expect(errors).toHaveLength(0)\n  })\n})\n`
+
+fs.writeFileSync(testFilePath, testTemplate)
+console.log(`Snapshot test created at ${testFilePath}`)
+
+console.log(
+  `\nBug report "${newBugReportNum}-${shortUuid}" successfully downloaded with fixture and test.`,
+)


### PR DESCRIPTION
## Summary
- add a helper script that downloads a bug report, scaffolds a fixture, and creates a matching snapshot test
- expose the new script through package.json and document it in the README so contributors can find it

## Testing
- bunx tsc --noEmit


------
https://chatgpt.com/codex/tasks/task_b_68e1937c5c9c832e9ede215b46ecab87