### PR TITLE
feat: support multi-layer operations in unravel solver

### DIFF
--- a/lib/solvers/UnravelSolver/UnravelMultiSectionSolver.ts
+++ b/lib/solvers/UnravelSolver/UnravelMultiSectionSolver.ts
@@ -23,6 +23,19 @@ import { getIntraNodeCrossingsFromSegmentPoints } from "lib/utils/getIntraNodeCr
 import { getNodesNearNode } from "./getNodesNearNode"
 import { CacheProvider } from "lib/cache/types"
 
+const LAYER_STROKE_DASH: Array<string | undefined> = [
+  undefined,
+  "10 5",
+  "5 5",
+  "2 6",
+  "15 3 3 3",
+]
+
+const getStrokeDashForLayer = (layer: number): string | undefined => {
+  if (!Number.isFinite(layer)) return undefined
+  return LAYER_STROKE_DASH[layer] ?? "4 4"
+}
+
 export class UnravelMultiSectionSolver extends BaseSolver {
   nodeMap: Map<CapacityMeshNodeId, CapacityMeshNode>
   dedupedSegmentMap: Map<SegmentId, SegmentWithAssignedPoints>
@@ -375,7 +388,7 @@ export class UnravelMultiSectionSolver extends BaseSolver {
 
           let strokeDash: string | undefined
           if (sameLayer) {
-            strokeDash = layer === 0 ? undefined : "10 5" // Solid for layer 0, long dash for other layers
+            strokeDash = getStrokeDashForLayer(layer)
           } else {
             strokeDash = "3 3 10" // Mixed dash for transitions between layers
           }

--- a/lib/solvers/UnravelSolver/getLayerOptions.ts
+++ b/lib/solvers/UnravelSolver/getLayerOptions.ts
@@ -1,0 +1,50 @@
+export interface HasAvailableZ {
+  availableZ: number[]
+}
+
+/**
+ * Returns the layers that are available across all of the provided segments,
+ * preserving the ordering from the first segment and removing duplicates.
+ */
+export const getCommonAvailableLayers = (
+  segments: HasAvailableZ[],
+): number[] => {
+  if (segments.length === 0) return []
+
+  const [first, ...rest] = segments
+  const seenLayers = new Set<number>()
+  const commonLayers: number[] = []
+
+  for (const layer of first.availableZ) {
+    if (seenLayers.has(layer)) continue
+    if (rest.every((segment) => segment.availableZ.includes(layer))) {
+      seenLayers.add(layer)
+      commonLayers.push(layer)
+    }
+  }
+
+  return commonLayers
+}
+
+/**
+ * Returns all alternative layers that a segment can use, excluding any layers
+ * in the provided exclusion set. The order of layers is preserved from the
+ * segment's availableZ array.
+ */
+export const getAlternativeLayersForSegment = (
+  segment: HasAvailableZ,
+  exclude: Iterable<number>,
+): number[] => {
+  const excludeSet = new Set(exclude)
+  const seenLayers = new Set<number>()
+  const alternativeLayers: number[] = []
+
+  for (const layer of segment.availableZ) {
+    if (excludeSet.has(layer)) continue
+    if (seenLayers.has(layer)) continue
+    seenLayers.add(layer)
+    alternativeLayers.push(layer)
+  }
+
+  return alternativeLayers
+}

--- a/tests/solvers/unravel-section-solver.test.ts
+++ b/tests/solvers/unravel-section-solver.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test"
+import { UnravelSectionSolver } from "../../lib/solvers/UnravelSolver/UnravelSectionSolver"
+import { SegmentWithAssignedPoints } from "../../lib/solvers/CapacityMeshSolver/CapacitySegmentToPointSolver"
+import { CapacityMeshNode } from "../../lib/types"
+import { UnravelOperation } from "../../lib/solvers/UnravelSolver/types"
+
+const isChangeLayerOperation = (
+  operation: UnravelOperation,
+): operation is Extract<UnravelOperation, { type: "change_layer" }> =>
+  operation.type === "change_layer"
+
+const createTestSolver = () => {
+  const node: CapacityMeshNode = {
+    capacityMeshNodeId: "node1",
+    center: { x: 0, y: 0 },
+    width: 10,
+    height: 10,
+    layer: "layer0",
+    availableZ: [0, 1, 2, 3],
+  }
+
+  const segments: SegmentWithAssignedPoints[] = [
+    {
+      capacityMeshNodeId: "node1",
+      nodePortSegmentId: "segA1",
+      start: { x: -2, y: -2 },
+      end: { x: -1, y: -1 },
+      availableZ: [0, 1, 2, 3],
+      connectionNames: ["netA"],
+      assignedPoints: [
+        {
+          connectionName: "netA",
+          point: { x: -1, y: -1, z: 0 },
+        },
+      ],
+    },
+    {
+      capacityMeshNodeId: "node1",
+      nodePortSegmentId: "segA2",
+      start: { x: 1, y: 1 },
+      end: { x: 2, y: 2 },
+      availableZ: [0, 1, 2, 3],
+      connectionNames: ["netA"],
+      assignedPoints: [
+        {
+          connectionName: "netA",
+          point: { x: 1, y: 1, z: 0 },
+        },
+      ],
+    },
+    {
+      capacityMeshNodeId: "node1",
+      nodePortSegmentId: "segB1",
+      start: { x: -2, y: 2 },
+      end: { x: -1, y: 1 },
+      availableZ: [0, 1, 2, 3],
+      connectionNames: ["netB"],
+      assignedPoints: [
+        {
+          connectionName: "netB",
+          point: { x: -1, y: 1, z: 0 },
+        },
+      ],
+    },
+    {
+      capacityMeshNodeId: "node1",
+      nodePortSegmentId: "segB2",
+      start: { x: 1, y: -1 },
+      end: { x: 2, y: -2 },
+      availableZ: [0, 1, 2, 3],
+      connectionNames: ["netB"],
+      assignedPoints: [
+        {
+          connectionName: "netB",
+          point: { x: 1, y: -1, z: 0 },
+        },
+      ],
+    },
+  ]
+
+  const nodeIdToSegmentIds = new Map([
+    ["node1", segments.map((segment) => segment.nodePortSegmentId!)],
+  ])
+
+  const segmentIdToNodeIds = new Map(
+    segments.map((segment) => [segment.nodePortSegmentId!, ["node1"]]),
+  )
+
+  return new UnravelSectionSolver({
+    rootNodeId: "node1",
+    nodeMap: new Map([["node1", node]]),
+    dedupedSegments: segments,
+    nodeIdToSegmentIds,
+    segmentIdToNodeIds,
+  })
+}
+
+describe("UnravelSectionSolver", () => {
+  test("proposes layer changes across all available layers for crossings", () => {
+    const solver = createTestSolver()
+    const candidate = solver.createInitialCandidate()
+    const issue = candidate.issues.find(
+      (item) => item.type === "same_layer_crossing",
+    )
+
+    if (!issue || issue.type !== "same_layer_crossing") {
+      throw new Error("Expected a same layer crossing issue to be detected")
+    }
+
+    const operations = solver.getOperationsForIssue(candidate, issue)
+
+    const segmentPairLayerChanges = operations
+      .filter(
+        (op): op is Extract<UnravelOperation, { type: "change_layer" }> =>
+          isChangeLayerOperation(op) && op.segmentPointIds.length === 2,
+      )
+      .map((op) => op.newZ)
+
+    const singlePointLayerChanges = operations
+      .filter(
+        (op): op is Extract<UnravelOperation, { type: "change_layer" }> =>
+          isChangeLayerOperation(op) && op.segmentPointIds.length === 1,
+      )
+      .map((op) => op.newZ)
+
+    expect([...new Set(segmentPairLayerChanges)].sort()).toEqual([1, 2, 3])
+    expect([...new Set(singlePointLayerChanges)].sort()).toEqual([1, 2, 3])
+  })
+})

--- a/tests/utils/get-layer-options.test.ts
+++ b/tests/utils/get-layer-options.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test"
+import {
+  getAlternativeLayersForSegment,
+  getCommonAvailableLayers,
+} from "../../lib/solvers/UnravelSolver/getLayerOptions"
+
+describe("getCommonAvailableLayers", () => {
+  test("returns the intersection while preserving order", () => {
+    const result = getCommonAvailableLayers([
+      { availableZ: [0, 1, 2, 3] },
+      { availableZ: [1, 2, 3, 4] },
+      { availableZ: [2, 3, 4] },
+    ])
+
+    expect(result).toEqual([2, 3])
+  })
+
+  test("returns an empty list when no overlap exists", () => {
+    const result = getCommonAvailableLayers([
+      { availableZ: [0, 1] },
+      { availableZ: [2, 3] },
+    ])
+
+    expect(result).toEqual([])
+  })
+})
+
+describe("getAlternativeLayersForSegment", () => {
+  test("filters out excluded layers and deduplicates", () => {
+    const result = getAlternativeLayersForSegment(
+      { availableZ: [0, 1, 1, 2, 3] },
+      [1, 3],
+    )
+
+    expect(result).toEqual([0, 2])
+  })
+})


### PR DESCRIPTION
## Summary
- generalize the unravel section solver's layer change operations to consider all available layers and eliminate duplicate proposals
- add shared helpers for intersecting available layers and update multi-section visualization styling for additional layers
- introduce targeted unit tests to cover multi-layer logic and solver behavior

## Testing
- bun test tests/utils/get-layer-options.test.ts
- bun test tests/solvers/unravel-section-solver.test.ts
- BUN_INSTALL=skip bunx --bun tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68e1e7bfc3a4832e82abaab2dc8b5c8d