### PR TITLE
Add script to bake keyboard4 cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "vercel-build": "cosmos-export",
     "repomix:lib": "repomix --ignore 'testing/**,**/TwoRouteHighDensitySolver/**,**/RouteStitchingSolver/**,solvers/CapacitySegmentPointOptimizer/CapacitySegmentPointOptimizer.ts' lib",
     "bug-report": "bun run scripts/download-bug-report.ts",
-    "bug-report-with-test": "bun run scripts/create-bug-report-test.ts"
+    "bug-report-with-test": "bun run scripts/create-bug-report-test.ts",
+    "bake-cache": "bun run scripts/bake-cache.ts"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/scripts/bake-cache.ts
+++ b/scripts/bake-cache.ts
@@ -1,0 +1,47 @@
+import { mkdir, writeFile } from "node:fs/promises"
+import { dirname, resolve } from "node:path"
+import keyboard4 from "../examples/legacy/assets/keyboard4.json"
+import { CapacityMeshSolver, getGlobalInMemoryCache } from "../lib"
+import type { SimpleRouteJson } from "../lib/types"
+
+const DEFAULT_OUTPUT_PATH = "./keyboard4-cache.json"
+
+async function ensureDirectoryExists(filePath: string) {
+  const directory = dirname(filePath)
+  await mkdir(directory, { recursive: true })
+}
+
+async function main() {
+  const outputPathArg = process.argv[2]
+  const outputPath = resolve(
+    process.cwd(),
+    outputPathArg ?? DEFAULT_OUTPUT_PATH,
+  )
+
+  const srj = keyboard4 as unknown as SimpleRouteJson
+  const solver = new CapacityMeshSolver(srj)
+
+  console.log(`Baking keyboard4 cache to ${outputPath}...`)
+
+  solver.solve()
+
+  if (solver.failed || !solver.solved) {
+    const errorMessage = `Keyboard4 solver failed: ${solver.error ?? "unknown error"}`
+    throw new Error(errorMessage)
+  }
+
+  const cache = getGlobalInMemoryCache()
+  const cacheEntries = Array.from(cache.cache.entries())
+  const cacheObject = Object.fromEntries(cacheEntries)
+
+  await ensureDirectoryExists(outputPath)
+  await writeFile(outputPath, JSON.stringify(cacheObject, null, 2), "utf-8")
+
+  const completionMessage = `Cache baked successfully to ${outputPath}\n`
+  process.stdout.write(completionMessage)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- add a cache baking script that solves the keyboard4 example and serializes the generated cache to JSON
- register a `bun run bake-cache` helper to run the new script from the command line

## Testing
- bunx --bun tsc --noEmit
- bun run bake-cache ./tmp-cache.json

------
https://chatgpt.com/codex/tasks/task_b_68e5acabff0c832e9650a5b521cf9db2