### PR TITLE
Add nominal trace width to simple route connections

### DIFF
--- a/lib/types/srj-types.ts
+++ b/lib/types/srj-types.ts
@@ -23,6 +23,7 @@ export interface Obstacle {
 export interface SimpleRouteConnection {
   name: string
   netConnectionName?: string
+  nominalTraceWidth?: number
   pointsToConnect: Array<{
     x: number
     y: number


### PR DESCRIPTION
## Summary
- add an optional nominalTraceWidth field to SimpleRouteConnection

## Testing
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68f161e3f424832e8903b26876954293