### PR TITLE
Add optional netIsAssignable flag to SRJ obstacles

### DIFF
--- a/lib/types/srj-types.ts
+++ b/lib/types/srj-types.ts
@@ -18,6 +18,7 @@ export interface Obstacle {
   width: number
   height: number
   connectedTo: TraceId[]
+  netIsAssignable?: boolean
 }
 
 export interface SimpleRouteConnection {


### PR DESCRIPTION
## Summary
- add an optional `netIsAssignable` field to the SRJ obstacle type so consumers can detect assignable nets

## Testing
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68fd3838aa9c832ea519f34f0cc7e8e5