### PR TITLE
Add lightweight previews for capacity pathing solvers

### DIFF
--- a/lib/solvers/AssignableViaAutoroutingPipeline/HyperAssignableViaCapacityPathingSolver.ts
+++ b/lib/solvers/AssignableViaAutoroutingPipeline/HyperAssignableViaCapacityPathingSolver.ts
@@ -1,3 +1,4 @@
+import type { GraphicsObject } from "graphics-debug"
 import { HyperParameterSupervisorSolver } from "lib/solvers/HyperParameterSupervisorSolver"
 import type { CapacityHyperParameters } from "lib/solvers/CapacityHyperParameters"
 import { AssignableViaCapacityPathingSolver_DirectiveSubOptimal } from "./AssignableViaCapacityPathing/AssignableViaCapacityPathingSolver_DirectiveSubOptimal"
@@ -82,5 +83,13 @@ export class HyperAssignableViaCapacityPathingSolver extends HyperParameterSuper
         ...hyperParameters,
       },
     })
+  }
+
+  preview(): GraphicsObject {
+    const bestSupervisedSolver = this.getSupervisedSolverWithBestFitness()
+    if (bestSupervisedSolver) {
+      return bestSupervisedSolver.solver.preview()
+    }
+    return {}
   }
 }

--- a/tests/core1.test.tsx
+++ b/tests/core1.test.tsx
@@ -28,7 +28,9 @@ test("core1 - simple circuit", async () => {
 
   const circuitJson = circuit.getCircuitJson()
 
-  expect(convertCircuitJsonToPcbSvg(circuitJson)).toMatchSvgSnapshot(
-    import.meta.path,
-  )
+  expect(
+    convertCircuitJsonToPcbSvg(
+      circuitJson as Parameters<typeof convertCircuitJsonToPcbSvg>[0],
+    ),
+  ).toMatchSvgSnapshot(import.meta.path)
 })

--- a/tests/core2.test.tsx
+++ b/tests/core2.test.tsx
@@ -36,7 +36,9 @@ test("core2 - two traces", async () => {
 
   const circuitJson = circuit.getCircuitJson()
 
-  expect(convertCircuitJsonToPcbSvg(circuitJson)).toMatchSvgSnapshot(
-    import.meta.path,
-  )
+  expect(
+    convertCircuitJsonToPcbSvg(
+      circuitJson as Parameters<typeof convertCircuitJsonToPcbSvg>[0],
+    ),
+  ).toMatchSvgSnapshot(import.meta.path)
 })

--- a/tests/core3.test.tsx
+++ b/tests/core3.test.tsx
@@ -44,7 +44,9 @@ test("core3 - 0402 columns", async () => {
 
   const circuitJson = circuit.getCircuitJson()
 
-  expect(convertCircuitJsonToPcbSvg(circuitJson)).toMatchSvgSnapshot(
-    import.meta.path,
-  )
+  expect(
+    convertCircuitJsonToPcbSvg(
+      circuitJson as Parameters<typeof convertCircuitJsonToPcbSvg>[0],
+    ),
+  ).toMatchSvgSnapshot(import.meta.path)
 })


### PR DESCRIPTION
## Summary
- expose a compact preview from AssignableViaCapacityPathingSolver_DirectiveSubOptimal that only returns a handful of recent route segments
- surface the best supervised solver preview from HyperAssignableViaCapacityPathingSolver
- adjust core autorouter snapshot tests to cast the circuit JSON when converting to SVG so they remain type-safe

## Testing
- bunx tsc --noEmit
- bun test tests/unassigned-obstacles/HyperAssignableViaCapacityPathingSolver


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690ce3ca0c2c832eb7c29d0a38955df4)