### PR TITLE
Add off-board obstacle connectivity metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ interface Obstacle {
   width: number
   height: number
   connectedTo: string[] // TraceIds
+  offBoardConnectsTo?: string[] // TraceIds connected off-board
 }
 
 interface SimpleRouteConnection {

--- a/lib/types/srj-types.ts
+++ b/lib/types/srj-types.ts
@@ -19,6 +19,7 @@ export interface Obstacle {
   height: number
   connectedTo: TraceId[]
   netIsAssignable?: boolean
+  offBoardConnectsTo?: TraceId[]
 }
 
 export interface SimpleRouteConnection {

--- a/lib/utils/getConnectivityMapFromSimpleRouteJson.ts
+++ b/lib/utils/getConnectivityMapFromSimpleRouteJson.ts
@@ -11,7 +11,14 @@ export const getConnectivityMapFromSimpleRouteJson = (srj: SimpleRouteJson) => {
     }
   }
   for (const obstacle of srj.obstacles) {
-    connMap.addConnections([obstacle.connectedTo])
+    const offBoardConnections = obstacle.offBoardConnectsTo ?? []
+    const connectionGroup = Array.from(
+      new Set([...obstacle.connectedTo, ...offBoardConnections]),
+    )
+
+    if (connectionGroup.length > 0) {
+      connMap.addConnections([connectionGroup])
+    }
   }
   return connMap
 }

--- a/tests/utils/getConnectivityMapFromSimpleRouteJson.test.ts
+++ b/tests/utils/getConnectivityMapFromSimpleRouteJson.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test"
+import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
+import type { SimpleRouteJson } from "lib/types"
+
+describe("getConnectivityMapFromSimpleRouteJson", () => {
+  test("includes off-board obstacle connections", () => {
+    const srj: SimpleRouteJson = {
+      layerCount: 2,
+      minTraceWidth: 0.2,
+      bounds: { minX: 0, maxX: 10, minY: 0, maxY: 10 },
+      connections: [],
+      obstacles: [
+        {
+          type: "rect",
+          layers: ["top"],
+          center: { x: 1, y: 1 },
+          width: 1,
+          height: 1,
+          connectedTo: ["obstacle_a"],
+          offBoardConnectsTo: ["obstacle_b"],
+        },
+        {
+          type: "rect",
+          layers: ["top"],
+          center: { x: 2, y: 2 },
+          width: 1,
+          height: 1,
+          connectedTo: ["obstacle_b"],
+        },
+      ],
+    }
+
+    const connMap = getConnectivityMapFromSimpleRouteJson(srj)
+
+    expect(connMap.areIdsConnected("obstacle_a", "obstacle_b")).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- add an optional `offBoardConnectsTo` array to SRJ obstacles to describe off-board connectivity
- merge off-board connections into the connectivity map so assignable obstacles share nets
- document the new field and cover it with a unit test

## Testing
- bunx tsc --noEmit *(fails: existing type errors in tests/core[1-3].test.tsx)*
- bun test tests/utils/getConnectivityMapFromSimpleRouteJson.test.ts
- bun run format


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690fb96a72fc832eb924dc603dba3674)