### PR TITLE
Fix capacity mesh layer splitting above obstacles

### DIFF
--- a/lib/solvers/CapacityMeshSolver/CapacityMeshNodeSolver2_NodesUnderObstacles.ts
+++ b/lib/solvers/CapacityMeshSolver/CapacityMeshNodeSolver2_NodesUnderObstacles.ts
@@ -199,10 +199,55 @@ export class CapacityMeshNodeSolver2_NodeUnderObstacle extends CapacityMeshNodeS
 
     const childNodes: CapacityMeshNode[] = []
 
-    // Split availableZ into individual layers
-    const otherZBlocks = node.availableZ.map((z) => [z])
+    const overlappingObstacles = this.getXYZOverlappingObstacles(node)
+    const nodeAvailableZSet = new Set(node.availableZ)
 
-    for (const zBlock of otherZBlocks) {
+    const blockedZLayers = new Set<number>()
+    for (const obstacle of overlappingObstacles) {
+      const obstacleZLayers =
+        obstacle.zLayers ??
+        obstacle.layers
+          ?.map((layerName) => mapLayerNameToZ(layerName, this.layerCount))
+          .filter((z): z is number => Number.isFinite(z))
+
+      if (!obstacleZLayers) continue
+
+      for (const z of obstacleZLayers) {
+        if (nodeAvailableZSet.has(z)) {
+          blockedZLayers.add(z)
+        }
+      }
+    }
+
+    const sortedAvailableZ = [...node.availableZ].sort((a, b) => a - b)
+
+    const availableZBlocks: number[][] = []
+    let currentBlock: number[] = []
+
+    for (const z of sortedAvailableZ) {
+      if (blockedZLayers.has(z)) {
+        if (currentBlock.length > 0) {
+          availableZBlocks.push(currentBlock)
+          currentBlock = []
+        }
+        continue
+      }
+
+      currentBlock.push(z)
+    }
+
+    if (currentBlock.length > 0) {
+      availableZBlocks.push(currentBlock)
+    }
+
+    const zBlocksToUse =
+      blockedZLayers.size > 0
+        ? availableZBlocks
+        : sortedAvailableZ.map((z) => [z])
+
+    for (const zBlock of zBlocksToUse) {
+      if (zBlock.length === 0) continue
+
       const childNode = this.createChildNodeAtPosition(node, {
         center: { ...node.center },
         width: node.width,

--- a/tests/bugs/capacity-mesh-z-layer-merging.test.ts
+++ b/tests/bugs/capacity-mesh-z-layer-merging.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test"
+import { CapacityMeshNodeSolver2_NodeUnderObstacle } from "lib/solvers/CapacityMeshSolver/CapacityMeshNodeSolver2_NodesUnderObstacles"
+import type { CapacityMeshNode } from "lib/types/capacity-mesh-types"
+import type { SimpleRouteJson } from "lib/types/srj-types"
+
+const createSolver = () => {
+  const srj: SimpleRouteJson = {
+    layerCount: 4,
+    minTraceWidth: 0.25,
+    obstacles: [
+      {
+        type: "rect",
+        layers: ["top"],
+        zLayers: [0],
+        center: { x: 0, y: 0 },
+        width: 1,
+        height: 1,
+        connectedTo: [],
+      },
+    ],
+    connections: [],
+    bounds: { minX: -5, minY: -5, maxX: 5, maxY: 5 },
+  }
+
+  return new CapacityMeshNodeSolver2_NodeUnderObstacle(srj)
+}
+
+describe("CapacityMeshNodeSolver2_NodeUnderObstacle", () => {
+  it("merges available layers above a single-layer obstacle", () => {
+    const solver = createSolver()
+
+    const node: CapacityMeshNode = {
+      capacityMeshNodeId: "test-node",
+      center: { x: 0, y: 0 },
+      width: 2,
+      height: 2,
+      layer: "top",
+      availableZ: [0, 1, 2, 3],
+      _depth: 1,
+      _containsObstacle: true,
+      _completelyInsideObstacle: false,
+    }
+
+    const zSubNodes = solver.getZSubdivisionChildNodes(node)
+
+    expect(zSubNodes).toHaveLength(1)
+    expect(zSubNodes[0]?.availableZ).toEqual([1, 2, 3])
+  })
+})


### PR DESCRIPTION
## Summary
- group contiguous unblocked Z layers when subdividing mesh nodes above obstacles so they stay routable together
- add a regression test to ensure a z=0 obstacle keeps layers 1-3 combined

## Testing
- `bun test tests/bugs/capacity-mesh-z-layer-merging.test.ts`
- `bunx tsc --noEmit` *(fails: existing type errors in tests/core{1,2,3}.test.tsx complaining about mismatched simple_bug component types)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6916727d37d8832e86361e3987529689)