### PR TITLE
Fix capacity mesh layer merging above obstacles

### DIFF
--- a/lib/solvers/CapacityMeshSolver/CapacityMeshNodeSolver2_NodesUnderObstacles.ts
+++ b/lib/solvers/CapacityMeshSolver/CapacityMeshNodeSolver2_NodesUnderObstacles.ts
@@ -197,12 +197,55 @@ export class CapacityMeshNodeSolver2_NodeUnderObstacle extends CapacityMeshNodeS
   getZSubdivisionChildNodes(node: CapacityMeshNode): CapacityMeshNode[] {
     if (node.availableZ.length === 1) return []
 
+    const overlappingObstacles = node._containsObstacle
+      ? this.getXYZOverlappingObstacles(node)
+      : []
+
+    const blockedZ = new Set<number>()
+    for (const obstacle of overlappingObstacles) {
+      for (const z of obstacle.zLayers ?? []) {
+        if (node.availableZ.includes(z)) {
+          blockedZ.add(z)
+        }
+      }
+    }
+
+    const unobstructedZ = node.availableZ.filter((z) => !blockedZ.has(z))
+    if (unobstructedZ.length === 0) return []
+
+    const hasActualObstacleOverlap = blockedZ.size > 0
+
+    const shouldForceSingleLayerSplit =
+      node.width < this.VIA_DIAMETER + this.OBSTACLE_MARGIN &&
+      !hasActualObstacleOverlap
+
+    let zBlocks: number[][]
+
+    if (shouldForceSingleLayerSplit) {
+      zBlocks = unobstructedZ.map((z) => [z])
+    } else {
+      const sortedZ = Array.from(new Set(unobstructedZ)).sort((a, b) => a - b)
+      zBlocks = []
+      let currentBlock: number[] = []
+
+      for (const z of sortedZ) {
+        const lastZ = currentBlock[currentBlock.length - 1]
+        if (currentBlock.length === 0 || z === lastZ + 1) {
+          currentBlock.push(z)
+        } else {
+          zBlocks.push(currentBlock)
+          currentBlock = [z]
+        }
+      }
+
+      if (currentBlock.length > 0) {
+        zBlocks.push(currentBlock)
+      }
+    }
+
     const childNodes: CapacityMeshNode[] = []
 
-    // Split availableZ into individual layers
-    const otherZBlocks = node.availableZ.map((z) => [z])
-
-    for (const zBlock of otherZBlocks) {
+    for (const zBlock of zBlocks) {
       const childNode = this.createChildNodeAtPosition(node, {
         center: { ...node.center },
         width: node.width,

--- a/tests/bugs/capacity-mesh-z-splitting.test.ts
+++ b/tests/bugs/capacity-mesh-z-splitting.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test"
+import { CapacityMeshNodeSolver2_NodeUnderObstacle } from "lib/solvers/CapacityMeshSolver/CapacityMeshNodeSolver2_NodesUnderObstacles"
+import type { CapacityMeshNode, SimpleRouteJson } from "lib/types"
+
+describe("CapacityMeshNodeSolver2_NodeUnderObstacle", () => {
+  test("merges unobstructed layers above single-layer obstacle", () => {
+    const srj: SimpleRouteJson = {
+      layerCount: 4,
+      minTraceWidth: 0.2,
+      bounds: { minX: 0, maxX: 10, minY: 0, maxY: 10 },
+      connections: [],
+      obstacles: [
+        {
+          type: "rect",
+          layers: ["top"],
+          center: { x: 5, y: 5 },
+          width: 1,
+          height: 1,
+          connectedTo: [],
+        },
+      ],
+    }
+
+    const solver = new CapacityMeshNodeSolver2_NodeUnderObstacle(srj)
+    solver.solve()
+
+    const obstacle = srj.obstacles[0]
+    const obsLeft = obstacle.center.x - obstacle.width / 2
+    const obsRight = obstacle.center.x + obstacle.width / 2
+    const obsBottom = obstacle.center.y - obstacle.height / 2
+    const obsTop = obstacle.center.y + obstacle.height / 2
+
+    const overlappingNodes = solver.finishedNodes.filter((node) => {
+      const nodeLeft = node.center.x - node.width / 2
+      const nodeRight = node.center.x + node.width / 2
+      const nodeBottom = node.center.y - node.height / 2
+      const nodeTop = node.center.y + node.height / 2
+      return (
+        nodeLeft < obsRight &&
+        nodeRight > obsLeft &&
+        nodeBottom < obsTop &&
+        nodeTop > obsBottom
+      )
+    })
+
+    const groups = new Map<string, CapacityMeshNode[]>()
+    for (const node of overlappingNodes) {
+      const key = [
+        node.center.x.toFixed(4),
+        node.center.y.toFixed(4),
+        node.width.toFixed(4),
+        node.height.toFixed(4),
+      ].join(":")
+      const list = groups.get(key)
+      if (list) {
+        list.push(node)
+      } else {
+        groups.set(key, [node])
+      }
+    }
+
+    expect(groups.size).toBeGreaterThan(0)
+    for (const [key, nodes] of groups.entries()) {
+      expect(nodes.length).toBe(1)
+      expect(nodes[0].availableZ).toEqual([1, 2, 3])
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- merge unobstructed Z layers when subdividing capacity mesh nodes under single-layer obstacles
- keep single-layer splitting for non-obstacle cases while preserving multi-layer nodes for remaining layers
- add regression test ensuring nodes above a top-layer obstacle retain [1,2,3] availability

## Testing
- bun test tests/bugs/capacity-mesh-z-splitting.test.ts
- bunx tsc --noEmit *(fails: existing type errors in tests/core*.test.tsx)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6916727d37d8832e86361e3987529689)