### PR TITLE
Support configurable via diameters in autorouter pipeline

### DIFF
--- a/lib/solvers/AutoroutingPipelineSolver.ts
+++ b/lib/solvers/AutoroutingPipelineSolver.ts
@@ -109,6 +109,7 @@ export class AutoroutingPipelineSolver extends BaseSolver {
   uselessViaRemovalSolver2?: UselessViaRemovalSolver
   multiSimplifiedPathSolver1?: MultiSimplifiedPathSolver
   multiSimplifiedPathSolver2?: MultiSimplifiedPathSolver
+  viaDiameter: number
 
   startTimeOfPhase: Record<string, number>
   endTimeOfPhase: Record<string, number>
@@ -283,6 +284,7 @@ export class AutoroutingPipelineSolver extends BaseSolver {
     //       assignedSegments: cms.segmentToPointSolver?.solvedSegments || [],
     //       colorMap: cms.colorMap,
     //       nodes: cms.nodeTargetMerger?.newNodes || [],
+    //       viaDiameter: cms.viaDiameter,
     //     },
     //   ],
     // ),
@@ -306,6 +308,7 @@ export class AutoroutingPipelineSolver extends BaseSolver {
           [],
         colorMap: cms.colorMap,
         connMap: cms.connMap,
+        viaDiameter: cms.viaDiameter,
       },
     ]),
     definePipelineStep(
@@ -317,6 +320,7 @@ export class AutoroutingPipelineSolver extends BaseSolver {
           hdRoutes: cms.highDensityRouteSolver!.routes,
           colorMap: cms.colorMap,
           layerCount: cms.srj.layerCount,
+          defaultViaDiameter: cms.viaDiameter,
         },
       ],
     ),
@@ -344,6 +348,7 @@ export class AutoroutingPipelineSolver extends BaseSolver {
           connMap: cms.connMap,
           colorMap: cms.colorMap,
           outline: cms.srj.outline,
+          defaultViaDiameter: cms.viaDiameter,
         },
       ],
     ),
@@ -371,6 +376,7 @@ export class AutoroutingPipelineSolver extends BaseSolver {
           connMap: cms.connMap,
           colorMap: cms.colorMap,
           outline: cms.srj.outline,
+          defaultViaDiameter: cms.viaDiameter,
         },
       ],
     ),
@@ -382,6 +388,7 @@ export class AutoroutingPipelineSolver extends BaseSolver {
   ) {
     super()
     this.MAX_ITERATIONS = 100e6
+    this.viaDiameter = srj.minViaDiameter ?? 0.6
 
     // If capacityDepth is not provided, calculate it automatically
     if (opts.capacityDepth === undefined) {

--- a/lib/solvers/CapacityMeshSolver/CapacityMeshNodeSolver2_NodesUnderObstacles.ts
+++ b/lib/solvers/CapacityMeshSolver/CapacityMeshNodeSolver2_NodesUnderObstacles.ts
@@ -42,6 +42,7 @@ export class CapacityMeshNodeSolver2_NodeUnderObstacle extends CapacityMeshNodeS
     public opts: CapacityMeshNodeSolverOptions = {},
   ) {
     super(srj, opts)
+    this.VIA_DIAMETER = srj.minViaDiameter ?? this.VIA_DIAMETER
   }
 
   isNodeCompletelyOutsideBounds(node: CapacityMeshNode): boolean {

--- a/lib/solvers/HighDensitySolver/HighDensitySolver.ts
+++ b/lib/solvers/HighDensitySolver/HighDensitySolver.ts
@@ -20,6 +20,7 @@ export class HighDensitySolver extends BaseSolver {
   // Defaults as specified: viaDiameter of 0.6 and traceThickness of 0.15
   readonly defaultViaDiameter = 0.6
   readonly defaultTraceThickness = 0.15
+  viaDiameter: number
 
   failedSolvers: (IntraNodeRouteSolver | HyperSingleIntraNodeSolver)[]
   activeSubSolver: IntraNodeRouteSolver | HyperSingleIntraNodeSolver | null =
@@ -30,10 +31,12 @@ export class HighDensitySolver extends BaseSolver {
     nodePortPoints,
     colorMap,
     connMap,
+    viaDiameter,
   }: {
     nodePortPoints: NodeWithPortPoints[]
     colorMap?: Record<string, string>
     connMap?: ConnectivityMap
+    viaDiameter?: number
   }) {
     super()
     this.unsolvedNodePortPoints = nodePortPoints
@@ -42,6 +45,7 @@ export class HighDensitySolver extends BaseSolver {
     this.routes = []
     this.failedSolvers = []
     this.MAX_ITERATIONS = 1e6
+    this.viaDiameter = viaDiameter ?? this.defaultViaDiameter
   }
 
   /**
@@ -82,6 +86,7 @@ export class HighDensitySolver extends BaseSolver {
       nodeWithPortPoints: node,
       colorMap: this.colorMap,
       connMap: this.connMap,
+      viaDiameter: this.viaDiameter,
     })
     this.updateCacheStats()
   }

--- a/lib/solvers/HighDensitySolver/IntraNodeSolver.ts
+++ b/lib/solvers/HighDensitySolver/IntraNodeSolver.ts
@@ -26,6 +26,7 @@ export class IntraNodeRouteSolver extends BaseSolver {
   failedSubSolvers: SingleHighDensityRouteSolver[]
   hyperParameters: Partial<HighDensityHyperParameters>
   minDistBetweenEnteringPoints: number
+  viaDiameter: number
 
   activeSubSolver: SingleHighDensityRouteSolver | null = null
   connMap?: ConnectivityMap
@@ -45,6 +46,7 @@ export class IntraNodeRouteSolver extends BaseSolver {
     colorMap?: Record<string, string>
     hyperParameters?: Partial<HighDensityHyperParameters>
     connMap?: ConnectivityMap
+    viaDiameter?: number
   }) {
     const { nodeWithPortPoints, colorMap } = params
     super()
@@ -54,6 +56,7 @@ export class IntraNodeRouteSolver extends BaseSolver {
     this.hyperParameters = params.hyperParameters ?? {}
     this.failedSubSolvers = []
     this.connMap = params.connMap
+    this.viaDiameter = params.viaDiameter ?? 0.6
     const unsolvedConnectionsMap: Map<
       string,
       { x: number; y: number; z: number }[]
@@ -195,6 +198,7 @@ export class IntraNodeRouteSolver extends BaseSolver {
         layerCount: 2,
         hyperParameters: this.hyperParameters,
         connMap: this.connMap,
+        viaDiameter: this.viaDiameter,
       })
   }
 

--- a/lib/solvers/HighDensitySolver/MultiHeadPolyLineIntraNodeSolver/MultiHeadPolyLineIntraNodeSolver.ts
+++ b/lib/solvers/HighDensitySolver/MultiHeadPolyLineIntraNodeSolver/MultiHeadPolyLineIntraNodeSolver.ts
@@ -65,6 +65,7 @@ export class MultiHeadPolyLineIntraNodeSolver extends BaseSolver {
     colorMap?: Record<string, string>
     hyperParameters?: Partial<HighDensityHyperParameters>
     connMap?: ConnectivityMap
+    viaDiameter?: number
   }) {
     super()
     this.MAX_ITERATIONS = 10e3
@@ -77,6 +78,7 @@ export class MultiHeadPolyLineIntraNodeSolver extends BaseSolver {
       params.hyperParameters?.SEGMENTS_PER_POLYLINE ?? 3
     this.BOUNDARY_PADDING = params.hyperParameters?.BOUNDARY_PADDING ?? 0.05
     this.connMap = params.connMap
+    this.viaDiameter = params.viaDiameter ?? this.viaDiameter
 
     // TODO swap with more sophisticated grid in SingleHighDensityRouteSolver
     this.cellSize = this.nodeWithPortPoints.width / 1024

--- a/lib/solvers/HighDensitySolver/MultiHeadPolyLineIntraNodeSolver/MultiHeadPolyLineIntraNodeSolver3_ViaPossibilitiesSolverIntegration.ts
+++ b/lib/solvers/HighDensitySolver/MultiHeadPolyLineIntraNodeSolver/MultiHeadPolyLineIntraNodeSolver3_ViaPossibilitiesSolverIntegration.ts
@@ -43,6 +43,7 @@ export class MultiHeadPolyLineIntraNodeSolver3 extends MultiHeadPolyLineIntraNod
       hyperParameters: {
         SHUFFLE_SEED: shuffleSeed,
       },
+      viaDiameter: this.viaDiameter,
     })
 
     viaSolver.solve()

--- a/lib/solvers/HyperHighDensitySolver/HyperSingleIntraNodeSolver.ts
+++ b/lib/solvers/HyperHighDensitySolver/HyperSingleIntraNodeSolver.ts
@@ -181,11 +181,13 @@ export class HyperSingleIntraNodeSolver extends HyperParameterSupervisorSolver<
     if (hyperParameters.CLOSED_FORM_TWO_TRACE_SAME_LAYER) {
       return new TwoCrossingRoutesHighDensitySolver({
         nodeWithPortPoints: this.nodeWithPortPoints,
+        viaDiameter: this.constructorParams.viaDiameter,
       }) as any
     }
     if (hyperParameters.CLOSED_FORM_TWO_TRACE_TRANSITION_CROSSING) {
       return new SingleTransitionCrossingRouteSolver({
         nodeWithPortPoints: this.nodeWithPortPoints,
+        viaDiameter: this.constructorParams.viaDiameter,
       }) as any
     }
     if (hyperParameters.MULTI_HEAD_POLYLINE_SOLVER) {
@@ -193,6 +195,7 @@ export class HyperSingleIntraNodeSolver extends HyperParameterSupervisorSolver<
         nodeWithPortPoints: this.nodeWithPortPoints,
         connMap: this.connMap,
         hyperParameters: hyperParameters,
+        viaDiameter: this.constructorParams.viaDiameter,
       }) as any
     }
     return new CachedIntraNodeRouteSolver({

--- a/lib/solvers/RouteStitchingSolver/MultipleHighDensityRouteStitchSolver.ts
+++ b/lib/solvers/RouteStitchingSolver/MultipleHighDensityRouteStitchSolver.ts
@@ -26,18 +26,15 @@ export class MultipleHighDensityRouteStitchSolver extends BaseSolver {
     hdRoutes: HighDensityIntraNodeRoute[]
     colorMap?: Record<string, string>
     layerCount: number
+    defaultViaDiameter?: number
   }) {
     super()
     this.colorMap = opts.colorMap ?? {}
 
-    if (opts.hdRoutes.length > 0) {
-      this.defaultTraceThickness = opts.hdRoutes[0].traceThickness
-      this.defaultViaDiameter = opts.hdRoutes[0].viaDiameter
-    } else {
-      // Fallback defaults if no hdRoutes are provided at all
-      this.defaultTraceThickness = 0.15
-      this.defaultViaDiameter = 0.6
-    }
+    const firstRoute = opts.hdRoutes[0]
+    this.defaultTraceThickness = firstRoute?.traceThickness ?? 0.15
+    this.defaultViaDiameter =
+      firstRoute?.viaDiameter ?? opts.defaultViaDiameter ?? 0.6
 
     this.unsolvedRoutes = opts.connections.map((c) => ({
       connectionName: c.name,

--- a/lib/solvers/SimplifiedPathSolver/MultiSimplifiedPathSolver.ts
+++ b/lib/solvers/SimplifiedPathSolver/MultiSimplifiedPathSolver.ts
@@ -19,6 +19,7 @@ export class MultiSimplifiedPathSolver extends BaseSolver {
   connMap: ConnectivityMap
   colorMap: Record<string, string>
   outline?: Array<{ x: number; y: number }>
+  defaultViaDiameter: number
 
   constructor(params: {
     unsimplifiedHdRoutes: HighDensityIntraNodeRoute[]
@@ -26,6 +27,7 @@ export class MultiSimplifiedPathSolver extends BaseSolver {
     connMap?: ConnectivityMap
     colorMap?: Record<string, string>
     outline?: Array<{ x: number; y: number }>
+    defaultViaDiameter?: number
   }) {
     super()
     this.MAX_ITERATIONS = 100e6
@@ -35,6 +37,7 @@ export class MultiSimplifiedPathSolver extends BaseSolver {
     this.connMap = params.connMap || new ConnectivityMap({})
     this.colorMap = params.colorMap || {}
     this.outline = params.outline
+    this.defaultViaDiameter = params.defaultViaDiameter ?? 0.6
 
     this.simplifiedHdRoutes = []
   }
@@ -114,7 +117,7 @@ export class MultiSimplifiedPathSolver extends BaseSolver {
       for (const via of route.vias || []) {
         graphics.circles.push({
           center: via,
-          radius: route.viaDiameter / 2 || 0.3, // Default radius if viaDiameter not specified
+          radius: (route.viaDiameter ?? this.defaultViaDiameter) / 2,
           fill: "rgba(0, 0, 255, 0.4)",
         })
       }

--- a/lib/solvers/ViaPossibilitiesSolver/ViaPossibilitiesSolver.ts
+++ b/lib/solvers/ViaPossibilitiesSolver/ViaPossibilitiesSolver.ts
@@ -93,13 +93,16 @@ export class ViaPossibilitiesSolver extends BaseSolver {
   nodeWidth: number
   availableZ: number[]
   GREEDY_MULTIPLIER = 1
+  viaDiameter: number
 
   constructor({
     nodeWithPortPoints,
     colorMap,
+    viaDiameter,
   }: {
     nodeWithPortPoints: NodeWithPortPoints
     colorMap?: Record<string, string>
+    viaDiameter?: number
   }) {
     super()
     this.MAX_ITERATIONS = 100e3
@@ -112,6 +115,7 @@ export class ViaPossibilitiesSolver extends BaseSolver {
     this.portPairMap = getPortPairMap(nodeWithPortPoints)
     this.stats.solutionsFound = 0
     this.availableZ = nodeWithPortPoints.availableZ ?? [0, 1]
+    this.viaDiameter = viaDiameter ?? 0.6
 
     this.transitionConnectionNames = Array.from(
       this.portPairMap
@@ -754,7 +758,7 @@ export class ViaPossibilitiesSolver extends BaseSolver {
           const color = colorMap[connectionName] ?? "black"
           graphics.circles!.push({
             center: face.centroid,
-            radius: 0.25,
+            radius: this.viaDiameter / 2,
             fill: safeTransparentize(color, 0.5), // Make via fill 50% transparent
             stroke: "white",
             label: `Via: ${connectionName}`,

--- a/lib/solvers/ViaPossibilitiesSolver/ViaPossibilitiesSolver2.ts
+++ b/lib/solvers/ViaPossibilitiesSolver/ViaPossibilitiesSolver2.ts
@@ -57,6 +57,7 @@ export class ViaPossibilitiesSolver2 extends BaseSolver {
   VIA_INTERSECTION_BUFFER_DISTANCE = 0.05
   PLACEHOLDER_WALL_BUFFER_DISTANCE = 0.1
   NEW_HEAD_WALL_BUFFER_DISTANCE = 0.05
+  viaDiameter: number
 
   unprocessedConnections: ConnectionName[]
 
@@ -72,10 +73,12 @@ export class ViaPossibilitiesSolver2 extends BaseSolver {
     nodeWithPortPoints,
     colorMap,
     hyperParameters,
+    viaDiameter,
   }: {
     nodeWithPortPoints: NodeWithPortPoints
     colorMap?: Record<string, string>
     hyperParameters?: ViaPossibilities2HyperParameters
+    viaDiameter?: number
   }) {
     super()
     this.MAX_ITERATIONS = 100e3
@@ -90,6 +93,7 @@ export class ViaPossibilitiesSolver2 extends BaseSolver {
     this.hyperParameters = hyperParameters ?? {
       SHUFFLE_SEED: 0,
     }
+    this.viaDiameter = viaDiameter ?? 0.6
 
     this.unprocessedConnections = Array.from(this.portPairMap.keys()).sort()
     if (hyperParameters?.SHUFFLE_SEED) {
@@ -392,7 +396,7 @@ export class ViaPossibilitiesSolver2 extends BaseSolver {
             // Draw Via for Z change
             graphics.circles!.push({
               center: { x: p1.x, y: p1.y },
-              radius: 0.3, // Diameter 0.6
+              radius: this.viaDiameter / 2,
               fill: safeTransparentize(color, 0.5),
               label: `${labelPrefix}: ${connectionName} Via (z${p1.z}->z${p2.z})`,
             })
@@ -425,7 +429,7 @@ export class ViaPossibilitiesSolver2 extends BaseSolver {
         if (p1.x === p2.x && p1.y === p2.y && p1.z !== p2.z) {
           graphics.circles!.push({
             center: { x: p1.x, y: p1.y },
-            radius: 0.3,
+            radius: this.viaDiameter / 2,
             fill: safeTransparentize(color, 0.5),
             label: `Current: ${this.currentConnectionName} Via (z${p1.z}->z${p2.z})`,
           })

--- a/lib/utils/convertSrjToGraphicsObject.ts
+++ b/lib/utils/convertSrjToGraphicsObject.ts
@@ -11,6 +11,7 @@ export const convertSrjToGraphicsObject = (srj: SimpleRouteJson) => {
 
   const colorMap: Record<string, string> = getColorMap(srj)
   const layerCount = 2
+  const viaRadius = (srj.minViaDiameter ?? 0.6) / 2
 
   // Add points for each connection's pointsToConnect
   if (srj.connections) {
@@ -42,7 +43,7 @@ export const convertSrjToGraphicsObject = (srj: SimpleRouteJson) => {
           // Add a circle for the via
           circles.push({
             center: { x: routePoint.x, y: routePoint.y },
-            radius: 0.3, // 0.6 via diameter
+            radius: viaRadius,
             fill: "blue",
             stroke: "none",
             layer: "z0,1",

--- a/lib/utils/getTunedTotalCapacity1.ts
+++ b/lib/utils/getTunedTotalCapacity1.ts
@@ -13,10 +13,11 @@ import { CapacityMeshNode } from "lib/types/capacity-mesh-types"
 export const getTunedTotalCapacity1 = (
   nodeOrWidth: CapacityMeshNode | { width: number; availableZ?: number[] },
   maxCapacityFactor = 1,
+  opts: { viaDiameter?: number; obstacleMargin?: number } = {},
 ) => {
-  const VIA_DIAMETER = 0.6
+  const VIA_DIAMETER = opts.viaDiameter ?? 0.6
   const TRACE_WIDTH = 0.15
-  const obstacleMargin = 0.2
+  const obstacleMargin = opts.obstacleMargin ?? 0.2
 
   const width = "width" in nodeOrWidth ? nodeOrWidth.width : nodeOrWidth
   const viaLengthAcross = width / (VIA_DIAMETER / 2 + obstacleMargin)


### PR DESCRIPTION
## Summary
- propagate `SimpleRouteJson.minViaDiameter` through the autorouting pipeline so high-density solvers and stitchers honor configurable via sizing
- update capacity estimation, intra-node, and via possibility solvers to accept injected via diameters and adjust calculations and visualizations
- refresh utilities and simplified path visualization to render vias with the configured diameter

## Testing
- bunx tsc --noEmit *(fails: existing type errors in tests/core1.test.tsx, tests/core2.test.tsx, tests/core3.test.tsx)*
- bun run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6917e81474ec832ea6d67f8e7392b712)