### PR TITLE
Create test with four spaced obstacles and routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   "dependencies": {
     "bun-match-svg": "^0.0.14",
     "fast-json-stable-stringify": "^2.1.0",
-    "object-hash": "^3.0.0"
+    "object-hash": "^3.0.0",
+    "sharp": "^0.34.5"
   }
 }

--- a/tests/__snapshots__/four-obstacles.snap.svg
+++ b/tests/__snapshots__/four-obstacles.snap.svg
@@ -1,0 +1,44 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><circle data-type="point" data-label="A_net " data-x="0" data-y="0" cx="110" cy="320" r="3" fill="black"/></g><g><circle data-type="point" data-label="A_net " data-x="12" data-y="0" cx="530" cy="320" r="3" fill="black"/></g><g><circle data-type="point" data-label="A_net (top)" data-x="0" data-y="0" cx="110" cy="320" r="3" fill="hsl(0, 100%, 50%)"/></g><g><circle data-type="point" data-label="A_net (top)" data-x="12" data-y="0" cx="530" cy="320" r="3" fill="hsl(0, 100%, 50%)"/></g><g><polyline data-points="-2,-2 14,-2 14,2 -2,2 -2,-2" data-type="line" data-label="" points="40,390 600,390 600,250 40,250 40,390" fill="none" stroke="rgba(255,0,0,0.25)" stroke-width="1px"/></g><g><polyline data-points="12,0 10.118562851039272,0" data-type="line" data-label="" points="530,320 464.1496997863745,320" fill="none" stroke="rgba(255,0,0,0.5)" stroke-width="5.25"/></g><g><polyline data-points="10.118562851039272,0 9.68123471201786,0.43732813902141215" data-type="line" data-label="" points="464.1496997863745,320 448.8432149206251,304.69351513425056" fill="none" stroke="rgba(255,0,0,0.5)" stroke-width="5.25"/></g><g><polyline data-points="9.68123471201786,0.43732813902141215 9.5,0.5" data-type="line" data-label="" points="448.8432149206251,304.69351513425056 442.5,302.5" fill="none" stroke="rgba(255,0,0,0.5)" stroke-width="5.25"/></g><g><polyline data-points="9.5,0.5 2.5759348135018496,0.5" data-type="line" data-label="" points="442.5,302.5 200.15771847256474,302.5" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="5.25"/></g><g><polyline data-points="2.5759348135018496,0.5 2.550623209001233,0.4746883954993835" data-type="line" data-label="" points="200.15771847256474,302.5 199.27181231504318,303.38590615752156" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="5.25"/></g><g><polyline data-points="2.550623209001233,0.4746883954993835 2.5,0.5" data-type="line" data-label="" points="199.27181231504318,303.38590615752156 197.5,302.5" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="5.25"/></g><g><polyline data-points="2.5,0.5 0.5,0.5" data-type="line" data-label="" points="197.5,302.5 127.5,302.5" fill="none" stroke="rgba(255,0,0,0.5)" stroke-width="5.25"/></g><g><polyline data-points="0.5,0.5 0,0" data-type="line" data-label="" points="127.5,302.5 110,320" fill="none" stroke="rgba(255,0,0,0.5)" stroke-width="5.25"/></g><g><rect data-type="rect" data-label="top" data-x="0" data-y="0" x="92.5" y="302.5" width="35" height="35" fill="rgba(255,0,0,0.25)" stroke="black" stroke-width="0.02857142857142857"/></g><g><rect data-type="rect" data-label="top" data-x="4" data-y="0" x="232.5" y="302.5" width="35" height="35" fill="rgba(255,0,0,0.25)" stroke="black" stroke-width="0.02857142857142857"/></g><g><rect data-type="rect" data-label="top" data-x="8" data-y="0" x="372.5" y="302.5" width="35" height="35" fill="rgba(255,0,0,0.25)" stroke="black" stroke-width="0.02857142857142857"/></g><g><rect data-type="rect" data-label="top" data-x="12" data-y="0" x="512.5" y="302.5" width="35" height="35" fill="rgba(255,0,0,0.25)" stroke="black" stroke-width="0.02857142857142857"/></g><g><rect data-type="rect" data-label="" data-x="0" data-y="0" x="92.5" y="302.5" width="35" height="35" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.02857142857142857"/></g><g><rect data-type="rect" data-label="" data-x="4" data-y="0" x="232.5" y="302.5" width="35" height="35" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.02857142857142857"/></g><g><rect data-type="rect" data-label="" data-x="8" data-y="0" x="372.5" y="302.5" width="35" height="35" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.02857142857142857"/></g><g><rect data-type="rect" data-label="" data-x="12" data-y="0" x="512.5" y="302.5" width="35" height="35" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.02857142857142857"/></g><circle data-type="circle" data-label="" data-x="9.5" data-y="0.5" cx="442.5" cy="302.5" r="10.5" fill="blue" stroke="none" stroke-width="0.02857142857142857"/><circle data-type="circle" data-label="" data-x="2.5" data-y="0.5" cx="197.5" cy="302.5" r="10.5" fill="blue" stroke="none" stroke-width="0.02857142857142857"/><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":35,"c":0,"e":110,"b":0,"d":-35,"f":320};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/fixtures/four-obstacles/four-obstacles.fixture.tsx
+++ b/tests/fixtures/four-obstacles/four-obstacles.fixture.tsx
@@ -1,0 +1,7 @@
+import { AutoroutingPipelineDebugger } from "lib/testing/AutoroutingPipelineDebugger"
+import { SimpleRouteJson } from "lib/types"
+import simpleRouteJson from "./four-obstacles.srj.json"
+
+export default () => (
+  <AutoroutingPipelineDebugger srj={simpleRouteJson as SimpleRouteJson} />
+)

--- a/tests/fixtures/four-obstacles/four-obstacles.srj.json
+++ b/tests/fixtures/four-obstacles/four-obstacles.srj.json
@@ -1,0 +1,57 @@
+{
+  "layerCount": 2,
+  "minTraceWidth": 0.15,
+  "bounds": {
+    "minX": -2,
+    "maxX": 14,
+    "minY": -2,
+    "maxY": 2
+  },
+  "obstacles": [
+    {
+      "type": "rect",
+      "layers": ["top"],
+      "center": { "x": 0, "y": 0 },
+      "width": 1,
+      "height": 1,
+      "connectedTo": ["A_net"]
+    },
+    {
+      "type": "rect",
+      "layers": ["top"],
+      "center": { "x": 4, "y": 0 },
+      "width": 1,
+      "height": 1,
+      "connectedTo": [],
+      "netIsAssignable": true,
+      "offBoardConnectsTo": ["BC_NET"]
+    },
+    {
+      "type": "rect",
+      "layers": ["top"],
+      "center": { "x": 8, "y": 0 },
+      "width": 1,
+      "height": 1,
+      "connectedTo": [],
+      "netIsAssignable": true,
+      "offBoardConnectsTo": ["BC_NET"]
+    },
+    {
+      "type": "rect",
+      "layers": ["top"],
+      "center": { "x": 12, "y": 0 },
+      "width": 1,
+      "height": 1,
+      "connectedTo": ["A_net"]
+    }
+  ],
+  "connections": [
+    {
+      "name": "A_net",
+      "pointsToConnect": [
+        { "x": 0, "y": 0, "layer": "top", "pointId": "A" },
+        { "x": 12, "y": 0, "layer": "top", "pointId": "D" }
+      ]
+    }
+  ]
+}

--- a/tests/four-obstacles.test.ts
+++ b/tests/four-obstacles.test.ts
@@ -1,0 +1,14 @@
+import { test, expect } from "bun:test"
+import { AutoroutingPipelineSolver } from "lib"
+import { getLastStepSvg } from "./fixtures/getLastStepSvg"
+import simpleRouteJson from "./fixtures/four-obstacles/four-obstacles.srj.json"
+
+test("four obstacles - A and D routed with B and C as assignable obstacles", () => {
+  const solver = new AutoroutingPipelineSolver(simpleRouteJson as any)
+
+  solver.solve()
+
+  expect(getLastStepSvg(solver.visualize())).toMatchSvgSnapshot(
+    import.meta.path
+  )
+})


### PR DESCRIPTION
Created a test scenario with four 1mm x 1mm obstacles (A, B, C, D) spaced 4mm apart. A and D are connected via pointsToConnect, while B and C are assignable obstacles with offBoardConnectsTo=["BC_NET"].

Includes:
- SRJ fixture file with obstacle and connection definitions
- TSX fixture for visual debugging
- Test with SVG snapshot verification