### PR TITLE
Add off-board obstacle routing snapshot test

### DIFF
--- a/examples/features/off-board-obstacles/off-board-assignable.fixture.tsx
+++ b/examples/features/off-board-obstacles/off-board-assignable.fixture.tsx
@@ -1,0 +1,68 @@
+import { AutoroutingPipelineSolver } from "lib"
+import { AutoroutingPipelineDebugger } from "lib/testing/AutoroutingPipelineDebugger"
+import type { SimpleRouteJson } from "lib/types"
+
+export const simpleRouteJson: SimpleRouteJson = {
+  bounds: {
+    minX: -12,
+    maxX: 12,
+    minY: -6,
+    maxY: 6,
+  },
+  obstacles: [
+    {
+      type: "rect",
+      layers: ["top"],
+      center: { x: -6, y: 0 },
+      width: 1,
+      height: 1,
+      connectedTo: ["pad_a"],
+    },
+    {
+      type: "rect",
+      layers: ["top"],
+      center: { x: -2, y: 0 },
+      width: 1,
+      height: 1,
+      connectedTo: [],
+      netIsAssignable: true,
+      offBoardConnectsTo: ["BC_NET"],
+    },
+    {
+      type: "rect",
+      layers: ["top"],
+      center: { x: 2, y: 0 },
+      width: 1,
+      height: 1,
+      connectedTo: [],
+      netIsAssignable: true,
+      offBoardConnectsTo: ["BC_NET"],
+    },
+    {
+      type: "rect",
+      layers: ["top"],
+      center: { x: 6, y: 0 },
+      width: 1,
+      height: 1,
+      connectedTo: ["pad_d"],
+    },
+  ],
+  connections: [
+    {
+      name: "AD_NET",
+      pointsToConnect: [
+        { x: -6, y: 0, layer: "top", pointId: "pad_a" },
+        { x: 6, y: 0, layer: "top", pointId: "pad_d" },
+      ],
+    },
+  ],
+  layerCount: 2,
+  minTraceWidth: 0.2,
+}
+
+export default () => (
+  <AutoroutingPipelineDebugger
+    srj={simpleRouteJson}
+    createSolver={(srj, opts) => new AutoroutingPipelineSolver(srj, opts)}
+  />
+)

--- a/tests/features/off-board-obstacles/__snapshots__/off-board-assignable.snap.svg
+++ b/tests/features/off-board-obstacles/__snapshots__/off-board-assignable.snap.svg
@@ -1,0 +1,44 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><circle data-type="point" data-label="AD_NET " data-x="-6" data-y="0" cx="180" cy="320" r="3" fill="black"/></g><g><circle data-type="point" data-label="AD_NET " data-x="6" data-y="0" cx="460" cy="320" r="3" fill="black"/></g><g><circle data-type="point" data-label="AD_NET (top)" data-x="-6" data-y="0" cx="180" cy="320" r="3" fill="hsl(0, 100%, 50%)"/></g><g><circle data-type="point" data-label="AD_NET (top)" data-x="6" data-y="0" cx="460" cy="320" r="3" fill="hsl(0, 100%, 50%)"/></g><g><polyline data-points="-12,-6 12,-6 12,6 -12,6 -12,-6" data-type="line" data-label="" points="40,460 600,460 600,180 40,180 40,460" fill="none" stroke="rgba(255,0,0,0.25)" stroke-width="1px"/></g><g><polyline data-points="6,0 5.25,0.375" data-type="line" data-label="" points="460,320 442.5,311.25" fill="none" stroke="rgba(255,0,0,0.5)" stroke-width="3.4999999999999996"/></g><g><polyline data-points="5.25,0.375 4.5,0.375" data-type="line" data-label="" points="442.5,311.25 425,311.25" fill="none" stroke="rgba(255,0,0,0.5)" stroke-width="3.4999999999999996"/></g><g><polyline data-points="4.5,0.375 3.75,1.5" data-type="line" data-label="" points="425,311.25 407.5,285" fill="none" stroke="rgba(255,0,0,0.5)" stroke-width="3.4999999999999996"/></g><g><polyline data-points="3.75,1.5 3,2.25" data-type="line" data-label="" points="407.5,285 390,267.5" fill="none" stroke="rgba(255,0,0,0.5)" stroke-width="3.4999999999999996"/></g><g><polyline data-points="3,2.25 1.5,2.25" data-type="line" data-label="" points="390,267.5 355,267.5" fill="none" stroke="rgba(255,0,0,0.5)" stroke-width="3.4999999999999996"/></g><g><polyline data-points="1.5,2.25 0,2.25" data-type="line" data-label="" points="355,267.5 320,267.5" fill="none" stroke="rgba(255,0,0,0.5)" stroke-width="3.4999999999999996"/></g><g><polyline data-points="0,2.25 -1.5,2.25" data-type="line" data-label="" points="320,267.5 285,267.5" fill="none" stroke="rgba(255,0,0,0.5)" stroke-width="3.4999999999999996"/></g><g><polyline data-points="-1.5,2.25 -2.625,1.5" data-type="line" data-label="" points="285,267.5 258.75,285" fill="none" stroke="rgba(255,0,0,0.5)" stroke-width="3.4999999999999996"/></g><g><polyline data-points="-2.625,1.5 -3,1.125" data-type="line" data-label="" points="258.75,285 250,293.75" fill="none" stroke="rgba(255,0,0,0.5)" stroke-width="3.4999999999999996"/></g><g><polyline data-points="-3,1.125 -4.5,0.375" data-type="line" data-label="" points="250,293.75 215,311.25" fill="none" stroke="rgba(255,0,0,0.5)" stroke-width="3.4999999999999996"/></g><g><polyline data-points="-4.5,0.375 -5.25,0.375" data-type="line" data-label="" points="215,311.25 197.5,311.25" fill="none" stroke="rgba(255,0,0,0.5)" stroke-width="3.4999999999999996"/></g><g><polyline data-points="-5.25,0.375 -6,0" data-type="line" data-label="" points="197.5,311.25 180,320" fill="none" stroke="rgba(255,0,0,0.5)" stroke-width="3.4999999999999996"/></g><g><rect data-type="rect" data-label="top" data-x="-6" data-y="0" x="168.33333333333334" y="308.3333333333333" width="23.333333333333343" height="23.33333333333337" fill="rgba(255,0,0,0.25)" stroke="black" stroke-width="0.04285714285714286"/></g><g><rect data-type="rect" data-label="top" data-x="-2" data-y="0" x="261.6666666666667" y="308.3333333333333" width="23.333333333333314" height="23.33333333333337" fill="rgba(255,0,0,0.25)" stroke="black" stroke-width="0.04285714285714286"/></g><g><rect data-type="rect" data-label="top" data-x="2" data-y="0" x="355" y="308.3333333333333" width="23.333333333333314" height="23.33333333333337" fill="rgba(255,0,0,0.25)" stroke="black" stroke-width="0.04285714285714286"/></g><g><rect data-type="rect" data-label="top" data-x="6" data-y="0" x="448.3333333333333" y="308.3333333333333" width="23.333333333333314" height="23.33333333333337" fill="rgba(255,0,0,0.25)" stroke="black" stroke-width="0.04285714285714286"/></g><g><rect data-type="rect" data-label="" data-x="-6" data-y="0" x="168.33333333333334" y="308.3333333333333" width="23.333333333333343" height="23.33333333333337" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.04285714285714286"/></g><g><rect data-type="rect" data-label="" data-x="-2" data-y="0" x="261.6666666666667" y="308.3333333333333" width="23.333333333333314" height="23.33333333333337" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.04285714285714286"/></g><g><rect data-type="rect" data-label="" data-x="2" data-y="0" x="355" y="308.3333333333333" width="23.333333333333314" height="23.33333333333337" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.04285714285714286"/></g><g><rect data-type="rect" data-label="" data-x="6" data-y="0" x="448.3333333333333" y="308.3333333333333" width="23.333333333333314" height="23.33333333333337" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.04285714285714286"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":23.333333333333332,"c":0,"e":320,"b":0,"d":-23.333333333333332,"f":320};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/features/off-board-obstacles/off-board-assignable.test.ts
+++ b/tests/features/off-board-obstacles/off-board-assignable.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver } from "lib"
+import type { SimpleRouteJson } from "lib/types"
+import { getLastStepSvg } from "../../fixtures/getLastStepSvg"
+import { simpleRouteJson } from "../../../examples/features/off-board-obstacles/off-board-assignable.fixture"
+
+test("routes with assignable off-board obstacles between pads", () => {
+  const solver = new AutoroutingPipelineSolver(
+    simpleRouteJson as SimpleRouteJson,
+  )
+  solver.solve()
+
+  expect(getLastStepSvg(solver.visualize())).toMatchSvgSnapshot(
+    import.meta.path,
+  )
+})


### PR DESCRIPTION
## Summary
- add a simple route fixture with four spaced pads and assignable off-board obstacles tied to BC_NET
- add an SVG snapshot test that routes between the outer pads through this scenario

## Testing
- BUN_UPDATE_SNAPSHOTS=1 bun test tests/features/off-board-obstacles/off-board-assignable.test.ts
- bunx tsc --noEmit (fails in existing core tests)
- bun run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69235222d5ec832e8dc94338fd1a0b7c)