### PR TITLE
Add same-net via merger stage

### DIFF
--- a/lib/solvers/AutoroutingPipelineSolver.ts
+++ b/lib/solvers/AutoroutingPipelineSolver.ts
@@ -51,6 +51,7 @@ import { CapacityPathingGreedySolver } from "./CapacityPathingSectionSolver/Capa
 import { CacheProvider } from "lib/cache/types"
 import { getGlobalInMemoryCache } from "lib/cache/setupGlobalCaches"
 import { NetToPointPairsSolver2_OffBoardConnection } from "./NetToPointPairsSolver2_OffBoardConnection/NetToPointPairsSolver2_OffBoardConnection"
+import { SameNetViaMerger } from "./SameNetViaMerger/SameNetViaMerger"
 
 interface CapacityMeshSolverOptions {
   capacityDepth?: number
@@ -110,6 +111,7 @@ export class AutoroutingPipelineSolver extends BaseSolver {
   uselessViaRemovalSolver2?: UselessViaRemovalSolver
   multiSimplifiedPathSolver1?: MultiSimplifiedPathSolver
   multiSimplifiedPathSolver2?: MultiSimplifiedPathSolver
+  sameNetViaMerger?: SameNetViaMerger
   viaDiameter: number
   minTraceWidth: number
 
@@ -383,6 +385,12 @@ export class AutoroutingPipelineSolver extends BaseSolver {
         },
       ],
     ),
+    definePipelineStep("sameNetViaMerger", SameNetViaMerger, (cms) => [
+      {
+        hdRoutes: cms._getHdRoutesBeforeSameNetMerge(),
+        connections: cms.srj.connections,
+      },
+    ]),
   ]
 
   constructor(
@@ -641,13 +649,20 @@ export class AutoroutingPipelineSolver extends BaseSolver {
     return match ? match[1] : mstConnectionName
   }
 
-  _getOutputHdRoutes(): HighDensityRoute[] {
+  private _getHdRoutesBeforeSameNetMerge(): HighDensityRoute[] {
     return (
       this.multiSimplifiedPathSolver2?.simplifiedHdRoutes ??
       this.uselessViaRemovalSolver2?.getOptimizedHdRoutes() ??
       this.multiSimplifiedPathSolver1?.simplifiedHdRoutes ??
       this.uselessViaRemovalSolver1?.getOptimizedHdRoutes() ??
       this.highDensityStitchSolver!.mergedHdRoutes
+    )
+  }
+
+  _getOutputHdRoutes(): HighDensityRoute[] {
+    return (
+      this.sameNetViaMerger?.mergedHdRoutes ??
+      this._getHdRoutesBeforeSameNetMerge()
     )
   }
 

--- a/lib/solvers/SameNetViaMerger/SameNetViaMerger.ts
+++ b/lib/solvers/SameNetViaMerger/SameNetViaMerger.ts
@@ -1,0 +1,134 @@
+import { BaseSolver } from "../BaseSolver"
+import type { SimpleRouteConnection } from "lib/types"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+
+type ViaReference = { routeIdx: number; viaIdx: number }
+
+type ViaCluster = {
+  sumX: number
+  sumY: number
+  count: number
+  references: ViaReference[]
+}
+
+type SameNetViaMergerOptions = {
+  hdRoutes: HighDensityRoute[]
+  connections: SimpleRouteConnection[]
+}
+
+export class SameNetViaMerger extends BaseSolver {
+  mergedHdRoutes: HighDensityRoute[]
+  private connectionToNetName: Map<string, string>
+  private tolerance = 1e-4
+
+  constructor(options: SameNetViaMergerOptions) {
+    super()
+    this.mergedHdRoutes = options.hdRoutes.map((route) => ({
+      ...route,
+      route: route.route.map((point) => ({ ...point })),
+      vias: route.vias.map((via) => ({ ...via })),
+    }))
+
+    this.connectionToNetName = new Map(
+      options.connections.map((connection) => [
+        connection.name,
+        connection.netConnectionName ?? connection.name,
+      ]),
+    )
+  }
+
+  private normalizeConnectionName(connectionName: string) {
+    const match = connectionName.match(/^(.+?)_mst\d+$/)
+    return match ? match[1] : connectionName
+  }
+
+  private getNetName(connectionName: string) {
+    const normalized = this.normalizeConnectionName(connectionName)
+    return (
+      this.connectionToNetName.get(normalized) ??
+      this.connectionToNetName.get(connectionName) ??
+      normalized
+    )
+  }
+
+  private findOrCreateCluster(clusters: ViaCluster[], x: number, y: number) {
+    for (const cluster of clusters) {
+      const centerX = cluster.sumX / cluster.count
+      const centerY = cluster.sumY / cluster.count
+      const dx = centerX - x
+      const dy = centerY - y
+      if (dx * dx + dy * dy <= this.tolerance * this.tolerance) return cluster
+    }
+
+    const newCluster: ViaCluster = {
+      sumX: 0,
+      sumY: 0,
+      count: 0,
+      references: [],
+    }
+    clusters.push(newCluster)
+    return newCluster
+  }
+
+  private adjustRoutePoints(
+    route: HighDensityRoute,
+    canonicalX: number,
+    canonicalY: number,
+  ) {
+    for (const point of route.route) {
+      const dx = point.x - canonicalX
+      const dy = point.y - canonicalY
+      if (dx * dx + dy * dy <= this.tolerance * this.tolerance) {
+        point.x = canonicalX
+        point.y = canonicalY
+      }
+    }
+  }
+
+  _step() {
+    const clustersByNet = new Map<string, ViaCluster[]>()
+
+    this.mergedHdRoutes.forEach((route, routeIdx) => {
+      const netName = this.getNetName(route.connectionName)
+      const clusters = clustersByNet.get(netName) ?? []
+      clustersByNet.set(netName, clusters)
+
+      route.vias.forEach((via, viaIdx) => {
+        const cluster = this.findOrCreateCluster(clusters, via.x, via.y)
+        cluster.sumX += via.x
+        cluster.sumY += via.y
+        cluster.count += 1
+        cluster.references.push({ routeIdx, viaIdx })
+      })
+    })
+
+    const canonicalByRoute = new Map<number, Array<{ x: number; y: number }>>()
+
+    for (const clusters of clustersByNet.values()) {
+      for (const cluster of clusters) {
+        if (cluster.count === 0) continue
+        const canonicalX = cluster.sumX / cluster.count
+        const canonicalY = cluster.sumY / cluster.count
+
+        for (const ref of cluster.references) {
+          const route = this.mergedHdRoutes[ref.routeIdx]
+          route.vias[ref.viaIdx].x = canonicalX
+          route.vias[ref.viaIdx].y = canonicalY
+
+          const list = canonicalByRoute.get(ref.routeIdx) ?? []
+          canonicalByRoute.set(ref.routeIdx, list)
+          list.push({ x: canonicalX, y: canonicalY })
+        }
+      }
+    }
+
+    for (const [routeIdx, canonicalPositions] of canonicalByRoute.entries()) {
+      const route = this.mergedHdRoutes[routeIdx]
+      for (const position of canonicalPositions) {
+        this.adjustRoutePoints(route, position.x, position.y)
+      }
+    }
+
+    this.solved = true
+  }
+}

--- a/tests/utils/same-net-via-merger.test.ts
+++ b/tests/utils/same-net-via-merger.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "bun:test"
+import { SameNetViaMerger } from "lib/solvers/SameNetViaMerger/SameNetViaMerger"
+import type { SimpleRouteConnection } from "lib/types"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+
+const buildRoute = (
+  connectionName: string,
+  viaX: number,
+  viaY: number,
+): HighDensityRoute => ({
+  connectionName,
+  traceThickness: 0.15,
+  viaDiameter: 0.6,
+  vias: [{ x: viaX, y: viaY }],
+  route: [
+    { x: 0, y: 0, z: 0 },
+    { x: viaX, y: viaY, z: 1 },
+  ],
+})
+
+describe("SameNetViaMerger", () => {
+  it("merges overlapping vias on the same net and updates routes", () => {
+    const hdRoutes: HighDensityRoute[] = [
+      buildRoute("connA_mst0", 1, 1),
+      buildRoute("connA_mst1", 1.00005, 1.00005),
+      buildRoute("connB", 1.00005, 1.00005),
+    ]
+
+    const merger = new SameNetViaMerger({
+      hdRoutes,
+      connections: [
+        { name: "connA", netConnectionName: "NET1", pointsToConnect: [] },
+        { name: "connB", pointsToConnect: [] },
+      ] satisfies SimpleRouteConnection[],
+    })
+
+    merger.solve()
+
+    const mergedRoutes = merger.mergedHdRoutes
+    const expectedCanonical = (1 + 1.00005) / 2
+
+    expect(merger.solved).toBeTrue()
+    expect(mergedRoutes[0].vias[0].x).toBeCloseTo(expectedCanonical, 6)
+    expect(mergedRoutes[1].vias[0].x).toBeCloseTo(expectedCanonical, 6)
+    expect(mergedRoutes[0].route[1].x).toBeCloseTo(expectedCanonical, 6)
+    expect(mergedRoutes[1].route[1].x).toBeCloseTo(expectedCanonical, 6)
+
+    // Different net should not be merged with NET1 vias
+    expect(mergedRoutes[2].vias[0].x).toBeCloseTo(1.00005, 6)
+  })
+})


### PR DESCRIPTION
## Summary
- add a SameNetViaMerger solver to co-locate overlapping vias that belong to the same net
- append the via merger as the final AutoroutingPipelineSolver stage and return merged routes
- cover the merger behavior with a focused unit test

## Testing
- bun test tests/utils/same-net-via-merger.test.ts
- bunx tsc --noEmit *(fails: existing type errors in tests/core*.test.ts)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6924fc443988832e830df0624c06a048)