### PR TITLE
feat: Add configurable iterative trace simplification solver

### DIFF
--- a/lib/solvers/AutoroutingPipelineSolver.ts
+++ b/lib/solvers/AutoroutingPipelineSolver.ts
@@ -46,7 +46,6 @@ import {
 import { CapacityMeshEdgeSolver2_NodeTreeOptimization } from "./CapacityMeshSolver/CapacityMeshEdgeSolver2_NodeTreeOptimization"
 import { DeadEndSolver } from "./DeadEndSolver/DeadEndSolver"
 import { UselessViaRemovalSolver } from "./UselessViaRemovalSolver/UselessViaRemovalSolver"
-import { SameNetViaMergerSolver } from "./SameNetViaMergerSolver/SameNetViaMergerSolver"
 import { CapacityPathingSolver5 } from "./CapacityPathingSolver/CapacityPathingSolver5"
 import { CapacityPathingGreedySolver } from "./CapacityPathingSectionSolver/CapacityPathingGreedySolver"
 import { CacheProvider } from "lib/cache/types"
@@ -109,7 +108,6 @@ export class AutoroutingPipelineSolver extends BaseSolver {
   singleLayerNodeMerger?: SingleLayerNodeMergerSolver
   strawSolver?: StrawSolver
   deadEndSolver?: DeadEndSolver
-  sameNetViaMerger?: SameNetViaMergerSolver
   traceSimplificationSolver?: TraceSimplificationSolver
   viaDiameter: number
   minTraceWidth: number
@@ -333,16 +331,6 @@ export class AutoroutingPipelineSolver extends BaseSolver {
         },
       ],
     ),
-    definePipelineStep("sameNetViaMerger", SameNetViaMergerSolver, (cms) => [
-      {
-        inputHdRoutes: cms.traceSimplificationSolver!.simplifiedHdRoutes,
-        obstacles: cms.srj.obstacles,
-        colorMap: cms.colorMap,
-        layerCount: cms.srj.layerCount,
-        connMap: cms.connMap,
-        outline: cms.srj.outline,
-      },
-    ]),
   ]
 
   constructor(
@@ -595,7 +583,6 @@ export class AutoroutingPipelineSolver extends BaseSolver {
 
   _getOutputHdRoutes(): HighDensityRoute[] {
     return (
-      this.sameNetViaMerger?.getMergedViaHdRoutes() ??
       this.traceSimplificationSolver?.simplifiedHdRoutes ??
       this.highDensityStitchSolver!.mergedHdRoutes
     )

--- a/lib/solvers/TraceSimplificationSolver/TraceSimplificationSolver.ts
+++ b/lib/solvers/TraceSimplificationSolver/TraceSimplificationSolver.ts
@@ -4,28 +4,29 @@ import { Obstacle } from "lib/types"
 import { ConnectivityMap } from "circuit-json-to-connectivity-map"
 import { UselessViaRemovalSolver } from "lib/solvers/UselessViaRemovalSolver/UselessViaRemovalSolver"
 import { MultiSimplifiedPathSolver } from "lib/solvers/SimplifiedPathSolver/MultiSimplifiedPathSolver"
+import { SameNetViaMergerSolver } from "lib/solvers/SameNetViaMergerSolver/SameNetViaMergerSolver"
 import { GraphicsObject } from "graphics-debug"
 
-type Phase = "via_removal" | "path_simplification"
+type Phase = "via_removal" | "via_merging" | "path_simplification"
 
 /**
  * TraceSimplificationSolver consolidates trace optimization by iteratively applying
- * via removal and path simplification phases. It reduces redundant vias and simplifies
- * routing paths through configurable iterations.
+ * via removal, via merging, and path simplification phases. It reduces redundant vias
+ * and simplifies routing paths through configurable iterations.
  *
- * The solver operates in two alternating phases per iteration:
+ * The solver operates in three alternating phases per iteration:
  * 1. "via_removal" - Removes unnecessary vias from routes using UselessViaRemovalSolver
- * 2. "path_simplification" - Simplifies routing paths using MultiSimplifiedPathSolver
+ * 2. "via_merging" - Merges redundant vias on the same net using SameNetViaMergerSolver
+ * 3. "path_simplification" - Simplifies routing paths using MultiSimplifiedPathSolver
  *
- * Each iteration consists of both phases executed sequentially. The default is 2 iterations,
- * meaning the solver runs via_removal → path_simplification → via_removal → path_simplification.
+ * Each iteration consists of all phases executed sequentially.
  */
 export class TraceSimplificationSolver extends BaseSolver {
   /** The current state of high-density routes being progressively simplified */
   private hdRoutes: HighDensityRoute[] = []
   /** Current iteration count (0-indexed) */
   private currentRun = 0
-  /** Total number of iterations to run (each iteration includes both phases) */
+  /** Total number of iterations to run (each iteration includes all phases) */
   private totalIterations: number
   /** Current phase of simplification being executed */
   private currentPhase: Phase = "via_removal"
@@ -90,6 +91,8 @@ export class TraceSimplificationSolver extends BaseSolver {
 
         // Advance phase
         if (this.currentPhase === "via_removal") {
+          this.currentPhase = "via_merging"
+        } else if (this.currentPhase === "via_merging") {
           this.currentPhase = "path_simplification"
         } else {
           this.currentPhase = "via_removal"
@@ -123,6 +126,19 @@ export class TraceSimplificationSolver extends BaseSolver {
           })
           this.extractResult = (s) =>
             (s as UselessViaRemovalSolver).getOptimizedHdRoutes() ?? []
+          break
+
+        case "via_merging":
+          this.activeSubSolver = new SameNetViaMergerSolver({
+            inputHdRoutes: this.hdRoutes,
+            obstacles: this.simplificationConfig.obstacles,
+            colorMap: this.simplificationConfig.colorMap,
+            layerCount: this.simplificationConfig.layerCount,
+            connMap: this.simplificationConfig.connMap,
+            outline: this.simplificationConfig.outline,
+          })
+          this.extractResult = (s) =>
+            (s as SameNetViaMergerSolver).getMergedViaHdRoutes() ?? []
           break
 
         case "path_simplification":


### PR DESCRIPTION
ref: https://discord.com/channels/1233487248129921135/1446762452556709912/1446763245116461137

## Summary
- Introduces TraceSimplificationSolver to optimize PCB traces through configurable iterations of via removal and path simplification
- Consolidates 4 separate pipeline steps into a single, maintainable solver with adjustable iteration count

## Details
The new `TraceSimplificationSolver` provides iterative trace optimization by alternating between two phases:
1. **Via Removal**: Removes unnecessary vias using `UselessViaRemovalSolver`
2. **Path Simplification**: Simplifies routing paths using `MultiSimplifiedPathSolver`

The solver runs these phases in sequence for a configurable number of iterations (default: 2), producing cleaner routes with fewer unnecessary vias.

### Benefits
- **Cleaner Routes**: Produces optimized traces with minimal vias
- **Configurable**: Iteration count can be adjusted based on complexity needs
- **Maintainable**: Consolidates repetitive optimization logic into a single component
- **Extensible**: Easy to add new optimization phases in the future

### Pipeline Integration
Replaces 4 separate solver steps in `AutoroutingPipelineSolver`:
- `uselessViaRemovalSolver1` + `multiSimplifiedPathSolver1` + `uselessViaRemovalSolver2` + `multiSimplifiedPathSolver2`

With a single configurable step:
- `traceSimplificationSolver` (iterations: 2)