### PR TITLE
Add obstacle clipping regression bugreport20

### DIFF
--- a/examples/bug-reports/bugreport20-obstacle-clipping.fixture.tsx
+++ b/examples/bug-reports/bugreport20-obstacle-clipping.fixture.tsx
@@ -1,0 +1,7 @@
+// @ts-nocheck
+import { AutoroutingPipelineDebugger } from "lib/testing/AutoroutingPipelineDebugger"
+import bugReportJson from "./bugreport20-obstacle-clipping.json"
+
+export default () => {
+  return <AutoroutingPipelineDebugger srj={bugReportJson} />
+}

--- a/examples/bug-reports/bugreport20-obstacle-clipping.json
+++ b/examples/bug-reports/bugreport20-obstacle-clipping.json
@@ -1,0 +1,109 @@
+{
+  "bounds": {
+    "minX": -10,
+    "maxX": 10,
+    "minY": -10,
+    "maxY": 10
+  },
+  "obstacles": [
+    {
+      "type": "rect",
+      "layers": ["top"],
+      "center": {
+        "x": -0.51,
+        "y": 0
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_0",
+        "connectivity_net11",
+        "source_port_0",
+        "pcb_smtpad_0",
+        "pcb_port_0"
+      ],
+      "zLayers": [0]
+    },
+    {
+      "type": "rect",
+      "layers": ["top"],
+      "center": {
+        "x": 0.51,
+        "y": 0
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_1",
+        "connectivity_net12",
+        "source_port_1",
+        "pcb_smtpad_1",
+        "pcb_port_1"
+      ],
+      "zLayers": [0]
+    },
+    {
+      "type": "rect",
+      "layers": ["top"],
+      "center": {
+        "x": 4.49,
+        "y": 0
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_2",
+        "connectivity_net0",
+        "source_trace_0",
+        "source_port_3",
+        "source_port_2",
+        "pcb_port_2",
+        "pcb_smtpad_2",
+        "pcb_port_3"
+      ],
+      "zLayers": [0]
+    },
+    {
+      "type": "rect",
+      "layers": ["top"],
+      "center": {
+        "x": 5.51,
+        "y": 0
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_3",
+        "connectivity_net14",
+        "source_port_4",
+        "pcb_smtpad_3",
+        "pcb_port_4"
+      ],
+      "zLayers": [0]
+    }
+  ],
+  "connections": [
+    {
+      "name": "source_trace_0",
+      "source_trace_id": "source_trace_0",
+      "pointsToConnect": [
+        {
+          "x": 4.49,
+          "y": 0,
+          "layer": "top",
+          "pointId": "pcb_port_3",
+          "pcb_port_id": "pcb_port_3"
+        },
+        {
+          "x": -0.51,
+          "y": 0,
+          "layer": "top",
+          "pointId": "pcb_port_2",
+          "pcb_port_id": "pcb_port_2"
+        }
+      ]
+    }
+  ],
+  "layerCount": 2,
+  "minTraceWidth": 0.15
+}

--- a/tests/bugs/__snapshots__/bugreport20-obstacle-clipping.snap.svg
+++ b/tests/bugs/__snapshots__/bugreport20-obstacle-clipping.snap.svg
@@ -1,0 +1,44 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><circle data-type="point" data-label="source_trace_0 pcb_port_3" data-x="4.49" data-y="0" cx="445.72" cy="320" r="3" fill="black"/></g><g><circle data-type="point" data-label="source_trace_0 pcb_port_2" data-x="-0.51" data-y="0" cx="305.72" cy="320" r="3" fill="black"/></g><g><circle data-type="point" data-label="source_trace_0 (top)" data-x="4.49" data-y="0" cx="445.72" cy="320" r="3" fill="hsl(0, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_0 (top)" data-x="-0.51" data-y="0" cx="305.72" cy="320" r="3" fill="hsl(0, 100%, 50%)"/></g><g><polyline data-points="-10,-10 10,-10 10,10 -10,10 -10,-10" data-type="line" data-label="" points="40,600 600,600 600,40 40,40 40,600" fill="none" stroke="rgba(255,0,0,0.25)" stroke-width="1px"/></g><g><polyline data-points="4.49,0 4.49,-0.3200000000000002" data-type="line" data-label="" points="445.72,320 445.72,328.96" fill="none" stroke="rgba(255,0,0,0.5)" stroke-width="4.2"/></g><g><polyline data-points="4.49,-0.3200000000000002 -0.51,-0.3200000000000002" data-type="line" data-label="" points="445.72,328.96 305.72,328.96" fill="none" stroke="rgba(255,0,0,0.5)" stroke-width="4.2"/></g><g><polyline data-points="-0.51,-0.3200000000000002 -0.51,0" data-type="line" data-label="" points="305.72,328.96 305.72,320" fill="none" stroke="rgba(255,0,0,0.5)" stroke-width="4.2"/></g><g><rect data-type="rect" data-label="top" data-x="-0.51" data-y="0" x="298.16" y="311.04" width="15.119999999999948" height="17.91999999999996" fill="rgba(255,0,0,0.25)" stroke="black" stroke-width="0.03571428571428571"/></g><g><rect data-type="rect" data-label="top" data-x="0.51" data-y="0" x="326.72" y="311.04" width="15.119999999999948" height="17.91999999999996" fill="rgba(255,0,0,0.25)" stroke="black" stroke-width="0.03571428571428571"/></g><g><rect data-type="rect" data-label="top" data-x="4.49" data-y="0" x="438.16" y="311.04" width="15.119999999999948" height="17.91999999999996" fill="rgba(255,0,0,0.25)" stroke="black" stroke-width="0.03571428571428571"/></g><g><rect data-type="rect" data-label="top" data-x="5.51" data-y="0" x="466.72" y="311.04" width="15.119999999999948" height="17.91999999999996" fill="rgba(255,0,0,0.25)" stroke="black" stroke-width="0.03571428571428571"/></g><g><rect data-type="rect" data-label="" data-x="-0.51" data-y="0" x="298.16" y="311.04" width="15.119999999999948" height="17.91999999999996" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.03571428571428571"/></g><g><rect data-type="rect" data-label="" data-x="0.51" data-y="0" x="326.72" y="311.04" width="15.119999999999948" height="17.91999999999996" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.03571428571428571"/></g><g><rect data-type="rect" data-label="" data-x="4.49" data-y="0" x="438.16" y="311.04" width="15.119999999999948" height="17.91999999999996" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.03571428571428571"/></g><g><rect data-type="rect" data-label="" data-x="5.51" data-y="0" x="466.72" y="311.04" width="15.119999999999948" height="17.91999999999996" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.03571428571428571"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":28,"c":0,"e":320,"b":0,"d":-28,"f":320};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/bugs/bugreport20-obstacle-clipping.test.ts
+++ b/tests/bugs/bugreport20-obstacle-clipping.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver } from "lib"
+import bugReport from "../../examples/bug-reports/bugreport20-obstacle-clipping.json" assert {
+  type: "json",
+}
+import type { SimpleRouteJson } from "lib/types"
+import { getLastStepSvg } from "../fixtures/getLastStepSvg"
+
+const srj = bugReport as SimpleRouteJson
+
+// Regression: obstacle-clipping solver previously got stuck when safe intervals became empty
+// for segments adjacent to small rectangular obstacles around the endpoints.
+
+test("bugreport20-obstacle-clipping.json", () => {
+  const solver = new AutoroutingPipelineSolver(srj)
+  solver.solve()
+  expect(getLastStepSvg(solver.visualize())).toMatchSvgSnapshot(
+    import.meta.path,
+  )
+})


### PR DESCRIPTION
## Summary
- Add minimal SRJ with four small rect obstacles and one connection
- Add debugger fixture and SVG regression test to guard obstacle-clipping behavior

This branch is based on upstream/main as requested.