### PR TITLE
Add board outline regression bugreport21

### DIFF
--- a/examples/bug-reports/bugreport21-board-outline.fixture.tsx
+++ b/examples/bug-reports/bugreport21-board-outline.fixture.tsx
@@ -1,0 +1,7 @@
+// @ts-nocheck
+import { AutoroutingPipelineDebugger } from "lib/testing/AutoroutingPipelineDebugger"
+import bugReportJson from "./bugreport21-board-outline.json"
+
+export default () => {
+  return <AutoroutingPipelineDebugger srj={bugReportJson} />
+}

--- a/examples/bug-reports/bugreport21-board-outline.json
+++ b/examples/bug-reports/bugreport21-board-outline.json
@@ -1,0 +1,148 @@
+{
+  "bounds": {
+    "minX": -9,
+    "maxX": 9,
+    "minY": -7,
+    "maxY": 7
+  },
+  "obstacles": [
+    {
+      "type": "rect",
+      "layers": ["top"],
+      "center": {
+        "x": -5.51,
+        "y": -4
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_0",
+        "connectivity_net11",
+        "source_port_0",
+        "pcb_smtpad_0",
+        "pcb_port_0"
+      ],
+      "zLayers": [0]
+    },
+    {
+      "type": "rect",
+      "layers": ["top"],
+      "center": {
+        "x": -4.49,
+        "y": -4
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_1",
+        "connectivity_net0",
+        "source_trace_0",
+        "source_port_1",
+        "source_port_3",
+        "pcb_smtpad_1",
+        "pcb_port_1",
+        "pcb_smtpad_3",
+        "pcb_port_3"
+      ],
+      "zLayers": [0]
+    },
+    {
+      "type": "rect",
+      "layers": ["top"],
+      "center": {
+        "x": 4.49,
+        "y": -4
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_2",
+        "connectivity_net12",
+        "source_port_2",
+        "pcb_smtpad_2",
+        "pcb_port_2"
+      ],
+      "zLayers": [0]
+    },
+    {
+      "type": "rect",
+      "layers": ["top"],
+      "center": {
+        "x": 5.51,
+        "y": -4
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_3",
+        "connectivity_net0",
+        "source_trace_0",
+        "source_port_1",
+        "source_port_3",
+        "pcb_smtpad_1",
+        "pcb_port_1",
+        "pcb_smtpad_3",
+        "pcb_port_3"
+      ],
+      "zLayers": [0]
+    }
+  ],
+  "connections": [
+    {
+      "name": "source_trace_0",
+      "source_trace_id": "source_trace_0",
+      "pointsToConnect": [
+        {
+          "x": -4.49,
+          "y": -4,
+          "layer": "top",
+          "pointId": "pcb_port_1",
+          "pcb_port_id": "pcb_port_1"
+        },
+        {
+          "x": 5.51,
+          "y": -4,
+          "layer": "top",
+          "pointId": "pcb_port_3",
+          "pcb_port_id": "pcb_port_3"
+        }
+      ]
+    }
+  ],
+  "layerCount": 2,
+  "minTraceWidth": 0.15,
+  "outline": [
+    {
+      "x": -8,
+      "y": -6
+    },
+    {
+      "x": -2,
+      "y": -6
+    },
+    {
+      "x": -2,
+      "y": 2
+    },
+    {
+      "x": 2,
+      "y": 2
+    },
+    {
+      "x": 2,
+      "y": -6
+    },
+    {
+      "x": 8,
+      "y": -6
+    },
+    {
+      "x": 8,
+      "y": 6
+    },
+    {
+      "x": -8,
+      "y": 6
+    }
+  ]
+}

--- a/tests/bugs/__snapshots__/bugreport21-board-outline.snap.svg
+++ b/tests/bugs/__snapshots__/bugreport21-board-outline.snap.svg
@@ -1,0 +1,44 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><circle data-type="point" data-label="source_trace_0 pcb_port_1" data-x="-4.49" data-y="-4" cx="180.3111111111111" cy="444.44444444444446" r="3" fill="black"/></g><g><circle data-type="point" data-label="source_trace_0 pcb_port_3" data-x="5.51" data-y="-4" cx="491.4222222222222" cy="444.44444444444446" r="3" fill="black"/></g><g><circle data-type="point" data-label="source_trace_0 (top)" data-x="-4.49" data-y="-4" cx="180.3111111111111" cy="444.44444444444446" r="3" fill="hsl(0, 100%, 50%)"/></g><g><circle data-type="point" data-label="source_trace_0 (top)" data-x="5.51" data-y="-4" cx="491.4222222222222" cy="444.44444444444446" r="3" fill="hsl(0, 100%, 50%)"/></g><g><polyline data-points="-9,-7 9,-7 9,7 -9,7 -9,-7" data-type="line" data-label="" points="40,537.7777777777778 600,537.7777777777778 600,102.22222222222223 40,102.22222222222223 40,537.7777777777778" fill="none" stroke="rgba(255,0,0,0.25)" stroke-width="1px"/></g><g><polyline data-points="-8,-6 -2,-6 -2,2 2,2 2,-6 8,-6 8,6 -8,6 -8,-6" data-type="line" data-label="" points="71.11111111111111,506.66666666666663 257.77777777777777,506.66666666666663 257.77777777777777,257.77777777777777 382.22222222222223,257.77777777777777 382.22222222222223,506.66666666666663 568.8888888888889,506.66666666666663 568.8888888888889,133.33333333333334 71.11111111111111,133.33333333333334 71.11111111111111,506.66666666666663" fill="none" stroke="rgba(0, 136, 255, 0.95)" stroke-width="1px"/></g><g><polyline data-points="-4.49,-4 -4.49,-4.32" data-type="line" data-label="" points="180.3111111111111,444.44444444444446 180.3111111111111,454.4" fill="none" stroke="rgba(255,0,0,0.5)" stroke-width="4.666666666666666"/></g><g><polyline data-points="-4.49,-4.32 5.51,-4.32" data-type="line" data-label="" points="180.3111111111111,454.4 491.4222222222222,454.4" fill="none" stroke="rgba(255,0,0,0.5)" stroke-width="4.666666666666666"/></g><g><polyline data-points="5.51,-4.32 5.51,-4" data-type="line" data-label="" points="491.4222222222222,454.4 491.4222222222222,444.44444444444446" fill="none" stroke="rgba(255,0,0,0.5)" stroke-width="4.666666666666666"/></g><g><rect data-type="rect" data-label="top" data-x="-5.51" data-y="-4" x="140.1777777777778" y="434.4888888888889" width="16.799999999999955" height="19.911111111111097" fill="rgba(255,0,0,0.25)" stroke="black" stroke-width="0.03214285714285715"/></g><g><rect data-type="rect" data-label="top" data-x="-4.49" data-y="-4" x="171.91111111111113" y="434.4888888888889" width="16.799999999999955" height="19.911111111111097" fill="rgba(255,0,0,0.25)" stroke="black" stroke-width="0.03214285714285715"/></g><g><rect data-type="rect" data-label="top" data-x="4.49" data-y="-4" x="451.2888888888889" y="434.4888888888889" width="16.799999999999955" height="19.911111111111097" fill="rgba(255,0,0,0.25)" stroke="black" stroke-width="0.03214285714285715"/></g><g><rect data-type="rect" data-label="top" data-x="5.51" data-y="-4" x="483.02222222222224" y="434.4888888888889" width="16.799999999999955" height="19.911111111111097" fill="rgba(255,0,0,0.25)" stroke="black" stroke-width="0.03214285714285715"/></g><g><rect data-type="rect" data-label="" data-x="-5.51" data-y="-4" x="140.1777777777778" y="434.4888888888889" width="16.799999999999955" height="19.911111111111097" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.03214285714285715"/></g><g><rect data-type="rect" data-label="" data-x="-4.49" data-y="-4" x="171.91111111111113" y="434.4888888888889" width="16.799999999999955" height="19.911111111111097" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.03214285714285715"/></g><g><rect data-type="rect" data-label="" data-x="4.49" data-y="-4" x="451.2888888888889" y="434.4888888888889" width="16.799999999999955" height="19.911111111111097" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.03214285714285715"/></g><g><rect data-type="rect" data-label="" data-x="5.51" data-y="-4" x="483.02222222222224" y="434.4888888888889" width="16.799999999999955" height="19.911111111111097" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.03214285714285715"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":31.11111111111111,"c":0,"e":320,"b":0,"d":-31.11111111111111,"f":320};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/bugs/bugreport21-board-outline.test.ts
+++ b/tests/bugs/bugreport21-board-outline.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver } from "lib"
+import bugReport from "../../examples/bug-reports/bugreport21-board-outline.json" assert {
+  type: "json",
+}
+import type { SimpleRouteJson } from "lib/types"
+import { getLastStepSvg } from "../fixtures/getLastStepSvg"
+
+const srj = bugReport as SimpleRouteJson
+
+// Regression: board outline with four pads on the bottom edge
+// and a connection running between inner pads with nearby obstacles.
+
+test("bugreport21-board-outline.json", () => {
+  const solver = new AutoroutingPipelineSolver(srj)
+  solver.solve()
+  expect(getLastStepSvg(solver.visualize())).toMatchSvgSnapshot(
+    import.meta.path,
+  )
+})


### PR DESCRIPTION
## Summary
- Add minimal SRJ with board outline and four pads on bottom edge
- Add debugger fixture and SVG regression test to guard behavior at board outline

Branch is based on upstream/main as requested.