### PR TITLE
Allow multilayer start nodes to pass obstacle checks

### DIFF
--- a/lib/solvers/CapacityMeshSolver/CapacityMeshNodeSolver1.ts
+++ b/lib/solvers/CapacityMeshSolver/CapacityMeshNodeSolver1.ts
@@ -412,6 +412,9 @@ export class CapacityMeshNodeSolver extends BaseSolver {
         childNode._targetConnectionName = target.connectionName
         childNode.availableZ = target.availableZ
         childNode._containsTarget = true
+        if (target.availableZ.length > 1) {
+          childNode._allowMovingThroughLayersWithoutVia = true
+        }
       }
 
       if (childNode._containsObstacle) {

--- a/lib/solvers/CapacityPathingSolver/CapacityPathingSolver.ts
+++ b/lib/solvers/CapacityPathingSolver/CapacityPathingSolver.ts
@@ -333,6 +333,8 @@ export class CapacityPathingSolver extends BaseSolver {
         this.connectionsWithNodes[this.currentConnectionIndex].connection.name
       if (
         neighborNode._containsObstacle &&
+        !neighborNode._allowMovingThroughLayersWithoutVia &&
+        !currentCandidate.node._allowMovingThroughLayersWithoutVia &&
         !this.canTravelThroughObstacle(neighborNode, connectionName)
       ) {
         continue

--- a/lib/types/capacity-mesh-types.ts
+++ b/lib/types/capacity-mesh-types.ts
@@ -19,6 +19,7 @@ export interface CapacityMeshNode {
   _containsObstacle?: boolean
   _containsTarget?: boolean
   _targetConnectionName?: string
+  _allowMovingThroughLayersWithoutVia?: boolean
   _strawNode?: boolean
   _strawParentCapacityMeshNodeId?: CapacityMeshNodeId
   _isVirtualOffboard?: boolean


### PR DESCRIPTION
## Summary
- mark capacity mesh nodes created from multi-layer connection points so they can be used for via-free layer changes
- allow the pathing solvers to traverse obstacle nodes when either side is explicitly marked as layer-change-friendly

## Testing
- bun test tests/bugs/bugreport18-1b2d06.test.ts
- bunx tsc --noEmit *(fails: pre-existing type incompatibilities in tests/core1.test.tsx, tests/core2.test.tsx, tests/core3.test.tsx)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6935d9f87bb4832e8a570d3486f931fd)