### PR TITLE
Allow multilayer start nodes to switch layers

### DIFF
--- a/lib/solvers/CapacityPathingSectionSolver/CapacityPathingMultiSectionSolver.ts
+++ b/lib/solvers/CapacityPathingSectionSolver/CapacityPathingMultiSectionSolver.ts
@@ -30,6 +30,7 @@ import {
 import { getNodeEdgeMap } from "../CapacityMeshSolver/getNodeEdgeMap"
 import { CachedHyperCapacityPathingSingleSectionSolver } from "./CachedHyperCapacityPathingSingleSectionSolver"
 import { CacheProvider } from "lib/cache/types"
+import { buildLayerFlexibleNeighborMap } from "lib/utils/buildLayerFlexibleNeighborMap"
 
 type CapacityMeshEdgeId = string
 
@@ -45,6 +46,8 @@ export class CapacityPathingMultiSectionSolver extends BaseSolver {
   nodeEdgeMap: Map<CapacityMeshEdgeId, CapacityMeshEdge[]>
   connectionsWithNodes: Array<ConnectionPathWithNodes> = [] // Initialize here
   colorMap: Record<string, string>
+
+  layerFlexibleNeighborMap: Map<CapacityMeshNodeId, CapacityMeshNodeId[]>
 
   initialSolver: CapacityPathingGreedySolver
   cacheProvider?: CacheProvider | null
@@ -140,6 +143,10 @@ export class CapacityPathingMultiSectionSolver extends BaseSolver {
       this.nodes.map((node) => [node.capacityMeshNodeId, node]),
     )
     this.nodeEdgeMap = getNodeEdgeMap(this.edges)
+    this.layerFlexibleNeighborMap = buildLayerFlexibleNeighborMap({
+      connections: this.simpleRouteJson.connections,
+      nodes: this.nodes,
+    })
     this.initialSolver =
       params.initialPathingSolver ||
       new CapacityPathingGreedySolver({
@@ -291,6 +298,7 @@ export class CapacityPathingMultiSectionSolver extends BaseSolver {
         colorMap: this.colorMap,
         centerNodeId: this.currentSection.centerNodeId,
         nodeEdgeMap: this.nodeEdgeMap,
+        layerFlexibleNeighborMap: this.layerFlexibleNeighborMap,
         hyperParameters: {
           EXPANSION_DEGREES: this.currentSchedule.MAX_EXPANSION_DEGREES,
         },

--- a/lib/solvers/CapacityPathingSectionSolver/CapacityPathingSingleSectionSolver.ts
+++ b/lib/solvers/CapacityPathingSectionSolver/CapacityPathingSingleSectionSolver.ts
@@ -47,6 +47,7 @@ export interface CapacityPathingSingleSectionPathingSolverParams {
   nodeMap?: Map<CapacityMeshNodeId, CapacityMeshNode>
   nodeEdgeMap?: Map<CapacityMeshNodeId, CapacityMeshEdge[]>
   hyperParameters?: CpssPathingSolverHyperParameters
+  layerFlexibleNeighborMap?: Map<CapacityMeshNodeId, CapacityMeshNodeId[]>
 }
 
 export class CapacityPathingSingleSectionSolver extends BaseSolver {
@@ -66,6 +67,9 @@ export class CapacityPathingSingleSectionSolver extends BaseSolver {
   totalNodeCapacityMap: Map<CapacityMeshNodeId, number> // Added: Stores total capacity for each node
   centerNodeId: string
   private currentSectionScore: number = 0
+
+  layerFlexibleNeighborMap: Map<CapacityMeshNodeId, CapacityMeshNodeId[]> =
+    new Map()
 
   MAX_CANDIDATES_IN_MEMORY = 10_000
 
@@ -103,6 +107,7 @@ export class CapacityPathingSingleSectionSolver extends BaseSolver {
       new Map(this.sectionNodes.map((n) => [n.capacityMeshNodeId, n]))
     this.nodeEdgeMap = params.nodeEdgeMap ?? getNodeEdgeMap(this.sectionEdges) // Use only section edges
     this.colorMap = params.colorMap ?? {}
+    this.layerFlexibleNeighborMap = params.layerFlexibleNeighborMap ?? new Map()
 
     // Initialize capacity map, potentially with starting values
     this.usedNodeCapacityMap = new Map(
@@ -235,15 +240,24 @@ export class CapacityPathingSingleSectionSolver extends BaseSolver {
   getNeighboringNodes(node: CapacityMeshNode): CapacityMeshNode[] {
     if (!this.nodeMap.has(node.capacityMeshNodeId)) return [] // Node not in section
 
-    return (
+    const edgeNeighborIds =
       this.nodeEdgeMap
         .get(node.capacityMeshNodeId)
         ?.flatMap((edge): CapacityMeshNodeId[] =>
           edge.nodeIds.filter((n) => n !== node.capacityMeshNodeId),
-        )
-        .map((nId) => this.nodeMap.get(nId)!)
-        .filter(Boolean) ?? [] // Ensure nodes exist in the section map and filter out undefined
-    )
+        ) ?? []
+
+    const layerFlexibleNeighborIds =
+      this.layerFlexibleNeighborMap.get(node.capacityMeshNodeId) ?? []
+
+    const allNeighborIds = new Set<CapacityMeshNodeId>([
+      ...edgeNeighborIds,
+      ...layerFlexibleNeighborIds,
+    ])
+
+    return Array.from(allNeighborIds)
+      .map((nId) => this.nodeMap.get(nId)!)
+      .filter(Boolean) // Ensure nodes exist in the section map and filter out undefined
   }
 
   // Adapted from CapacityPathingSolver - uses section's nodeEdgeMap

--- a/lib/solvers/CapacityPathingSolver/CapacityPathingSolver.ts
+++ b/lib/solvers/CapacityPathingSolver/CapacityPathingSolver.ts
@@ -13,6 +13,7 @@ import { CapacityHyperParameters } from "../CapacityHyperParameters"
 import { GraphicsObject } from "graphics-debug"
 import { safeTransparentize } from "../colors"
 import { createRectFromCapacityNode } from "lib/utils/createRectFromCapacityNode"
+import { buildLayerFlexibleNeighborMap } from "lib/utils/buildLayerFlexibleNeighborMap"
 
 export type Candidate = {
   prevCandidate: Candidate | null
@@ -45,6 +46,8 @@ export class CapacityPathingSolver extends BaseSolver {
   connectionNameToGoalNodeIds: Map<string, CapacityMeshNodeId[]>
   colorMap: Record<string, string>
   maxDepthOfNodes: number
+
+  layerFlexibleNeighborMap: Map<CapacityMeshNodeId, CapacityMeshNodeId[]>
 
   activeCandidateStraightLineDistance?: number
 
@@ -84,6 +87,10 @@ export class CapacityPathingSolver extends BaseSolver {
       this.getConnectionsWithNodes()
     this.connectionsWithNodes = connectionsWithNodes
     this.connectionNameToGoalNodeIds = connectionNameToGoalNodeIds
+    this.layerFlexibleNeighborMap = buildLayerFlexibleNeighborMap({
+      connections: this.simpleRouteJson.connections,
+      nodes: this.nodes,
+    })
     this.hyperParameters = hyperParameters
     this.usedNodeCapacityMap = new Map(
       this.nodes.map((node) => [node.capacityMeshNodeId, 0]),
@@ -190,12 +197,24 @@ export class CapacityPathingSolver extends BaseSolver {
   }
 
   getNeighboringNodes(node: CapacityMeshNode) {
-    return this.nodeEdgeMap
-      .get(node.capacityMeshNodeId)!
-      .flatMap((edge): CapacityMeshNodeId[] =>
-        edge.nodeIds.filter((n) => n !== node.capacityMeshNodeId),
-      )
-      .map((n) => this.nodeMap.get(n)!)
+    const edgeNeighborIds =
+      this.nodeEdgeMap
+        .get(node.capacityMeshNodeId)!
+        .flatMap((edge): CapacityMeshNodeId[] =>
+          edge.nodeIds.filter((n) => n !== node.capacityMeshNodeId),
+        ) ?? []
+
+    const layerFlexibleNeighborIds =
+      this.layerFlexibleNeighborMap.get(node.capacityMeshNodeId) ?? []
+
+    const allNeighborIds = new Set<CapacityMeshNodeId>([
+      ...edgeNeighborIds,
+      ...layerFlexibleNeighborIds,
+    ])
+
+    return Array.from(allNeighborIds)
+      .map((n) => this.nodeMap.get(n))
+      .filter((n): n is CapacityMeshNode => Boolean(n))
   }
 
   getCapacityPaths() {

--- a/lib/utils/buildLayerFlexibleNeighborMap.ts
+++ b/lib/utils/buildLayerFlexibleNeighborMap.ts
@@ -1,0 +1,71 @@
+import { distance } from "@tscircuit/math-utils"
+import type {
+  CapacityMeshNode,
+  CapacityMeshNodeId,
+  SimpleRouteConnection,
+} from "lib/types"
+import { isMultiLayerConnectionPoint } from "./connection-point-utils"
+
+const nodeContainsPoint = (
+  node: CapacityMeshNode,
+  point: { x: number; y: number },
+) => {
+  const halfWidth = node.width / 2
+  const halfHeight = node.height / 2
+  return (
+    Math.abs(node.center.x - point.x) <= halfWidth &&
+    Math.abs(node.center.y - point.y) <= halfHeight
+  )
+}
+
+export const buildLayerFlexibleNeighborMap = ({
+  connections,
+  nodes,
+}: {
+  connections: SimpleRouteConnection[]
+  nodes: CapacityMeshNode[]
+}): Map<CapacityMeshNodeId, CapacityMeshNodeId[]> => {
+  const neighborMap = new Map<CapacityMeshNodeId, CapacityMeshNodeId[]>()
+  const nodesByConnection = new Map<string, CapacityMeshNode[]>()
+
+  for (const node of nodes) {
+    if (!node._targetConnectionName) continue
+    if (!nodesByConnection.has(node._targetConnectionName)) {
+      nodesByConnection.set(node._targetConnectionName, [])
+    }
+    nodesByConnection.get(node._targetConnectionName)!.push(node)
+  }
+
+  for (const connection of connections) {
+    const targetNodesForConnection =
+      nodesByConnection.get(connection.name) ?? []
+
+    for (const point of connection.pointsToConnect) {
+      if (!isMultiLayerConnectionPoint(point)) continue
+      const overlappingTargetNodes = targetNodesForConnection.filter((node) =>
+        nodeContainsPoint(node, point),
+      )
+
+      if (overlappingTargetNodes.length < 2) continue
+
+      // Connect overlapping target nodes together so we can switch layers at the start
+      for (const node of overlappingTargetNodes) {
+        const neighbors = neighborMap.get(node.capacityMeshNodeId) ?? []
+        for (const otherNode of overlappingTargetNodes) {
+          if (otherNode.capacityMeshNodeId === node.capacityMeshNodeId) continue
+          if (neighbors.includes(otherNode.capacityMeshNodeId)) continue
+
+          // Prefer nodes that are actually the same physical location to avoid long jumps
+          if (distance(node.center, otherNode.center) > node.width) continue
+
+          neighbors.push(otherNode.capacityMeshNodeId)
+        }
+        if (neighbors.length > 0) {
+          neighborMap.set(node.capacityMeshNodeId, neighbors)
+        }
+      }
+    }
+  }
+
+  return neighborMap
+}


### PR DESCRIPTION
## Summary
- add a helper to link overlapping multilayer connection targets so their nodes can share neighbors
- let the pathing solver use the flexible neighbor map to change layers at multilayer start points without vias
- propagate the same neighbor flexibility into section optimization so both passes respect the new behavior

## Testing
- `bunx tsc --noEmit` *(fails: existing type mismatches in tests/core*.test.tsx)*
- `bun test tests/bugs/bugreport18-1b2d06.test.ts`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6935d9f87bb4832e8a570d3486f931fd)