### PR TITLE
Add multilayer connection points fixture and snapshot test

### DIFF
--- a/examples/features/multilayerconnectionpoints/multilayerconnectionpoints01.fixture.tsx
+++ b/examples/features/multilayerconnectionpoints/multilayerconnectionpoints01.fixture.tsx
@@ -1,0 +1,47 @@
+import { AutoroutingPipelineDebugger } from "lib/testing/AutoroutingPipelineDebugger"
+import type { SimpleRouteJson } from "lib/types"
+
+export const simpleRouteJson: SimpleRouteJson = {
+  bounds: {
+    minX: -8,
+    maxX: 8,
+    minY: -4,
+    maxY: 4,
+  },
+  obstacles: [
+    {
+      type: "rect",
+      layers: ["top", "bottom"],
+      center: { x: -4, y: 0 },
+      width: 2,
+      height: 2,
+      connectedTo: ["left_pad"],
+    },
+    {
+      type: "rect",
+      layers: ["bottom"],
+      center: { x: 4, y: 0 },
+      width: 2,
+      height: 2,
+      connectedTo: ["right_pad"],
+    },
+  ],
+  connections: [
+    {
+      name: "LEFT_TO_RIGHT",
+      pointsToConnect: [
+        {
+          x: -4,
+          y: 0,
+          layers: ["top", "bottom"],
+          pointId: "left_pad",
+        },
+        { x: 4, y: 0, layer: "bottom", pointId: "right_pad" },
+      ],
+    },
+  ],
+  layerCount: 2,
+  minTraceWidth: 0.2,
+}
+
+export default () => <AutoroutingPipelineDebugger srj={simpleRouteJson} />

--- a/tests/features/multilayerconnectionpoints/__snapshots__/multilayerconnectionpoints01.snap.svg
+++ b/tests/features/multilayerconnectionpoints/__snapshots__/multilayerconnectionpoints01.snap.svg
@@ -1,0 +1,44 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><circle data-type="point" data-label="LEFT_TO_RIGHT " data-x="-4" data-y="0" cx="180" cy="320" r="3" fill="black"/></g><g><circle data-type="point" data-label="LEFT_TO_RIGHT " data-x="4" data-y="0" cx="460" cy="320" r="3" fill="black"/></g><g><circle data-type="point" data-label="LEFT_TO_RIGHT (top,bottom)" data-x="-4" data-y="0" cx="180" cy="320" r="3" fill="hsl(0, 100%, 50%)"/></g><g><circle data-type="point" data-label="LEFT_TO_RIGHT (bottom)" data-x="4" data-y="0" cx="460" cy="320" r="3" fill="hsl(0, 100%, 50%)"/></g><g><polyline data-points="-8,-4 8,-4 8,4 -8,4 -8,-4" data-type="line" data-label="" points="40,460 600,460 600,180 40,180 40,460" fill="none" stroke="rgba(255,0,0,0.25)" stroke-width="1px"/></g><g><polyline data-points="-4,0 -3,0" data-type="line" data-label="" points="180,320 215,320" fill="none" stroke="rgba(255,0,0,0.5)" stroke-width="5.25"/></g><g><polyline data-points="-3,0 0,0" data-type="line" data-label="" points="215,320 320,320" fill="none" stroke="rgba(255,0,0,0.5)" stroke-width="5.25"/></g><g><polyline data-points="0,0 3,0" data-type="line" data-label="" points="320,320 425,320" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="5.25"/></g><g><polyline data-points="3,0 4,0" data-type="line" data-label="" points="425,320 460,320" fill="none" stroke="rgba(0,0,255,0.5)" stroke-width="5.25"/></g><g><rect data-type="rect" data-label="top, bottom" data-x="-4" data-y="0" x="145" y="285" width="70" height="70" fill="rgba(255,0,0,0.25)" stroke="black" stroke-width="0.02857142857142857"/></g><g><rect data-type="rect" data-label="bottom" data-x="4" data-y="0" x="425" y="285" width="70" height="70" fill="rgba(0,0,255,0.25)" stroke="black" stroke-width="0.02857142857142857"/></g><g><rect data-type="rect" data-label="" data-x="-4" data-y="0" x="145" y="285" width="70" height="70" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.02857142857142857"/></g><g><rect data-type="rect" data-label="" data-x="4" data-y="0" x="425" y="285" width="70" height="70" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.02857142857142857"/></g><circle data-type="circle" data-label="" data-x="0" data-y="0" cx="320" cy="320" r="10.5" fill="blue" stroke="none" stroke-width="0.02857142857142857"/><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":35,"c":0,"e":320,"b":0,"d":-35,"f":320};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/features/multilayerconnectionpoints/multilayerconnectionpoints01.test.ts
+++ b/tests/features/multilayerconnectionpoints/multilayerconnectionpoints01.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver } from "lib"
+import type { SimpleRouteJson } from "lib/types"
+import { getLastStepSvg } from "../../fixtures/getLastStepSvg"
+import { simpleRouteJson } from "../../../examples/features/multilayerconnectionpoints/multilayerconnectionpoints01.fixture"
+
+test("routes multilayer connection point with mixed layer obstacles", () => {
+  const solver = new AutoroutingPipelineSolver(
+    simpleRouteJson as SimpleRouteJson,
+  )
+  solver.solve()
+
+  expect(getLastStepSvg(solver.visualize())).toMatchSvgSnapshot(
+    import.meta.path,
+  )
+})


### PR DESCRIPTION
## Summary
- add a multilayer connection points feature fixture showing mixed-layer obstacles and pads
- add a corresponding svg snapshot test to capture the autorouter output for the scenario

## Testing
- BUN_UPDATE_SNAPSHOTS=1 bun test tests/features/multilayerconnectionpoints
- bunx tsc --noEmit *(fails: pre-existing type errors in tests/core1.test.tsx, tests/core2.test.tsx, tests/core3.test.tsx)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6935dd37ee54832e828178a4f2cc2ef3)