### PR TITLE
Add via count note to bugreport18 snapshot test

### DIFF
--- a/tests/bugs/bugreport18-1b2d06.test.ts
+++ b/tests/bugs/bugreport18-1b2d06.test.ts
@@ -14,4 +14,12 @@ test("bugreport18-1b2d06.json", () => {
   expect(getLastStepSvg(solver.visualize())).toMatchSvgSnapshot(
     import.meta.path,
   )
+
+  const simplifiedTraces = solver.getOutputSimplifiedPcbTraces()
+  const viaCount = simplifiedTraces
+    .flatMap((trace) => trace.route)
+    .filter((segment) => segment.route_type === "via").length
+
+  // TODO: Expect no vias once via removal is fixed
+  // expect(viaCount).toBe(0)
 })


### PR DESCRIPTION
## Summary
- count vias in the bugreport18 svg snapshot test to document current behavior
- add a commented expectation noting the desired future via-free routing outcome

## Testing
- BUN_UPDATE_SNAPSHOTS=1 bun test tests/bugs/bugreport18-1b2d06.test.ts
- bunx tsc --noEmit *(fails: existing type errors in tests/core1.test.tsx, tests/core2.test.tsx, tests/core3.test.tsx)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6935f583927c832e8d88d93b07ff43ba)