### PR TITLE
Set RectDiffSolver max aspect ratio

### DIFF
--- a/lib/solvers/AutoroutingPipelineSolver.ts
+++ b/lib/solvers/AutoroutingPipelineSolver.ts
@@ -145,7 +145,12 @@ export class AutoroutingPipelineSolver extends BaseSolver {
       RectDiffSolver,
       // Cast to any because RectDiffSolver uses an older SimpleRouteJson type
       // that doesn't support MultiLayerConnectionPoint yet
-      (cms) => [{ simpleRouteJson: cms.srjWithPointPairs! as any }],
+      (cms) => [
+        {
+          simpleRouteJson: cms.srjWithPointPairs! as any,
+          gridOptions: { maxAspectRatio: 1.2 },
+        },
+      ],
       {
         onSolved: (cms) => {
           cms.capacityNodes = cms.nodeSolver?.getOutput().meshNodes ?? []


### PR DESCRIPTION
## Summary
- configure the RectDiffSolver in the autorouting pipeline to use a 1.2 max aspect ratio when building the capacity mesh

## Testing
- bunx tsc --noEmit *(fails: existing type errors in tests/core*.test.tsx)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69384d4aa848832e81887dd11b01d94b)