### PR TITLE
Replace MST name parsing with explicit connection metadata

### DIFF
--- a/lib/solvers/AssignableViaAutoroutingPipeline/AssignableViaAutoroutingPipelineSolver.ts
+++ b/lib/solvers/AssignableViaAutoroutingPipeline/AssignableViaAutoroutingPipelineSolver.ts
@@ -669,15 +669,8 @@ export class AssignableViaAutoroutingPipelineSolver extends BaseSolver {
     return {}
   }
 
-  /**
-   * Get original connection name from connection name with MST suffix
-   * @param mstConnectionName The MST-suffixed connection name (e.g. "connection1_mst0")
-   * @returns The original connection name (e.g. "connection1")
-   */
-  private getOriginalConnectionName(mstConnectionName: string): string {
-    // MST connections are named like "connection_mst0", so extract the original name
-    const match = mstConnectionName.match(/^(.+?)_mst\d+$/)
-    return match ? match[1] : mstConnectionName
+  private getOriginalConnectionName(connection: SimpleRouteConnection): string {
+    return connection.originalConnectionName || connection.name
   }
 
   _getOutputHdRoutes(): HighDensityRoute[] {
@@ -705,10 +698,8 @@ export class AssignableViaAutoroutingPipelineSolver extends BaseSolver {
     const connections = this.srjWithPointPairs?.connections ?? []
 
     for (const connection of connections) {
-      // Find the original connection name for this connection
-      // For fragmented connections like "AD_NET_frag_0", get original "AD_NET"
-      const fragMatch = connection.name.match(/^(.+?)_frag_\d+$/)
-      const originalName = fragMatch ? fragMatch[1] : connection.name
+      const originalName =
+        connection.originalConnectionName ?? connection.name
 
       const netConnectionName =
         connection.netConnectionName ??
@@ -720,15 +711,15 @@ export class AssignableViaAutoroutingPipelineSolver extends BaseSolver {
         (r) => r.connectionName === connection.name,
       )
 
-      for (let i = 0; i < hdRoutes.length; i++) {
-        const hdRoute = hdRoutes[i]
-        const simplifiedPcbTrace: SimplifiedPcbTrace = {
-          type: "pcb_trace",
-          pcb_trace_id: `${connection.name}_${i}`,
-          connection_name:
-            netConnectionName ?? this.getOriginalConnectionName(originalName),
-          route: convertHdRouteToSimplifiedRoute(hdRoute, this.srj.layerCount),
-        }
+        for (let i = 0; i < hdRoutes.length; i++) {
+          const hdRoute = hdRoutes[i]
+          const simplifiedPcbTrace: SimplifiedPcbTrace = {
+            type: "pcb_trace",
+            pcb_trace_id: `${connection.name}_${i}`,
+            connection_name:
+              netConnectionName ?? this.getOriginalConnectionName(connection),
+            route: convertHdRouteToSimplifiedRoute(hdRoute, this.srj.layerCount),
+          }
 
         traces.push(simplifiedPcbTrace)
       }

--- a/lib/solvers/AssignableViaAutoroutingPipeline/OffboardPathFragmentSolver.ts
+++ b/lib/solvers/AssignableViaAutoroutingPipeline/OffboardPathFragmentSolver.ts
@@ -178,6 +178,10 @@ export class OffboardPathFragmentSolver extends BaseSolver {
           name: fragment.connectionName,
           pointsToConnect,
           netConnectionName: originalConnection.netConnectionName,
+          isMstConnection: originalConnection.isMstConnection,
+          originalConnectionName:
+            originalConnection.originalConnectionName ||
+            originalConnection.name,
         })
       }
     }

--- a/lib/solvers/AutoroutingPipelineSolver.ts
+++ b/lib/solvers/AutoroutingPipelineSolver.ts
@@ -570,15 +570,8 @@ export class AutoroutingPipelineSolver extends BaseSolver {
     return {}
   }
 
-  /**
-   * Get original connection name from connection name with MST suffix
-   * @param mstConnectionName The MST-suffixed connection name (e.g. "connection1_mst0")
-   * @returns The original connection name (e.g. "connection1")
-   */
-  private getOriginalConnectionName(mstConnectionName: string): string {
-    // MST connections are named like "connection_mst0", so extract the original name
-    const match = mstConnectionName.match(/^(.+?)_mst\d+$/)
-    return match ? match[1] : mstConnectionName
+  private getOriginalConnectionName(connection: SimpleRouteConnection): string {
+    return connection.originalConnectionName || connection.name
   }
 
   _getOutputHdRoutes(): HighDensityRoute[] {
@@ -617,7 +610,7 @@ export class AutoroutingPipelineSolver extends BaseSolver {
           pcb_trace_id: `${connection.name}_${i}`,
           connection_name:
             netConnectionName ??
-            this.getOriginalConnectionName(connection.name),
+            this.getOriginalConnectionName(connection),
           route: convertHdRouteToSimplifiedRoute(hdRoute, this.srj.layerCount),
         }
 

--- a/lib/solvers/NetToPointPairsSolver/NetToPointPairsSolver.ts
+++ b/lib/solvers/NetToPointPairsSolver/NetToPointPairsSolver.ts
@@ -79,7 +79,9 @@ export class NetToPointPairsSolver extends BaseSolver {
       this.newConnections.push({
         pointsToConnect: [edge.from, edge.to],
         name: `${connection.name}_mst${mstIdx++}`,
-        netConnectionName: connection.netConnectionName,
+        netConnectionName: connection.netConnectionName || connection.name,
+        isMstConnection: true,
+        originalConnectionName: connection.name,
       })
     }
   }

--- a/lib/solvers/NetToPointPairsSolver2_OffBoardConnection/NetToPointPairsSolver2_OffBoardConnection.ts
+++ b/lib/solvers/NetToPointPairsSolver2_OffBoardConnection/NetToPointPairsSolver2_OffBoardConnection.ts
@@ -174,7 +174,10 @@ export class NetToPointPairsSolver2_OffBoardConnection extends NetToPointPairsSo
       this.newConnections.push({
         pointsToConnect: optimizedMstEdge.pointsToConnect,
         name: `${currentConnection.name}_mst${mstEdgeIndex++}`,
-        netConnectionName: currentConnection.netConnectionName,
+        netConnectionName:
+          currentConnection.netConnectionName || currentConnection.name,
+        isMstConnection: true,
+        originalConnectionName: currentConnection.name,
       })
     }
   }

--- a/lib/testing/utils/convertToCircuitJson.ts
+++ b/lib/testing/utils/convertToCircuitJson.ts
@@ -95,8 +95,7 @@ function createSourceTraces(
       .map((point) => point.pcb_port_id!)
       .filter(Boolean)
 
-    // Look for original connection name (might be MST-suffixed by NetToPointPairsSolver)
-    const baseName = connection.name.replace(/_mst\d+$/, "")
+    const baseName = connection.originalConnectionName || connection.name
     const netConnectionName = connection.netConnectionName || baseName
 
     // Test for obstacles we're inside of
@@ -339,7 +338,7 @@ export function convertToCircuitJson(
   // Build a map of connection names to simplify lookups
   const connectionMap = new Map<string, string>()
   srjWithPointPairs.connections.forEach((conn) => {
-    const baseName = conn.name.replace(/_mst\d+$/, "")
+    const baseName = conn.originalConnectionName || conn.name
     connectionMap.set(conn.name, conn.netConnectionName || baseName)
   })
 

--- a/lib/types/srj-types.ts
+++ b/lib/types/srj-types.ts
@@ -49,6 +49,10 @@ export interface Obstacle {
 export interface SimpleRouteConnection {
   name: string
   isOffBoard?: boolean
+  /** True when this connection was produced by splitting a multi-point net */
+  isMstConnection?: boolean
+  /** Original connection name before MST splitting or other transformations */
+  originalConnectionName?: string
   netConnectionName?: string
   nominalTraceWidth?: number
   pointsToConnect: Array<ConnectionPoint>


### PR DESCRIPTION
## Summary
- add metadata fields to mark MST-derived connections and preserve their original names
- propagate MST metadata through connection splitting and offboard fragmentation
- use stored metadata instead of parsing `_mst` suffixes when generating traces and circuit JSON

## Testing
- npm test *(fails: Missing script "test" in package.json)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69386cdf478483289f31cc46edb9ebc1)