### PR TITLE
Add aspect ratio split stage to autorouting pipeline

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,6 +2,7 @@ export {
   CapacityMeshSolver,
   AutoroutingPipelineSolver,
 } from "./solvers/AutoroutingPipelineSolver"
+export { CapacityNodeAspectRatioSolver } from "./solvers/CapacityMeshSolver/CapacityNodeAspectRatioSolver"
 export {
   getTunedTotalCapacity1,
   calculateOptimalCapacityDepth,

--- a/lib/solvers/AutoroutingPipelineSolver.ts
+++ b/lib/solvers/AutoroutingPipelineSolver.ts
@@ -53,11 +53,13 @@ import { getGlobalInMemoryCache } from "lib/cache/setupGlobalCaches"
 import { NetToPointPairsSolver2_OffBoardConnection } from "./NetToPointPairsSolver2_OffBoardConnection/NetToPointPairsSolver2_OffBoardConnection"
 import { RectDiffSolver } from "@tscircuit/rectdiff"
 import { TraceSimplificationSolver } from "./TraceSimplificationSolver/TraceSimplificationSolver"
+import { CapacityNodeAspectRatioSolver } from "./CapacityMeshSolver/CapacityNodeAspectRatioSolver"
 
 interface CapacityMeshSolverOptions {
   capacityDepth?: number
   targetMinCapacity?: number
   cacheProvider?: CacheProvider | null
+  maxNodeAspectRatio?: number
 }
 export type AutoroutingPipelineSolverOptions = CapacityMeshSolverOptions
 
@@ -94,6 +96,7 @@ function definePipelineStep<
 export class AutoroutingPipelineSolver extends BaseSolver {
   netToPointPairsSolver?: NetToPointPairsSolver
   nodeSolver?: RectDiffSolver
+  nodeAspectRatioSolver?: CapacityNodeAspectRatioSolver
   nodeTargetMerger?: CapacityNodeTargetMerger
   edgeSolver?: CapacityMeshEdgeSolver
   initialPathingSolver?: CapacityPathingGreedySolver
@@ -149,6 +152,22 @@ export class AutoroutingPipelineSolver extends BaseSolver {
       {
         onSolved: (cms) => {
           cms.capacityNodes = cms.nodeSolver?.getOutput().meshNodes ?? []
+        },
+      },
+    ),
+    definePipelineStep(
+      "nodeAspectRatioSolver",
+      CapacityNodeAspectRatioSolver,
+      (cms) => [
+        {
+          nodes: cms.capacityNodes!,
+          maxAspectRatio: cms.opts.maxNodeAspectRatio,
+        },
+      ],
+      {
+        onSolved: (cms) => {
+          cms.capacityNodes =
+            cms.nodeAspectRatioSolver?.getResultNodes() ?? null
         },
       },
     ),

--- a/lib/solvers/CapacityMeshSolver/CapacityNodeAspectRatioSolver.ts
+++ b/lib/solvers/CapacityMeshSolver/CapacityNodeAspectRatioSolver.ts
@@ -1,0 +1,102 @@
+import { BaseSolver } from "lib/solvers/BaseSolver"
+import type { CapacityMeshNode } from "lib/types"
+
+type CapacityNodeAspectRatioSolverParams = {
+  nodes: CapacityMeshNode[]
+  maxAspectRatio?: number
+}
+
+export class CapacityNodeAspectRatioSolver extends BaseSolver {
+  nodes: CapacityMeshNode[]
+  maxAspectRatio: number
+
+  constructor({
+    nodes,
+    maxAspectRatio = 1.2,
+  }: CapacityNodeAspectRatioSolverParams) {
+    super()
+    this.nodes = nodes
+    this.maxAspectRatio = maxAspectRatio
+    this.MAX_ITERATIONS = 1
+  }
+
+  _step() {
+    const splitNodes: CapacityMeshNode[] = []
+
+    for (const node of this.nodes) {
+      const minDimension = Math.min(node.width, node.height)
+
+      if (minDimension === 0) {
+        splitNodes.push(node)
+        continue
+      }
+
+      const aspectRatio = Math.max(node.width, node.height) / minDimension
+
+      if (aspectRatio <= this.maxAspectRatio) {
+        splitNodes.push(node)
+        continue
+      }
+
+      if (node.width >= node.height) {
+        const splitCount = Math.max(
+          1,
+          Math.ceil(node.width / (node.height * this.maxAspectRatio)),
+        )
+        const segmentWidth = node.width / splitCount
+        const startX = node.center.x - node.width / 2
+
+        for (let i = 0; i < splitCount; i++) {
+          const centerX = startX + segmentWidth * (i + 0.5)
+          splitNodes.push(
+            this.createSplitNode(node, i, {
+              center: { x: centerX, y: node.center.y },
+              width: segmentWidth,
+              height: node.height,
+            }),
+          )
+        }
+      } else {
+        const splitCount = Math.max(
+          1,
+          Math.ceil(node.height / (node.width * this.maxAspectRatio)),
+        )
+        const segmentHeight = node.height / splitCount
+        const startY = node.center.y - node.height / 2
+
+        for (let i = 0; i < splitCount; i++) {
+          const centerY = startY + segmentHeight * (i + 0.5)
+          splitNodes.push(
+            this.createSplitNode(node, i, {
+              center: { x: node.center.x, y: centerY },
+              width: node.width,
+              height: segmentHeight,
+            }),
+          )
+        }
+      }
+    }
+
+    this.nodes = splitNodes
+    this.solved = true
+  }
+
+  private createSplitNode(
+    node: CapacityMeshNode,
+    index: number,
+    dims: { center: { x: number; y: number }; width: number; height: number },
+  ): CapacityMeshNode {
+    return {
+      ...node,
+      capacityMeshNodeId: `${node.capacityMeshNodeId}_split${index + 1}`,
+      center: dims.center,
+      width: dims.width,
+      height: dims.height,
+      _parent: node,
+    }
+  }
+
+  getResultNodes() {
+    return this.nodes
+  }
+}

--- a/tests/features/node-aspect-ratio-solver.test.ts
+++ b/tests/features/node-aspect-ratio-solver.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "bun:test"
+import { CapacityNodeAspectRatioSolver } from "lib/solvers/CapacityMeshSolver/CapacityNodeAspectRatioSolver"
+import type { CapacityMeshNode } from "lib/types"
+
+const baseNode: CapacityMeshNode = {
+  capacityMeshNodeId: "node-1",
+  center: { x: 0, y: 0 },
+  width: 1,
+  height: 1,
+  layer: "top",
+  availableZ: [0],
+}
+
+test("does not split nodes within aspect ratio threshold", () => {
+  const solver = new CapacityNodeAspectRatioSolver({ nodes: [baseNode] })
+
+  solver.solve()
+
+  expect(solver.getResultNodes()).toHaveLength(1)
+  expect(solver.getResultNodes()[0]).toEqual(baseNode)
+})
+
+test("splits wide nodes to meet aspect ratio threshold", () => {
+  const wideNode: CapacityMeshNode = {
+    ...baseNode,
+    capacityMeshNodeId: "wide",
+    width: 10,
+    height: 2,
+  }
+
+  const solver = new CapacityNodeAspectRatioSolver({
+    nodes: [wideNode],
+    maxAspectRatio: 1.2,
+  })
+
+  solver.solve()
+
+  const nodes = solver.getResultNodes()
+
+  expect(nodes).toHaveLength(5)
+  expect(nodes.every((n) => n.width <= 2.5 && n.height === 2)).toBeTrue()
+  expect(nodes.map((n) => n.capacityMeshNodeId)).toEqual([
+    "wide_split1",
+    "wide_split2",
+    "wide_split3",
+    "wide_split4",
+    "wide_split5",
+  ])
+  expect(nodes[0]?.center.x).toBeCloseTo(-4)
+  expect(nodes.at(-1)?.center.x).toBeCloseTo(4)
+})
+
+test("splits tall nodes to meet aspect ratio threshold", () => {
+  const tallNode: CapacityMeshNode = {
+    ...baseNode,
+    capacityMeshNodeId: "tall",
+    width: 2,
+    height: 10,
+  }
+
+  const solver = new CapacityNodeAspectRatioSolver({
+    nodes: [tallNode],
+    maxAspectRatio: 1.2,
+  })
+
+  solver.solve()
+
+  const nodes = solver.getResultNodes()
+
+  expect(nodes).toHaveLength(5)
+  expect(nodes.every((n) => n.height <= 2.5 && n.width === 2)).toBeTrue()
+  expect(nodes[0]?.center.y).toBeCloseTo(-4)
+  expect(nodes.at(-1)?.center.y).toBeCloseTo(4)
+})


### PR DESCRIPTION
## Summary
- add a capacity node aspect ratio solver that splits elongated nodes
- insert the solver into the autorouting pipeline after rectdiff and export it
- add targeted tests covering wide and tall node splitting

## Testing
- bunx tsc --noEmit *(fails: existing type errors in tests/core*.test.ts)*
- bun test tests/features/node-aspect-ratio-solver.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6938e69535a0832e80cbfda0eb8eaa03)