### PR TITLE
Add single-layer node splitter stage

### DIFF
--- a/lib/solvers/AutoroutingPipelineSolver.ts
+++ b/lib/solvers/AutoroutingPipelineSolver.ts
@@ -36,6 +36,7 @@ import { UnravelMultiSectionSolver } from "./UnravelSolver/UnravelMultiSectionSo
 import { CapacityPathingMultiSectionSolver } from "./CapacityPathingSectionSolver/CapacityPathingMultiSectionSolver" // Added import
 import { StrawSolver } from "./StrawSolver/StrawSolver"
 import { SingleLayerNodeMergerSolver } from "./SingleLayerNodeMerger/SingleLayerNodeMergerSolver"
+import { SingleLayerNodeSplitterSolver } from "./SingleLayerNodeSplitter/SingleLayerNodeSplitterSolver"
 import { CapacityNodeTargetMerger2 } from "./CapacityNodeTargetMerger/CapacityNodeTargetMerger2"
 import { SingleSimplifiedPathSolver } from "./SimplifiedPathSolver/SingleSimplifiedPathSolver"
 import { MultiSimplifiedPathSolver } from "./SimplifiedPathSolver/MultiSimplifiedPathSolver"
@@ -106,11 +107,15 @@ export class AutoroutingPipelineSolver extends BaseSolver {
   highDensityRouteSolver?: HighDensitySolver
   highDensityStitchSolver?: MultipleHighDensityRouteStitchSolver
   singleLayerNodeMerger?: SingleLayerNodeMergerSolver
+  singleLayerNodeSplitter?: SingleLayerNodeSplitterSolver
   strawSolver?: StrawSolver
   deadEndSolver?: DeadEndSolver
   traceSimplificationSolver?: TraceSimplificationSolver
   viaDiameter: number
   minTraceWidth: number
+  obstacleMargin: number
+  minSingleLayerNodeSize: number
+  maxSingleLayerNodeSize: number
 
   startTimeOfPhase: Record<string, number>
   endTimeOfPhase: Record<string, number>
@@ -149,6 +154,22 @@ export class AutoroutingPipelineSolver extends BaseSolver {
       {
         onSolved: (cms) => {
           cms.capacityNodes = cms.nodeSolver?.getOutput().meshNodes ?? []
+        },
+      },
+    ),
+    definePipelineStep(
+      "singleLayerNodeSplitter",
+      SingleLayerNodeSplitterSolver,
+      (cms) => [
+        {
+          nodes: cms.capacityNodes!,
+          minSingleLayerNodeSize: cms.minSingleLayerNodeSize,
+          maxSingleLayerNodeSize: cms.maxSingleLayerNodeSize,
+        },
+      ],
+      {
+        onSolved: (cms) => {
+          cms.capacityNodes = cms.singleLayerNodeSplitter?.newNodes ?? []
         },
       },
     ),
@@ -341,6 +362,9 @@ export class AutoroutingPipelineSolver extends BaseSolver {
     this.MAX_ITERATIONS = 100e6
     this.viaDiameter = srj.minViaDiameter ?? 0.6
     this.minTraceWidth = srj.minTraceWidth
+    this.obstacleMargin = srj.obstacleMargin ?? 0.2
+    this.minSingleLayerNodeSize = this.minTraceWidth + this.obstacleMargin
+    this.maxSingleLayerNodeSize = this.minSingleLayerNodeSize * 2
 
     // If capacityDepth is not provided, calculate it automatically
     if (opts.capacityDepth === undefined) {

--- a/lib/solvers/SingleLayerNodeSplitter/SingleLayerNodeSplitterSolver.ts
+++ b/lib/solvers/SingleLayerNodeSplitter/SingleLayerNodeSplitterSolver.ts
@@ -1,0 +1,106 @@
+import { BaseSolver } from "../BaseSolver"
+import { CapacityMeshNode } from "lib/types"
+
+export type SingleLayerNodeSplitterSolverParams = {
+  nodes: CapacityMeshNode[]
+  minSingleLayerNodeSize: number
+  maxSingleLayerNodeSize: number
+}
+
+export class SingleLayerNodeSplitterSolver extends BaseSolver {
+  nodes: CapacityMeshNode[]
+  minSingleLayerNodeSize: number
+  maxSingleLayerNodeSize: number
+  newNodes: CapacityMeshNode[] = []
+
+  constructor(params: SingleLayerNodeSplitterSolverParams) {
+    super()
+    this.nodes = params.nodes
+    this.minSingleLayerNodeSize = params.minSingleLayerNodeSize
+    this.maxSingleLayerNodeSize = params.maxSingleLayerNodeSize
+    this.MAX_ITERATIONS = 1
+  }
+
+  private partitionDimension(
+    totalSize: number,
+    minSize: number,
+    maxSize: number,
+  ): number[] {
+    if (totalSize <= maxSize) return [totalSize]
+
+    const minSegments = Math.ceil(totalSize / maxSize)
+    const maxSegments = Math.max(minSegments, Math.floor(totalSize / minSize))
+
+    let chosenSegments = minSegments
+    for (let segments = minSegments; segments <= maxSegments; segments++) {
+      const size = totalSize / segments
+      if (size >= minSize && size <= maxSize) {
+        chosenSegments = segments
+        break
+      }
+    }
+
+    const baseSize = totalSize / chosenSegments
+    const sizes = Array.from({ length: chosenSegments }, () => baseSize)
+    const totalOfSizes = baseSize * chosenSegments
+    sizes[sizes.length - 1] += totalSize - totalOfSizes
+
+    return sizes
+  }
+
+  private splitNode(node: CapacityMeshNode): CapacityMeshNode[] {
+    if (node.availableZ.length !== 1) return [node]
+
+    const widthPartitions = this.partitionDimension(
+      node.width,
+      this.minSingleLayerNodeSize,
+      this.maxSingleLayerNodeSize,
+    )
+    const heightPartitions = this.partitionDimension(
+      node.height,
+      this.minSingleLayerNodeSize,
+      this.maxSingleLayerNodeSize,
+    )
+
+    if (widthPartitions.length === 1 && heightPartitions.length === 1) {
+      return [node]
+    }
+
+    const minX = node.center.x - node.width / 2
+    const minY = node.center.y - node.height / 2
+
+    const splitNodes: CapacityMeshNode[] = []
+    let nodeIndex = 0
+
+    let currentY = minY
+    for (const height of heightPartitions) {
+      let currentX = minX
+      for (const width of widthPartitions) {
+        const newNode: CapacityMeshNode = {
+          ...node,
+          capacityMeshNodeId: `${node.capacityMeshNodeId}_${nodeIndex++}`,
+          width,
+          height,
+          center: {
+            x: currentX + width / 2,
+            y: currentY + height / 2,
+          },
+          _adjacentNodeIds: undefined,
+        }
+        splitNodes.push(newNode)
+        currentX += width
+      }
+      currentY += height
+    }
+
+    return splitNodes
+  }
+
+  _step() {
+    for (const node of this.nodes) {
+      this.newNodes.push(...this.splitNode(node))
+    }
+
+    this.solved = true
+  }
+}

--- a/lib/types/srj-types.ts
+++ b/lib/types/srj-types.ts
@@ -26,6 +26,7 @@ export type ConnectionTempId = string
 export interface SimpleRouteJson {
   layerCount: number
   minTraceWidth: number
+  obstacleMargin?: number
   minViaDiameter?: number
   obstacles: Obstacle[]
   connections: Array<SimpleRouteConnection>

--- a/tests/single-layer-node-splitter.test.ts
+++ b/tests/single-layer-node-splitter.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test"
+import { AutoroutingPipelineSolver } from "lib"
+import { SingleLayerNodeSplitterSolver } from "lib/solvers/SingleLayerNodeSplitter/SingleLayerNodeSplitterSolver"
+import type { CapacityMeshNode } from "lib/types"
+
+describe("SingleLayerNodeSplitterSolver", () => {
+  const baseNode: CapacityMeshNode = {
+    capacityMeshNodeId: "node-1",
+    center: { x: 0, y: 0 },
+    width: 6,
+    height: 4,
+    layer: "top",
+    availableZ: [0],
+  }
+
+  test("splits single-layer nodes into bounded sizes", () => {
+    const solver = new SingleLayerNodeSplitterSolver({
+      nodes: [baseNode],
+      minSingleLayerNodeSize: 2,
+      maxSingleLayerNodeSize: 4,
+    })
+
+    solver.step()
+
+    expect(solver.newNodes.length).toBeGreaterThan(1)
+    solver.newNodes.forEach((node) => {
+      expect(node.width).toBeGreaterThanOrEqual(2)
+      expect(node.width).toBeLessThanOrEqual(4)
+      expect(node.height).toBeGreaterThanOrEqual(2)
+      expect(node.height).toBeLessThanOrEqual(4)
+      expect(node.availableZ).toEqual([0])
+    })
+
+    const totalArea = solver.newNodes.reduce(
+      (sum, node) => sum + node.width * node.height,
+      0,
+    )
+    expect(totalArea).toBeCloseTo(baseNode.width * baseNode.height)
+  })
+
+  test("keeps multi-layer nodes intact", () => {
+    const multiLayerNode: CapacityMeshNode = {
+      ...baseNode,
+      availableZ: [0, 1],
+      capacityMeshNodeId: "multi",
+    }
+
+    const solver = new SingleLayerNodeSplitterSolver({
+      nodes: [multiLayerNode],
+      minSingleLayerNodeSize: 2,
+      maxSingleLayerNodeSize: 4,
+    })
+
+    solver.step()
+
+    expect(solver.newNodes).toHaveLength(1)
+    expect(solver.newNodes[0]).toMatchObject(multiLayerNode)
+  })
+})
+
+describe("AutoroutingPipelineSolver single-layer node sizing", () => {
+  test("computes min and max single-layer node sizes from trace width and obstacle margin", () => {
+    const srj = {
+      layerCount: 2,
+      minTraceWidth: 0.25,
+      obstacleMargin: 0.15,
+      obstacles: [],
+      connections: [],
+      bounds: { minX: 0, maxX: 10, minY: 0, maxY: 10 },
+    }
+
+    const solver = new AutoroutingPipelineSolver(srj as any)
+    expect(solver.minSingleLayerNodeSize).toBeCloseTo(0.4)
+    expect(solver.maxSingleLayerNodeSize).toBeCloseTo(0.8)
+
+    const stageNames = solver.pipelineDef.map((step) => step.solverName)
+    const nodeSolverIndex = stageNames.indexOf("nodeSolver")
+    const splitterIndex = stageNames.indexOf("singleLayerNodeSplitter")
+
+    expect(splitterIndex).toBeGreaterThan(nodeSolverIndex)
+  })
+})


### PR DESCRIPTION
## Summary
- add a single-layer node splitter solver and insert it after rectdiff in the autorouting pipeline
- derive node size bounds from the trace width and obstacle margin values
- add targeted tests to validate splitter behavior and pipeline configuration

## Testing
- bun test tests/single-layer-node-splitter.test.ts
- bunx tsc --noEmit *(fails due to existing type errors in tests/core[1-3].test.ts)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693a2afb1f14832e96603c55ff04ea37)