### PR TITLE
Add corner radius to obstacles

### DIFF
--- a/lib/testing/utils/convertToCircuitJson.ts
+++ b/lib/testing/utils/convertToCircuitJson.ts
@@ -213,20 +213,31 @@ function createPcbSmtPads(srj: SimpleRouteJson): AnyCircuitElement[] {
     // Default to rectangular pads; SRJ obstacles generally provide width/height
     const width = obstacle.width ?? 0
     const height = obstacle.height ?? 0
+    const cornerRadius = obstacle.corner_radius ?? 0
     const x = obstacle.center?.x ?? obstacle.x
     const y = obstacle.center?.y ?? obstacle.y
 
     if (typeof x !== "number" || typeof y !== "number") continue
 
+    const shape: "rect" | "circle" | "roundrect" =
+      cornerRadius <= 0
+        ? "rect"
+        : cornerRadius >= Math.min(width, height) / 2 && Math.abs(width - height) < 1e-9
+          ? "circle"
+          : "roundrect"
+
     pads.push({
       type: "pcb_smtpad",
       pcb_smtpad_id: id,
       layer,
-      shape: "rect",
+      shape,
       width,
       height,
       x,
       y,
+      ...(cornerRadius > 0 && shape !== "circle"
+        ? { corner_radius: cornerRadius }
+        : {}),
       ...(pcbPortId ? { pcb_port_id: pcbPortId } : {}),
     } as any)
   }

--- a/lib/types/srj-types.ts
+++ b/lib/types/srj-types.ts
@@ -41,6 +41,12 @@ export interface Obstacle {
   center: { x: number; y: number }
   width: number
   height: number
+  /**
+   * Optional corner radius for rounded-rect obstacles.
+   * A large enough radius on a square approximates a circle and
+   * non-square dimensions with a radius allow representing slots.
+   */
+  corner_radius?: number
   connectedTo: Array<TraceId | NetId>
   netIsAssignable?: boolean
   offBoardConnectsTo?: Array<OffBoardConnectionId>


### PR DESCRIPTION
## Summary
- add optional `corner_radius` to SRJ obstacles
- propagate obstacle corner radius into generated pcb_smtpad elements and derive pad shape

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693a45d8c6288328a2ef2cd7767c12aa)