### PR TITLE
Add port point pathing to autorouting pipeline

### DIFF
--- a/lib/solvers/AutoroutingPipelineSolver.ts
+++ b/lib/solvers/AutoroutingPipelineSolver.ts
@@ -9,18 +9,8 @@ import type {
   TraceId,
 } from "../types"
 import { BaseSolver } from "./BaseSolver"
-import { CapacityMeshEdgeSolver } from "./CapacityMeshSolver/CapacityMeshEdgeSolver"
-import { CapacityMeshNodeSolver } from "./CapacityMeshSolver/CapacityMeshNodeSolver1"
-import { CapacityMeshNodeSolver2_NodeUnderObstacle } from "./CapacityMeshSolver/CapacityMeshNodeSolver2_NodesUnderObstacles"
-import { CapacityPathingSolver } from "./CapacityPathingSolver/CapacityPathingSolver"
-import { CapacityEdgeToPortSegmentSolver } from "./CapacityMeshSolver/CapacityEdgeToPortSegmentSolver"
 import { getColorMap } from "./colors"
-import { CapacitySegmentToPointSolver } from "./CapacityMeshSolver/CapacitySegmentToPointSolver"
 import { HighDensitySolver } from "./HighDensitySolver/HighDensitySolver"
-import type { NodePortSegment } from "../types/capacity-edges-to-port-segments-types"
-import { CapacityPathingSolver2_AvoidLowCapacity } from "./CapacityPathingSolver/CapacityPathingSolver2_AvoidLowCapacity"
-import { CapacityPathingSolver3_FlexibleNegativeCapacity_AvoidLowCapacity } from "./CapacityPathingSolver/CapacityPathingSolver3_FlexibleNegativeCapacity_AvoidLowCapacity"
-import { CapacityPathingSolver4_FlexibleNegativeCapacity } from "./CapacityPathingSolver/CapacityPathingSolver4_FlexibleNegativeCapacity_AvoidLowCapacity_FixedDistanceCost"
 import { ConnectivityMap } from "circuit-json-to-connectivity-map"
 import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
 import { CapacityNodeTargetMerger } from "./CapacityNodeTargetMerger/CapacityNodeTargetMerger"
@@ -32,8 +22,6 @@ import { mergeRouteSegments } from "lib/utils/mergeRouteSegments"
 import { mapLayerNameToZ } from "lib/utils/mapLayerNameToZ"
 import { MultipleHighDensityRouteStitchSolver } from "./RouteStitchingSolver/MultipleHighDensityRouteStitchSolver"
 import { convertSrjToGraphicsObject } from "lib/utils/convertSrjToGraphicsObject"
-import { UnravelMultiSectionSolver } from "./UnravelSolver/UnravelMultiSectionSolver"
-import { CapacityPathingMultiSectionSolver } from "./CapacityPathingSectionSolver/CapacityPathingMultiSectionSolver" // Added import
 import { StrawSolver } from "./StrawSolver/StrawSolver"
 import { SingleLayerNodeMergerSolver } from "./SingleLayerNodeMerger/SingleLayerNodeMergerSolver"
 import { CapacityNodeTargetMerger2 } from "./CapacityNodeTargetMerger/CapacityNodeTargetMerger2"
@@ -46,13 +34,13 @@ import {
 import { CapacityMeshEdgeSolver2_NodeTreeOptimization } from "./CapacityMeshSolver/CapacityMeshEdgeSolver2_NodeTreeOptimization"
 import { DeadEndSolver } from "./DeadEndSolver/DeadEndSolver"
 import { UselessViaRemovalSolver } from "./UselessViaRemovalSolver/UselessViaRemovalSolver"
-import { CapacityPathingSolver5 } from "./CapacityPathingSolver/CapacityPathingSolver5"
-import { CapacityPathingGreedySolver } from "./CapacityPathingSectionSolver/CapacityPathingGreedySolver"
 import { CacheProvider } from "lib/cache/types"
 import { getGlobalInMemoryCache } from "lib/cache/setupGlobalCaches"
 import { NetToPointPairsSolver2_OffBoardConnection } from "./NetToPointPairsSolver2_OffBoardConnection/NetToPointPairsSolver2_OffBoardConnection"
 import { RectDiffSolver } from "@tscircuit/rectdiff"
 import { TraceSimplificationSolver } from "./TraceSimplificationSolver/TraceSimplificationSolver"
+import { AvailableSegmentPointSolver } from "./AvailableSegmentPointSolver"
+import { PortPointPathingSolver } from "./PortPointPathingSolver"
 
 interface CapacityMeshSolverOptions {
   capacityDepth?: number
@@ -96,12 +84,9 @@ export class AutoroutingPipelineSolver extends BaseSolver {
   nodeSolver?: RectDiffSolver
   nodeTargetMerger?: CapacityNodeTargetMerger
   edgeSolver?: CapacityMeshEdgeSolver
-  initialPathingSolver?: CapacityPathingGreedySolver
-  pathingOptimizer?: CapacityPathingMultiSectionSolver
-  edgeToPortSegmentSolver?: CapacityEdgeToPortSegmentSolver
   colorMap: Record<string, string>
-  segmentToPointSolver?: CapacitySegmentToPointSolver
-  unravelMultiSectionSolver?: UnravelMultiSectionSolver
+  availableSegmentPointSolver?: AvailableSegmentPointSolver
+  portPointPathingSolver?: PortPointPathingSolver
   segmentToPointOptimizer?: CapacitySegmentPointOptimizer
   highDensityRouteSolver?: HighDensitySolver
   highDensityStitchSolver?: MultipleHighDensityRouteStitchSolver
@@ -202,98 +187,34 @@ export class AutoroutingPipelineSolver extends BaseSolver {
       },
     ),
     definePipelineStep(
-      "initialPathingSolver",
-      CapacityPathingGreedySolver,
+      "availableSegmentPointSolver",
+      AvailableSegmentPointSolver,
+      (cms) => [
+        {
+          nodes: cms.capacityNodes!,
+          edges: cms.capacityEdges || [],
+          traceWidth: cms.minTraceWidth,
+        },
+      ],
+    ),
+    definePipelineStep(
+      "portPointPathingSolver",
+      PortPointPathingSolver,
       (cms) => [
         {
           simpleRouteJson: cms.srjWithPointPairs!,
           nodes: cms.capacityNodes!,
           edges: cms.capacityEdges || [],
+          availableSegmentPoints:
+            cms.availableSegmentPointSolver?.availableSegmentPoints ?? [],
           colorMap: cms.colorMap,
-          hyperParameters: {
-            MAX_CAPACITY_FACTOR: 1,
-          },
-        },
-      ],
-    ),
-    definePipelineStep(
-      "pathingOptimizer",
-      // CapacityPathingSolver5,
-      CapacityPathingMultiSectionSolver,
-      (cms) => [
-        // Replaced solver class
-        {
-          initialPathingSolver: cms.initialPathingSolver,
-          simpleRouteJson: cms.srjWithPointPairs!,
-          nodes: cms.capacityNodes!,
-          edges: cms.capacityEdges || [],
-          colorMap: cms.colorMap,
-          cacheProvider: cms.cacheProvider,
-          hyperParameters: {
-            MAX_CAPACITY_FACTOR: 1,
-          },
-        },
-      ],
-    ),
-    definePipelineStep(
-      "edgeToPortSegmentSolver",
-      CapacityEdgeToPortSegmentSolver,
-      (cms) => [
-        {
-          nodes: cms.capacityNodes!,
-          edges: cms.capacityEdges || [],
-          capacityPaths: cms.pathingOptimizer?.getCapacityPaths() || [],
-          colorMap: cms.colorMap,
-        },
-      ],
-    ),
-    definePipelineStep(
-      "segmentToPointSolver",
-      CapacitySegmentToPointSolver,
-      (cms) => {
-        const allSegments: NodePortSegment[] = []
-        if (cms.edgeToPortSegmentSolver?.nodePortSegments) {
-          cms.edgeToPortSegmentSolver.nodePortSegments.forEach((segs) => {
-            allSegments.push(...segs)
-          })
-        }
-        return [
-          {
-            segments: allSegments,
-            colorMap: cms.colorMap,
-            nodes: cms.capacityNodes!,
-          },
-        ]
-      },
-    ),
-    // definePipelineStep(
-    //   "segmentToPointOptimizer",
-    //   CapacitySegmentPointOptimizer,
-    //   (cms) => [
-    //     {
-    //       assignedSegments: cms.segmentToPointSolver?.solvedSegments || [],
-    //       colorMap: cms.colorMap,
-    //       nodes: cms.nodeTargetMerger?.newNodes || [],
-    //       viaDiameter: cms.viaDiameter,
-    //     },
-    //   ],
-    // ),
-    definePipelineStep(
-      "unravelMultiSectionSolver",
-      UnravelMultiSectionSolver,
-      (cms) => [
-        {
-          assignedSegments: cms.segmentToPointSolver?.solvedSegments || [],
-          colorMap: cms.colorMap,
-          nodes: cms.capacityNodes!,
-          cacheProvider: this.cacheProvider,
         },
       ],
     ),
     definePipelineStep("highDensityRouteSolver", HighDensitySolver, (cms) => [
       {
         nodePortPoints:
-          cms.unravelMultiSectionSolver?.getNodesWithPortPoints() ??
+          cms.portPointPathingSolver?.getNodesWithPortPoints() ??
           cms.segmentToPointOptimizer?.getNodesWithPortPoints() ??
           [],
         colorMap: cms.colorMap,
@@ -424,13 +345,9 @@ export class AutoroutingPipelineSolver extends BaseSolver {
     const strawSolverViz = this.strawSolver?.visualize()
     const edgeViz = this.edgeSolver?.visualize()
     const deadEndViz = this.deadEndSolver?.visualize()
-    const initialPathingViz = this.initialPathingSolver?.visualize()
-    const pathingOptimizerViz = this.pathingOptimizer?.visualize()
-    const edgeToPortSegmentViz = this.edgeToPortSegmentSolver?.visualize()
-    const segmentToPointViz = this.segmentToPointSolver?.visualize()
-    const segmentOptimizationViz =
-      this.unravelMultiSectionSolver?.visualize() ??
-      this.segmentToPointOptimizer?.visualize()
+    const availableSegmentPointViz =
+      this.availableSegmentPointSolver?.visualize?.()
+    const portPointPathingViz = this.portPointPathingSolver?.visualize?.()
     const highDensityViz = this.highDensityRouteSolver?.visualize()
     const highDensityStitchViz = this.highDensityStitchSolver?.visualize()
     const traceSimplificationViz = this.traceSimplificationSolver?.visualize()
@@ -502,11 +419,8 @@ export class AutoroutingPipelineSolver extends BaseSolver {
       strawSolverViz,
       edgeViz,
       deadEndViz,
-      initialPathingViz,
-      pathingOptimizerViz,
-      edgeToPortSegmentViz,
-      segmentToPointViz,
-      segmentOptimizationViz,
+      availableSegmentPointViz,
+      portPointPathingViz,
       highDensityViz ? combineVisualizations(problemViz, highDensityViz) : null,
       highDensityStitchViz,
       traceSimplificationViz,
@@ -547,19 +461,19 @@ export class AutoroutingPipelineSolver extends BaseSolver {
       return { lines }
     }
 
-    if (this.pathingOptimizer) {
-      const lines: Line[] = []
-      for (const connection of this.pathingOptimizer.connectionsWithNodes) {
-        if (!connection.path) continue
-        lines.push({
-          points: connection.path.map((n) => ({
-            x: n.center.x,
-            y: n.center.y,
-          })),
-          strokeColor: this.colorMap[connection.connection.name],
-        })
+    if (this.portPointPathingSolver && this.portPointPathingSolver.solved) {
+      const points: GraphicsObject["points"] = []
+      for (const node of this.portPointPathingSolver.getNodesWithPortPoints()) {
+        for (const pt of node.portPoints) {
+          points?.push({
+            x: pt.x,
+            y: pt.y,
+            label: `${pt.connectionName}`,
+            color: this.colorMap[pt.connectionName ?? ""] ?? "#555",
+          })
+        }
       }
-      return { lines }
+      return { points: points ?? [] }
     }
 
     // This output is good as-is

--- a/lib/solvers/AvailableSegmentPointSolver.ts
+++ b/lib/solvers/AvailableSegmentPointSolver.ts
@@ -1,0 +1,137 @@
+import { BaseSolver } from "./BaseSolver"
+import type { CapacityMeshEdge, CapacityMeshNode } from "lib/types"
+
+export type AvailableSegmentPoint = {
+  id: string
+  nodeId: string
+  edgeId: string
+  x: number
+  y: number
+  z: number
+  partnerId: string
+}
+
+export class AvailableSegmentPointSolver extends BaseSolver {
+  nodes: CapacityMeshNode[]
+  edges: CapacityMeshEdge[]
+  traceWidth: number
+  availableSegmentPoints: AvailableSegmentPoint[] = []
+
+  constructor({
+    nodes,
+    edges,
+    traceWidth,
+  }: {
+    nodes: CapacityMeshNode[]
+    edges: CapacityMeshEdge[]
+    traceWidth: number
+  }) {
+    super()
+    this.nodes = nodes
+    this.edges = edges
+    this.traceWidth = traceWidth
+    this.MAX_ITERATIONS = 1
+  }
+
+  _step() {
+    for (const edge of this.edges) {
+      const [nodeAId, nodeBId] = edge.nodeIds
+      const nodeA = this.nodes.find((n) => n.capacityMeshNodeId === nodeAId)
+      const nodeB = this.nodes.find((n) => n.capacityMeshNodeId === nodeBId)
+      if (!nodeA || !nodeB) continue
+
+      const mutuallyAvailableZ = nodeA.availableZ.filter((z) =>
+        nodeB.availableZ.includes(z),
+      )
+
+      if (mutuallyAvailableZ.length === 0) continue
+
+      const segment = findOverlappingSegment(nodeA, nodeB)
+      const segLength = Math.hypot(
+        segment.end.x - segment.start.x,
+        segment.end.y - segment.start.y,
+      )
+      const portCount = Math.max(1, Math.floor(segLength / this.traceWidth))
+
+      for (const z of mutuallyAvailableZ) {
+        for (let i = 1; i <= portCount; i++) {
+          const fraction = i / (portCount + 1)
+          const x =
+            segment.start.x + (segment.end.x - segment.start.x) * fraction
+          const y =
+            segment.start.y + (segment.end.y - segment.start.y) * fraction
+
+          const idA = `${edge.capacityMeshEdgeId}-${z}-${i}-A`
+          const idB = `${edge.capacityMeshEdgeId}-${z}-${i}-B`
+
+          this.availableSegmentPoints.push(
+            {
+              id: idA,
+              nodeId: nodeA.capacityMeshNodeId,
+              edgeId: edge.capacityMeshEdgeId,
+              x,
+              y,
+              z,
+              partnerId: idB,
+            },
+            {
+              id: idB,
+              nodeId: nodeB.capacityMeshNodeId,
+              edgeId: edge.capacityMeshEdgeId,
+              x,
+              y,
+              z,
+              partnerId: idA,
+            },
+          )
+        }
+      }
+    }
+
+    this.solved = true
+  }
+}
+
+function findOverlappingSegment(
+  node: CapacityMeshNode,
+  adjNode: CapacityMeshNode,
+): { start: { x: number; y: number }; end: { x: number; y: number } } {
+  const xOverlap = {
+    start: Math.max(
+      node.center.x - node.width / 2,
+      adjNode.center.x - adjNode.width / 2,
+    ),
+    end: Math.min(
+      node.center.x + node.width / 2,
+      adjNode.center.x + adjNode.width / 2,
+    ),
+  }
+
+  const yOverlap = {
+    start: Math.max(
+      node.center.y - node.height / 2,
+      adjNode.center.y - adjNode.height / 2,
+    ),
+    end: Math.min(
+      node.center.y + node.height / 2,
+      adjNode.center.y + adjNode.height / 2,
+    ),
+  }
+
+  const xRange = xOverlap.end - xOverlap.start
+  const yRange = yOverlap.end - yOverlap.start
+
+  if (xRange < yRange) {
+    const x = (xOverlap.start + xOverlap.end) / 2
+    return {
+      start: { x, y: yOverlap.start },
+      end: { x, y: yOverlap.end },
+    }
+  } else {
+    const y = (yOverlap.start + yOverlap.end) / 2
+    return {
+      start: { x: xOverlap.start, y },
+      end: { x: xOverlap.end, y },
+    }
+  }
+}

--- a/lib/solvers/PortPointPathingSolver.ts
+++ b/lib/solvers/PortPointPathingSolver.ts
@@ -1,0 +1,221 @@
+import { BaseSolver } from "./BaseSolver"
+import type {
+  CapacityMeshEdge,
+  CapacityMeshNode,
+  SimpleRouteJson,
+} from "lib/types"
+import { AvailableSegmentPoint } from "./AvailableSegmentPointSolver"
+import { calculateNodeProbabilityOfFailure } from "./UnravelSolver/calculateCrossingProbabilityOfFailure"
+import type {
+  NodeWithPortPoints,
+  PortPoint,
+} from "lib/types/high-density-types"
+
+interface GraphEdge {
+  target: string
+  weight: number
+}
+
+export class PortPointPathingSolver extends BaseSolver {
+  connections: SimpleRouteJson["connections"]
+  nodes: CapacityMeshNode[]
+  edges: CapacityMeshEdge[]
+  availableSegmentPoints: AvailableSegmentPoint[]
+  colorMap: Record<string, string>
+
+  nodeMap: Map<string, CapacityMeshNode>
+  adjacency: Map<string, GraphEdge[]> = new Map()
+  usedPortPoints: Map<string, PortPoint[]> = new Map()
+
+  constructor({
+    simpleRouteJson,
+    nodes,
+    edges,
+    availableSegmentPoints,
+    colorMap,
+  }: {
+    simpleRouteJson: SimpleRouteJson
+    nodes: CapacityMeshNode[]
+    edges: CapacityMeshEdge[]
+    availableSegmentPoints: AvailableSegmentPoint[]
+    colorMap?: Record<string, string>
+  }) {
+    super()
+    this.connections = simpleRouteJson.connections
+    this.nodes = nodes
+    this.edges = edges
+    this.availableSegmentPoints = availableSegmentPoints
+    this.colorMap = colorMap ?? {}
+    this.nodeMap = new Map(nodes.map((n) => [n.capacityMeshNodeId, n]))
+    this.MAX_ITERATIONS = 10_000
+    this.buildAdjacency()
+  }
+
+  buildAdjacency() {
+    const pointsByNode = new Map<string, AvailableSegmentPoint[]>()
+    for (const pt of this.availableSegmentPoints) {
+      if (!pointsByNode.has(pt.nodeId)) pointsByNode.set(pt.nodeId, [])
+      pointsByNode.get(pt.nodeId)!.push(pt)
+    }
+
+    for (const pt of this.availableSegmentPoints) {
+      const neighbors: GraphEdge[] = []
+
+      // Connect to partner across edge
+      const partner = this.availableSegmentPoints.find(
+        (p) => p.id === pt.partnerId,
+      )
+      if (partner) {
+        neighbors.push({
+          target: partner.id,
+          weight: 0.001,
+        })
+      }
+
+      // Connect to other points within node
+      const siblings = pointsByNode.get(pt.nodeId) ?? []
+      const node = this.nodeMap.get(pt.nodeId)
+      for (const sibling of siblings) {
+        if (sibling.id === pt.id) continue
+        const distance = Math.hypot(sibling.x - pt.x, sibling.y - pt.y)
+        const entryExitLayerChanges = sibling.z === pt.z ? 0 : 1
+        const transitionCrossings = entryExitLayerChanges
+        const pf = node
+          ? calculateNodeProbabilityOfFailure(
+              node,
+              0,
+              entryExitLayerChanges,
+              transitionCrossings,
+            )
+          : 0
+        const weight = distance + pf
+        neighbors.push({ target: sibling.id, weight })
+      }
+
+      this.adjacency.set(pt.id, neighbors)
+    }
+  }
+
+  _step() {
+    for (const connection of this.connections) {
+      const targetNodes = this.nodes.filter(
+        (n) => n._targetConnectionName === connection.name,
+      )
+      if (targetNodes.length < 2) continue
+      const [startNode, endNode] = targetNodes
+
+      const startPoints = this.availableSegmentPoints.filter(
+        (pt) => pt.nodeId === startNode.capacityMeshNodeId,
+      )
+      const endPoints = this.availableSegmentPoints.filter(
+        (pt) => pt.nodeId === endNode.capacityMeshNodeId,
+      )
+
+      if (startPoints.length === 0 || endPoints.length === 0) continue
+
+      const { path } = shortestPath(
+        this.adjacency,
+        startPoints.map((p) => p.id),
+        new Set(endPoints.map((p) => p.id)),
+      )
+      if (!path) continue
+
+      for (const pointId of path) {
+        const point = this.availableSegmentPoints.find((p) => p.id === pointId)
+        if (!point) continue
+        if (!this.usedPortPoints.has(point.nodeId)) {
+          const node = this.nodeMap.get(point.nodeId)!
+          this.usedPortPoints.set(point.nodeId, [
+            {
+              x: node.center.x,
+              y: node.center.y,
+              z: point.z,
+              connectionName: connection.name,
+            },
+          ])
+        }
+        this.usedPortPoints.get(point.nodeId)!.push({
+          x: point.x,
+          y: point.y,
+          z: point.z,
+          connectionName: connection.name,
+          rootConnectionName: connection.netConnectionName,
+        })
+      }
+    }
+
+    this.solved = true
+  }
+
+  getNodesWithPortPoints(): NodeWithPortPoints[] {
+    if (!this.solved) {
+      throw new Error("PortPointPathingSolver not solved")
+    }
+
+    return this.nodes.map((node) => ({
+      capacityMeshNodeId: node.capacityMeshNodeId,
+      center: node.center,
+      width: node.width,
+      height: node.height,
+      portPoints: this.usedPortPoints.get(node.capacityMeshNodeId) ?? [],
+      availableZ: node.availableZ,
+    }))
+  }
+}
+
+function shortestPath(
+  adjacency: Map<string, GraphEdge[]>,
+  startIds: string[],
+  goalIds: Set<string>,
+): { path: string[] | null } {
+  const distances = new Map<string, number>()
+  const previous = new Map<string, string | null>()
+  const queue = new Set<string>()
+
+  for (const start of startIds) {
+    distances.set(start, 0)
+    previous.set(start, null)
+    queue.add(start)
+  }
+
+  const getMin = () => {
+    let minId: string | null = null
+    let minDist = Infinity
+    for (const id of queue) {
+      const dist = distances.get(id) ?? Infinity
+      if (dist < minDist) {
+        minDist = dist
+        minId = id
+      }
+    }
+    return { minId, minDist }
+  }
+
+  while (queue.size > 0) {
+    const { minId } = getMin()
+    if (!minId) break
+    queue.delete(minId)
+
+    if (goalIds.has(minId)) {
+      const path = []
+      let current: string | null = minId
+      while (current) {
+        path.unshift(current)
+        current = previous.get(current) ?? null
+      }
+      return { path }
+    }
+
+    const neighbors = adjacency.get(minId) ?? []
+    for (const { target, weight } of neighbors) {
+      const alt = (distances.get(minId) ?? Infinity) + weight
+      if (alt < (distances.get(target) ?? Infinity)) {
+        distances.set(target, alt)
+        previous.set(target, minId)
+        queue.add(target)
+      }
+    }
+  }
+
+  return { path: null }
+}


### PR DESCRIPTION
## Summary
- introduce available port point discovery before pathing to build a layer-aware adjacency graph
- add port point-based pathing solver using crossing probability costs and wire it into the autorouting pipeline
- update pipeline visualization/preview to reflect new solvers and port point usage

## Testing
- `bunx tsc --noEmit` *(hangs; interrupted)*
- `bun run format`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693b34ab8d40832eb99e1f907a536ed0)