### PR TITLE
Display full active solver chain in pipeline debugger

### DIFF
--- a/lib/testing/AutoroutingPipelineDebugger.tsx
+++ b/lib/testing/AutoroutingPipelineDebugger.tsx
@@ -630,7 +630,15 @@ export const AutoroutingPipelineDebugger = ({
         <div className="border p-2 rounded">
           Active Stage:{" "}
           <span className="font-bold">
-            {solver.activeSubSolver?.constructor.name ?? "None"}
+            {(() => {
+              const chain: string[] = []
+              let current = solver.activeSubSolver
+              while (current) {
+                chain.push(current.constructor.name)
+                current = current.activeSubSolver
+              }
+              return chain.length > 0 ? chain.join(" -> ") : "None"
+            })()}
           </span>
         </div>
         {solver.error && (


### PR DESCRIPTION
## Summary
- Shows the complete hierarchy of nested active sub-solvers in the debugger UI
- Displays solver chain as "SolverA -> SolverB -> SolverC" instead of just showing the immediate sub-solver
- Provides better visibility into the full solver execution stack

## Changes
- Modified `AutoroutingPipelineDebugger.tsx` to traverse the complete `activeSubSolver` chain
- Displays all nested solvers joined with arrows for clear visualization

## Test plan
- Open the autorouting pipeline debugger
- Verify that nested solver chains are displayed correctly
- Confirm the full hierarchy is visible when multiple solvers are active