### PR TITLE
Preserve identifier names during build minification

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "start": "cosmos",
-    "build": "tsup ./lib/index.ts --minify terser --external @tscircuit/core --external circuit-to-svg --format esm --dts --sourcemap",
+    "build": "tsup --config tsup.config.ts",
     "bench": "bun test tests/spatial-index-bench.test.ts",
     "format": "biome format --write .",
     "format:check": "biome format .",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "tsup"
+
+export default defineConfig({
+  entry: ["lib/index.ts"],
+  format: ["esm"],
+  dts: true,
+  sourcemap: true,
+  minify: "terser",
+  external: ["@tscircuit/core", "circuit-to-svg"],
+  keepNames: true,
+  terserOptions: {
+    mangle: false,
+    keep_classnames: true,
+    keep_fnames: true,
+  },
+})


### PR DESCRIPTION
## Summary
- add a tsup configuration that keeps function/class names and disables identifier mangling in Terser
- update the build script to use the shared tsup config
- note that the build output size increased from 393,822 bytes to 584,622 bytes because names are preserved

## Testing
- ✅ bun run build
- ⚠️ bunx tsc --noEmit *(fails due to existing TS2345 errors in tests/core1.test.tsx, tests/core2.test.tsx, tests/core3.test.tsx)*
- ✅ bun run format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69433caf0c8c832ebe5b946075ccb1fc)