### PR TITLE
Improve error propagation from ViaPossibilitiesSolver2

### DIFF
--- a/lib/solvers/HighDensitySolver/MultiHeadPolyLineIntraNodeSolver/MultiHeadPolyLineIntraNodeSolver3_ViaPossibilitiesSolverIntegration.ts
+++ b/lib/solvers/HighDensitySolver/MultiHeadPolyLineIntraNodeSolver/MultiHeadPolyLineIntraNodeSolver3_ViaPossibilitiesSolverIntegration.ts
@@ -49,6 +49,8 @@ export class MultiHeadPolyLineIntraNodeSolver3 extends MultiHeadPolyLineIntraNod
     viaSolver.solve()
 
     if (viaSolver.failed || !viaSolver.solved) {
+      this.failed = true
+      this.error = `ViaPossibilitiesSolver2 failed with: ${viaSolver.error}`
       return null
     }
 

--- a/lib/solvers/ViaPossibilitiesSolver/ViaPossibilitiesSolver2.ts
+++ b/lib/solvers/ViaPossibilitiesSolver/ViaPossibilitiesSolver2.ts
@@ -250,6 +250,7 @@ export class ViaPossibilitiesSolver2 extends BaseSolver {
       // Check if adding this via would exceed the limit
       if (this.currentViaCount >= this.maxViaCount) {
         this.failed = true
+        this.error = `Exceeded max via count of ${this.maxViaCount}`
         return
       }
     }
@@ -280,7 +281,7 @@ export class ViaPossibilitiesSolver2 extends BaseSolver {
       // Determine the Z level to switch to (the one NOT occupied by the intersected segment)
       const nextZ = this.availableZ.find((z) => z !== intersectedSegmentZ)!
       if (nextZ === undefined) {
-        console.error("Could not determine next Z level for via placement!")
+        this.error = "Could not determine next Z level for via placement!"
         this.failed = true // Mark as failed if Z logic breaks
         return
       }


### PR DESCRIPTION
This change improves error handling and propagation in the ViaPossibilitiesSolver2 and its consumers.             

 • Sets the .error property in ViaPossibilitiesSolver2 when it fails due to exceeding the maximum via count or    
   being unable to determine a Z-layer for a via.                                                                 
 • Updates MultiHeadPolyLineIntraNodeSolver3 to propagate the error message from a failed ViaPossibilitiesSolver2 
   instance.                                                                                                      

This makes debugging solver failures easier by providing specific error messages instead of just a failed: true   
status. 