### PR TITLE
refactor: consolidate redundant layer transition features in getIntraNodeCrossings

### DIFF
--- a/lib/solvers/HighDensitySolver/MultiHeadPolyLineIntraNodeSolver/MultiHeadPolyLineIntraNodeSolver.ts
+++ b/lib/solvers/HighDensitySolver/MultiHeadPolyLineIntraNodeSolver/MultiHeadPolyLineIntraNodeSolver.ts
@@ -107,11 +107,10 @@ export class MultiHeadPolyLineIntraNodeSolver extends BaseSolver {
     ).size
     this.uniqueConnections = uniqueConnections
 
-    const { numSameLayerCrossings, numTransitions } = getIntraNodeCrossings(
-      this.nodeWithPortPoints,
-    )
+    const { numSameLayerCrossings, numEntryExitLayerChanges } =
+      getIntraNodeCrossings(this.nodeWithPortPoints)
 
-    this.minViaCount = numSameLayerCrossings * 2 + numTransitions
+    this.minViaCount = numSameLayerCrossings * 2 + numEntryExitLayerChanges
     this.maxViaCount = Math.min(
       Math.floor(areaInsideNode / areaPerVia),
       Math.ceil(uniqueConnections * 1.5),

--- a/lib/utils/getIntraNodeCrossings.ts
+++ b/lib/utils/getIntraNodeCrossings.ts
@@ -15,8 +15,6 @@ export const getIntraNodeCrossings = (node: NodeWithPortPoints) => {
     connectionName: string
   }[] = []
 
-  let numEntryExitLayerChanges = 0
-
   for (const A of node.portPoints) {
     if (pointPairs.some((p) => p.connectionName === A.connectionName)) {
       continue
@@ -37,7 +35,6 @@ export const getIntraNodeCrossings = (node: NodeWithPortPoints) => {
       pointPair.points.push({ x: B.x, y: B.y, z: B.z })
     }
     if (pointPair.points.some((p) => p.z !== pointPair.z)) {
-      numEntryExitLayerChanges++
       transitionPairPoints.push(pointPair)
       continue
     }
@@ -86,8 +83,7 @@ export const getIntraNodeCrossings = (node: NodeWithPortPoints) => {
 
   return {
     numSameLayerCrossings,
-    numEntryExitLayerChanges,
+    numEntryExitLayerChanges: transitionPairPoints.length,
     numTransitionPairCrossings,
-    numTransitions: transitionPairPoints.length,
   }
 }


### PR DESCRIPTION
Nutshell: **We were counting the layer transition twice**;


- Simplified getIntraNodeCrossings: Removed the redundant numTransitions return value and the manual numEntryExitLayerChanges counter. Both are now consolidated into a single numEntryExitLayerChanges field derived directly from transitionPairPoints.length.

- Updated MultiHeadPolyLineIntraNodeSolver: Aligned the solver with these changes by renaming its internal usage of numTransitions to numEntryExitLayerChanges.

- Improved Maintainability: The logic now has a single source of truth for layer-change counts, reducing the risk of divergent values.