### PR TITLE
Implement getConstructorParams for autorouting pipeline solvers

### DIFF
--- a/lib/autorouter-pipelines/AssignableAutoroutingPipeline1/AssignableAutoroutingPipeline1Solver.ts
+++ b/lib/autorouter-pipelines/AssignableAutoroutingPipeline1/AssignableAutoroutingPipeline1Solver.ts
@@ -457,6 +457,10 @@ export class AssignableAutoroutingPipeline1Solver extends BaseSolver {
     this.timeSpentOnPhase = {}
   }
 
+  getConstructorParams() {
+    return [this.srj, this.opts] as const
+  }
+
   currentPipelineStepIndex = 0
   _step() {
     const pipelineStepDef = this.pipelineDef[this.currentPipelineStepIndex]

--- a/lib/autorouter-pipelines/AssignableAutoroutingPipeline2/AssignableAutoroutingPipeline2.ts
+++ b/lib/autorouter-pipelines/AssignableAutoroutingPipeline2/AssignableAutoroutingPipeline2.ts
@@ -377,6 +377,10 @@ export class AssignableAutoroutingPipeline2 extends BaseSolver {
     this.timeSpentOnPhase = {}
   }
 
+  getConstructorParams() {
+    return [this.srj, this.opts] as const
+  }
+
   currentPipelineStepIndex = 0
   _step() {
     const pipelineStepDef = this.pipelineDef[this.currentPipelineStepIndex]

--- a/lib/autorouter-pipelines/AutoroutingPipeline1_OriginalUnravel/AutoroutingPipeline1_OriginalUnravel.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline1_OriginalUnravel/AutoroutingPipeline1_OriginalUnravel.ts
@@ -370,6 +370,10 @@ export class AutoroutingPipeline1_OriginalUnravel extends BaseSolver {
     this.timeSpentOnPhase = {}
   }
 
+  getConstructorParams() {
+    return [this.srj, this.opts] as const
+  }
+
   currentPipelineStepIndex = 0
   _step() {
     const pipelineStepDef = this.pipelineDef[this.currentPipelineStepIndex]

--- a/lib/autorouter-pipelines/AutoroutingPipeline2_PortPointPathing/AutoroutingPipelineSolver2_PortPointPathing.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline2_PortPointPathing/AutoroutingPipelineSolver2_PortPointPathing.ts
@@ -378,6 +378,10 @@ export class AutoroutingPipelineSolver2_PortPointPathing extends BaseSolver {
     this.timeSpentOnPhase = {}
   }
 
+  getConstructorParams() {
+    return [this.srj, this.opts] as const
+  }
+
   currentPipelineStepIndex = 0
   _step() {
     const pipelineStepDef = this.pipelineDef[this.currentPipelineStepIndex]


### PR DESCRIPTION
### Motivation

- The debugger and pipeline machinery expect `getConstructorParams` to be present so pipeline instances can be reconstructed without hitting the BaseSolver default error. 
- Several pipeline classes inherited from `BaseSolver` lacked an implementation and would throw when callers attempted to read constructor parameters. 

### Description

- Implement `getConstructorParams()` on the four pipeline solvers to return `[
  this.srj,
  this.opts
] as const` for consistent reconstruction. 
- Files modified: `AutoroutingPipeline1_OriginalUnravel.ts`, `AutoroutingPipelineSolver2_PortPointPathing.ts`, `AssignableAutoroutingPipeline1Solver.ts`, and `AssignableAutoroutingPipeline2.ts`.
- Keep constructor argument ordering aligned across pipeline variants so `getConstructorParams` returns the same shape for each pipeline.

### Testing

- Ran `bunx tsc --noEmit`, which reported TypeScript errors in `tests/core*.test.tsx` (type mismatches), so typecheck did not fully succeed. 
- Ran `bun run format`, which completed successfully and formatted files. 
- No unit tests were added or updated in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694b3bd435b4832e938d708e93feb7bd)