### PR TITLE
Fix intra-node overlap crossing detection and add regression test

### DIFF
--- a/lib/utils/getIntraNodeCrossings.ts
+++ b/lib/utils/getIntraNodeCrossings.ts
@@ -2,7 +2,7 @@ import { doSegmentsIntersect } from "@tscircuit/math-utils"
 import { NodeWithPortPoints } from "lib/types/high-density-types"
 
 // Intersection calculation is only accurate to 0.00001 (0.01mm)
-const intSpace = (a: number) => Math.floor(a * 10000)
+const intSpace = (a: number) => Math.round(a * 10000)
 
 export const getIntraNodeCrossings = (node: NodeWithPortPoints) => {
   // Count the number of crossings

--- a/tests/utils/getIntraNodeCrossings01.test.ts
+++ b/tests/utils/getIntraNodeCrossings01.test.ts
@@ -51,4 +51,65 @@ describe("getIntraNodeCrossings", () => {
 
     expect(result.numSameLayerCrossings).toBe(1)
   })
+
+  test("detects overlapping horizontal segments with floating point drift", () => {
+    const nodeWithPortPoints = {
+      capacityMeshNodeId: "cmn_6",
+      center: {
+        x: -2.7499999999999956,
+        y: 11.129999999999999,
+      },
+      width: 6.260000000000003,
+      height: 3.9399999999999995,
+      portPoints: [
+        {
+          x: -5.879999999999997,
+          y: 11.030000000000001,
+          z: 0,
+          connectionName: "source_net_1_mst4",
+          rootConnectionName: "source_net_1",
+        },
+        {
+          x: 0.3750000000000031,
+          y: 13.099999999999998,
+          z: 0,
+          connectionName: "source_net_1_mst4",
+          rootConnectionName: "source_net_1",
+        },
+        {
+          x: -5.294999999999999,
+          y: 13.1,
+          z: 0,
+          connectionName: "source_net_3",
+          rootConnectionName: "source_net_3",
+        },
+        {
+          x: -1.27,
+          y: 13.099999999999998,
+          z: 0,
+          connectionName: "source_net_3",
+          rootConnectionName: "source_net_3",
+        },
+        {
+          x: -5.654999999999998,
+          y: 13.1,
+          z: 0,
+          connectionName: "source_net_1_mst2",
+          rootConnectionName: "source_net_1",
+        },
+        {
+          x: -2.54,
+          y: 13.099999999999998,
+          z: 0,
+          connectionName: "source_net_1_mst2",
+          rootConnectionName: "source_net_1",
+        },
+      ],
+      availableZ: [0],
+    }
+
+    const result = getIntraNodeCrossings(nodeWithPortPoints)
+
+    expect(result.numSameLayerCrossings).toBe(1)
+  })
 })


### PR DESCRIPTION
### Motivation
- Floating point normalization in intra-node crossing detection used `Math.floor` which broke detection of colinear/overlapping segments after tiny coordinate drift. 
- The change aims to correctly detect overlaps inside a single node so `calculateNodePf` and related solvers get accurate crossing counts.

### Description
- Update the normalization helper `intSpace` in `getIntraNodeCrossings` from `Math.floor(a * 10000)` to `Math.round(a * 10000)` to preserve colinear overlaps. 
- Add a regression test that reproduces the floating-point drift case by exercising `getIntraNodeCrossings` for the problematic `cmn_6` node. 
- The test is added to `tests/utils/getIntraNodeCrossings01.test.ts` alongside the existing floating point crossing test.

### Testing
- Ran `bun test tests/utils/getIntraNodeCrossings01.test.ts` and both tests passed (2 pass, 0 fail). 
- Ran `bunx tsc --noEmit` which reported type errors in unrelated core test fixtures (`tests/core*.test.tsx`), so full typecheck failures are unrelated to the change in `getIntraNodeCrossings`.
- All automated tests added in this PR succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6951c71f1108832eaf3684bd1b713780)