### PR TITLE
Add multilayer board outline routes to TraceKeepoutSolver

### DIFF
--- a/lib/solvers/TraceKeepoutSolver/TraceKeepoutSolver.ts
+++ b/lib/solvers/TraceKeepoutSolver/TraceKeepoutSolver.ts
@@ -553,33 +553,23 @@ export class TraceKeepoutSolver extends BaseSolver {
     // Create a route for each edge of the outline (on all layers)
     // We create separate routes for each edge so the spatial index can find them efficiently
     // Each route needs a unique connection name for the spatial index
+    const layerCount = this.input.srj.layerCount ?? 2
     for (let i = 0; i < outlinePoints.length; i++) {
       const start = outlinePoints[i]!
       const end = outlinePoints[(i + 1) % outlinePoints.length]!
 
-      // Create route on z=0 (top layer)
-      routes.push({
-        connectionName: `${BOARD_OUTLINE_CONNECTION_NAME}_${i}_z0`,
-        traceThickness: 0.01, // Thin trace for outline
-        viaDiameter: 0,
-        route: [
-          { x: start.x, y: start.y, z: 0 },
-          { x: end.x, y: end.y, z: 0 },
-        ],
-        vias: [],
-      })
-
-      // Create route on z=1 (bottom layer)
-      routes.push({
-        connectionName: `${BOARD_OUTLINE_CONNECTION_NAME}_${i}_z1`,
-        traceThickness: 0.01,
-        viaDiameter: 0,
-        route: [
-          { x: start.x, y: start.y, z: 1 },
-          { x: end.x, y: end.y, z: 1 },
-        ],
-        vias: [],
-      })
+      for (let layerIndex = 0; layerIndex < layerCount; layerIndex++) {
+        routes.push({
+          connectionName: `${BOARD_OUTLINE_CONNECTION_NAME}_${i}_z${layerIndex}`,
+          traceThickness: 0.01, // Thin trace for outline
+          viaDiameter: 0,
+          route: [
+            { x: start.x, y: start.y, z: layerIndex },
+            { x: end.x, y: end.y, z: layerIndex },
+          ],
+          vias: [],
+        })
+      }
     }
 
     return routes


### PR DESCRIPTION
### Motivation
- The board outline was previously emitted only for two hardcoded layers which prevented correct multilayer keepout behavior.
- The solver needs outline traces on every board layer so the spatial index can treat the board edge as an obstacle per-layer.

### Description
- Update `createBoardOutlineRoutes` to derive `layerCount` from `this.input.srj.layerCount` with a default of `2`.
- Emit an outline `HighDensityRoute` for each outline edge on every layer by looping `layerIndex` from `0` to `layerCount-1` and setting the point `z` to `layerIndex`.
- Keep trace thickness, via diameter, and unique `connectionName` (now including the layer index) consistent with prior behavior.

### Testing
- Ran `bun test tests/features/keepoutsolver` against the updated solver.
- All automated tests in that suite passed: `4 pass`, `1 skip`, `0 fail`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6952c8793c8c8328a4ce601aaed3c5ed)