### PR TITLE
Fix jumper probability area calculation

### DIFF
--- a/lib/solvers/MultiSectionPortPointOptimizer/calculateNodeProbabilityOfFailureWithJumpers.ts
+++ b/lib/solvers/MultiSectionPortPointOptimizer/calculateNodeProbabilityOfFailureWithJumpers.ts
@@ -5,7 +5,8 @@ export const calculateNodeProbabilityOfFailureWithJumpers = (
   node: CapacityMeshNode,
   numSameLayerCrossings: number,
 ) => {
-  const nodeArea = node.width * node.height
+  const minDimension = Math.min(node.width, node.height)
+  const nodeArea = minDimension * minDimension
   const jumpersWeCanFitInNode = nodeArea * JUMPERS_PER_MM_SQUARED
   const estimatedRequiredJumpers = numSameLayerCrossings ** 1.5
   return Math.min(1, estimatedRequiredJumpers / jumpersWeCanFitInNode)


### PR DESCRIPTION
Instead of using width * height for the node area when calculating jumper probability, use the minimum dimension squared. This provides a more conservative estimate for elongated nodes where the smaller dimension is the limiting factor for fitting jumpers.