### PR TITLE
Export AutoroutingPipelineSolver3_HgPortPointPathing from lib index

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -5,6 +5,7 @@ export {
 export { AutoroutingPipeline1_OriginalUnravel } from "./autorouter-pipelines/AutoroutingPipeline1_OriginalUnravel/AutoroutingPipeline1_OriginalUnravel"
 export { AssignableAutoroutingPipeline2 } from "./autorouter-pipelines/AssignableAutoroutingPipeline2/AssignableAutoroutingPipeline2"
 export { AssignableAutoroutingPipeline3 } from "./autorouter-pipelines/AssignableAutoroutingPipeline3/AssignableAutoroutingPipeline3"
+export { AutoroutingPipelineSolver3_HgPortPointPathing } from "./autorouter-pipelines/AutoroutingPipeline2_PortPointPathing/AutoroutingPipelineSolver3_HgPortPointPathing"
 export {
   getTunedTotalCapacity1,
   calculateOptimalCapacityDepth,


### PR DESCRIPTION
### Motivation
- Expose `AutoroutingPipelineSolver3_HgPortPointPathing` from the package entrypoint so consumers can import the Hg port point pathing solver directly.

### Description
- Added `export { AutoroutingPipelineSolver3_HgPortPointPathing } from "./autorouter-pipelines/AutoroutingPipeline2_PortPointPathing/AutoroutingPipelineSolver3_HgPortPointPathing"` to `lib/index.ts`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698496a30ef08328926280a99f06bb8c)