### PR TITLE
Add port IDs to output trace wire segments

### DIFF
--- a/lib/autorouter-pipelines/AssignableAutoroutingPipeline1/AssignableAutoroutingPipeline1Solver.ts
+++ b/lib/autorouter-pipelines/AssignableAutoroutingPipeline1/AssignableAutoroutingPipeline1Solver.ts
@@ -41,6 +41,7 @@ import { HyperAssignableViaCapacityPathingSolver } from "./HyperAssignableViaCap
 import { AssignableViaCapacityPathingSolver_DirectiveSubOptimal } from "./AssignableViaCapacityPathing/AssignableViaCapacityPathingSolver_DirectiveSubOptimal"
 import { OffboardCapacityNodeSolver } from "./OffboardCapacityNodeSolver"
 import { OffboardPathFragmentSolver } from "./OffboardPathFragmentSolver"
+import { addPortIdsToRoute } from "lib/utils/addPortIdsToRoute"
 
 interface CapacityMeshSolverOptions {
   capacityDepth?: number
@@ -713,12 +714,20 @@ export class AssignableAutoroutingPipeline1Solver extends BaseSolver {
 
       for (let i = 0; i < hdRoutes.length; i++) {
         const hdRoute = hdRoutes[i]
+        const route = convertHdRouteToSimplifiedRoute(
+          hdRoute,
+          this.srj.layerCount,
+        )
+
+        // Add port IDs to the first and last wire segments
+        addPortIdsToRoute(route, connection.pointsToConnect)
+
         const simplifiedPcbTrace: SimplifiedPcbTrace = {
           type: "pcb_trace",
           pcb_trace_id: `${connection.name}_${i}`,
           connection_name:
             netConnectionName ?? rootConnectionName ?? connection.name,
-          route: convertHdRouteToSimplifiedRoute(hdRoute, this.srj.layerCount),
+          route,
         }
 
         traces.push(simplifiedPcbTrace)

--- a/lib/autorouter-pipelines/AssignableAutoroutingPipeline2/AssignableAutoroutingPipeline2.ts
+++ b/lib/autorouter-pipelines/AssignableAutoroutingPipeline2/AssignableAutoroutingPipeline2.ts
@@ -54,6 +54,7 @@ import {
 } from "lib/solvers/PortPointPathingSolver/HyperPortPointPathingSolver"
 import { RelateNodesToOffBoardConnectionsSolver } from "./RelateNodesToOffBoardConnectionsSolver"
 import { updateConnMapWithOffboardObstacleConnections } from "./updateConnMapWithOffboardObstacleConnections"
+import { addPortIdsToRoute } from "lib/utils/addPortIdsToRoute"
 
 interface CapacityMeshSolverOptions {
   capacityDepth?: number
@@ -725,6 +726,14 @@ export class AssignableAutoroutingPipeline2 extends BaseSolver {
 
       for (let i = 0; i < hdRoutes.length; i++) {
         const hdRoute = hdRoutes[i]
+        const route = convertHdRouteToSimplifiedRoute(
+          hdRoute,
+          this.srj.layerCount,
+        )
+
+        // Add port IDs to the first and last wire segments
+        addPortIdsToRoute(route, connection.pointsToConnect)
+
         const simplifiedPcbTrace: SimplifiedPcbTrace = {
           type: "pcb_trace",
           pcb_trace_id: `${connection.name}_${i}`,
@@ -732,7 +741,7 @@ export class AssignableAutoroutingPipeline2 extends BaseSolver {
             netConnectionName ??
             connection.rootConnectionName ??
             connection.name,
-          route: convertHdRouteToSimplifiedRoute(hdRoute, this.srj.layerCount),
+          route,
         }
 
         traces.push(simplifiedPcbTrace)

--- a/lib/autorouter-pipelines/AssignableAutoroutingPipeline3/AssignableAutoroutingPipeline3.ts
+++ b/lib/autorouter-pipelines/AssignableAutoroutingPipeline3/AssignableAutoroutingPipeline3.ts
@@ -62,6 +62,7 @@ import {
 import { RelateNodesToOffBoardConnectionsSolver } from "../AssignableAutoroutingPipeline2/RelateNodesToOffBoardConnectionsSolver"
 import { updateConnMapWithOffboardObstacleConnections } from "../AssignableAutoroutingPipeline2/updateConnMapWithOffboardObstacleConnections"
 import { TraceKeepoutSolver } from "lib/solvers/TraceKeepoutSolver/TraceKeepoutSolver"
+import { addPortIdsToRoute } from "lib/utils/addPortIdsToRoute"
 
 interface CapacityMeshSolverOptions {
   capacityDepth?: number
@@ -774,6 +775,14 @@ export class AssignableAutoroutingPipeline3 extends BaseSolver {
 
       for (let i = 0; i < hdRoutes.length; i++) {
         const hdRoute = hdRoutes[i]
+        const route = convertHdRouteToSimplifiedRoute(
+          hdRoute,
+          this.srj.layerCount,
+        )
+
+        // Add port IDs to the first and last wire segments
+        addPortIdsToRoute(route, connection.pointsToConnect)
+
         const simplifiedPcbTrace: SimplifiedPcbTrace = {
           type: "pcb_trace",
           pcb_trace_id: `${connection.name}_${i}`,
@@ -781,7 +790,7 @@ export class AssignableAutoroutingPipeline3 extends BaseSolver {
             netConnectionName ??
             connection.rootConnectionName ??
             connection.name,
-          route: convertHdRouteToSimplifiedRoute(hdRoute, this.srj.layerCount),
+          route,
         }
 
         traces.push(simplifiedPcbTrace)

--- a/lib/autorouter-pipelines/AutoroutingPipeline1_OriginalUnravel/AutoroutingPipeline1_OriginalUnravel.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline1_OriginalUnravel/AutoroutingPipeline1_OriginalUnravel.ts
@@ -54,6 +54,7 @@ import { NetToPointPairsSolver2_OffBoardConnection } from "lib/solvers/NetToPoin
 import { RectDiffPipeline } from "@tscircuit/rectdiff"
 import { TraceSimplificationSolver } from "lib/solvers/TraceSimplificationSolver/TraceSimplificationSolver"
 import { NoOffBoardMultipleHighDensityRouteStitchSolver } from "lib/solvers/RouteStitchingSolver/NoOffBoardMultipleHighDensityRouteStitchSolver"
+import { addPortIdsToRoute } from "lib/utils/addPortIdsToRoute"
 
 interface CapacityMeshSolverOptions {
   capacityDepth?: number
@@ -620,6 +621,14 @@ export class AutoroutingPipeline1_OriginalUnravel extends BaseSolver {
 
       for (let i = 0; i < hdRoutes.length; i++) {
         const hdRoute = hdRoutes[i]
+        const route = convertHdRouteToSimplifiedRoute(
+          hdRoute,
+          this.srj.layerCount,
+        )
+
+        // Add port IDs to the first and last wire segments
+        addPortIdsToRoute(route, connection.pointsToConnect)
+
         const simplifiedPcbTrace: SimplifiedPcbTrace = {
           type: "pcb_trace",
           pcb_trace_id: `${connection.name}_${i}`,
@@ -627,7 +636,7 @@ export class AutoroutingPipeline1_OriginalUnravel extends BaseSolver {
             netConnectionName ??
             connection.rootConnectionName ??
             connection.name,
-          route: convertHdRouteToSimplifiedRoute(hdRoute, this.srj.layerCount),
+          route,
         }
 
         traces.push(simplifiedPcbTrace)

--- a/lib/autorouter-pipelines/AutoroutingPipeline2_PortPointPathing/AutoroutingPipelineSolver2_PortPointPathing.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline2_PortPointPathing/AutoroutingPipelineSolver2_PortPointPathing.ts
@@ -49,6 +49,7 @@ import { UniformPortDistributionSolver } from "lib/solvers/UniformPortDistributi
 import { TraceWidthSolver } from "../../solvers/TraceWidthSolver/TraceWidthSolver"
 import { getDrcErrors } from "lib/testing/getDrcErrors"
 import { convertToCircuitJson } from "lib/testing/utils/convertToCircuitJson"
+import { addPortIdsToRoute } from "lib/utils/addPortIdsToRoute"
 
 interface CapacityMeshSolverOptions {
   capacityDepth?: number
@@ -655,6 +656,14 @@ export class AutoroutingPipelineSolver2_PortPointPathing extends BaseSolver {
 
       for (let i = 0; i < hdRoutes.length; i++) {
         const hdRoute = hdRoutes[i]
+        const route = convertHdRouteToSimplifiedRoute(
+          hdRoute,
+          this.srj.layerCount,
+        )
+
+        // Add port IDs to the first and last wire segments
+        addPortIdsToRoute(route, connection.pointsToConnect)
+
         const simplifiedPcbTrace: SimplifiedPcbTrace = {
           type: "pcb_trace",
           pcb_trace_id: `${connection.name}_${i}`,
@@ -662,7 +671,7 @@ export class AutoroutingPipelineSolver2_PortPointPathing extends BaseSolver {
             netConnectionName ??
             connection.rootConnectionName ??
             connection.name,
-          route: convertHdRouteToSimplifiedRoute(hdRoute, this.srj.layerCount),
+          route,
         }
 
         traces.push(simplifiedPcbTrace)

--- a/lib/autorouter-pipelines/AutoroutingPipeline2_PortPointPathing/AutoroutingPipelineSolver3_HgPortPointPathing.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline2_PortPointPathing/AutoroutingPipelineSolver3_HgPortPointPathing.ts
@@ -50,6 +50,7 @@ import { UniformPortDistributionSolver } from "lib/solvers/UniformPortDistributi
 import { TraceWidthSolver } from "../../solvers/TraceWidthSolver/TraceWidthSolver"
 import { getDrcErrors } from "lib/testing/getDrcErrors"
 import { convertToCircuitJson } from "lib/testing/utils/convertToCircuitJson"
+import { addPortIdsToRoute } from "lib/utils/addPortIdsToRoute"
 
 interface CapacityMeshSolverOptions {
   capacityDepth?: number
@@ -662,6 +663,14 @@ export class AutoroutingPipelineSolver3_HgPortPointPathing extends BaseSolver {
 
       for (let i = 0; i < hdRoutes.length; i++) {
         const hdRoute = hdRoutes[i]
+        const route = convertHdRouteToSimplifiedRoute(
+          hdRoute,
+          this.srj.layerCount,
+        )
+
+        // Add port IDs to the first and last wire segments
+        addPortIdsToRoute(route, connection.pointsToConnect)
+
         const simplifiedPcbTrace: SimplifiedPcbTrace = {
           type: "pcb_trace",
           pcb_trace_id: `${connection.name}_${i}`,
@@ -669,7 +678,7 @@ export class AutoroutingPipelineSolver3_HgPortPointPathing extends BaseSolver {
             netConnectionName ??
             connection.rootConnectionName ??
             connection.name,
-          route: convertHdRouteToSimplifiedRoute(hdRoute, this.srj.layerCount),
+          route,
         }
 
         traces.push(simplifiedPcbTrace)

--- a/lib/types/srj-types.ts
+++ b/lib/types/srj-types.ts
@@ -90,6 +90,10 @@ export interface SimplifiedPcbTrace {
         y: number
         width: number
         layer: string
+        /** ID of the pcb_port this wire segment starts from (only on first wire segment) */
+        start_pcb_port_id?: string
+        /** ID of the pcb_port this wire segment ends at (only on last wire segment) */
+        end_pcb_port_id?: string
       }
     | {
         route_type: "via"

--- a/lib/utils/addPortIdsToRoute.ts
+++ b/lib/utils/addPortIdsToRoute.ts
@@ -1,0 +1,46 @@
+import type { ConnectionPoint, SimplifiedPcbTraces } from "lib/types"
+
+/**
+ * Adds start_pcb_port_id and end_pcb_port_id to the first and last wire
+ * segments of a route based on the connection's pointsToConnect.
+ *
+ * This is critical for downstream tools (like DRC checks) that need to
+ * build connectivity maps to determine which traces connect to which ports.
+ */
+export const addPortIdsToRoute = (
+  route: SimplifiedPcbTraces[number]["route"],
+  pointsToConnect: ConnectionPoint[],
+): void => {
+  if (route.length === 0 || pointsToConnect.length < 2) return
+
+  const startPortId = pointsToConnect[0]?.pcb_port_id
+  const endPortId = pointsToConnect[1]?.pcb_port_id
+
+  // Find first wire segment and add start_pcb_port_id
+  if (startPortId) {
+    const firstWireIndex = route.findIndex((s) => s.route_type === "wire")
+    if (firstWireIndex !== -1) {
+      const segment = route[firstWireIndex]
+      if (segment.route_type === "wire") {
+        segment.start_pcb_port_id = startPortId
+      }
+    }
+  }
+
+  // Find last wire segment and add end_pcb_port_id
+  if (endPortId) {
+    let lastWireIndex = -1
+    for (let i = route.length - 1; i >= 0; i--) {
+      if (route[i].route_type === "wire") {
+        lastWireIndex = i
+        break
+      }
+    }
+    if (lastWireIndex !== -1) {
+      const segment = route[lastWireIndex]
+      if (segment.route_type === "wire") {
+        segment.end_pcb_port_id = endPortId
+      }
+    }
+  }
+}

--- a/tests/features/port-ids-in-output/port-ids-in-output.test.ts
+++ b/tests/features/port-ids-in-output/port-ids-in-output.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test"
+import { AutoroutingPipelineSolver } from "../../../lib"
+import type { SimpleRouteJson } from "../../../lib/types"
+
+describe("port IDs in output", () => {
+  test("output traces should include start_pcb_port_id and end_pcb_port_id on wire segments", () => {
+    const srj: SimpleRouteJson = {
+      layerCount: 2,
+      minTraceWidth: 0.15,
+      obstacles: [
+        {
+          type: "rect",
+          layers: ["top"],
+          center: { x: 0, y: 0 },
+          width: 1,
+          height: 1,
+          connectedTo: ["connection_0"],
+        },
+        {
+          type: "rect",
+          layers: ["top"],
+          center: { x: 5, y: 0 },
+          width: 1,
+          height: 1,
+          connectedTo: ["connection_0"],
+        },
+      ],
+      connections: [
+        {
+          name: "connection_0",
+          pointsToConnect: [
+            { x: 0, y: 0, layer: "top", pcb_port_id: "pcb_port_start" },
+            { x: 5, y: 0, layer: "top", pcb_port_id: "pcb_port_end" },
+          ],
+        },
+      ],
+      bounds: { minX: -5, maxX: 10, minY: -5, maxY: 5 },
+    }
+
+    const solver = new AutoroutingPipelineSolver(srj)
+    solver.solve()
+
+    expect(solver.solved).toBe(true)
+    expect(solver.failed).toBe(false)
+
+    const traces = solver.getOutputSimplifiedPcbTraces()
+    expect(traces.length).toBeGreaterThan(0)
+
+    // Find the trace for our connection
+    const trace = traces.find((t) => t.connection_name === "connection_0")
+    expect(trace).toBeDefined()
+
+    // Get wire segments only
+    const wireSegments = trace!.route.filter((s) => s.route_type === "wire")
+    expect(wireSegments.length).toBeGreaterThan(0)
+
+    // First wire segment should have start_pcb_port_id
+    const firstWire = wireSegments[0]
+    expect(firstWire).toHaveProperty("start_pcb_port_id", "pcb_port_start")
+
+    // Last wire segment should have end_pcb_port_id
+    const lastWire = wireSegments[wireSegments.length - 1]
+    expect(lastWire).toHaveProperty("end_pcb_port_id", "pcb_port_end")
+  })
+
+  test("getOutputSimpleRouteJson includes port IDs in traces", () => {
+    const srj: SimpleRouteJson = {
+      layerCount: 2,
+      minTraceWidth: 0.15,
+      obstacles: [
+        {
+          type: "rect",
+          layers: ["top"],
+          center: { x: 0, y: 0 },
+          width: 1,
+          height: 1,
+          connectedTo: ["net_1"],
+        },
+        {
+          type: "rect",
+          layers: ["top"],
+          center: { x: 3, y: 3 },
+          width: 1,
+          height: 1,
+          connectedTo: ["net_1"],
+        },
+      ],
+      connections: [
+        {
+          name: "net_1",
+          pointsToConnect: [
+            { x: 0, y: 0, layer: "top", pcb_port_id: "port_A" },
+            { x: 3, y: 3, layer: "top", pcb_port_id: "port_B" },
+          ],
+        },
+      ],
+      bounds: { minX: -5, maxX: 10, minY: -5, maxY: 10 },
+    }
+
+    const solver = new AutoroutingPipelineSolver(srj)
+    solver.solve()
+
+    const outputSrj = solver.getOutputSimpleRouteJson()
+    expect(outputSrj.traces).toBeDefined()
+    expect(outputSrj.traces!.length).toBeGreaterThan(0)
+
+    const trace = outputSrj.traces![0]
+    const wireSegments = trace.route.filter((s) => s.route_type === "wire")
+
+    // Verify port IDs are present
+    const firstWire = wireSegments[0]
+    const lastWire = wireSegments[wireSegments.length - 1]
+
+    if (firstWire.route_type === "wire") {
+      expect(firstWire.start_pcb_port_id).toBe("port_A")
+    }
+    if (lastWire.route_type === "wire") {
+      expect(lastWire.end_pcb_port_id).toBe("port_B")
+    }
+  })
+})

--- a/tests/utils/addPortIdsToRoute.test.ts
+++ b/tests/utils/addPortIdsToRoute.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test"
+import type { ConnectionPoint, SimplifiedPcbTraces } from "../../lib/types"
+import { addPortIdsToRoute } from "../../lib/utils/addPortIdsToRoute"
+
+describe("addPortIdsToRoute", () => {
+  test("adds start_pcb_port_id to first wire segment and end_pcb_port_id to last wire segment", () => {
+    const route: SimplifiedPcbTraces[number]["route"] = [
+      { route_type: "wire", x: 0, y: 0, width: 0.2, layer: "top" },
+      { route_type: "wire", x: 1, y: 0, width: 0.2, layer: "top" },
+      { route_type: "wire", x: 2, y: 0, width: 0.2, layer: "top" },
+    ]
+
+    const pointsToConnect: ConnectionPoint[] = [
+      { x: 0, y: 0, layer: "top", pcb_port_id: "pcb_port_0" },
+      { x: 2, y: 0, layer: "top", pcb_port_id: "pcb_port_1" },
+    ]
+
+    addPortIdsToRoute(route, pointsToConnect)
+
+    expect(route[0]).toHaveProperty("start_pcb_port_id", "pcb_port_0")
+    expect(route[0]).not.toHaveProperty("end_pcb_port_id")
+    expect(route[1]).not.toHaveProperty("start_pcb_port_id")
+    expect(route[1]).not.toHaveProperty("end_pcb_port_id")
+    expect(route[2]).toHaveProperty("end_pcb_port_id", "pcb_port_1")
+    expect(route[2]).not.toHaveProperty("start_pcb_port_id")
+  })
+
+  test("handles routes with vias - finds correct first and last wire segments", () => {
+    const route: SimplifiedPcbTraces[number]["route"] = [
+      { route_type: "wire", x: 0, y: 0, width: 0.2, layer: "top" },
+      { route_type: "wire", x: 1, y: 0, width: 0.2, layer: "top" },
+      { route_type: "via", x: 1, y: 0, from_layer: "top", to_layer: "bottom" },
+      { route_type: "wire", x: 1, y: 0, width: 0.2, layer: "bottom" },
+      { route_type: "wire", x: 2, y: 0, width: 0.2, layer: "bottom" },
+    ]
+
+    const pointsToConnect: ConnectionPoint[] = [
+      { x: 0, y: 0, layer: "top", pcb_port_id: "pcb_port_5" },
+      { x: 2, y: 0, layer: "bottom", pcb_port_id: "pcb_port_6" },
+    ]
+
+    addPortIdsToRoute(route, pointsToConnect)
+
+    // First wire segment should have start_pcb_port_id
+    expect(route[0]).toHaveProperty("start_pcb_port_id", "pcb_port_5")
+    // Last wire segment should have end_pcb_port_id
+    expect(route[4]).toHaveProperty("end_pcb_port_id", "pcb_port_6")
+    // Via should not have port IDs
+    expect(route[2]).not.toHaveProperty("start_pcb_port_id")
+    expect(route[2]).not.toHaveProperty("end_pcb_port_id")
+  })
+
+  test("handles empty route gracefully", () => {
+    const route: SimplifiedPcbTraces[number]["route"] = []
+    const pointsToConnect: ConnectionPoint[] = [
+      { x: 0, y: 0, layer: "top", pcb_port_id: "pcb_port_0" },
+      { x: 2, y: 0, layer: "top", pcb_port_id: "pcb_port_1" },
+    ]
+
+    // Should not throw
+    addPortIdsToRoute(route, pointsToConnect)
+    expect(route.length).toBe(0)
+  })
+
+  test("handles missing pcb_port_id gracefully", () => {
+    const route: SimplifiedPcbTraces[number]["route"] = [
+      { route_type: "wire", x: 0, y: 0, width: 0.2, layer: "top" },
+      { route_type: "wire", x: 2, y: 0, width: 0.2, layer: "top" },
+    ]
+
+    const pointsToConnect: ConnectionPoint[] = [
+      { x: 0, y: 0, layer: "top" }, // No pcb_port_id
+      { x: 2, y: 0, layer: "top", pcb_port_id: "pcb_port_1" },
+    ]
+
+    addPortIdsToRoute(route, pointsToConnect)
+
+    // First segment should not have start_pcb_port_id since it was undefined
+    expect(route[0]).not.toHaveProperty("start_pcb_port_id")
+    // Last segment should still have end_pcb_port_id
+    expect(route[1]).toHaveProperty("end_pcb_port_id", "pcb_port_1")
+  })
+
+  test("handles single wire segment", () => {
+    const route: SimplifiedPcbTraces[number]["route"] = [
+      { route_type: "wire", x: 0, y: 0, width: 0.2, layer: "top" },
+    ]
+
+    const pointsToConnect: ConnectionPoint[] = [
+      { x: 0, y: 0, layer: "top", pcb_port_id: "pcb_port_0" },
+      { x: 0, y: 0, layer: "top", pcb_port_id: "pcb_port_1" },
+    ]
+
+    addPortIdsToRoute(route, pointsToConnect)
+
+    // Single segment should have both start and end port IDs
+    expect(route[0]).toHaveProperty("start_pcb_port_id", "pcb_port_0")
+    expect(route[0]).toHaveProperty("end_pcb_port_id", "pcb_port_1")
+  })
+})


### PR DESCRIPTION
Adds start_pcb_port_id and end_pcb_port_id to wire segments in autorouted traces, enabling downstream tools (like DRC connectivity checks) to properly identify which ports traces connect to. Without this, traces were missing port IDs causing false-positive "trace overlapping different net" errors when traces legitimately touched their connected pads.