### PR TITLE
Fix benchmark workflow permissions and argument passing

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -12,7 +12,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   post-instructions:
@@ -144,13 +144,14 @@ jobs:
           CONCURRENCY: ${{ steps.parse.outputs.concurrency }}
         run: |
           chmod +x ./benchmark.sh
+          CMD=(./benchmark.sh --concurrency "$CONCURRENCY")
           if [ -n "$SOLVER_NAME" ]; then
-            ./benchmark.sh "$SOLVER_NAME" "$SCENARIO_LIMIT" --concurrency "$CONCURRENCY"
-          elif [ -n "$SCENARIO_LIMIT" ]; then
-            ./benchmark.sh _ "$SCENARIO_LIMIT" --concurrency "$CONCURRENCY"
-          else
-            ./benchmark.sh --concurrency "$CONCURRENCY"
+            CMD+=(--solver "$SOLVER_NAME")
           fi
+          if [ -n "$SCENARIO_LIMIT" ]; then
+            CMD+=(--scenario-limit "$SCENARIO_LIMIT")
+          fi
+          "${CMD[@]}"
 
       - name: Upload benchmark result
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- changed from read to write so the token can post PR comments 
- switched from positional args to  --solver/--scenario-limit flags to fix the empty string bug when SCENARIO_LIMIT is not 
  provided                          
