### PR TITLE
Add workflow_dispatch for benchmark and exclude assignable solvers by default

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,6 +6,30 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      solver_name:
+        description: Solver name to benchmark (optional)
+        required: false
+        type: string
+      scenario_limit:
+        description: Number of scenarios to run (optional)
+        required: false
+        type: string
+      concurrency:
+        description: Number of workers per solver
+        required: false
+        default: "16"
+        type: string
+      include_assignable:
+        description: Include assignable pipelines
+        required: false
+        default: false
+        type: boolean
+      ref:
+        description: Git ref (branch, tag, or SHA) to benchmark
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -16,7 +40,7 @@ jobs:
   benchmark:
     name: Run benchmark
     if: |
-      github.event_name == 'push' || (
+      github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         github.event.comment.user.type != 'Bot' &&
@@ -43,6 +67,7 @@ jobs:
             let concurrency = '16'
             let ref = context.sha
             let statusCommentId = ''
+            let includeAssignable = false
 
             if (isComment) {
               const body = context.payload.comment.body.trim()
@@ -54,6 +79,10 @@ jobs:
                 if (token === '--concurrency') {
                   concurrency = tokens[i + 1] || concurrency
                   i += 1
+                  continue
+                }
+                if (token === '--include-assignable') {
+                  includeAssignable = true
                   continue
                 }
                 positional.push(token)
@@ -83,9 +112,20 @@ jobs:
               statusCommentId = String(statusComment.data.id)
             }
 
+
+            if (context.eventName === 'workflow_dispatch') {
+              const inputs = context.payload.inputs || {}
+              solverName = (inputs.solver_name || '').trim()
+              scenarioLimit = (inputs.scenario_limit || '').trim()
+              concurrency = (inputs.concurrency || concurrency).trim()
+              includeAssignable = inputs.include_assignable === true || inputs.include_assignable === 'true'
+              ref = (inputs.ref || '').trim() || ref
+            }
+
             core.setOutput('solver_name', solverName)
             core.setOutput('scenario_limit', scenarioLimit)
             core.setOutput('concurrency', concurrency)
+            core.setOutput('include_assignable', includeAssignable ? 'true' : 'false')
             core.setOutput('ref', ref)
             core.setOutput('status_comment_id', statusCommentId)
 
@@ -107,6 +147,7 @@ jobs:
           SOLVER_NAME: ${{ steps.parse.outputs.solver_name }}
           SCENARIO_LIMIT: ${{ steps.parse.outputs.scenario_limit }}
           CONCURRENCY: ${{ steps.parse.outputs.concurrency }}
+          INCLUDE_ASSIGNABLE: ${{ steps.parse.outputs.include_assignable }}
         run: |
           chmod +x ./benchmark.sh
           CMD=(./benchmark.sh --concurrency "$CONCURRENCY")
@@ -115,6 +156,9 @@ jobs:
           fi
           if [ -n "$SCENARIO_LIMIT" ]; then
             CMD+=(--scenario-limit "$SCENARIO_LIMIT")
+          fi
+          if [ "$INCLUDE_ASSIGNABLE" = "true" ]; then
+            CMD+=(--include-assignable)
           fi
           "${CMD[@]}"
           cp benchmark-result.txt benchmark-result-pr.txt

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -4,9 +4,10 @@ set -euo pipefail
 SOLVER_NAME=""
 SCENARIO_LIMIT=""
 CONCURRENCY="${BENCHMARK_CONCURRENCY:-4}"
+INCLUDE_ASSIGNABLE=false
 
 get_solvers() {
-  bun --eval '
+  INCLUDE_ASSIGNABLE="$INCLUDE_ASSIGNABLE" bun --eval '
     import { readFileSync } from "node:fs"
     import { join } from "node:path"
 
@@ -21,20 +22,24 @@ get_solvers() {
       return aliasMatch ? aliasMatch[1] : name
     })
 
-    console.log(solvers.join("\n"))
+    const includeAssignable = process.env.INCLUDE_ASSIGNABLE === "true"
+    const filtered = includeAssignable ? solvers : solvers.filter(name => !name.includes("Assignable"))
+
+    console.log(filtered.join("\n"))
   ' 2>/dev/null || true
 }
 
 print_help() {
   cat <<'EOF'
 Usage:
-  ./benchmark.sh [solver-name|_] [scenario-limit] [--concurrency N]
-  ./benchmark.sh [--solver NAME] [--scenario-limit N] [--concurrency N]
+  ./benchmark.sh [solver-name|_] [scenario-limit] [--concurrency N] [--include-assignable]
+  ./benchmark.sh [--solver NAME] [--scenario-limit N] [--concurrency N] [--include-assignable]
 
 Options:
   --solver NAME        Run only one solver (same as first positional arg)
   --scenario-limit N   Run only first N scenarios (same as second positional arg)
   --concurrency N      Number of Bun workers used per solver (default: 4)
+  --include-assignable Include assignable pipelines (excluded by default)
   -h, --help           Show this help
 
 Examples:
@@ -42,6 +47,7 @@ Examples:
   ./benchmark.sh AutoroutingPipelineSolver
   ./benchmark.sh _ 20 --concurrency 8
   ./benchmark.sh --solver AutoroutingPipelineSolver --scenario-limit 20
+  ./benchmark.sh --include-assignable
 EOF
 
   SOLVERS="$(get_solvers)"
@@ -84,6 +90,10 @@ while [ "$#" -gt 0 ]; do
       CONCURRENCY="${2:-}"
       shift 2
       ;;
+    --include-assignable)
+      INCLUDE_ASSIGNABLE=true
+      shift
+      ;;
     *)
       echo "Unknown argument: $1"
       echo "Run ./benchmark.sh --help for usage"
@@ -100,6 +110,10 @@ fi
 
 if [ -n "$SCENARIO_LIMIT" ]; then
   CMD+=("--scenario-limit" "$SCENARIO_LIMIT")
+fi
+
+if [ "$INCLUDE_ASSIGNABLE" != true ]; then
+  CMD+=("--exclude-assignable")
 fi
 
 "${CMD[@]}"

--- a/scripts/benchmark/index.ts
+++ b/scripts/benchmark/index.ts
@@ -25,6 +25,7 @@ type BenchmarkOptions = {
   solverName?: string
   scenarioLimit?: number
   concurrency: number
+  excludeAssignable: boolean
 }
 
 const formatTime = (timeMs: number | null) => {
@@ -57,7 +58,7 @@ const getPercentileMs = (
 
 const parseArgs = (): BenchmarkOptions => {
   const args = process.argv.slice(2)
-  const options: BenchmarkOptions = { concurrency: 4 }
+  const options: BenchmarkOptions = { concurrency: 4, excludeAssignable: false }
 
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i]
@@ -74,6 +75,10 @@ const parseArgs = (): BenchmarkOptions => {
     if (arg === "--concurrency") {
       options.concurrency = Number.parseInt(args[i + 1], 10)
       i += 1
+      continue
+    }
+    if (arg === "--exclude-assignable") {
+      options.excludeAssignable = true
       continue
     }
     throw new Error(`Unknown argument: ${arg}`)
@@ -93,7 +98,9 @@ const parseArgs = (): BenchmarkOptions => {
   return options
 }
 
-const loadSolverNames = async (): Promise<string[]> => {
+const loadSolverNames = async (
+  excludeAssignable: boolean,
+): Promise<string[]> => {
   // Use autorouter-pipelines/index.ts as the source of truth for benchmarkable solvers
   const pipelinesIndexPath = path.join(
     process.cwd(),
@@ -112,10 +119,16 @@ const loadSolverNames = async (): Promise<string[]> => {
   const libIndexPath = path.join(process.cwd(), "lib", "index.ts")
   const libIndex = await readFile(libIndexPath, "utf8")
 
-  return pipelineNames.map((name) => {
+  const solverNames = pipelineNames.map((name) => {
     const aliasMatch = libIndex.match(new RegExp(`${name}\\s+as\\s+(\\w+)`))
     return aliasMatch ? aliasMatch[1] : name
   })
+
+  if (!excludeAssignable) {
+    return solverNames
+  }
+
+  return solverNames.filter((name) => !name.includes("Assignable"))
 }
 
 const loadScenarios = (scenarioLimit?: number) => {
@@ -247,8 +260,9 @@ const runSolverWithWorkers = async (
 }
 
 const main = async () => {
-  const { solverName, scenarioLimit, concurrency } = parseArgs()
-  const availableSolvers = await loadSolverNames()
+  const { solverName, scenarioLimit, concurrency, excludeAssignable } =
+    parseArgs()
+  const availableSolvers = await loadSolverNames(excludeAssignable)
   const solvers = solverName ? [solverName] : availableSolvers
 
   if (solverName && !availableSolvers.includes(solverName)) {


### PR DESCRIPTION
### Motivation

- Allow running the benchmark manually from the GitHub UI and provide an option to opt into assignable pipelines while keeping them excluded by default to speed typical runs.
- Make it possible to pass solver, scenario limit, concurrency, ref, and assignable inclusion from both issue comments and manual dispatch so CI runs are consistent.

### Description

- Add `workflow_dispatch` to `.github/workflows/benchmark.yml` with inputs `solver_name`, `scenario_limit`, `concurrency`, `include_assignable`, and `ref`, and extend parsing to accept these inputs. 
- Wire a new `include_assignable` output from the workflow parser into the Run step so the job can pass `--include-assignable` to the shell runner when requested.
- Change `benchmark.sh` to exclude assignable pipelines by default using an `INCLUDE_ASSIGNABLE` toggle and add a `--include-assignable` CLI option to opt in. 
- Update `scripts/benchmark/index.ts` to accept a new `--exclude-assignable` flag and filter solver names (removing names containing `Assignable`) when exclusion is requested.

### Testing

- Ran TypeScript typecheck with `bunx tsc --noEmit` and it succeeded. 
- Ran formatter with `bun run format` which completed successfully. 
- Validated shell script syntax with `bash -n benchmark.sh` which passed. 
- Executed `./benchmark.sh --help` to confirm usage and solver listing behavior and it printed expected help and filtered solver list.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a71b283e70832e9567d1e7e916db51)