### PR TITLE
Optimize SingleHighDensityRouteSolver obstacle checks with Flatbush

### DIFF
--- a/lib/solvers/HighDensitySolver/SingleHighDensityRouteSolver.ts
+++ b/lib/solvers/HighDensitySolver/SingleHighDensityRouteSolver.ts
@@ -4,6 +4,7 @@ import {
   pointToSegmentDistance,
 } from "@tscircuit/math-utils"
 import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import Flatbush from "flatbush"
 import type { GraphicsObject } from "graphics-debug"
 import {
   Node,
@@ -54,6 +55,11 @@ export class SingleHighDensityRouteSolver extends BaseSolver {
   hyperParameters: Partial<HighDensityHyperParameters>
 
   connMap?: ConnectivityMap
+
+  obstacleSegments: IndexedObstacleSegment[] = []
+  obstacleSegmentIndex: Flatbush | null = null
+  obstacleVias: IndexedObstacleVia[] = []
+  obstacleViaIndex: Flatbush | null = null
 
   /** For debugging/animating the exploration */
   debug_exploredNodesOrdered: string[]
@@ -109,6 +115,7 @@ export class SingleHighDensityRouteSolver extends BaseSolver {
     this.debug_nodesTooCloseToObstacle = new Set()
     this.debug_nodePathToParentIntersectsObstacle = new Set()
     this.numRoutes = this.obstacleRoutes.length + this.futureConnections.length
+    this.buildObstacleIndexes()
     const bestRowOrColumnCount = Math.ceil(5 * (this.numRoutes + 1))
     let numXCells = this.boundsSize.width / this.cellStep
     let numYCells = this.boundsSize.height / this.cellStep
@@ -215,29 +222,37 @@ export class SingleHighDensityRouteSolver extends BaseSolver {
       }
     }
 
-    for (const route of this.obstacleRoutes) {
-      const connectedToObstacle = this.connMap?.areIdsConnected?.(
-        this.connectionName,
-        route.connectionName,
+    const traceProximity = this.traceThickness + margin
+    if (this.obstacleSegmentIndex) {
+      const nearbySegmentIds = this.obstacleSegmentIndex.search(
+        node.x - traceProximity,
+        node.y - traceProximity,
+        node.x + traceProximity,
+        node.y + traceProximity,
       )
-
-      if (!connectedToObstacle) {
-        const pointPairs = getSameLayerPointPairs(route)
-        for (const pointPair of pointPairs) {
-          if (
-            (isVia || pointPair.z === node.z) &&
-            pointToSegmentDistance(node, pointPair.A, pointPair.B) <
-              this.traceThickness + margin
-          ) {
-            return true
-          }
+      for (const segmentId of nearbySegmentIds) {
+        const segment = this.obstacleSegments[segmentId]
+        if (!segment || segment.connectedToCurrentConnection) continue
+        if (!isVia && segment.z !== node.z) continue
+        if (
+          pointToSegmentDistance(node, segment.A, segment.B) < traceProximity
+        ) {
+          return true
         }
       }
-      for (const via of route.vias) {
-        if (
-          distance(node, via) <
-          this.viaDiameter / 2 + this.traceThickness / 2 + margin
-        ) {
+    }
+
+    const viaProximity = this.viaDiameter / 2 + this.traceThickness / 2 + margin
+    if (this.obstacleViaIndex) {
+      const nearbyViaIds = this.obstacleViaIndex.search(
+        node.x - viaProximity,
+        node.y - viaProximity,
+        node.x + viaProximity,
+        node.y + viaProximity,
+      )
+      for (const viaId of nearbyViaIds) {
+        const via = this.obstacleVias[viaId]
+        if (via && distance(node, via) < viaProximity) {
           return true
         }
       }
@@ -270,20 +285,89 @@ export class SingleHighDensityRouteSolver extends BaseSolver {
   doesPathToParentIntersectObstacle(node: Node) {
     const parent = node.parent
     if (!parent) return false
-    for (const route of this.obstacleRoutes) {
-      const obstacleIsConnectedToNewPath = this.connMap?.areIdsConnected?.(
-        this.connectionName,
-        route.connectionName,
-      )
-      if (obstacleIsConnectedToNewPath) continue
-      for (const pointPair of getSameLayerPointPairs(route)) {
-        if (pointPair.z !== node.z) continue
-        if (doSegmentsIntersect(node, parent, pointPair.A, pointPair.B)) {
-          return true
-        }
+    if (!this.obstacleSegmentIndex) return false
+
+    const minX = Math.min(node.x, parent.x)
+    const maxX = Math.max(node.x, parent.x)
+    const minY = Math.min(node.y, parent.y)
+    const maxY = Math.max(node.y, parent.y)
+
+    const nearbySegmentIds = this.obstacleSegmentIndex.search(
+      minX,
+      minY,
+      maxX,
+      maxY,
+    )
+
+    for (const segmentId of nearbySegmentIds) {
+      const segment = this.obstacleSegments[segmentId]
+      if (!segment || segment.connectedToCurrentConnection) continue
+      if (segment.z !== node.z) continue
+      if (doSegmentsIntersect(node, parent, segment.A, segment.B)) {
+        return true
       }
     }
     return false
+  }
+
+  buildObstacleIndexes() {
+    if (this.obstacleRoutes.length === 0) {
+      this.obstacleSegmentIndex = null
+      this.obstacleViaIndex = null
+      return
+    }
+
+    const obstacleSegments: IndexedObstacleSegment[] = []
+    const obstacleVias: IndexedObstacleVia[] = []
+
+    for (const route of this.obstacleRoutes) {
+      const connectedToCurrentConnection =
+        this.connMap?.areIdsConnected?.(
+          this.connectionName,
+          route.connectionName,
+        ) ?? false
+
+      for (const pointPair of getSameLayerPointPairs(route)) {
+        obstacleSegments.push({
+          ...pointPair,
+          connectedToCurrentConnection,
+        })
+      }
+
+      for (const via of route.vias) {
+        obstacleVias.push(via)
+      }
+    }
+
+    this.obstacleSegments = obstacleSegments
+    this.obstacleVias = obstacleVias
+
+    if (obstacleSegments.length > 0) {
+      const segmentIndex = new Flatbush(obstacleSegments.length)
+      for (const segment of obstacleSegments) {
+        segmentIndex.add(
+          Math.min(segment.A.x, segment.B.x),
+          Math.min(segment.A.y, segment.B.y),
+          Math.max(segment.A.x, segment.B.x),
+          Math.max(segment.A.y, segment.B.y),
+        )
+      }
+      segmentIndex.finish()
+      this.obstacleSegmentIndex = segmentIndex
+    } else {
+      this.obstacleSegmentIndex = null
+    }
+
+    if (obstacleVias.length > 0) {
+      const viaIndex = new Flatbush(obstacleVias.length)
+      for (const via of obstacleVias) {
+        viaIndex.add(via.x, via.y, via.x, via.y)
+      }
+      viaIndex.finish()
+      this.obstacleViaIndex = viaIndex
+    } else {
+      this.obstacleViaIndex = null
+    }
   }
 
   computeH(node: Node) {
@@ -652,6 +736,15 @@ export class SingleHighDensityRouteSolver extends BaseSolver {
     return graphics
   }
 }
+
+type IndexedObstacleSegment = {
+  z: number
+  A: { x: number; y: number; z: number }
+  B: { x: number; y: number; z: number }
+  connectedToCurrentConnection: boolean
+}
+
+type IndexedObstacleVia = { x: number; y: number }
 
 function getSameLayerPointPairs(route: HighDensityIntraNodeRoute) {
   const pointPairs: {

--- a/tests/single-high-density-route-solver.test.ts
+++ b/tests/single-high-density-route-solver.test.ts
@@ -1,0 +1,83 @@
+import { expect, test } from "bun:test"
+import { SingleHighDensityRouteSolver } from "lib/solvers/HighDensitySolver/SingleHighDensityRouteSolver"
+import type { HighDensityIntraNodeRoute } from "lib/types/high-density-types"
+
+const baseOpts = {
+  connectionName: "conn-a",
+  minDistBetweenEnteringPoints: 0.2,
+  bounds: { minX: 0, maxX: 10, minY: 0, maxY: 10 },
+  A: { x: 1, y: 1, z: 0 },
+  B: { x: 9, y: 9, z: 0 },
+  traceThickness: 0.2,
+  obstacleMargin: 0.1,
+  layerCount: 2,
+}
+
+test("SingleHighDensityRouteSolver indexes obstacle segments and vias", () => {
+  const obstacleRoutes: HighDensityIntraNodeRoute[] = [
+    {
+      connectionName: "conn-obstacle",
+      traceThickness: 0.2,
+      viaDiameter: 0.3,
+      route: [
+        { x: 2, y: 2, z: 0 },
+        { x: 8, y: 2, z: 0 },
+      ],
+      vias: [{ x: 6, y: 6 }],
+    },
+  ]
+
+  const solver = new SingleHighDensityRouteSolver({
+    ...baseOpts,
+    obstacleRoutes,
+  })
+
+  expect(solver.obstacleSegments.length).toBe(1)
+  expect(solver.obstacleVias.length).toBe(1)
+
+  expect(solver.isNodeTooCloseToObstacle({ x: 5, y: 2.1, z: 0 } as any)).toBe(
+    true,
+  )
+  expect(solver.isNodeTooCloseToObstacle({ x: 6, y: 6.05, z: 1 } as any)).toBe(
+    true,
+  )
+})
+
+test("SingleHighDensityRouteSolver ignores connected obstacle segments for clearance/intersection", () => {
+  const obstacleRoutes: HighDensityIntraNodeRoute[] = [
+    {
+      connectionName: "conn-connected",
+      traceThickness: 0.2,
+      viaDiameter: 0.3,
+      route: [
+        { x: 3, y: 3, z: 0 },
+        { x: 7, y: 3, z: 0 },
+      ],
+      vias: [],
+    },
+  ]
+
+  const solver = new SingleHighDensityRouteSolver({
+    ...baseOpts,
+    obstacleRoutes,
+    connMap: {
+      areIdsConnected: (a: string, b: string) =>
+        (a === "conn-a" && b === "conn-connected") ||
+        (a === "conn-connected" && b === "conn-a"),
+    } as any,
+  })
+
+  expect(solver.isNodeTooCloseToObstacle({ x: 5, y: 3.05, z: 0 } as any)).toBe(
+    false,
+  )
+
+  const intersectingNode = {
+    x: 5,
+    y: 4,
+    z: 0,
+    parent: { x: 5, y: 2, z: 0 },
+  }
+  expect(
+    solver.doesPathToParentIntersectObstacle(intersectingNode as any),
+  ).toBe(false)
+})


### PR DESCRIPTION
### Motivation
- The A* node-expansion hotspot was performing full scans of every obstacle route on every neighbor expansion, causing per-iteration cost to grow with obstacle count.
- Introduce a spatial index to reduce per-step work by restricting geometric tests to nearby obstacle primitives.

### Description
- Add Flatbush-backed spatial indexes for obstacle segments and vias and precompute per-segment connectivity flags via a new `buildObstacleIndexes()` call in the constructor.
- Replace full-array scans in `isNodeTooCloseToObstacle` with a bbox query against `obstacleSegmentIndex` / `obstacleViaIndex` followed by exact `pointToSegmentDistance` / `distance` checks for returned candidates, preserving layer and connected-net semantics.
- Replace full-array scans in `doesPathToParentIntersectObstacle` with a bbox query and then call `doSegmentsIntersect` only on nearby segments.
- Add focused unit tests `tests/single-high-density-route-solver.test.ts` that validate indexed detection of segment/via proximity and that connected obstacles are ignored for clearance and intersection checks.

### Testing
- Ran `bun test tests/single-high-density-route-solver.test.ts` and it passed (2 tests, 0 failures).
- Ran `bunx tsc --noEmit` for type checking and it completed successfully.
- Ran `bun run format` which formatted files successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a784b46940832ebe74c42a7d4fb0b1)