### PR TITLE
Add workflow run link to benchmark status comment

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -106,7 +106,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                body: `## 🏃 Autorouting Benchmark\n\n⏳ Running benchmark on \`${ref.slice(0, 7)}\`...`,
+                body: `## 🏃 Autorouting Benchmark\n\n⏳ Running benchmark on \`${ref.slice(0, 7)}\`...\n\n🔗 Workflow: [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})`,
               })
 
               statusCommentId = String(statusComment.data.id)


### PR DESCRIPTION
### Motivation
- Improve the `/benchmark` issue-comment status message so users can jump directly from the comment to the live GitHub Actions workflow run for easier debugging and log access.

### Description
- Update `.github/workflows/benchmark.yml` to include a “🔗 Workflow: [View run](<url>)” link in the initial status comment by adding the run URL `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`.

### Testing
- Ran `bunx tsc --noEmit` and `bun run format`, and both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a7ad1179f0832eb0340ef2dcbbfcb5)