### PR TITLE
Remove undersized nodes before subdivision

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline4_TinyHypergraph/AutoroutingPipelineSolver4_TinyHypergraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline4_TinyHypergraph/AutoroutingPipelineSolver4_TinyHypergraph.ts
@@ -52,6 +52,7 @@ interface CapacityMeshSolverOptions {
   effort?: number
   maxNodeDimension?: number
   maxNodeRatio?: number
+  minNodeArea?: number
 }
 export type AutoroutingPipelineSolverOptions = CapacityMeshSolverOptions
 
@@ -114,6 +115,7 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
   effort: number
   maxNodeDimension: number
   maxNodeRatio: number
+  minNodeArea: number
 
   startTimeOfPhase: Record<string, number>
   endTimeOfPhase: Record<string, number>
@@ -175,7 +177,12 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
     definePipelineStep(
       "nodeDimensionSubdivisionSolver",
       NodeDimensionSubdivisionSolver,
-      (cms) => [cms.capacityNodes!, cms.maxNodeDimension, cms.maxNodeRatio],
+      (cms) => [
+        cms.capacityNodes!,
+        cms.maxNodeDimension,
+        cms.maxNodeRatio,
+        cms.minNodeArea,
+      ],
       {
         onSolved: (cms) => {
           cms.capacityNodes =
@@ -399,6 +406,7 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
     this.effort = mutableOpts.effort ?? 1
     this.maxNodeDimension = mutableOpts.maxNodeDimension ?? 16
     this.maxNodeRatio = mutableOpts.maxNodeRatio ?? 6
+    this.minNodeArea = mutableOpts.minNodeArea ?? 0.1 ** 2
 
     if (mutableOpts.capacityDepth === undefined) {
       const boundsWidth = srj.bounds.maxX - srj.bounds.minX

--- a/lib/solvers/NodeDimensionSubdivisionSolver/NodeDimensionSubdivisionSolver.ts
+++ b/lib/solvers/NodeDimensionSubdivisionSolver/NodeDimensionSubdivisionSolver.ts
@@ -2,6 +2,8 @@ import type { GraphicsObject } from "graphics-debug"
 import type { CapacityMeshNode } from "lib/types"
 import { BaseSolver } from "lib/solvers/BaseSolver"
 
+const DEFAULT_MIN_NODE_AREA = 0.1 ** 2
+
 export class NodeDimensionSubdivisionSolver extends BaseSolver {
   public readonly outputNodes: CapacityMeshNode[]
 
@@ -9,6 +11,7 @@ export class NodeDimensionSubdivisionSolver extends BaseSolver {
     private readonly nodes: CapacityMeshNode[],
     private readonly maxNodeDimension: number,
     private readonly maxNodeRatio: number = Number.POSITIVE_INFINITY,
+    private readonly minNodeArea: number = DEFAULT_MIN_NODE_AREA,
   ) {
     super()
     this.outputNodes = []
@@ -58,7 +61,18 @@ export class NodeDimensionSubdivisionSolver extends BaseSolver {
     return { cols, rows }
   }
 
+  private shouldRemoveNode(node: CapacityMeshNode): boolean {
+    const hasMinAreaLimit =
+      Number.isFinite(this.minNodeArea) && this.minNodeArea > 0
+
+    return hasMinAreaLimit && node.width * node.height < this.minNodeArea
+  }
+
   private subdivideNode(node: CapacityMeshNode): CapacityMeshNode[] {
+    if (this.shouldRemoveNode(node)) {
+      return []
+    }
+
     const { cols, rows } = this.getSubdivisionGrid(node)
 
     if (cols === 1 && rows === 1) {
@@ -94,9 +108,15 @@ export class NodeDimensionSubdivisionSolver extends BaseSolver {
   override _step() {
     const inputCount = this.nodes.length
     let subdividedNodeCount = 0
+    let removedSmallNodeCount = 0
 
     for (const node of this.nodes) {
       const subdividedNodes = this.subdivideNode(node)
+      if (subdividedNodes.length === 0) {
+        removedSmallNodeCount++
+        continue
+      }
+
       if (subdividedNodes.length > 1) {
         subdividedNodeCount++
       }
@@ -107,8 +127,10 @@ export class NodeDimensionSubdivisionSolver extends BaseSolver {
       inputNodeCount: inputCount,
       outputNodeCount: this.outputNodes.length,
       subdividedNodeCount,
+      removedSmallNodeCount,
       maxNodeDimension: this.maxNodeDimension,
       maxNodeRatio: this.maxNodeRatio,
+      minNodeArea: this.minNodeArea,
     }
     this.solved = true
   }

--- a/tests/features/pipeline-node-dimension-cap.test.ts
+++ b/tests/features/pipeline-node-dimension-cap.test.ts
@@ -27,6 +27,7 @@ test("pipeline4 defaults node subdivision to 16mm with max node ratio 6", () => 
 
   expect(pipeline.maxNodeDimension).toBe(16)
   expect(pipeline.maxNodeRatio).toBe(6)
+  expect(pipeline.minNodeArea).toBe(0.1 ** 2)
   expect(pipeline.capacityNodes).toBeDefined()
   expect(
     Math.max(
@@ -47,11 +48,14 @@ test("pipeline4 defaults node subdivision to 16mm with max node ratio 6", () => 
     (pipeline.capacityNodes ?? []).filter((node) =>
       node.capacityMeshNodeId.includes("__sub_"),
     ).length,
-  ).toBeGreaterThan(2)
+  ).toBeGreaterThan(0)
   expect(pipeline.nodeDimensionSubdivisionSolver?.stats.maxNodeDimension).toBe(
     16,
   )
   expect(pipeline.nodeDimensionSubdivisionSolver?.stats.maxNodeRatio).toBe(6)
+  expect(pipeline.nodeDimensionSubdivisionSolver?.stats.minNodeArea).toBe(
+    0.1 ** 2,
+  )
 })
 
 test.skip("pipeline5 defaults node subdivision to 7mm with max node ratio 4", () => {

--- a/tests/node-dimension-subdivision-solver.test.ts
+++ b/tests/node-dimension-subdivision-solver.test.ts
@@ -75,8 +75,6 @@ test("NodeDimensionSubdivisionSolver allows overriding minNodeArea for tiny node
   solver.solve()
 
   expect(solver.outputNodes).toHaveLength(3)
-  expect(solver.outputNodes.every((node) => getNodeRatio(node) <= 2)).toBe(
-    true,
-  )
+  expect(solver.outputNodes.every((node) => getNodeRatio(node) <= 2)).toBe(true)
   expect(solver.stats.minNodeArea).toBe(0.001)
 })

--- a/tests/node-dimension-subdivision-solver.test.ts
+++ b/tests/node-dimension-subdivision-solver.test.ts
@@ -35,4 +35,48 @@ test("NodeDimensionSubdivisionSolver subdivides long thin nodes to satisfy maxNo
   expect(solver.outputNodes.every((node) => getNodeRatio(node) <= 4)).toBe(true)
   expect(solver.stats.maxNodeDimension).toBe(100)
   expect(solver.stats.maxNodeRatio).toBe(4)
+  expect(solver.stats.minNodeArea).toBe(0.1 ** 2)
+})
+
+test("NodeDimensionSubdivisionSolver removes nodes below the default minNodeArea before subdivision", () => {
+  const solver = new NodeDimensionSubdivisionSolver(
+    [createNode({ width: 0.2, height: 0.04 })],
+    100,
+    2,
+  )
+
+  solver.solve()
+
+  expect(solver.outputNodes).toHaveLength(0)
+  expect(solver.stats.removedSmallNodeCount).toBe(1)
+  expect(solver.stats.minNodeArea).toBe(0.1 ** 2)
+})
+
+test("NodeDimensionSubdivisionSolver keeps nodes exactly at the minNodeArea threshold", () => {
+  const solver = new NodeDimensionSubdivisionSolver(
+    [createNode({ width: 0.1, height: 0.1 })],
+    100,
+  )
+
+  solver.solve()
+
+  expect(solver.outputNodes).toHaveLength(1)
+  expect(solver.outputNodes[0]?.capacityMeshNodeId).toBe("cmn_0")
+})
+
+test("NodeDimensionSubdivisionSolver allows overriding minNodeArea for tiny nodes", () => {
+  const solver = new NodeDimensionSubdivisionSolver(
+    [createNode({ width: 0.2, height: 0.04 })],
+    100,
+    2,
+    0.001,
+  )
+
+  solver.solve()
+
+  expect(solver.outputNodes).toHaveLength(3)
+  expect(solver.outputNodes.every((node) => getNodeRatio(node) <= 2)).toBe(
+    true,
+  )
+  expect(solver.stats.minNodeArea).toBe(0.001)
 })


### PR DESCRIPTION
## Summary
- add a `minNodeArea` threshold to `NodeDimensionSubdivisionSolver` with a default of `0.1 ** 2`
- drop nodes smaller than the threshold instead of subdividing them
- pass the new option through pipeline 4 defaults and expose removal stats for debugging
- update pipeline and solver tests to cover default, boundary, and override behavior

## Testing
- `bun test tests/node-dimension-subdivision-solver.test.ts tests/features/pipeline-node-dimension-cap.test.ts`
- `bunx tsc --noEmit`