### PR TITLE
Add ConsolidateConnectedObstacles stage to Pipeline4

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline4_TinyHypergraph/AutoroutingPipelineSolver4_TinyHypergraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline4_TinyHypergraph/AutoroutingPipelineSolver4_TinyHypergraph.ts
@@ -30,6 +30,7 @@ import { AvailableSegmentPointSolver } from "../../solvers/AvailableSegmentPoint
 import { BaseSolver } from "../../solvers/BaseSolver"
 import { CapacityMeshEdgeSolver } from "../../solvers/CapacityMeshSolver/CapacityMeshEdgeSolver"
 import { CapacityMeshEdgeSolver2_NodeTreeOptimization } from "../../solvers/CapacityMeshSolver/CapacityMeshEdgeSolver2_NodeTreeOptimization"
+import { ConsolidateConnectedObstaclesSolver } from "../../solvers/ConsolidateConnectedObstaclesSolver/ConsolidateConnectedObstaclesSolver"
 import { CapacityNodeTargetMerger } from "../../solvers/CapacityNodeTargetMerger/CapacityNodeTargetMerger"
 import { DeadEndSolver } from "../../solvers/DeadEndSolver/DeadEndSolver"
 import { HighDensityForceImproveSolver } from "high-density-repair01/lib/HighDensityForceImproveSolver"
@@ -125,9 +126,11 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
   connMap: ConnectivityMap
   srjWithEscapeViaLocations?: SimpleRouteJson
   srjWithPointPairs?: SimpleRouteJson
+  srjWithConsolidatedObstacles?: SimpleRouteJson
   capacityNodes: CapacityMeshNode[] | null = null
   capacityEdges: CapacityMeshEdge[] | null = null
   highDensityNodePortPoints?: NodeWithPortPoints[]
+  consolidateConnectedObstaclesSolver?: ConsolidateConnectedObstaclesSolver
 
   cacheProvider: CacheProvider | null = null
   pipelineDef = [
@@ -157,9 +160,27 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
         onSolved: (cms) => {
           cms.srjWithPointPairs =
             cms.netToPointPairsSolver?.getNewSimpleRouteJson()
-          cms.colorMap = getColorMap(cms.srjWithPointPairs!, this.connMap)
           cms.connMap = getConnectivityMapFromSimpleRouteJson(
             cms.srjWithPointPairs!,
+          )
+          cms.colorMap = getColorMap(cms.srjWithPointPairs!, cms.connMap)
+        },
+      },
+    ),
+    definePipelineStep(
+      "consolidateConnectedObstaclesSolver",
+      ConsolidateConnectedObstaclesSolver,
+      (cms) => [cms.srjWithPointPairs!],
+      {
+        onSolved: (cms) => {
+          cms.srjWithConsolidatedObstacles =
+            cms.consolidateConnectedObstaclesSolver?.getOutputSimpleRouteJson()
+          cms.connMap = getConnectivityMapFromSimpleRouteJson(
+            cms.srjWithConsolidatedObstacles!,
+          )
+          cms.colorMap = getColorMap(
+            cms.srjWithConsolidatedObstacles!,
+            cms.connMap,
           )
         },
       },
@@ -167,7 +188,7 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
     definePipelineStep(
       "nodeSolver",
       RectDiffPipeline,
-      (cms) => [{ simpleRouteJson: cms.srjWithPointPairs! as any }],
+      (cms) => [{ simpleRouteJson: cms.getWorkingSrj() as any }],
       {
         onSolved: (cms) => {
           cms.capacityNodes = cms.nodeSolver?.getOutput().meshNodes ?? []
@@ -220,7 +241,7 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
         {
           capacityMeshNodes: cms.capacityNodes!,
           sharedEdgeSegments: cms.availableSegmentPointSolver!.getOutput(),
-          simpleRouteJson: cms.srjWithPointPairs!,
+          simpleRouteJson: cms.getWorkingSrj(),
         },
       ],
     ),
@@ -237,7 +258,7 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
           segmentPortPoints: sharedEdgeSegments.flatMap(
             (seg) => seg.portPoints,
           ),
-          simpleRouteJsonConnections: cms.srjWithPointPairs!.connections,
+          simpleRouteJsonConnections: cms.getWorkingSrj().connections,
         })
 
         return [
@@ -285,8 +306,8 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
             cms.portPointPathingSolver?.getOutput().inputNodeWithPortPoints ??
             [],
           minTraceWidth: cms.minTraceWidth,
-          obstacles: cms.srj.obstacles,
-          layerCount: cms.srj.layerCount,
+          obstacles: cms.getWorkingSrj().obstacles,
+          layerCount: cms.getWorkingSrj().layerCount,
         },
       ],
     ),
@@ -315,7 +336,7 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
           connMap: cms.connMap,
           viaDiameter: cms.viaDiameter,
           traceWidth: cms.minTraceWidth,
-          obstacleMargin: cms.srj.defaultObstacleMargin ?? 0.15,
+          obstacleMargin: cms.getWorkingSrj().defaultObstacleMargin ?? 0.15,
         },
       ]
     }),
@@ -328,7 +349,8 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
           hdRoutes: cms.highDensityRouteSolver!.routes,
           colorMap: cms.colorMap,
           totalStepsPerNode: Math.max(20, Math.round(60 * cms.effort)),
-          nodeAssignmentMargin: cms.srj.defaultObstacleMargin ?? 0.2,
+          nodeAssignmentMargin:
+            cms.getWorkingSrj().defaultObstacleMargin ?? 0.2,
         },
       ],
     ),
@@ -341,9 +363,9 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
           hdRoutes:
             cms.highDensityForceImproveSolver?.getOutput() ??
             cms.highDensityRouteSolver!.routes,
-          obstacles: cms.srj.obstacles,
+          obstacles: cms.getWorkingSrj().obstacles,
           colorMap: cms.colorMap,
-          repairMargin: cms.srj.defaultObstacleMargin ?? 0.2,
+          repairMargin: cms.getWorkingSrj().defaultObstacleMargin ?? 0.2,
         },
       ],
     ),
@@ -352,7 +374,7 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
       MultipleHighDensityRouteStitchSolver3,
       (cms) => [
         {
-          connections: cms.srjWithPointPairs!.connections,
+          connections: cms.getWorkingSrj().connections,
           hdRoutes:
             cms.highDensityRepairSolver?.getOutput() ??
             cms.highDensityForceImproveSolver?.getOutput() ??
@@ -369,12 +391,12 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
       (cms) => [
         {
           hdRoutes: cms.highDensityStitchSolver!.mergedHdRoutes,
-          obstacles: cms.srj.obstacles,
+          obstacles: cms.getWorkingSrj().obstacles,
           connMap: cms.connMap,
           colorMap: cms.colorMap,
-          outline: cms.srj.outline,
+          outline: cms.getWorkingSrj().outline,
           defaultViaDiameter: cms.viaDiameter,
-          layerCount: cms.srj.layerCount,
+          layerCount: cms.getWorkingSrj().layerCount,
           iterations: 2,
         },
       ],
@@ -382,12 +404,12 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
     definePipelineStep("traceWidthSolver", TraceWidthSolver, (cms) => [
       {
         hdRoutes: cms.traceSimplificationSolver!.simplifiedHdRoutes,
-        obstacles: cms.srj.obstacles,
+        obstacles: cms.getWorkingSrj().obstacles,
         connMap: cms.connMap,
         colorMap: cms.colorMap,
         minTraceWidth: cms.minTraceWidth,
-        connection: cms.srj.connections,
-        layerCount: cms.srj.layerCount,
+        connection: cms.getWorkingSrj().connections,
+        layerCount: cms.getWorkingSrj().layerCount,
       },
     ]),
   ]
@@ -430,6 +452,15 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
     this.startTimeOfPhase = {}
     this.endTimeOfPhase = {}
     this.timeSpentOnPhase = {}
+  }
+
+  getWorkingSrj(): SimpleRouteJson {
+    return (
+      this.srjWithConsolidatedObstacles ??
+      this.srjWithPointPairs ??
+      this.srjWithEscapeViaLocations ??
+      this.srj
+    )
   }
 
   getConstructorParams() {
@@ -508,16 +539,32 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
     const necessaryCrampedPortPointSolverViz =
       this.necessaryCrampedPortPointSolver?.visualize()
     const highDensityRouteSolverViz = this.highDensityRouteSolver?.visualize()
-    const problemOutline = this.srj.outline
+    const problemSrj = this.getWorkingSrj()
+    const problemOutline = problemSrj.outline
     const problemLines: Line[] = []
 
     problemLines.push({
       points: [
-        { x: this.srj.bounds?.minX ?? -50, y: this.srj.bounds?.minY ?? -50 },
-        { x: this.srj.bounds?.maxX ?? 50, y: this.srj.bounds?.minY ?? -50 },
-        { x: this.srj.bounds?.maxX ?? 50, y: this.srj.bounds?.maxY ?? 50 },
-        { x: this.srj.bounds?.minX ?? -50, y: this.srj.bounds?.maxY ?? 50 },
-        { x: this.srj.bounds?.minX ?? -50, y: this.srj.bounds?.minY ?? -50 },
+        {
+          x: problemSrj.bounds?.minX ?? -50,
+          y: problemSrj.bounds?.minY ?? -50,
+        },
+        {
+          x: problemSrj.bounds?.maxX ?? 50,
+          y: problemSrj.bounds?.minY ?? -50,
+        },
+        {
+          x: problemSrj.bounds?.maxX ?? 50,
+          y: problemSrj.bounds?.maxY ?? 50,
+        },
+        {
+          x: problemSrj.bounds?.minX ?? -50,
+          y: problemSrj.bounds?.maxY ?? 50,
+        },
+        {
+          x: problemSrj.bounds?.minX ?? -50,
+          y: problemSrj.bounds?.minY ?? -50,
+        },
       ],
       strokeColor: "rgba(255,0,0,0.25)",
     })
@@ -540,7 +587,7 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
 
     const problemViz = {
       points: [
-        ...this.srj.connections.flatMap((c) =>
+        ...problemSrj.connections.flatMap((c) =>
           c.pointsToConnect.map((p) => ({
             ...p,
             label: `${c.name} ${p.pcb_port_id ?? ""}`,
@@ -548,7 +595,7 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
         ),
       ],
       rects: [
-        ...(this.srj.obstacles ?? [])
+        ...(problemSrj.obstacles ?? [])
           .filter((o) => !o.isCopperPour)
           .map((o) => ({
             ...o,
@@ -668,7 +715,7 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
 
   getOutputSimpleRouteJson(): SimpleRouteJson {
     return {
-      ...this.srj,
+      ...this.getWorkingSrj(),
       traces: this.getOutputSimplifiedPcbTraces(),
     }
   }

--- a/lib/solvers/ConsolidateConnectedObstaclesSolver/ConsolidateConnectedObstaclesSolver.ts
+++ b/lib/solvers/ConsolidateConnectedObstaclesSolver/ConsolidateConnectedObstaclesSolver.ts
@@ -1,0 +1,530 @@
+import { BaseSolver } from "lib/solvers/BaseSolver"
+import { FlatbushIndex } from "lib/data-structures/FlatbushIndex"
+import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
+import type {
+  Obstacle,
+  SimpleRouteConnection,
+  SimpleRouteJson,
+} from "lib/types"
+
+type ObstacleWithRuntimeType = Obstacle & { type?: string }
+
+type Bbox = {
+  minX: number
+  minY: number
+  maxX: number
+  maxY: number
+}
+
+type IndexedObstacle = {
+  inputIndex: number
+  obstacle: ObstacleWithRuntimeType
+  rootConnectionName: string
+}
+
+type CandidateEdge = {
+  a: number
+  b: number
+  gap: number
+  inflation: number
+}
+
+type MergeComponent = {
+  rootConnectionName: string
+  inputIndexes: number[]
+  mergedObstacle: Obstacle
+}
+
+export interface ConsolidateConnectedObstaclesSolverOptions {
+  maxMergeGap?: number
+  maxAreaInflation?: number
+}
+
+const getObstacleBbox = (obstacle: ObstacleWithRuntimeType): Bbox => ({
+  minX: obstacle.center.x - obstacle.width / 2,
+  minY: obstacle.center.y - obstacle.height / 2,
+  maxX: obstacle.center.x + obstacle.width / 2,
+  maxY: obstacle.center.y + obstacle.height / 2,
+})
+
+const getBboxArea = (bbox: Bbox) =>
+  Math.max(0, bbox.maxX - bbox.minX) * Math.max(0, bbox.maxY - bbox.minY)
+
+const getBboxGap = (a: Bbox, b: Bbox) => ({
+  gapX: Math.max(0, Math.max(a.minX, b.minX) - Math.min(a.maxX, b.maxX)),
+  gapY: Math.max(0, Math.max(a.minY, b.minY) - Math.min(a.maxY, b.maxY)),
+})
+
+const unionBboxes = (a: Bbox, b: Bbox): Bbox => ({
+  minX: Math.min(a.minX, b.minX),
+  minY: Math.min(a.minY, b.minY),
+  maxX: Math.max(a.maxX, b.maxX),
+  maxY: Math.max(a.maxY, b.maxY),
+})
+
+const getLayerKey = (obstacle: ObstacleWithRuntimeType) =>
+  obstacle.layers.slice().sort().join("|")
+
+const getZLayerKey = (obstacle: ObstacleWithRuntimeType) =>
+  obstacle.zLayers
+    ? obstacle.zLayers
+        .slice()
+        .sort((a, b) => a - b)
+        .join("|")
+    : ""
+
+const getOffboardKey = (obstacle: ObstacleWithRuntimeType) =>
+  (obstacle.offBoardConnectsTo ?? []).slice().sort().join("|")
+
+const getConnectionIdsForRootResolution = (
+  connection: SimpleRouteConnection,
+  rootConnectionName: string,
+) => {
+  const ids = new Set<string>([
+    rootConnectionName,
+    connection.name,
+    ...(connection.mergedConnectionNames ?? []),
+  ])
+
+  for (const point of connection.pointsToConnect) {
+    if (point.pointId) ids.add(point.pointId)
+    if ("pcb_port_id" in point && point.pcb_port_id) {
+      ids.add(point.pcb_port_id)
+    }
+  }
+
+  return ids
+}
+
+export class ConsolidateConnectedObstaclesSolver extends BaseSolver {
+  outputSrj: SimpleRouteJson
+  mergedComponents: MergeComponent[] = []
+  maxMergeGap: number
+  maxAreaInflation: number
+
+  constructor(
+    public readonly inputSrj: SimpleRouteJson,
+    public readonly opts: ConsolidateConnectedObstaclesSolverOptions = {},
+  ) {
+    super()
+    this.outputSrj = inputSrj
+    this.maxMergeGap =
+      opts.maxMergeGap ??
+      Math.max(inputSrj.minTraceWidth, inputSrj.defaultObstacleMargin ?? 0.15)
+    this.maxAreaInflation = opts.maxAreaInflation ?? 1.25
+    this.MAX_ITERATIONS = 1
+  }
+
+  getConstructorParams() {
+    return [this.inputSrj, this.opts] as const
+  }
+
+  _step() {
+    this.outputSrj = this.createConsolidatedSimpleRouteJson()
+    this.solved = true
+  }
+
+  getOutputSimpleRouteJson() {
+    if (!this.solved) {
+      throw new Error("Cannot get output before solving is complete")
+    }
+    return this.outputSrj
+  }
+
+  private buildIdToRootConnectionNameMap() {
+    const idToRootConnectionName = new Map<string, string>()
+
+    for (const connection of this.inputSrj.connections) {
+      const rootConnectionName =
+        connection.rootConnectionName ?? connection.name
+
+      for (const id of getConnectionIdsForRootResolution(
+        connection,
+        rootConnectionName,
+      )) {
+        if (!idToRootConnectionName.has(id)) {
+          idToRootConnectionName.set(id, rootConnectionName)
+        }
+      }
+    }
+
+    return idToRootConnectionName
+  }
+
+  private resolveRootConnectionNamesForObstacle(
+    obstacle: ObstacleWithRuntimeType,
+    idToRootConnectionName: Map<string, string>,
+    netToRootConnectionNames: Map<string, string[]>,
+    connMap: ReturnType<typeof getConnectivityMapFromSimpleRouteJson>,
+  ) {
+    const rootConnectionNames = new Set<string>()
+    const idsToResolve = new Set<string>([
+      ...(obstacle.connectedTo ?? []),
+      ...(obstacle.offBoardConnectsTo ?? []),
+    ])
+
+    if (obstacle.obstacleId) {
+      idsToResolve.add(obstacle.obstacleId)
+    }
+
+    for (const id of idsToResolve) {
+      const directRootConnectionName = idToRootConnectionName.get(id)
+      if (directRootConnectionName) {
+        rootConnectionNames.add(directRootConnectionName)
+        continue
+      }
+
+      const netId = connMap.getNetConnectedToId(id)
+      if (!netId) continue
+
+      if (!netToRootConnectionNames.has(netId)) {
+        const connectedIds = connMap.getIdsConnectedToNet(netId) ?? []
+        const rootsOnNet = Array.from(
+          new Set(
+            connectedIds
+              .map((connectedId) => idToRootConnectionName.get(connectedId))
+              .filter(Boolean),
+          ),
+        ) as string[]
+        netToRootConnectionNames.set(netId, rootsOnNet)
+      }
+
+      for (const rootConnectionName of netToRootConnectionNames.get(netId) ??
+        []) {
+        rootConnectionNames.add(rootConnectionName)
+      }
+    }
+
+    return Array.from(rootConnectionNames)
+  }
+
+  private getMergeGroupKey(
+    obstacle: ObstacleWithRuntimeType,
+    rootConnectionName: string,
+  ) {
+    return [
+      rootConnectionName,
+      getLayerKey(obstacle),
+      getZLayerKey(obstacle),
+      obstacle.netIsAssignable ? "assignable" : "fixed",
+      getOffboardKey(obstacle),
+    ].join("::")
+  }
+
+  private buildMergeComponents(obstacles: IndexedObstacle[]): MergeComponent[] {
+    if (obstacles.length === 0) return []
+
+    if (obstacles.length === 1) {
+      const onlyObstacle = obstacles[0]!
+      return [
+        {
+          rootConnectionName: onlyObstacle.rootConnectionName,
+          inputIndexes: [onlyObstacle.inputIndex],
+          mergedObstacle: structuredClone(onlyObstacle.obstacle) as Obstacle,
+        },
+      ]
+    }
+
+    const index = new FlatbushIndex<number>(obstacles.length)
+    const bboxes = obstacles.map(({ obstacle }) => getObstacleBbox(obstacle))
+    const coveredAreas = obstacles.map(
+      ({ obstacle }) => obstacle.width * obstacle.height,
+    )
+    const parent = obstacles.map((_, obstacleIndex) => obstacleIndex)
+    const rank = obstacles.map(() => 0)
+
+    for (
+      let obstacleIndex = 0;
+      obstacleIndex < obstacles.length;
+      obstacleIndex++
+    ) {
+      const bbox = bboxes[obstacleIndex]!
+      index.insert(obstacleIndex, bbox.minX, bbox.minY, bbox.maxX, bbox.maxY)
+    }
+    index.finish()
+
+    const candidateEdges: CandidateEdge[] = []
+    for (
+      let obstacleIndex = 0;
+      obstacleIndex < obstacles.length;
+      obstacleIndex++
+    ) {
+      const bbox = bboxes[obstacleIndex]!
+      const nearbyObstacleIndexes = index.search(
+        bbox.minX - this.maxMergeGap,
+        bbox.minY - this.maxMergeGap,
+        bbox.maxX + this.maxMergeGap,
+        bbox.maxY + this.maxMergeGap,
+      )
+
+      for (const nearbyObstacleIndex of nearbyObstacleIndexes) {
+        if (nearbyObstacleIndex <= obstacleIndex) continue
+
+        const nearbyBbox = bboxes[nearbyObstacleIndex]!
+        const { gapX, gapY } = getBboxGap(bbox, nearbyBbox)
+        if (gapX > this.maxMergeGap || gapY > this.maxMergeGap) continue
+
+        const unionBbox = unionBboxes(bbox, nearbyBbox)
+        const inflation =
+          getBboxArea(unionBbox) /
+          (coveredAreas[obstacleIndex]! + coveredAreas[nearbyObstacleIndex]!)
+
+        if (inflation > this.maxAreaInflation) continue
+
+        candidateEdges.push({
+          a: obstacleIndex,
+          b: nearbyObstacleIndex,
+          gap: gapX + gapY,
+          inflation,
+        })
+      }
+    }
+
+    candidateEdges.sort((a, b) => a.gap - b.gap || a.inflation - b.inflation)
+
+    const find = (obstacleIndex: number): number => {
+      if (parent[obstacleIndex] === obstacleIndex) return obstacleIndex
+      parent[obstacleIndex] = find(parent[obstacleIndex]!)
+      return parent[obstacleIndex]!
+    }
+
+    const tryUnion = (a: number, b: number) => {
+      const rootA = find(a)
+      const rootB = find(b)
+      if (rootA === rootB) return
+
+      const bboxA = bboxes[rootA]!
+      const bboxB = bboxes[rootB]!
+      const { gapX, gapY } = getBboxGap(bboxA, bboxB)
+      if (gapX > this.maxMergeGap || gapY > this.maxMergeGap) return
+
+      const mergedBbox = unionBboxes(bboxA, bboxB)
+      const mergedArea = getBboxArea(mergedBbox)
+      const areaInflation =
+        mergedArea / (coveredAreas[rootA]! + coveredAreas[rootB]!)
+      if (areaInflation > this.maxAreaInflation) return
+
+      let parentRoot = rootA
+      let childRoot = rootB
+      if (rank[parentRoot]! < rank[childRoot]!) {
+        parentRoot = rootB
+        childRoot = rootA
+      }
+
+      parent[childRoot] = parentRoot
+      if (rank[parentRoot] === rank[childRoot]) {
+        rank[parentRoot]! += 1
+      }
+
+      bboxes[parentRoot] = mergedBbox
+      coveredAreas[parentRoot] += coveredAreas[childRoot]!
+    }
+
+    for (const candidateEdge of candidateEdges) {
+      tryUnion(candidateEdge.a, candidateEdge.b)
+    }
+
+    const componentIndexes = new Map<number, number[]>()
+    for (
+      let obstacleIndex = 0;
+      obstacleIndex < obstacles.length;
+      obstacleIndex++
+    ) {
+      const rootIndex = find(obstacleIndex)
+      const component = componentIndexes.get(rootIndex)
+      if (component) {
+        component.push(obstacleIndex)
+      } else {
+        componentIndexes.set(rootIndex, [obstacleIndex])
+      }
+    }
+
+    return Array.from(componentIndexes.values()).map((memberIndexes) => {
+      const sortedMemberIndexes = memberIndexes.slice().sort((a, b) => a - b)
+      const members = sortedMemberIndexes.map(
+        (memberIndex) => obstacles[memberIndex]!,
+      )
+      const firstMember = members[0]!
+
+      if (members.length === 1) {
+        return {
+          rootConnectionName: firstMember.rootConnectionName,
+          inputIndexes: [firstMember.inputIndex],
+          mergedObstacle: structuredClone(firstMember.obstacle) as Obstacle,
+        }
+      }
+
+      const mergedBbox = sortedMemberIndexes
+        .map((memberIndex) => bboxes[find(memberIndex)]!)
+        .reduce((currentBbox, nextBbox) => unionBboxes(currentBbox, nextBbox))
+
+      const connectedTo = Array.from(
+        new Set(
+          members.flatMap(({ obstacle }) => [
+            ...(obstacle.connectedTo ?? []),
+            ...(obstacle.obstacleId ? [obstacle.obstacleId] : []),
+          ]),
+        ),
+      )
+
+      const offBoardConnectsTo = Array.from(
+        new Set(
+          members.flatMap(({ obstacle }) => obstacle.offBoardConnectsTo ?? []),
+        ),
+      )
+
+      const mergedObstacle: Obstacle = {
+        type: "rect",
+        layers: firstMember.obstacle.layers.slice(),
+        center: {
+          x: (mergedBbox.minX + mergedBbox.maxX) / 2,
+          y: (mergedBbox.minY + mergedBbox.maxY) / 2,
+        },
+        width: mergedBbox.maxX - mergedBbox.minX,
+        height: mergedBbox.maxY - mergedBbox.minY,
+        connectedTo,
+        ...(firstMember.obstacle.zLayers
+          ? { zLayers: firstMember.obstacle.zLayers.slice() }
+          : {}),
+        ...(firstMember.obstacle.netIsAssignable
+          ? { netIsAssignable: true }
+          : {}),
+        ...(offBoardConnectsTo.length > 0 ? { offBoardConnectsTo } : {}),
+      }
+
+      return {
+        rootConnectionName: firstMember.rootConnectionName,
+        inputIndexes: members
+          .map((member) => member.inputIndex)
+          .sort((a, b) => a - b),
+        mergedObstacle,
+      }
+    })
+  }
+
+  private createConsolidatedSimpleRouteJson(): SimpleRouteJson {
+    const connMap = getConnectivityMapFromSimpleRouteJson(this.inputSrj)
+    const idToRootConnectionName = this.buildIdToRootConnectionNameMap()
+    const netToRootConnectionNames = new Map<string, string[]>()
+    const groupedObstacles = new Map<string, IndexedObstacle[]>()
+
+    for (
+      let obstacleIndex = 0;
+      obstacleIndex < this.inputSrj.obstacles.length;
+      obstacleIndex++
+    ) {
+      const obstacle = this.inputSrj.obstacles[
+        obstacleIndex
+      ] as ObstacleWithRuntimeType
+      if ((obstacle.type ?? "rect") !== "rect") continue
+      if (obstacle.isCopperPour) continue
+
+      const rootConnectionNames = this.resolveRootConnectionNamesForObstacle(
+        obstacle,
+        idToRootConnectionName,
+        netToRootConnectionNames,
+        connMap,
+      )
+
+      if (rootConnectionNames.length !== 1) continue
+
+      const rootConnectionName = rootConnectionNames[0]!
+      const mergeGroupKey = this.getMergeGroupKey(obstacle, rootConnectionName)
+      const mergeGroup = groupedObstacles.get(mergeGroupKey)
+      const indexedObstacle: IndexedObstacle = {
+        inputIndex: obstacleIndex,
+        obstacle,
+        rootConnectionName,
+      }
+
+      if (mergeGroup) {
+        mergeGroup.push(indexedObstacle)
+      } else {
+        groupedObstacles.set(mergeGroupKey, [indexedObstacle])
+      }
+    }
+
+    const replacementObstaclesByIndex = new Map<number, Obstacle>()
+    const skippedIndexes = new Set<number>()
+    this.mergedComponents = []
+
+    for (const indexedObstacles of groupedObstacles.values()) {
+      const mergeComponents = this.buildMergeComponents(indexedObstacles)
+      this.mergedComponents.push(
+        ...mergeComponents.filter(
+          (component) => component.inputIndexes.length > 1,
+        ),
+      )
+
+      for (const mergeComponent of mergeComponents) {
+        const [firstInputIndex, ...remainingIndexes] =
+          mergeComponent.inputIndexes
+        replacementObstaclesByIndex.set(
+          firstInputIndex!,
+          mergeComponent.mergedObstacle,
+        )
+        for (const remainingIndex of remainingIndexes) {
+          skippedIndexes.add(remainingIndex)
+        }
+      }
+    }
+
+    const outputObstacles: Obstacle[] = []
+    for (
+      let obstacleIndex = 0;
+      obstacleIndex < this.inputSrj.obstacles.length;
+      obstacleIndex++
+    ) {
+      if (skippedIndexes.has(obstacleIndex)) continue
+
+      const replacementObstacle = replacementObstaclesByIndex.get(obstacleIndex)
+      if (replacementObstacle) {
+        outputObstacles.push(replacementObstacle)
+      } else {
+        outputObstacles.push(
+          structuredClone(this.inputSrj.obstacles[obstacleIndex]!) as Obstacle,
+        )
+      }
+    }
+
+    this.stats.inputObstacleCount = this.inputSrj.obstacles.length
+    this.stats.outputObstacleCount = outputObstacles.length
+    this.stats.reducedObstacleCount =
+      this.inputSrj.obstacles.length - outputObstacles.length
+    this.stats.mergedComponentCount = this.mergedComponents.length
+    this.stats.mergedInputObstacleCount = this.mergedComponents.reduce(
+      (total, component) => total + component.inputIndexes.length,
+      0,
+    )
+    this.stats.maxMergeGap = this.maxMergeGap
+    this.stats.maxAreaInflation = this.maxAreaInflation
+
+    return {
+      ...this.inputSrj,
+      obstacles: outputObstacles,
+    }
+  }
+
+  visualize() {
+    const originalRects = this.inputSrj.obstacles
+      .filter(
+        (obstacle) =>
+          ((obstacle as ObstacleWithRuntimeType).type ?? "rect") === "rect",
+      )
+      .map((obstacle) => ({
+        ...obstacle,
+        fill: "rgba(0, 0, 0, 0.08)",
+        stroke: "rgba(0, 0, 0, 0.18)",
+      }))
+    const mergedRects = this.mergedComponents.map((component) => ({
+      ...component.mergedObstacle,
+      fill: "rgba(0, 170, 255, 0.18)",
+      stroke: "rgba(0, 170, 255, 0.95)",
+      label: `${component.rootConnectionName} (${component.inputIndexes.length})`,
+    }))
+
+    return {
+      rects: [...originalRects, ...mergedRects],
+    }
+  }
+}

--- a/tests/solvers/consolidate-connected-obstacles-solver.test.ts
+++ b/tests/solvers/consolidate-connected-obstacles-solver.test.ts
@@ -1,0 +1,114 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver4 } from "lib/autorouter-pipelines/AutoroutingPipeline4_TinyHypergraph/AutoroutingPipelineSolver4_TinyHypergraph"
+import { ConsolidateConnectedObstaclesSolver } from "lib/solvers/ConsolidateConnectedObstaclesSolver/ConsolidateConnectedObstaclesSolver"
+import type { SimpleRouteJson } from "lib/types"
+import cm5ioRoute from "../repro/CM5IO.route.json" with { type: "json" }
+
+const createSyntheticSrj = (): SimpleRouteJson => ({
+  layerCount: 2,
+  minTraceWidth: 0.1,
+  bounds: {
+    minX: -2,
+    maxX: 4,
+    minY: -2,
+    maxY: 2,
+  },
+  connections: [
+    {
+      name: "source_trace_0",
+      pointsToConnect: [
+        { x: -1, y: 0, layer: "top" },
+        { x: 1, y: 0, layer: "top" },
+      ],
+    },
+    {
+      name: "source_trace_1",
+      pointsToConnect: [
+        { x: 2, y: 0, layer: "top" },
+        { x: 3, y: 0, layer: "top" },
+      ],
+    },
+  ],
+  obstacles: [
+    {
+      type: "rect",
+      layers: ["top"],
+      center: { x: 0, y: 0 },
+      width: 0.5,
+      height: 1,
+      connectedTo: ["source_trace_0"],
+    },
+    {
+      type: "rect",
+      layers: ["top"],
+      center: { x: 0.55, y: 0 },
+      width: 0.5,
+      height: 1,
+      connectedTo: ["source_trace_0"],
+    },
+    {
+      type: "rect",
+      layers: ["top"],
+      center: { x: -1, y: 0 },
+      width: 0.5,
+      height: 1,
+      connectedTo: ["source_trace_0"],
+    },
+    {
+      type: "rect",
+      layers: ["top"],
+      center: { x: 0.55, y: 0 },
+      width: 0.5,
+      height: 1,
+      connectedTo: ["source_trace_1"],
+    },
+  ],
+})
+
+test("ConsolidateConnectedObstaclesSolver merges nearby same-root rects only", () => {
+  const srj = createSyntheticSrj()
+  const before = structuredClone(srj)
+  const solver = new ConsolidateConnectedObstaclesSolver(srj)
+
+  solver.solve()
+
+  const outputSrj = solver.getOutputSimpleRouteJson()
+  expect(outputSrj.obstacles).toHaveLength(3)
+  expect(solver.stats.reducedObstacleCount).toBe(1)
+
+  const mergedObstacle = outputSrj.obstacles.find(
+    (obstacle) =>
+      obstacle.connectedTo.includes("source_trace_0") &&
+      Math.abs(obstacle.width - 1.05) < 1e-9,
+  )
+
+  expect(mergedObstacle).toBeDefined()
+  expect(mergedObstacle?.height).toBeCloseTo(1, 10)
+  expect(mergedObstacle?.center.x).toBeCloseTo(0.275, 10)
+  expect(srj).toEqual(before)
+})
+
+test("Pipeline4 switches to the consolidated SRJ before node solving", () => {
+  const solver = new AutoroutingPipelineSolver4(createSyntheticSrj())
+
+  solver.solveUntilPhase("nodeSolver")
+
+  expect(solver.consolidateConnectedObstaclesSolver).toBeDefined()
+  expect(solver.srjWithConsolidatedObstacles).toBeDefined()
+  expect(solver.getWorkingSrj().obstacles).toHaveLength(3)
+  expect(
+    solver.consolidateConnectedObstaclesSolver?.stats.reducedObstacleCount,
+  ).toBe(1)
+})
+
+test("ConsolidateConnectedObstaclesSolver consolidates more than ten CM5IO pads", () => {
+  const srj = structuredClone(cm5ioRoute) as SimpleRouteJson
+  const solver = new ConsolidateConnectedObstaclesSolver(srj)
+
+  solver.solve()
+
+  expect(solver.stats.reducedObstacleCount).toBeGreaterThan(10)
+  expect(solver.getOutputSimpleRouteJson().obstacles.length).toBeLessThan(
+    srj.obstacles.length - 10,
+  )
+})


### PR DESCRIPTION
## Summary
- add `ConsolidateConnectedObstaclesSolver` to merge nearby same-root rect obstacles into consolidated SRJ rects
- run the new stage after point-pair generation and route all downstream Pipeline4 stages through the consolidated SRJ via `getWorkingSrj()`
- update Pipeline4 visualization and output to reflect the consolidated obstacle set
- add focused solver coverage plus a CM5IO regression test to verify significant pad consolidation

## Testing
- `bun test tests/solvers/consolidate-connected-obstacles-solver.test.ts tests/pipeline-immutability/autorouting-pipeline4-tiny-hypergraph.test.ts tests/features/pipeline4-circuit011-cmn6-multipoint-node.test.ts`
- `bunx tsc --noEmit --ignoreDeprecations 5.0`