### PR TITLE
tiny-hypergraph with non-center penalties

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "recharts": "^2.15.1",
     "tailwind-merge": "^3.2.0",
     "terser": "^5.43.1",
-    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#b2e4c0e25bb42b0ff5a2357a4e6b171ce1a290e9",
+    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#c21fc6657a6bc6df24529994b251cd5b8306ff97",
     "tsup": "^8.3.6",
     "typescript": "^5.9.3",
     "use-mouse-matrix-transform": "^1.3.0",


### PR DESCRIPTION
Updated the tiny-hypergraph dependency to a new commit hash.