### PR TITLE
Update tiny-hypergraph and remove invalid CM5IO routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "recharts": "^2.15.1",
     "tailwind-merge": "^3.2.0",
     "terser": "^5.43.1",
-    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#b2e4c0e25bb42b0ff5a2357a4e6b171ce1a290e9",
+    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#39d48b70623ba98370f57564b0c916348ae76f9f",
     "tsup": "^8.3.6",
     "typescript": "^5.9.3",
     "use-mouse-matrix-transform": "^1.3.0",

--- a/tests/repro/CM5IO.route.json
+++ b/tests/repro/CM5IO.route.json
@@ -43815,7 +43815,6 @@
         "connectivity_net1933",
         "pcb_smtpad_434",
         "pcb_smtpad_228",
-        "source_trace_171",
         "pcb_component_41_port_43",
         "pcb_component_71_port_118",
         "pcb_port_325",
@@ -69677,7 +69676,6 @@
         "connectivity_net2104",
         "pcb_plated_hole_83",
         "pcb_smtpad_336",
-        "source_trace_119",
         "pcb_component_34_port_4",
         "pcb_component_71_port_20",
         "pcb_port_240",
@@ -86078,7 +86076,6 @@
         "connectivity_net1933",
         "pcb_smtpad_434",
         "pcb_smtpad_228",
-        "source_trace_171",
         "pcb_component_41_port_43",
         "pcb_component_71_port_118",
         "pcb_port_325",
@@ -127102,7 +127099,6 @@
         "connectivity_net2104",
         "pcb_plated_hole_83",
         "pcb_smtpad_336",
-        "source_trace_119",
         "pcb_component_34_port_4",
         "pcb_component_71_port_20",
         "pcb_port_240",
@@ -142729,26 +142725,6 @@
       ]
     },
     {
-      "name": "source_trace_119",
-      "source_trace_id": "source_trace_119",
-      "pointsToConnect": [
-        {
-          "x": -17.46000000000035,
-          "y": 43.039999999999964,
-          "layer": "top",
-          "pointId": "pcb_port_240",
-          "pcb_port_id": "pcb_port_240"
-        },
-        {
-          "x": 35.45999999999967,
-          "y": 13.799999999999955,
-          "layer": "top",
-          "pointId": "pcb_port_461",
-          "pcb_port_id": "pcb_port_461"
-        }
-      ]
-    },
-    {
       "name": "source_trace_120",
       "source_trace_id": "source_trace_120",
       "pointsToConnect": [
@@ -143145,26 +143121,6 @@
           "layer": "top",
           "pointId": "pcb_port_557",
           "pcb_port_id": "pcb_port_557"
-        }
-      ]
-    },
-    {
-      "name": "source_trace_171",
-      "source_trace_id": "source_trace_171",
-      "pointsToConnect": [
-        {
-          "x": 66.24999999999966,
-          "y": -42.77500000000005,
-          "layer": "top",
-          "pointId": "pcb_port_325",
-          "pcb_port_id": "pcb_port_325"
-        },
-        {
-          "x": 1.459999999999667,
-          "y": 13.399999999999963,
-          "layer": "top",
-          "pointId": "pcb_port_559",
-          "pcb_port_id": "pcb_port_559"
         }
       ]
     },


### PR DESCRIPTION
## Summary
- bump `tiny-hypergraph` to `39d48b70623ba98370f57564b0c916348ae76f9f`
- remove invalid `source_trace_119` and `source_trace_171` connections from the CM5IO simple route JSON
- drop the matching stale obstacle `connectedTo` references for those removed routes

## Testing
- Not run (not requested)