### PR TITLE
Fix Pipeline4 preview fallback for tiny hypergraph pathing

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline4_TinyHypergraph/AutoroutingPipelineSolver4_TinyHypergraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline4_TinyHypergraph/AutoroutingPipelineSolver4_TinyHypergraph.ts
@@ -618,6 +618,11 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
       }
       return { lines }
     }
+
+    if (this.portPointPathingSolver) {
+      return this.portPointPathingSolver.preview()
+    }
+
     if (this.netToPointPairsSolver) {
       return this.netToPointPairsSolver.visualize()
     }

--- a/tests/autorouting-pipeline4-high-density-repair.test.ts
+++ b/tests/autorouting-pipeline4-high-density-repair.test.ts
@@ -174,6 +174,32 @@ test("pipeline4 stitch stage consumes repaired high density routes", () => {
   expect(stitchParams.hdRoutes).toEqual([repairedRoute])
 })
 
+test("pipeline4 preview falls back to tiny hypergraph pathing output", () => {
+  const pathingPreview = {
+    lines: [
+      {
+        points: [
+          { x: -0.5, y: 0 },
+          { x: 0.5, y: 0 },
+        ],
+        strokeColor: "#123456",
+      },
+    ],
+  }
+
+  const solver = new AutoroutingPipelineSolver4(srj)
+  solver.netToPointPairsSolver = {
+    visualize: () => ({
+      points: [{ x: 99, y: 99, color: "red" }],
+    }),
+  } as any
+  solver.portPointPathingSolver = {
+    preview: () => pathingPreview,
+  } as any
+
+  expect(solver.preview()).toEqual(pathingPreview)
+})
+
 test(
   "pipeline4 real case repair changes output routes",
   () => {


### PR DESCRIPTION
## Summary
- return `portPointPathingSolver.preview()` from Pipeline4 when high-density preview output is not available
- keep existing later-stage preview behavior unchanged
- add a regression test covering the tiny hypergraph pathing preview fallback

## Testing
- `bun test tests/autorouting-pipeline4-high-density-repair.test.ts`
- `bunx tsc --noEmit`