### PR TITLE
Add ccwRotationDegrees to SimpleRouteJson

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ interface SimpleRouteJson {
   obstacles: Obstacle[]
   connections: Array<SimpleRouteConnection>
   bounds: { minX: number; maxX: number; minY: number; maxY: number }
+  ccwRotationDegrees?: number
   traces?: SimplifiedPcbTraces // Optional for input
 }
 

--- a/lib/types/srj-types.ts
+++ b/lib/types/srj-types.ts
@@ -51,6 +51,7 @@ export interface SimpleRouteJson {
   connections: Array<SimpleRouteConnection>
   bounds: { minX: number; maxX: number; minY: number; maxY: number }
   outline?: Array<{ x: number; y: number }>
+  ccwRotationDegrees?: number
   traces?: SimplifiedPcbTraces
   jumpers?: Jumper[]
   allowJumpers?: boolean

--- a/tests/types/simple-route-json-ccw-rotation.test.ts
+++ b/tests/types/simple-route-json-ccw-rotation.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "bun:test"
+import type { SimpleRouteJson } from "../../lib/types/srj-types"
+
+test("SimpleRouteJson accepts optional ccwRotationDegrees", () => {
+  const srj: SimpleRouteJson = {
+    layerCount: 2,
+    minTraceWidth: 0.15,
+    ccwRotationDegrees: 90,
+    obstacles: [],
+    connections: [],
+    bounds: {
+      minX: 0,
+      maxX: 10,
+      minY: 0,
+      maxY: 5,
+    },
+  }
+
+  expect(srj.ccwRotationDegrees).toBe(90)
+})


### PR DESCRIPTION
## Summary
- Add optional `ccwRotationDegrees?: number` to the `SimpleRouteJson` type.
- Update the README example to match the public type surface.
- Add a unit test covering the new optional field.

## Testing
- `bun test /Users/seve/.codex/worktrees/ce57/tscircuit-autorouter/tests/types/simple-route-json-ccw-rotation.test.ts`