### PR TITLE
Add ccwRotationDegrees support to SRJ obstacles

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ interface Obstacle {
   center: { x: number; y: number }
   width: number
   height: number
+  ccwRotationDegrees?: number
   connectedTo: string[] // TraceIds
   isCopperPour?: boolean
   offBoardConnectsTo?: string[] // TraceIds connected off-board

--- a/lib/types/srj-types.ts
+++ b/lib/types/srj-types.ts
@@ -66,6 +66,8 @@ export interface Obstacle {
   center: { x: number; y: number }
   width: number
   height: number
+  /** Optional counter-clockwise rotation metadata in degrees. */
+  ccwRotationDegrees?: number
   connectedTo: Array<TraceId | NetId>
   isCopperPour?: boolean
   netIsAssignable?: boolean

--- a/tests/utils/createObjectsWithZLayers.test.ts
+++ b/tests/utils/createObjectsWithZLayers.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test"
+import type { SimpleRouteJson } from "lib/types"
+import { createObjectsWithZLayers } from "lib/utils/createObjectsWithZLayers"
+
+test("preserves obstacle ccwRotationDegrees while normalizing zLayers", () => {
+  const srj: SimpleRouteJson = {
+    layerCount: 2,
+    minTraceWidth: 0.2,
+    bounds: { minX: -5, maxX: 5, minY: -5, maxY: 5 },
+    connections: [],
+    obstacles: [
+      {
+        type: "rect",
+        layers: ["top"],
+        center: { x: 1, y: 2 },
+        width: 3,
+        height: 1,
+        ccwRotationDegrees: 45,
+        connectedTo: [],
+      },
+    ],
+  }
+
+  const [normalizedObstacle] = createObjectsWithZLayers(
+    srj.obstacles,
+    srj.layerCount,
+  )
+
+  expect(normalizedObstacle.ccwRotationDegrees).toBe(45)
+  expect(normalizedObstacle.zLayers).toEqual([0])
+})


### PR DESCRIPTION
## Summary
- Add optional `ccwRotationDegrees` to the public `Obstacle` type
- Document the new field in the README SRJ example
- Add a unit test covering obstacle normalization preserves the field

## Testing
- Not run (not requested)