### PR TITLE
Add tiny hypergraph BFS wrapper debugger

### DIFF
--- a/fixtures/features/portpointpathing/tinyhypergraph-bfs-upload.fixture.tsx
+++ b/fixtures/features/portpointpathing/tinyhypergraph-bfs-upload.fixture.tsx
@@ -1,4 +1,4 @@
-import { GenericSolverDebugger } from "@tscircuit/solver-utils/react"
+import { GenericSolverDebugger } from "lib/testing/GenericSolverDebugger"
 import { TinyHypergraphBfsPortPointPathingSolver } from "lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphBfsPortPointPathingSolver"
 import { useMemo, useState } from "react"
 
@@ -13,27 +13,45 @@ const GOOGLE_COLORS = [
 
 const title = "BFS & tiny hypergraph"
 
+const createSolverAtIteration = (
+  loadedInput: any,
+  targetIterationCount: number,
+) => {
+  const solver = new TinyHypergraphBfsPortPointPathingSolver(
+    (Array.isArray(loadedInput) ? loadedInput[0] : loadedInput) as any,
+  )
+
+  while (
+    solver.iterations < targetIterationCount &&
+    !solver.solved &&
+    !solver.failed
+  ) {
+    solver.step()
+  }
+
+  return solver
+}
+
 export default () => {
   const [rawJson, setRawJson] = useState("")
   const [loadedInput, setLoadedInput] = useState<any | null>(null)
   const [loadError, setLoadError] = useState<string | null>(null)
+  const [targetIterationInput, setTargetIterationInput] = useState("0")
 
-  const { solver, solverError } = useMemo(() => {
-    if (!loadedInput) return { solver: null, solverError: null }
+  const targetIterationCount = Math.max(
+    0,
+    Number.parseInt(targetIterationInput, 10) || 0,
+  )
+
+  const solverError = useMemo(() => {
+    if (!loadedInput) return null
     try {
-      return {
-        solver: new TinyHypergraphBfsPortPointPathingSolver(
-          (Array.isArray(loadedInput) ? loadedInput[0] : loadedInput) as any,
-        ),
-        solverError: null,
-      }
+      createSolverAtIteration(loadedInput, targetIterationCount)
+      return null
     } catch (error) {
-      return {
-        solver: null,
-        solverError: error instanceof Error ? error.message : String(error),
-      }
+      return error instanceof Error ? error.message : String(error)
     }
-  }, [loadedInput])
+  }, [loadedInput, targetIterationCount])
 
   const submitJson = () => {
     try {
@@ -63,27 +81,68 @@ export default () => {
     reader.readAsText(file)
   }
 
-  if (solver) {
+  if (loadedInput && !solverError) {
     return (
       <div style={{ padding: 24 }}>
-        <button
-          onClick={() => {
-            setLoadedInput(null)
-            setLoadError(null)
-          }}
+        <div
           style={{
+            display: "flex",
+            gap: 12,
+            flexWrap: "wrap",
+            alignItems: "center",
             marginBottom: 16,
-            border: "none",
-            background: "#f1f3f4",
-            borderRadius: 999,
-            padding: "10px 16px",
-            cursor: "pointer",
-            fontSize: 14,
           }}
         >
-          Load another JSON
-        </button>
-        <GenericSolverDebugger solver={solver as any} />
+          <button
+            onClick={() => {
+              setLoadedInput(null)
+              setLoadError(null)
+            }}
+            style={{
+              border: "none",
+              background: "#f1f3f4",
+              borderRadius: 999,
+              padding: "10px 16px",
+              cursor: "pointer",
+              fontSize: 14,
+            }}
+          >
+            Load another JSON
+          </button>
+
+          <label
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 8,
+              fontSize: 14,
+              color: "#202124",
+            }}
+          >
+            Start at iteration
+            <input
+              type="number"
+              min={0}
+              step={1}
+              value={targetIterationInput}
+              onChange={(e) => setTargetIterationInput(e.target.value)}
+              style={{
+                width: 120,
+                borderRadius: 999,
+                border: "1px solid #dadce0",
+                padding: "10px 14px",
+                fontSize: 14,
+              }}
+            />
+          </label>
+        </div>
+
+        <GenericSolverDebugger
+          key={`debugger-${targetIterationCount}`}
+          createSolver={() =>
+            createSolverAtIteration(loadedInput, targetIterationCount)
+          }
+        />
       </div>
     )
   }
@@ -135,7 +194,8 @@ export default () => {
           </div>
           <div style={{ fontSize: 14, color: "#5f6368", marginBottom: 16 }}>
             Paste any serialized `portPointPathingSolver_input.json` payload,
-            then open the step debugger.
+            then open the step debugger. You can also pre-run the solver to a
+            target iteration before the debugger mounts.
           </div>
 
           <textarea
@@ -185,6 +245,36 @@ export default () => {
             </div>
 
             <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+              <label
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 8,
+                  border: "1px solid #dadce0",
+                  background: "#fff",
+                  color: "#202124",
+                  borderRadius: 999,
+                  padding: "12px 18px",
+                  fontSize: 14,
+                }}
+              >
+                Stop at iteration
+                <input
+                  type="number"
+                  min={0}
+                  step={1}
+                  value={targetIterationInput}
+                  onChange={(e) => setTargetIterationInput(e.target.value)}
+                  style={{
+                    width: 96,
+                    borderRadius: 999,
+                    border: "1px solid #dadce0",
+                    padding: "8px 12px",
+                    fontSize: 14,
+                  }}
+                />
+              </label>
+
               <label
                 style={{
                   display: "inline-flex",

--- a/fixtures/features/portpointpathing/tinyhypergraph-bfs-upload.fixture.tsx
+++ b/fixtures/features/portpointpathing/tinyhypergraph-bfs-upload.fixture.tsx
@@ -1,0 +1,232 @@
+import { GenericSolverDebugger } from "@tscircuit/solver-utils/react"
+import { TinyHypergraphBfsPortPointPathingSolver } from "lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphBfsPortPointPathingSolver"
+import { useMemo, useState } from "react"
+
+const GOOGLE_COLORS = [
+  "#4285F4",
+  "#EA4335",
+  "#FBBC05",
+  "#4285F4",
+  "#34A853",
+  "#EA4335",
+]
+
+const title = "BFS & tiny hypergraph"
+
+export default () => {
+  const [rawJson, setRawJson] = useState("")
+  const [loadedInput, setLoadedInput] = useState<any | null>(null)
+  const [loadError, setLoadError] = useState<string | null>(null)
+
+  const { solver, solverError } = useMemo(() => {
+    if (!loadedInput) return { solver: null, solverError: null }
+    try {
+      return {
+        solver: new TinyHypergraphBfsPortPointPathingSolver(
+          (Array.isArray(loadedInput) ? loadedInput[0] : loadedInput) as any,
+        ),
+        solverError: null,
+      }
+    } catch (error) {
+      return {
+        solver: null,
+        solverError: error instanceof Error ? error.message : String(error),
+      }
+    }
+  }, [loadedInput])
+
+  const submitJson = () => {
+    try {
+      setLoadedInput(JSON.parse(rawJson))
+      setLoadError(null)
+    } catch (error) {
+      setLoadError(error instanceof Error ? error.message : String(error))
+    }
+  }
+
+  const uploadJsonFile = (file: File | null) => {
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = () => {
+      const text = typeof reader.result === "string" ? reader.result : ""
+      setRawJson(text)
+      try {
+        setLoadedInput(JSON.parse(text))
+        setLoadError(null)
+      } catch (error) {
+        setLoadError(error instanceof Error ? error.message : String(error))
+      }
+    }
+    reader.onerror = () => {
+      setLoadError("Failed to read uploaded file")
+    }
+    reader.readAsText(file)
+  }
+
+  if (solver) {
+    return (
+      <div style={{ padding: 24 }}>
+        <button
+          onClick={() => {
+            setLoadedInput(null)
+            setLoadError(null)
+          }}
+          style={{
+            marginBottom: 16,
+            border: "none",
+            background: "#f1f3f4",
+            borderRadius: 999,
+            padding: "10px 16px",
+            cursor: "pointer",
+            fontSize: 14,
+          }}
+        >
+          Load another JSON
+        </button>
+        <GenericSolverDebugger solver={solver as any} />
+      </div>
+    )
+  }
+
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background:
+          "radial-gradient(circle at top, rgba(66,133,244,0.08), transparent 32%), #ffffff",
+        padding: 24,
+        fontFamily: "Arial, Helvetica, sans-serif",
+      }}
+    >
+      <div style={{ width: "min(920px, 100%)", textAlign: "center" }}>
+        <div
+          style={{
+            fontSize: 72,
+            lineHeight: 1,
+            letterSpacing: -3,
+            marginBottom: 24,
+            fontWeight: 500,
+          }}
+        >
+          {title.split("").map((letter, index) => (
+            <span
+              key={`${letter}-${index}`}
+              style={{ color: GOOGLE_COLORS[index % GOOGLE_COLORS.length] }}
+            >
+              {letter}
+            </span>
+          ))}
+        </div>
+
+        <div
+          style={{
+            background: "#fff",
+            borderRadius: 28,
+            boxShadow: "0 2px 12px rgba(60,64,67,0.15)",
+            padding: 24,
+            textAlign: "left",
+          }}
+        >
+          <div style={{ fontSize: 20, marginBottom: 10, color: "#202124" }}>
+            Port Point Pathing Solver JSON
+          </div>
+          <div style={{ fontSize: 14, color: "#5f6368", marginBottom: 16 }}>
+            Paste any serialized `portPointPathingSolver_input.json` payload,
+            then open the step debugger.
+          </div>
+
+          <textarea
+            value={rawJson}
+            onChange={(e) => setRawJson(e.target.value)}
+            placeholder="Paste JSON here"
+            style={{
+              width: "100%",
+              minHeight: 360,
+              borderRadius: 18,
+              border: "1px solid #dadce0",
+              padding: 16,
+              fontSize: 13,
+              fontFamily:
+                "ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, monospace",
+              resize: "vertical",
+              boxSizing: "border-box",
+            }}
+          />
+
+          {(loadError || solverError) && (
+            <div
+              style={{
+                marginTop: 12,
+                color: "#c5221f",
+                fontSize: 14,
+                whiteSpace: "pre-wrap",
+              }}
+            >
+              {loadError ?? solverError}
+            </div>
+          )}
+
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              gap: 12,
+              marginTop: 16,
+              flexWrap: "wrap",
+            }}
+          >
+            <div style={{ fontSize: 13, color: "#5f6368" }}>
+              Example path:
+              {` /home/ohmx/Downloads/portPointPathingSolver_input.json`}
+            </div>
+
+            <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+              <label
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  border: "1px solid #dadce0",
+                  background: "#fff",
+                  color: "#1a73e8",
+                  borderRadius: 999,
+                  padding: "12px 22px",
+                  cursor: "pointer",
+                  fontSize: 14,
+                  fontWeight: 500,
+                }}
+              >
+                Upload JSON
+                <input
+                  type="file"
+                  accept=".json,application/json"
+                  onChange={(e) => uploadJsonFile(e.target.files?.[0] ?? null)}
+                  style={{ display: "none" }}
+                />
+              </label>
+
+              <button
+                onClick={submitJson}
+                style={{
+                  border: "none",
+                  background: "#1a73e8",
+                  color: "#fff",
+                  borderRadius: 999,
+                  padding: "12px 22px",
+                  cursor: "pointer",
+                  fontSize: 14,
+                  fontWeight: 500,
+                }}
+              >
+                Open Debugger
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/fixtures/features/portpointpathing/tinyhypergraph-bfs-upload.fixture.tsx
+++ b/fixtures/features/portpointpathing/tinyhypergraph-bfs-upload.fixture.tsx
@@ -1,4 +1,4 @@
-import { GenericSolverDebugger } from "lib/testing/GenericSolverDebugger"
+import { GenericSolverDebugger } from "@tscircuit/solver-utils/react"
 import { TinyHypergraphBfsPortPointPathingSolver } from "lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphBfsPortPointPathingSolver"
 import { useMemo, useState } from "react"
 
@@ -11,7 +11,7 @@ const GOOGLE_COLORS = [
   "#EA4335",
 ]
 
-const title = "BFS & tiny hypergraph"
+const title = "BFS & Tiny Hypergraph"
 
 const createSolverAtIteration = (
   loadedInput: any,
@@ -43,13 +43,21 @@ export default () => {
     Number.parseInt(targetIterationInput, 10) || 0,
   )
 
-  const solverError = useMemo(() => {
-    if (!loadedInput) return null
+  const { solver, solverError } = useMemo(() => {
+    if (!loadedInput) {
+      return { solver: null, solverError: null }
+    }
+
     try {
-      createSolverAtIteration(loadedInput, targetIterationCount)
-      return null
+      return {
+        solver: createSolverAtIteration(loadedInput, targetIterationCount),
+        solverError: null,
+      }
     } catch (error) {
-      return error instanceof Error ? error.message : String(error)
+      return {
+        solver: null,
+        solverError: error instanceof Error ? error.message : String(error),
+      }
     }
   }, [loadedInput, targetIterationCount])
 
@@ -81,7 +89,7 @@ export default () => {
     reader.readAsText(file)
   }
 
-  if (loadedInput && !solverError) {
+  if (loadedInput && solver && !solverError) {
     return (
       <div style={{ padding: 24 }}>
         <div
@@ -139,9 +147,7 @@ export default () => {
 
         <GenericSolverDebugger
           key={`debugger-${targetIterationCount}`}
-          createSolver={() =>
-            createSolverAtIteration(loadedInput, targetIterationCount)
-          }
+          solver={solver as any}
         />
       </div>
     )
@@ -258,7 +264,7 @@ export default () => {
                   fontSize: 14,
                 }}
               >
-                Stop at iteration
+                Start at iteration
                 <input
                   type="number"
                   min={0}

--- a/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphBfsPortPointPathingSolver.ts
+++ b/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphBfsPortPointPathingSolver.ts
@@ -289,9 +289,7 @@ export class TinyHypergraphBfsPortPointPathingSolver extends BaseSolver {
       const { activeRouteBfs, isNewConnectionStart } =
         this.getOrCreateActiveRouteBfs(activeTinySolver)
       if (activeRouteBfs && isNewConnectionStart) {
-        if (!activeRouteBfs.approved) {
-          this.runRouteBfsToCompletion(activeRouteBfs)
-        }
+        this.runRouteBfsToCompletion(activeRouteBfs)
         this.displayedRouteBfs = activeRouteBfs
         this.activeSubSolver = activeTinySolver
         this.progress = this.wrappedSolver.progress
@@ -505,11 +503,7 @@ export class TinyHypergraphBfsPortPointPathingSolver extends BaseSolver {
   }
 
   private runRouteBfsToCompletion(activeRouteBfs: ActiveTinyRouteBfs) {
-    while (
-      !this.failed &&
-      !activeRouteBfs.approved &&
-      activeRouteBfs.queue.length > 0
-    ) {
+    while (!this.failed && activeRouteBfs.queue.length > 0) {
       this.advanceRouteBfs(activeRouteBfs)
     }
   }
@@ -526,12 +520,13 @@ export class TinyHypergraphBfsPortPointPathingSolver extends BaseSolver {
     activeRouteBfs.lastExpandedPortIds = this.reconstructPortPath(current)
 
     if (activeRouteBfs.goalRegionIds.has(current.nextRegionId)) {
-      activeRouteBfs.lastExpandedPortIds = [
-        ...this.reconstructPortPath(current),
-        activeRouteBfs.goalPortId,
-      ]
-      activeRouteBfs.approved = true
-      return
+      if (!activeRouteBfs.approved) {
+        activeRouteBfs.lastExpandedPortIds = [
+          ...this.reconstructPortPath(current),
+          activeRouteBfs.goalPortId,
+        ]
+        activeRouteBfs.approved = true
+      }
     }
 
     const { solver } = activeRouteBfs
@@ -553,12 +548,13 @@ export class TinyHypergraphBfsPortPointPathingSolver extends BaseSolver {
       if (activeRouteBfs.blockedPortIds.has(neighborPortId)) continue
 
       if (neighborPortId === activeRouteBfs.goalPortId) {
-        activeRouteBfs.lastExpandedPortIds = [
-          ...this.reconstructPortPath(current),
-          neighborPortId,
-        ]
-        activeRouteBfs.approved = true
-        return
+        if (!activeRouteBfs.approved) {
+          activeRouteBfs.lastExpandedPortIds = [
+            ...this.reconstructPortPath(current),
+            neighborPortId,
+          ]
+          activeRouteBfs.approved = true
+        }
       }
 
       if (

--- a/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphBfsPortPointPathingSolver.ts
+++ b/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphBfsPortPointPathingSolver.ts
@@ -1,0 +1,899 @@
+import type { GraphicsObject } from "graphics-debug"
+import { BaseSolver } from "lib/solvers/BaseSolver"
+import type { InputNodeWithPortPoints } from "lib/solvers/PortPointPathingSolver/PortPointPathingSolver"
+import { calculateNodeProbabilityOfFailure } from "lib/solvers/UnravelSolver/calculateCrossingProbabilityOfFailure"
+import type { CapacityMeshNodeId } from "lib/types"
+import type { NodeWithPortPoints } from "lib/types/high-density-types"
+import { combineVisualizations } from "lib/utils/combineVisualizations"
+import { getIntraNodeCrossingsUsingCircle } from "lib/utils/getIntraNodeCrossingsUsingCircle"
+import type { HgPortPointPathingSolverParams } from "../hgportpointpathingsolver/types"
+import { TinyHypergraphPortPointPathingSolver } from "./TinyHypergraphPortPointPathingSolver"
+
+type SerializedRegion = {
+  regionId: string
+  pointIds: string[]
+  d: any
+}
+
+type SerializedPort = {
+  portId: string
+  region1Id: string
+  region2Id: string
+  d: {
+    portId: string
+    x: number
+    y: number
+    z: number
+    distToCentermostPortOnZ: number
+  }
+}
+
+type SerializedConnection = {
+  connectionId: string
+  mutuallyConnectedNetworkId?: string
+  startRegionId: string
+  endRegionId: string
+  simpleRouteConnection?: any
+}
+
+type SerializedHgPortPointPathingSolverParams = Omit<
+  HgPortPointPathingSolverParams,
+  "graph" | "connections"
+> & {
+  format?: string
+  graph: {
+    regions: SerializedRegion[]
+    ports: SerializedPort[]
+  }
+  connections: SerializedConnection[]
+}
+
+type NormalizedRegion = SerializedRegion & {
+  ports: SerializedPort[]
+}
+
+type NormalizedConnection = SerializedConnection & {
+  rootConnectionName: string
+  connectionName: string
+}
+
+type NormalizedData = {
+  regions: NormalizedRegion[]
+  ports: SerializedPort[]
+  connections: NormalizedConnection[]
+}
+
+type TinyRouteBfsState = {
+  portId: number
+  nextRegionId: number
+  prev: TinyRouteBfsState | null
+}
+
+type ActiveTinyRouteBfs = {
+  solver: any
+  routeId: number
+  routeLabel: string
+  startPortId: number
+  goalPortId: number
+  goalRegionIds: Set<number>
+  queue: TinyRouteBfsState[]
+  seen: Set<string>
+  lastExpandedPortIds: number[]
+  approved: boolean
+}
+
+const getConnectionNames = (connection: {
+  connectionId: string
+  mutuallyConnectedNetworkId?: string
+  simpleRouteConnection?: { rootConnectionName?: string; name?: string }
+}) => ({
+  rootConnectionName:
+    connection.simpleRouteConnection?.rootConnectionName ??
+    connection.mutuallyConnectedNetworkId ??
+    connection.connectionId,
+  connectionName:
+    connection.simpleRouteConnection?.name ?? connection.connectionId,
+})
+
+const serializePort = (port: {
+  d: {
+    portId: string
+    x: number
+    y: number
+    z: number
+    distToCentermostPortOnZ: number
+  }
+  region1: { regionId: string }
+  region2: { regionId: string }
+}): SerializedPort => ({
+  portId: port.d.portId,
+  region1Id: port.region1.regionId,
+  region2Id: port.region2.regionId,
+  d: {
+    portId: port.d.portId,
+    x: port.d.x,
+    y: port.d.y,
+    z: port.d.z,
+    distToCentermostPortOnZ: port.d.distToCentermostPortOnZ,
+  },
+})
+
+const isSerializedParams = (
+  params:
+    | HgPortPointPathingSolverParams
+    | SerializedHgPortPointPathingSolverParams,
+): params is SerializedHgPortPointPathingSolverParams =>
+  Boolean(
+    (params as SerializedHgPortPointPathingSolverParams).graph?.ports?.[0]
+      ?.region1Id,
+  )
+
+const normalizeParams = (
+  params:
+    | HgPortPointPathingSolverParams
+    | SerializedHgPortPointPathingSolverParams,
+): NormalizedData => {
+  if (isSerializedParams(params)) {
+    const regionMap = new Map<string, NormalizedRegion>()
+    for (const region of params.graph.regions) {
+      regionMap.set(region.regionId, { ...region, ports: [] })
+    }
+
+    const ports = params.graph.ports.map((port) => ({ ...port }))
+    for (const port of ports) {
+      regionMap.get(port.region1Id)?.ports.push(port)
+      regionMap.get(port.region2Id)?.ports.push(port)
+    }
+
+    return {
+      regions: [...regionMap.values()],
+      ports,
+      connections: params.connections.map((connection) => ({
+        ...connection,
+        ...getConnectionNames(connection),
+      })),
+    }
+  }
+
+  const regions = params.graph.regions.map(
+    (region): NormalizedRegion => ({
+      regionId: region.regionId,
+      pointIds: region.ports.map((port) => port.d.portId),
+      d: region.d,
+      ports: region.ports.map(serializePort),
+    }),
+  )
+
+  const portMap = new Map<string, SerializedPort>()
+  for (const region of regions) {
+    for (const port of region.ports) {
+      portMap.set(port.portId, port)
+    }
+  }
+
+  return {
+    regions,
+    ports: [...portMap.values()],
+    connections: params.connections.map((connection) => ({
+      connectionId: connection.connectionId,
+      mutuallyConnectedNetworkId: connection.mutuallyConnectedNetworkId,
+      startRegionId: connection.startRegion.regionId,
+      endRegionId: connection.endRegion.regionId,
+      simpleRouteConnection: connection.simpleRouteConnection,
+      ...getConnectionNames(connection),
+    })),
+  }
+}
+
+const createRuntimeParams = (
+  params:
+    | HgPortPointPathingSolverParams
+    | SerializedHgPortPointPathingSolverParams,
+): HgPortPointPathingSolverParams => {
+  if (!isSerializedParams(params)) {
+    return params
+  }
+
+  const normalized = normalizeParams(params)
+  const regionMap = new Map<string, any>()
+
+  for (const region of normalized.regions) {
+    regionMap.set(region.regionId, {
+      regionId: region.regionId,
+      d: region.d,
+      ports: [],
+    })
+  }
+
+  const graphPorts: any[] = []
+  for (const port of normalized.ports) {
+    const region1 = regionMap.get(port.region1Id)
+    const region2 = regionMap.get(port.region2Id)
+    if (!region1 || !region2) continue
+
+    const runtimePort = {
+      portId: port.portId,
+      region1,
+      region2,
+      d: {
+        ...port.d,
+        regions: [region1, region2],
+      },
+    }
+    graphPorts.push(runtimePort)
+    region1.ports.push(runtimePort)
+    region2.ports.push(runtimePort)
+  }
+
+  return {
+    graph: {
+      regions: [...regionMap.values()],
+      ports: graphPorts,
+    } as HgPortPointPathingSolverParams["graph"],
+    connections: normalized.connections.map((connection) => ({
+      connectionId: connection.connectionId,
+      mutuallyConnectedNetworkId: connection.mutuallyConnectedNetworkId,
+      startRegion: regionMap.get(connection.startRegionId),
+      endRegion: regionMap.get(connection.endRegionId),
+      simpleRouteConnection: connection.simpleRouteConnection,
+    })) as HgPortPointPathingSolverParams["connections"],
+    colorMap: params.colorMap,
+    inputSolvedRoutes: params.inputSolvedRoutes,
+    layerCount: params.layerCount,
+    effort: params.effort,
+    flags: params.flags,
+    weights: params.weights,
+    opts: params.opts,
+  }
+}
+
+export class TinyHypergraphBfsPortPointPathingSolver extends BaseSolver {
+  private readonly originalParams:
+    | HgPortPointPathingSolverParams
+    | SerializedHgPortPointPathingSolverParams
+  private readonly wrappedSolver: TinyHypergraphPortPointPathingSolver
+  private readonly originalRegionById = new Map<
+    CapacityMeshNodeId,
+    NormalizedRegion
+  >()
+  private activeRouteBfs: ActiveTinyRouteBfs | null = null
+  private displayedRouteBfs: ActiveTinyRouteBfs | null = null
+
+  constructor(
+    params:
+      | HgPortPointPathingSolverParams
+      | SerializedHgPortPointPathingSolverParams,
+  ) {
+    super()
+    this.originalParams = params
+    this.wrappedSolver = new TinyHypergraphPortPointPathingSolver(
+      createRuntimeParams(params),
+    )
+    this.MAX_ITERATIONS = this.wrappedSolver.MAX_ITERATIONS
+
+    for (const region of normalizeParams(params).regions) {
+      this.originalRegionById.set(region.d.capacityMeshNodeId, region)
+    }
+  }
+
+  getSolverName(): string {
+    return "TinyHypergraphBfsPortPointPathingSolver"
+  }
+
+  override _step() {
+    this.displayedRouteBfs = null
+    const activeTinySolver = this.getActiveTinySolver()
+    if (activeTinySolver) {
+      const { activeRouteBfs, isNewConnectionStart } =
+        this.getOrCreateActiveRouteBfs(activeTinySolver)
+      if (activeRouteBfs && isNewConnectionStart) {
+        if (!activeRouteBfs.approved) {
+          this.runRouteBfsToCompletion(activeRouteBfs)
+        }
+        this.displayedRouteBfs = activeRouteBfs
+        this.activeSubSolver = activeTinySolver
+        this.progress = this.wrappedSolver.progress
+        this.stats = {
+          ...(this.wrappedSolver.stats ?? {}),
+          bfsRouteId: activeRouteBfs.routeId,
+          bfsRouteLabel: activeRouteBfs.routeLabel,
+          bfsQueueSize: activeRouteBfs.queue.length,
+          bfsApproved: activeRouteBfs.approved,
+          bfsLastExpandedPortCount: activeRouteBfs.lastExpandedPortIds.length,
+        }
+        return
+      }
+    } else {
+      this.activeRouteBfs = null
+    }
+
+    this.wrappedSolver.step()
+    this.solved = this.wrappedSolver.solved
+    this.failed = this.wrappedSolver.failed
+    this.error = this.wrappedSolver.error
+    this.progress = this.wrappedSolver.progress
+    this.stats = this.wrappedSolver.stats
+    this.activeSubSolver = this.wrappedSolver.activeSubSolver ?? null
+  }
+
+  private getPipelineSolver(): any {
+    return (this.wrappedSolver as any).tinyPipelineSolver
+  }
+
+  private isTinySolver(candidate: any): boolean {
+    return Boolean(
+      candidate?.topology &&
+        candidate?.problem &&
+        candidate?.state &&
+        typeof candidate.getStartingNextRegionId === "function",
+    )
+  }
+
+  private findTinySolver(candidate: any): any | null {
+    if (!candidate) return null
+    if (this.isTinySolver(candidate)) return candidate
+    return (
+      this.findTinySolver(candidate.activeSubSolver) ??
+      this.findTinySolver(candidate.sectionSolver) ??
+      this.findTinySolver(candidate.baselineSolver) ??
+      this.findTinySolver(candidate.optimizedSolver) ??
+      null
+    )
+  }
+
+  private getActiveTinySolver(): any | null {
+    const pipelineSolver = this.getPipelineSolver()
+    return (
+      this.findTinySolver(this.wrappedSolver.activeSubSolver) ??
+      this.findTinySolver(pipelineSolver?.activeSubSolver) ??
+      this.findTinySolver(pipelineSolver?.getSolver?.("solveGraph")) ??
+      this.findTinySolver(pipelineSolver?.getInitialVisualizationSolver?.()) ??
+      null
+    )
+  }
+
+  private isPortReservedForDifferentNetForRoute(
+    solver: any,
+    portId: number,
+    routeNetId: number,
+  ) {
+    const reservedNetIds = solver.problemSetup?.portEndpointNetIds?.[portId]
+    if (!reservedNetIds) return false
+    for (const netId of reservedNetIds) {
+      if (netId !== routeNetId) return true
+    }
+    return false
+  }
+
+  private isRegionReservedForDifferentNetForRoute(
+    solver: any,
+    regionId: number,
+    routeNetId: number,
+  ) {
+    const reservedNetId = solver.problem.regionNetId[regionId]
+    return reservedNetId !== -1 && reservedNetId !== routeNetId
+  }
+
+  private getOrCreateActiveRouteBfs(solver: any): {
+    activeRouteBfs: ActiveTinyRouteBfs | null
+    isNewConnectionStart: boolean
+  } {
+    if (solver.state.currentRouteId !== undefined) {
+      if (
+        this.activeRouteBfs &&
+        this.activeRouteBfs.solver === solver &&
+        this.activeRouteBfs.routeId === solver.state.currentRouteId
+      ) {
+        return {
+          activeRouteBfs: this.activeRouteBfs,
+          isNewConnectionStart: false,
+        }
+      }
+      return { activeRouteBfs: null, isNewConnectionStart: false }
+    }
+
+    const nextRouteId = solver.state.unroutedRoutes[0]
+    if (nextRouteId === undefined) {
+      this.activeRouteBfs = null
+      return { activeRouteBfs: null, isNewConnectionStart: false }
+    }
+
+    if (
+      this.activeRouteBfs &&
+      this.activeRouteBfs.solver === solver &&
+      this.activeRouteBfs.routeId === nextRouteId
+    ) {
+      return {
+        activeRouteBfs: this.activeRouteBfs,
+        isNewConnectionStart: false,
+      }
+    }
+
+    const startingPortId = solver.problem.routeStartPort[nextRouteId]
+    const routeNetId = solver.problem.routeNet[nextRouteId]
+    const startingIncidentRegions =
+      solver.topology.incidentPortRegion[startingPortId] ?? []
+    const goalPortId = solver.problem.routeEndPort[nextRouteId]
+    const goalRegionIds = new Set<number>(
+      (solver.topology.incidentPortRegion[goalPortId] ?? []).filter(
+        (regionId: number) =>
+          !this.isRegionReservedForDifferentNetForRoute(
+            solver,
+            regionId,
+            routeNetId,
+          ),
+      ),
+    )
+
+    const startingStates = startingIncidentRegions
+      .filter((regionId: number) => {
+        const reservedNetId = solver.problem.regionNetId[regionId]
+        return reservedNetId === -1 || reservedNetId === routeNetId
+      })
+      .map(
+        (regionId: number): TinyRouteBfsState => ({
+          portId: startingPortId,
+          nextRegionId: regionId,
+          prev: null,
+        }),
+      )
+
+    if (startingStates.length === 0) {
+      this.failed = true
+      this.error = `BFS failed for route ${nextRouteId}: start port ${startingPortId} has no available region`
+      return { activeRouteBfs: null, isNewConnectionStart: false }
+    }
+
+    const routeMetadata = solver.problem.routeMetadata?.[nextRouteId]
+    this.activeRouteBfs = {
+      solver,
+      routeId: nextRouteId,
+      routeLabel:
+        routeMetadata?.simpleRouteConnection?.name ??
+        routeMetadata?.connectionId ??
+        `route-${nextRouteId}`,
+      startPortId: startingPortId,
+      goalPortId,
+      goalRegionIds,
+      queue: startingStates,
+      seen: new Set(
+        startingStates.map((state) => `${state.portId}:${state.nextRegionId}`),
+      ),
+      lastExpandedPortIds: [startingPortId],
+      approved:
+        startingPortId === goalPortId ||
+        startingStates.some((state) => goalRegionIds.has(state.nextRegionId)),
+    }
+
+    if (this.activeRouteBfs.approved) {
+      this.activeRouteBfs.lastExpandedPortIds =
+        startingPortId === goalPortId
+          ? [startingPortId]
+          : [startingPortId, goalPortId]
+    }
+
+    return {
+      activeRouteBfs: this.activeRouteBfs,
+      isNewConnectionStart: true,
+    }
+  }
+
+  private runRouteBfsToCompletion(activeRouteBfs: ActiveTinyRouteBfs) {
+    while (
+      !this.failed &&
+      !activeRouteBfs.approved &&
+      activeRouteBfs.queue.length > 0
+    ) {
+      this.advanceRouteBfs(activeRouteBfs)
+    }
+  }
+
+  private advanceRouteBfs(activeRouteBfs: ActiveTinyRouteBfs) {
+    const current = activeRouteBfs.queue.shift()
+    if (!current) {
+      this.failed = true
+      this.error = `BFS failed for ${activeRouteBfs.routeLabel}: ran out of candidate ports before reaching the goal side`
+      this.logBfsFailure(activeRouteBfs, "empty_queue")
+      return
+    }
+
+    activeRouteBfs.lastExpandedPortIds = this.reconstructPortPath(current)
+
+    if (activeRouteBfs.goalRegionIds.has(current.nextRegionId)) {
+      activeRouteBfs.lastExpandedPortIds = [
+        ...this.reconstructPortPath(current),
+        activeRouteBfs.goalPortId,
+      ]
+      activeRouteBfs.approved = true
+      return
+    }
+
+    const { solver } = activeRouteBfs
+    const routeNetId = solver.problem.routeNet[activeRouteBfs.routeId]
+    const neighbors =
+      solver.topology.regionIncidentPorts[current.nextRegionId] ?? []
+    for (const neighborPortId of neighbors) {
+      const assignedNetId = solver.state.portAssignment[neighborPortId]
+      if (
+        this.isPortReservedForDifferentNetForRoute(
+          solver,
+          neighborPortId,
+          routeNetId,
+        )
+      ) {
+        continue
+      }
+      if (neighborPortId === current.portId) continue
+
+      if (neighborPortId === activeRouteBfs.goalPortId) {
+        activeRouteBfs.lastExpandedPortIds = [
+          ...this.reconstructPortPath(current),
+          neighborPortId,
+        ]
+        activeRouteBfs.approved = true
+        return
+      }
+
+      if (
+        assignedNetId !== -1 &&
+        assignedNetId !== solver.problem.routeNet[activeRouteBfs.routeId]
+      ) {
+        continue
+      }
+      if (solver.problem.portSectionMask[neighborPortId] === 0) continue
+
+      const incidentRegions =
+        solver.topology.incidentPortRegion[neighborPortId] ?? []
+      const nextRegionId =
+        incidentRegions[0] === current.nextRegionId
+          ? incidentRegions[1]
+          : incidentRegions[0]
+
+      if (
+        nextRegionId === undefined ||
+        this.isRegionReservedForDifferentNetForRoute(
+          solver,
+          nextRegionId,
+          routeNetId,
+        )
+      ) {
+        continue
+      }
+
+      const stateKey = `${neighborPortId}:${nextRegionId}`
+      if (activeRouteBfs.seen.has(stateKey)) continue
+      activeRouteBfs.seen.add(stateKey)
+      activeRouteBfs.queue.push({
+        portId: neighborPortId,
+        nextRegionId,
+        prev: current,
+      })
+    }
+
+    if (activeRouteBfs.queue.length === 0 && !activeRouteBfs.approved) {
+      this.failed = true
+      this.error = `BFS failed for ${activeRouteBfs.routeLabel}: ran out of candidate ports before reaching the goal side`
+      this.logBfsFailure(activeRouteBfs, "frontier_exhausted")
+    }
+  }
+
+  private logBfsFailure(activeRouteBfs: ActiveTinyRouteBfs, reason: string) {
+    const { solver } = activeRouteBfs
+    const routeNetId = solver.problem.routeNet[activeRouteBfs.routeId]
+    console.log("[TinyHypergraphBfs] failure", {
+      reason,
+      routeId: activeRouteBfs.routeId,
+      routeLabel: activeRouteBfs.routeLabel,
+      routeNetId,
+      startPortId: activeRouteBfs.startPortId,
+      goalPortId: activeRouteBfs.goalPortId,
+      goalRegionIds: [...activeRouteBfs.goalRegionIds],
+      queueSize: activeRouteBfs.queue.length,
+      seenCount: activeRouteBfs.seen.size,
+      lastExpandedPortIds: activeRouteBfs.lastExpandedPortIds,
+      startIncidentRegions:
+        solver.topology.incidentPortRegion[activeRouteBfs.startPortId] ?? [],
+      goalIncidentRegions:
+        solver.topology.incidentPortRegion[activeRouteBfs.goalPortId] ?? [],
+    })
+  }
+
+  private reconstructPortPath(state: TinyRouteBfsState): number[] {
+    const portIds: number[] = []
+    let cursor: TinyRouteBfsState | null = state
+    while (cursor) {
+      portIds.unshift(cursor.portId)
+      cursor = cursor.prev
+    }
+    return portIds
+  }
+
+  private getRegionCenter(solver: any, regionId: number) {
+    const regionMetadata = solver.topology.regionMetadata?.[regionId]
+    const originalRegion = regionMetadata?.capacityMeshNodeId
+      ? this.originalRegionById.get(regionMetadata.capacityMeshNodeId)
+      : null
+
+    if (originalRegion?.d?.center) return originalRegion.d.center
+    if (regionMetadata?.center) return regionMetadata.center
+
+    if (regionMetadata?.bounds) {
+      return {
+        x: (regionMetadata.bounds.minX + regionMetadata.bounds.maxX) / 2,
+        y: (regionMetadata.bounds.minY + regionMetadata.bounds.maxY) / 2,
+      }
+    }
+
+    return null
+  }
+
+  private getPortPoint(solver: any, portId: number) {
+    const portMetadata = solver.topology.portMetadata?.[portId]
+    if (
+      typeof portMetadata?.x === "number" &&
+      typeof portMetadata?.y === "number"
+    ) {
+      return { x: portMetadata.x, y: portMetadata.y }
+    }
+    return null
+  }
+
+  private getRegionRect(
+    solver: any,
+    regionId: number,
+    opts: { fill: string; stroke: string; label: string },
+  ) {
+    const regionMetadata = solver.topology.regionMetadata?.[regionId]
+    const originalRegion = regionMetadata?.capacityMeshNodeId
+      ? this.originalRegionById.get(regionMetadata.capacityMeshNodeId)
+      : null
+    const center = this.getRegionCenter(solver, regionId)
+    if (!center) return null
+
+    return {
+      center,
+      width:
+        originalRegion?.d?.width ??
+        (regionMetadata?.bounds
+          ? regionMetadata.bounds.maxX - regionMetadata.bounds.minX
+          : 0.3),
+      height:
+        originalRegion?.d?.height ??
+        (regionMetadata?.bounds
+          ? regionMetadata.bounds.maxY - regionMetadata.bounds.minY
+          : 0.3),
+      fill: opts.fill,
+      stroke: opts.stroke,
+      label: opts.label,
+    }
+  }
+
+  private getCandidateReachability(
+    solver: any,
+    activeRouteBfs: ActiveTinyRouteBfs,
+  ) {
+    const routeNet = solver.problem.routeNet[activeRouteBfs.routeId]
+    const candidateRegionIds = new Set<number>()
+    const candidatePortIds = new Set<number>()
+    const reachableRegionIds = new Set<number>()
+    const reachablePortIds = new Set<number>()
+
+    for (
+      let regionId = 0;
+      regionId < (solver.topology.regionIncidentPorts?.length ?? 0);
+      regionId++
+    ) {
+      if (
+        !this.isRegionReservedForDifferentNetForRoute(
+          solver,
+          regionId,
+          routeNet,
+        )
+      ) {
+        candidateRegionIds.add(regionId)
+      }
+    }
+
+    for (
+      let portId = 0;
+      portId < (solver.topology.incidentPortRegion?.length ?? 0);
+      portId++
+    ) {
+      const assignedNetId = solver.state.portAssignment[portId]
+      if (
+        !this.isPortReservedForDifferentNetForRoute(solver, portId, routeNet) &&
+        (assignedNetId === -1 || assignedNetId === routeNet) &&
+        solver.problem.portSectionMask[portId] !== 0
+      ) {
+        candidatePortIds.add(portId)
+      }
+    }
+
+    for (const regionId of solver.topology.incidentPortRegion[
+      activeRouteBfs.startPortId
+    ] ?? []) {
+      if (candidateRegionIds.has(regionId)) {
+        reachableRegionIds.add(regionId)
+      }
+    }
+
+    for (const key of activeRouteBfs.seen) {
+      const [portIdText, regionIdText] = key.split(":")
+      const portId = Number(portIdText)
+      const regionId = Number(regionIdText)
+      if (Number.isFinite(portId)) reachablePortIds.add(portId)
+      if (Number.isFinite(regionId)) reachableRegionIds.add(regionId)
+    }
+
+    if (activeRouteBfs.approved) {
+      reachablePortIds.add(activeRouteBfs.goalPortId)
+      for (const regionId of solver.topology.incidentPortRegion[
+        activeRouteBfs.goalPortId
+      ] ?? []) {
+        if (candidateRegionIds.has(regionId)) {
+          reachableRegionIds.add(regionId)
+        }
+      }
+    }
+
+    return {
+      candidateRegionIds,
+      candidatePortIds,
+      reachableRegionIds,
+      reachablePortIds,
+    }
+  }
+
+  private createDottedLine(
+    start: { x: number; y: number },
+    end: { x: number; y: number },
+    color: string,
+  ) {
+    const dx = end.x - start.x
+    const dy = end.y - start.y
+    const length = Math.hypot(dx, dy)
+    if (length < 1e-9) return []
+
+    const dashLength = 0.18
+    const gapLength = 0.12
+    const segmentCount = Math.max(
+      1,
+      Math.floor(length / (dashLength + gapLength)),
+    )
+    const lines: NonNullable<GraphicsObject["lines"]> = []
+
+    for (let i = 0; i < segmentCount; i++) {
+      const distance0 = i * (dashLength + gapLength)
+      const distance1 = Math.min(length, distance0 + dashLength)
+      const t0 = distance0 / length
+      const t1 = distance1 / length
+      lines.push({
+        points: [
+          { x: start.x + dx * t0, y: start.y + dy * t0 },
+          { x: start.x + dx * t1, y: start.y + dy * t1 },
+        ],
+        stroke: color,
+      })
+    }
+
+    return lines
+  }
+
+  private visualizeActiveRouteBfs(): GraphicsObject {
+    const activeRouteBfs = this.displayedRouteBfs
+    if (!activeRouteBfs) {
+      return { points: [], lines: [], rects: [], circles: [] }
+    }
+
+    const { solver } = activeRouteBfs
+    const {
+      candidateRegionIds,
+      candidatePortIds,
+      reachableRegionIds,
+      reachablePortIds,
+    } = this.getCandidateReachability(solver, activeRouteBfs)
+
+    const rects: NonNullable<GraphicsObject["rects"]> = []
+    const points: NonNullable<GraphicsObject["points"]> = []
+    const lines: NonNullable<GraphicsObject["lines"]> = []
+
+    for (const regionId of candidateRegionIds) {
+      const reachable = reachableRegionIds.has(regionId)
+      const rect = this.getRegionRect(solver, regionId, {
+        fill: reachable ? "rgba(0, 102, 255, 0.14)" : "rgba(255, 59, 48, 0.12)",
+        stroke: reachable ? "#0066ff" : "#ff3b30",
+        label: `${reachable ? "reachable" : "unreachable"} region ${regionId}`,
+      })
+      if (rect) rects.push(rect)
+    }
+
+    for (const portId of candidatePortIds) {
+      const point = this.getPortPoint(solver, portId)
+      if (!point) continue
+      const reachable = reachablePortIds.has(portId)
+      points.push({
+        ...point,
+        color: reachable ? "#0066ff" : "#ff3b30",
+        label: `${reachable ? "reachable" : "unreachable"} port ${portId}`,
+      })
+    }
+
+    const routeMetadata = solver.problem.routeMetadata?.[activeRouteBfs.routeId]
+    const startTarget =
+      routeMetadata?.simpleRouteConnection?.pointsToConnect?.[0]
+    const endTarget = routeMetadata?.simpleRouteConnection?.pointsToConnect?.[1]
+    if (startTarget && endTarget) {
+      lines.push(
+        ...this.createDottedLine(
+          { x: startTarget.x, y: startTarget.y },
+          { x: endTarget.x, y: endTarget.y },
+          "#111111",
+        ),
+      )
+      points.push({
+        x: startTarget.x,
+        y: startTarget.y,
+        color: "#111111",
+        label: `start target ${activeRouteBfs.routeLabel}`,
+      })
+      points.push({
+        x: endTarget.x,
+        y: endTarget.y,
+        color: "#111111",
+        label: `end target ${activeRouteBfs.routeLabel}`,
+      })
+    }
+
+    return {
+      title: `BFS ${activeRouteBfs.routeLabel}${activeRouteBfs.approved ? " solved" : " active"}`,
+      rects,
+      points,
+      lines,
+      circles: [],
+    }
+  }
+
+  getOutput(): {
+    nodesWithPortPoints: NodeWithPortPoints[]
+    inputNodeWithPortPoints: InputNodeWithPortPoints[]
+  } {
+    return this.wrappedSolver.getOutput()
+  }
+
+  computeNodePf(node: InputNodeWithPortPoints): number | null {
+    const solvedNode = this.getOutput().nodesWithPortPoints.find(
+      (candidate) => candidate.capacityMeshNodeId === node.capacityMeshNodeId,
+    )
+    const originalRegion = this.originalRegionById.get(node.capacityMeshNodeId)
+
+    if (!solvedNode || !originalRegion) {
+      return null
+    }
+
+    const crossings = getIntraNodeCrossingsUsingCircle(solvedNode)
+
+    return calculateNodeProbabilityOfFailure(
+      originalRegion.d,
+      crossings.numSameLayerCrossings,
+      crossings.numEntryExitLayerChanges,
+      crossings.numTransitionPairCrossings,
+    )
+  }
+
+  override getConstructorParams() {
+    return [this.originalParams] as const
+  }
+
+  override tryFinalAcceptance() {}
+
+  override preview(): GraphicsObject {
+    return this.visualize()
+  }
+
+  override visualize(): GraphicsObject {
+    return combineVisualizations(
+      this.wrappedSolver.visualize(),
+      this.visualizeActiveRouteBfs(),
+    )
+  }
+}

--- a/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphBfsPortPointPathingSolver.ts
+++ b/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphBfsPortPointPathingSolver.ts
@@ -414,8 +414,10 @@ export class TinyHypergraphBfsPortPointPathingSolver extends BaseSolver {
     const startingPortId = solver.problem.routeStartPort[nextRouteId]
     const routeNetId = solver.problem.routeNet[nextRouteId]
     const routeMetadata = solver.problem.routeMetadata?.[nextRouteId]
-    const routeRootConnectionName =
-      this.getRouteRootConnectionName(routeMetadata, nextRouteId)
+    const routeRootConnectionName = this.getRouteRootConnectionName(
+      routeMetadata,
+      nextRouteId,
+    )
     const blockedPortIds = this.getBlockedPortIdsForRoute(
       solver,
       routeRootConnectionName,

--- a/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphBfsPortPointPathingSolver.ts
+++ b/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphBfsPortPointPathingSolver.ts
@@ -73,6 +73,7 @@ type ActiveTinyRouteBfs = {
   solver: any
   routeId: number
   routeLabel: string
+  routeRootConnectionName: string | null
   startPortId: number
   goalPortId: number
   goalRegionIds: Set<number>
@@ -80,6 +81,7 @@ type ActiveTinyRouteBfs = {
   seen: Set<string>
   lastExpandedPortIds: number[]
   approved: boolean
+  blockedPortIds: Set<number>
 }
 
 const getConnectionNames = (connection: {
@@ -411,9 +413,26 @@ export class TinyHypergraphBfsPortPointPathingSolver extends BaseSolver {
 
     const startingPortId = solver.problem.routeStartPort[nextRouteId]
     const routeNetId = solver.problem.routeNet[nextRouteId]
+    const routeMetadata = solver.problem.routeMetadata?.[nextRouteId]
+    const routeRootConnectionName =
+      this.getRouteRootConnectionName(routeMetadata, nextRouteId)
+    const blockedPortIds = this.getBlockedPortIdsForRoute(
+      solver,
+      routeRootConnectionName,
+    )
+    if (blockedPortIds.has(startingPortId)) {
+      this.failed = true
+      this.error = `BFS failed for route ${nextRouteId}: start port ${startingPortId} is blocked by a solved route`
+      return { activeRouteBfs: null, isNewConnectionStart: false }
+    }
     const startingIncidentRegions =
       solver.topology.incidentPortRegion[startingPortId] ?? []
     const goalPortId = solver.problem.routeEndPort[nextRouteId]
+    if (blockedPortIds.has(goalPortId)) {
+      this.failed = true
+      this.error = `BFS failed for route ${nextRouteId}: goal port ${goalPortId} is blocked by a solved route`
+      return { activeRouteBfs: null, isNewConnectionStart: false }
+    }
     const goalRegionIds = new Set<number>(
       (solver.topology.incidentPortRegion[goalPortId] ?? []).filter(
         (regionId: number) =>
@@ -444,7 +463,6 @@ export class TinyHypergraphBfsPortPointPathingSolver extends BaseSolver {
       return { activeRouteBfs: null, isNewConnectionStart: false }
     }
 
-    const routeMetadata = solver.problem.routeMetadata?.[nextRouteId]
     this.activeRouteBfs = {
       solver,
       routeId: nextRouteId,
@@ -452,6 +470,7 @@ export class TinyHypergraphBfsPortPointPathingSolver extends BaseSolver {
         routeMetadata?.simpleRouteConnection?.name ??
         routeMetadata?.connectionId ??
         `route-${nextRouteId}`,
+      routeRootConnectionName,
       startPortId: startingPortId,
       goalPortId,
       goalRegionIds,
@@ -467,6 +486,7 @@ export class TinyHypergraphBfsPortPointPathingSolver extends BaseSolver {
         startingStates.some((state: TinyRouteBfsState) =>
           goalRegionIds.has(state.nextRegionId),
         ),
+      blockedPortIds,
     }
 
     if (this.activeRouteBfs.approved) {
@@ -528,6 +548,7 @@ export class TinyHypergraphBfsPortPointPathingSolver extends BaseSolver {
         continue
       }
       if (neighborPortId === current.portId) continue
+      if (activeRouteBfs.blockedPortIds.has(neighborPortId)) continue
 
       if (neighborPortId === activeRouteBfs.goalPortId) {
         activeRouteBfs.lastExpandedPortIds = [
@@ -677,6 +698,7 @@ export class TinyHypergraphBfsPortPointPathingSolver extends BaseSolver {
     activeRouteBfs: ActiveTinyRouteBfs,
   ) {
     const routeNet = solver.problem.routeNet[activeRouteBfs.routeId]
+    const blockedPortIds = activeRouteBfs.blockedPortIds
     const candidateRegionIds = new Set<number>()
     const candidatePortIds = new Set<number>()
     const reachableRegionIds = new Set<number>()
@@ -707,7 +729,8 @@ export class TinyHypergraphBfsPortPointPathingSolver extends BaseSolver {
       if (
         !this.isPortReservedForDifferentNetForRoute(solver, portId, routeNet) &&
         (assignedNetId === -1 || assignedNetId === routeNet) &&
-        solver.problem.portSectionMask[portId] !== 0
+        solver.problem.portSectionMask[portId] !== 0 &&
+        !blockedPortIds.has(portId)
       ) {
         candidatePortIds.add(portId)
       }
@@ -745,7 +768,45 @@ export class TinyHypergraphBfsPortPointPathingSolver extends BaseSolver {
       candidatePortIds,
       reachableRegionIds,
       reachablePortIds,
+      blockedPortIds,
     }
+  }
+
+  private getRouteRootConnectionName(
+    routeMetadata: any,
+    routeId: number,
+  ): string | null {
+    return (
+      routeMetadata?.simpleRouteConnection?.rootConnectionName ??
+      routeMetadata?.mutuallyConnectedNetworkId ??
+      routeMetadata?.connectionId ??
+      `route-${routeId}`
+    )
+  }
+
+  private getBlockedPortIdsForRoute(
+    solver: any,
+    routeRootConnectionName: string | null,
+  ) {
+    const blockedPortIds = new Set<number>()
+    const regionSegments = solver.state?.regionSegments ?? []
+
+    for (const segments of regionSegments) {
+      for (const [routeId, fromPortId, toPortId] of segments ?? []) {
+        const routeMetadata = solver.problem.routeMetadata?.[routeId]
+        const segmentRootName = this.getRouteRootConnectionName(
+          routeMetadata,
+          routeId,
+        )
+        if (segmentRootName && segmentRootName === routeRootConnectionName) {
+          continue
+        }
+        blockedPortIds.add(fromPortId)
+        blockedPortIds.add(toPortId)
+      }
+    }
+
+    return blockedPortIds
   }
 
   private createDottedLine(
@@ -795,11 +856,15 @@ export class TinyHypergraphBfsPortPointPathingSolver extends BaseSolver {
       candidatePortIds,
       reachableRegionIds,
       reachablePortIds,
+      blockedPortIds,
     } = this.getCandidateReachability(solver, activeRouteBfs)
 
     const rects: NonNullable<GraphicsObject["rects"]> = []
     const points: NonNullable<GraphicsObject["points"]> = []
     const lines: NonNullable<GraphicsObject["lines"]> = []
+    const solvedRouteViz = this.getSolvedRouteVisualizationFromSegments(solver)
+    points.push(...solvedRouteViz.points)
+    lines.push(...solvedRouteViz.lines)
 
     for (const regionId of candidateRegionIds) {
       const reachable = reachableRegionIds.has(regionId)
@@ -819,6 +884,16 @@ export class TinyHypergraphBfsPortPointPathingSolver extends BaseSolver {
         ...point,
         color: reachable ? "#0066ff" : "#ff3b30",
         label: `${reachable ? "reachable" : "unreachable"} port ${portId}`,
+      })
+    }
+
+    for (const portId of blockedPortIds) {
+      const point = this.getPortPoint(solver, portId)
+      if (!point) continue
+      points.push({
+        ...point,
+        color: "#ff2d96",
+        label: `blocked port ${portId}`,
       })
     }
 
@@ -855,6 +930,44 @@ export class TinyHypergraphBfsPortPointPathingSolver extends BaseSolver {
       lines,
       circles: [],
     }
+  }
+
+  private getSolvedRouteVisualizationFromSegments(solver: any) {
+    const points: NonNullable<GraphicsObject["points"]> = []
+    const lines: NonNullable<GraphicsObject["lines"]> = []
+    const seenPoints = new Set<number>()
+    const regionSegments = solver.state?.regionSegments ?? []
+
+    for (const segments of regionSegments) {
+      for (const [routeId, fromPortId, toPortId] of segments ?? []) {
+        const fromPoint = this.getPortPoint(solver, fromPortId)
+        const toPoint = this.getPortPoint(solver, toPortId)
+        if (fromPoint && toPoint) {
+          lines.push({
+            points: [fromPoint, toPoint],
+            strokeColor: "#ff2d96",
+          })
+        }
+        if (fromPoint && !seenPoints.has(fromPortId)) {
+          seenPoints.add(fromPortId)
+          points.push({
+            ...fromPoint,
+            color: "#ff2d96",
+            label: `solved port ${fromPortId}`,
+          })
+        }
+        if (toPoint && !seenPoints.has(toPortId)) {
+          seenPoints.add(toPortId)
+          points.push({
+            ...toPoint,
+            color: "#ff2d96",
+            label: `solved port ${toPortId}`,
+          })
+        }
+      }
+    }
+
+    return { points, lines }
   }
 
   getOutput(): {

--- a/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphBfsPortPointPathingSolver.ts
+++ b/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphBfsPortPointPathingSolver.ts
@@ -15,17 +15,19 @@ type SerializedRegion = {
   d: any
 }
 
+type PortData = {
+  portId: string
+  x: number
+  y: number
+  z: number
+  distToCentermostPortOnZ: number
+}
+
 type SerializedPort = {
   portId: string
   region1Id: string
   region2Id: string
-  d: {
-    portId: string
-    x: number
-    y: number
-    z: number
-    distToCentermostPortOnZ: number
-  }
+  d: PortData
 }
 
 type SerializedConnection = {
@@ -73,7 +75,6 @@ type ActiveTinyRouteBfs = {
   solver: any
   routeId: number
   routeLabel: string
-  routeRootConnectionName: string | null
   startPortId: number
   goalPortId: number
   goalRegionIds: Set<number>
@@ -84,11 +85,13 @@ type ActiveTinyRouteBfs = {
   blockedPortIds: Set<number>
 }
 
-const getConnectionNames = (connection: {
+type ConnectionNameSource = {
   connectionId: string
   mutuallyConnectedNetworkId?: string
   simpleRouteConnection?: { rootConnectionName?: string; name?: string }
-}) => ({
+}
+
+const getConnectionNames = (connection: ConnectionNameSource) => ({
   rootConnectionName:
     connection.simpleRouteConnection?.rootConnectionName ??
     connection.mutuallyConnectedNetworkId ??
@@ -97,17 +100,13 @@ const getConnectionNames = (connection: {
     connection.simpleRouteConnection?.name ?? connection.connectionId,
 })
 
-const serializePort = (port: {
-  d: {
-    portId: string
-    x: number
-    y: number
-    z: number
-    distToCentermostPortOnZ: number
-  }
+type RuntimePortInput = {
+  d: PortData
   region1: { regionId: string }
   region2: { regionId: string }
-}): SerializedPort => ({
+}
+
+const serializePort = (port: RuntimePortInput): SerializedPort => ({
   portId: port.d.portId,
   region1Id: port.region1.regionId,
   region2Id: port.region2.regionId,
@@ -470,7 +469,6 @@ export class TinyHypergraphBfsPortPointPathingSolver extends BaseSolver {
         routeMetadata?.simpleRouteConnection?.name ??
         routeMetadata?.connectionId ??
         `route-${nextRouteId}`,
-      routeRootConnectionName,
       startPortId: startingPortId,
       goalPortId,
       goalRegionIds,
@@ -517,12 +515,13 @@ export class TinyHypergraphBfsPortPointPathingSolver extends BaseSolver {
       return
     }
 
-    activeRouteBfs.lastExpandedPortIds = this.reconstructPortPath(current)
+    const currentPath = this.reconstructPortPath(current)
+    activeRouteBfs.lastExpandedPortIds = currentPath
 
     if (activeRouteBfs.goalRegionIds.has(current.nextRegionId)) {
       if (!activeRouteBfs.approved) {
         activeRouteBfs.lastExpandedPortIds = [
-          ...this.reconstructPortPath(current),
+          ...currentPath,
           activeRouteBfs.goalPortId,
         ]
         activeRouteBfs.approved = true
@@ -807,6 +806,28 @@ export class TinyHypergraphBfsPortPointPathingSolver extends BaseSolver {
     return blockedPortIds
   }
 
+  private getPortLabel(solver: any, portId: number, reachable: boolean) {
+    const incidentRegions = solver.topology.incidentPortRegion?.[portId] ?? []
+    const uniqueIncidentRegions = [
+      ...new Set(
+        incidentRegions.map((regionId: number) => {
+          const metadata = solver.topology.regionMetadata?.[regionId]
+          return metadata?.capacityMeshNodeId ?? regionId
+        }),
+      ),
+    ]
+
+    return [
+      `port ${portId}`,
+      `reachable=${reachable}`,
+      `regions=${
+        uniqueIncidentRegions.length > 0
+          ? uniqueIncidentRegions.join(",")
+          : "none"
+      }`,
+    ].join("\n")
+  }
+
   private createDottedLine(
     start: { x: number; y: number },
     end: { x: number; y: number },
@@ -881,17 +902,18 @@ export class TinyHypergraphBfsPortPointPathingSolver extends BaseSolver {
       points.push({
         ...point,
         color: reachable ? "#0066ff" : "#ff3b30",
-        label: `${reachable ? "reachable" : "unreachable"} port ${portId}`,
+        label: this.getPortLabel(solver, portId, reachable),
       })
     }
 
     for (const portId of blockedPortIds) {
       const point = this.getPortPoint(solver, portId)
       if (!point) continue
+      const reachable = reachablePortIds.has(portId)
       points.push({
         ...point,
         color: "#ff2d96",
-        label: `blocked port ${portId}`,
+        label: this.getPortLabel(solver, portId, reachable),
       })
     }
 

--- a/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphBfsPortPointPathingSolver.ts
+++ b/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphBfsPortPointPathingSolver.ts
@@ -457,12 +457,16 @@ export class TinyHypergraphBfsPortPointPathingSolver extends BaseSolver {
       goalRegionIds,
       queue: startingStates,
       seen: new Set(
-        startingStates.map((state) => `${state.portId}:${state.nextRegionId}`),
+        startingStates.map(
+          (state: TinyRouteBfsState) => `${state.portId}:${state.nextRegionId}`,
+        ),
       ),
       lastExpandedPortIds: [startingPortId],
       approved:
         startingPortId === goalPortId ||
-        startingStates.some((state) => goalRegionIds.has(state.nextRegionId)),
+        startingStates.some((state: TinyRouteBfsState) =>
+          goalRegionIds.has(state.nextRegionId),
+        ),
     }
 
     if (this.activeRouteBfs.approved) {
@@ -772,7 +776,7 @@ export class TinyHypergraphBfsPortPointPathingSolver extends BaseSolver {
           { x: start.x + dx * t0, y: start.y + dy * t0 },
           { x: start.x + dx * t1, y: start.y + dy * t1 },
         ],
-        stroke: color,
+        strokeColor: color,
       })
     }
 


### PR DESCRIPTION
Run BFS each time before we solve a new connection fixture and solver!

here is an example of the solver detecting impossible to solve problem
<img width="855" height="597" alt="image" src="https://github.com/user-attachments/assets/55332304-44cf-48da-86f7-0fdbd9a8bd68" />

<img width="855" height="597" alt="image" src="https://github.com/user-attachments/assets/79bd87c7-366d-47ff-89cb-42b13d5c4899" />


here is an picture of it when it can solve
<img width="855" height="597" alt="image" src="https://github.com/user-attachments/assets/8c2db06e-c5c5-4aad-8ce9-38f59d0b556c" />
<img width="855" height="597" alt="image" src="https://github.com/user-attachments/assets/72e01316-4357-4a07-b964-f259f2d15d08" />


By default, BFS runs until there are no more candidate nodes left to explore. If it finds the target node, the search is successful; otherwise, the solver fails.

How dose it work?

Download the input for tiny hyper graph and the just past it or use file upload

<img width="969" height="849" alt="image" src="https://github.com/user-attachments/assets/5de340ef-0073-4bb1-a6dd-58a2683c4bee" />

