### PR TITLE
Skip zero-length trace segments from duplicate route points

### DIFF
--- a/lib/utils/convertHdRouteToSimplifiedRoute.ts
+++ b/lib/utils/convertHdRouteToSimplifiedRoute.ts
@@ -10,6 +10,7 @@ import { mapZToLayerName } from "./mapZToLayerName"
 
 type Point = { x: number; y: number; z: number }
 const DEFAULT_TERMINAL_VIA_ATTACH_TOLERANCE = 0.25
+const SAME_POINT_TOLERANCE = 1e-12
 
 export interface ConvertHdRouteToSimplifiedRouteOptions {
   connectionPoints?: ReadonlyArray<ConnectionPoint>
@@ -23,6 +24,15 @@ export interface ConvertHdRouteToSimplifiedRouteOptions {
 type HdRouteWithOptionalJumpers = HighDensityIntraNodeRoute & {
   jumpers?: Jumper[]
 }
+
+const areSameXyPoint = (
+  a: Pick<Point, "x" | "y"> | undefined,
+  b: Pick<Point, "x" | "y"> | undefined,
+) =>
+  !!a &&
+  !!b &&
+  Math.abs(a.x - b.x) <= SAME_POINT_TOLERANCE &&
+  Math.abs(a.y - b.y) <= SAME_POINT_TOLERANCE
 
 const findNearestTerminalViaPoint = ({
   endpoint,
@@ -238,7 +248,9 @@ export const convertHdRouteToSimplifiedRoute = (
       currentZ = point.z
     } else {
       // Continue on the same layer
-      currentLayerPoints.push(point)
+      if (!areSameXyPoint(currentLayerPoints[currentLayerPoints.length - 1], point)) {
+        currentLayerPoints.push(point)
+      }
     }
   }
 

--- a/lib/utils/convertHdRouteToSimplifiedRoute.ts
+++ b/lib/utils/convertHdRouteToSimplifiedRoute.ts
@@ -248,7 +248,12 @@ export const convertHdRouteToSimplifiedRoute = (
       currentZ = point.z
     } else {
       // Continue on the same layer
-      if (!areSameXyPoint(currentLayerPoints[currentLayerPoints.length - 1], point)) {
+      if (
+        !areSameXyPoint(
+          currentLayerPoints[currentLayerPoints.length - 1],
+          point,
+        )
+      ) {
         currentLayerPoints.push(point)
       }
     }

--- a/tests/utils/convertHdRouteToSimplifiedRoute.test.ts
+++ b/tests/utils/convertHdRouteToSimplifiedRoute.test.ts
@@ -226,6 +226,78 @@ describe("convertHdRouteToSimplifiedRoute", () => {
     `)
   })
 
+  test("removes consecutive duplicate points on the same layer", () => {
+    const input: HighDensityIntraNodeRoute = {
+      connectionName: "duplicate-point-route",
+      traceThickness: 0.2,
+      viaDiameter: 0.6,
+      route: [
+        { x: 1, y: 1, z: 0 },
+        { x: 1, y: 1, z: 0 },
+        { x: 2, y: 1, z: 0 },
+      ],
+      vias: [],
+    }
+
+    const result = convertHdRouteToSimplifiedRoute(input, 2)
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "layer": "top",
+          "route_type": "wire",
+          "width": 0.2,
+          "x": 1,
+          "y": 1,
+        },
+        {
+          "layer": "top",
+          "route_type": "wire",
+          "width": 0.2,
+          "x": 2,
+          "y": 1,
+        },
+      ]
+    `)
+  })
+
+  test("zero-length segment repro preserves the original duplicate point pair", () => {
+    const route = [
+      {
+        route_type: "wire",
+        x: -3.9823015744754504,
+        y: 18.50630157447545,
+        width: 0.6,
+        layer: "top",
+      },
+      {
+        route_type: "wire",
+        x: -3.9823015744754504,
+        y: 18.50630157447545,
+        width: 0.6,
+        layer: "top",
+      },
+    ]
+
+    expect(route).toMatchInlineSnapshot(`
+      [
+        {
+          "layer": "top",
+          "route_type": "wire",
+          "width": 0.6,
+          "x": -3.9823015744754504,
+          "y": 18.50630157447545,
+        },
+        {
+          "layer": "top",
+          "route_type": "wire",
+          "width": 0.6,
+          "x": -3.9823015744754504,
+          "y": 18.50630157447545,
+        },
+      ]
+    `)
+  })
+
   test("serializes terminal vias from single-layer connection points", () => {
     const input: HighDensityIntraNodeRoute = {
       connectionName: "terminal-via-route",


### PR DESCRIPTION
This PR prevents zero-length trace segments from being emitted when autorouter route data contains consecutive duplicate points.

Previously, convertHdRouteToSimplifiedRoute preserved adjacent same-layer duplicates such as A -> A -> B, which could later become a degenerate A -> A copper segment in exported PCB output. That kind of ghost segment can trigger downstream DRC issues even when the visible routing looks correct.
