### PR TITLE
fix(autorouter): resolve bugreport50 node cmn_645__sub_0_0 

### DIFF
--- a/lib/solvers/HighDensitySolver/SingleLayerNoDifferentRootIntersectionsIntraNodeSolver.ts
+++ b/lib/solvers/HighDensitySolver/SingleLayerNoDifferentRootIntersectionsIntraNodeSolver.ts
@@ -410,7 +410,7 @@ export class SingleLayerNoDifferentRootIntersectionsIntraNodeSolver extends Base
   static isApplicable(node: NodeWithPortPoints) {
     const availableZ = uniqueAvailableZ(node)
     if (availableZ.length !== 1) return false
-    if (node.portPoints.length > 10) return false
+    if (node.portPoints.length > 12) return false
 
     const bounds = getBounds(node)
     if (node.portPoints.some((point) => getEdge(point, bounds) === null)) {


### PR DESCRIPTION

This fixes `bugreport50` node `cmn_645__sub_0_0` by expanding `SingleLayerNoDifferentRootIntersectionsIntraNodeSolver.isApplicable` from `>10` to `>12` port points.

<img width="1703" height="1028" alt="Screenshot 2026-04-26 at 4 53 37 PM" src="https://github.com/user-attachments/assets/e1b570fb-d8ca-46aa-ac61-4e7eafc859cb" />
<img width="1457" height="958" alt="Screenshot 2026-04-26 at 4 54 18 PM" src="https://github.com/user-attachments/assets/49798fa5-52a1-4484-acf0-ec093bf8776f" />
