### PR TITLE
Add pipeline 6 benchmark support and solver fallbacks

### DIFF
--- a/benchmark.sh
+++ b/benchmark.sh
@@ -17,6 +17,7 @@ resolve_pipeline_solver_name() {
     3) echo "AutoroutingPipelineSolver3_HgPortPointPathing" ;;
     4) echo "AutoroutingPipelineSolver4" ;;
     5) echo "AutoroutingPipelineSolver5" ;;
+    6) echo "AutoroutingPipelineSolver6" ;;
     *)
       echo "Unknown pipeline: $1" >&2
       exit 1
@@ -69,7 +70,7 @@ Usage:
 
 Options:
   --solver NAME        Run only one solver (same as first positional arg)
-  --pipeline N         Run a numbered pipeline alias (1-5)
+  --pipeline N         Run a numbered pipeline alias (1-6)
   --scenario-limit N   Run only first N scenarios (same as second positional arg)
   --concurrency N      Number of Bun workers used per solver, or "auto"
   --effort N           Override scenario effort multiplier
@@ -92,6 +93,7 @@ Examples:
   ./benchmark.sh --solver AutoroutingPipelineSolver4 --dataset zdwiel --scenario-limit 20
   ./benchmark.sh --pipeline 4
   ./benchmark.sh --pipeline 5
+  ./benchmark.sh --pipeline 6
   ./benchmark.sh --solver AutoroutingPipelineSolver4 --dataset srj05 --scenario-limit 20
   ./benchmark.sh --include-assignable
 EOF

--- a/lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/PolyHypergraphPortPointPathingSolver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/PolyHypergraphPortPointPathingSolver.ts
@@ -1,36 +1,36 @@
-import {
-  applySerializedRegionNetIdsToLoadedProblem,
-  buildPolyHyperGraphFromRegions,
-  computeConvexRegions,
-  PORT_MARGIN_FROM_SEGMENT_ENDPOINT,
-  PORT_SPACING,
-  type ConvexRegionsComputeResult,
-  type LayerMergeMode,
-  type SerializedPolyHyperGraph,
-} from "pcb-poly-hyper-graph"
 import type { GraphicsObject } from "graphics-debug"
 import { BaseSolver } from "lib/solvers/BaseSolver"
 import type {
   InputNodeWithPortPoints,
   InputPortPoint,
 } from "lib/solvers/PortPointPathingSolver/PortPointPathingSolver"
+import { calculateNodeProbabilityOfFailure } from "lib/solvers/UnravelSolver/calculateCrossingProbabilityOfFailure"
 import type { CapacityMeshNodeId, SimpleRouteJson } from "lib/types"
 import type { PortPoint } from "lib/types/high-density-types"
 import { getIntraNodeCrossingsUsingCircle } from "lib/utils/getIntraNodeCrossingsUsingCircle"
-import { calculateNodeProbabilityOfFailure } from "lib/solvers/UnravelSolver/calculateCrossingProbabilityOfFailure"
 import {
-  loadSerializedHyperGraphAsPoly,
-  PolyHyperGraphSolver,
+  type ConvexRegionsComputeResult,
+  type LayerMergeMode,
+  PORT_MARGIN_FROM_SEGMENT_ENDPOINT,
+  PORT_SPACING,
+  type SerializedPolyHyperGraph,
+  applySerializedRegionNetIdsToLoadedProblem,
+  buildPolyHyperGraphFromRegions,
+  computeConvexRegions,
+} from "pcb-poly-hyper-graph"
+import {
   type PolyHyperGraphLoadResult,
+  PolyHyperGraphSolver,
   type PolyHyperGraphSolverOptions,
+  loadSerializedHyperGraphAsPoly,
 } from "tiny-hypergraph-poly/lib/index"
-import type { PolyNodeWithPortPoints } from "./types"
 import {
   getConnectedObstacleRegionsFromSrj,
   getPolyGraphConnectionsFromSrj,
   getPolyGraphPolygonsFromSrj,
   getPolyGraphRectsFromSrj,
 } from "./srjToPolyHyperGraph"
+import type { PolyNodeWithPortPoints } from "./types"
 
 type RouteMetadata = {
   connectionId: string
@@ -112,24 +112,34 @@ export class PolyHypergraphPortPointPathingSolver extends BaseSolver {
   reservedRegionCount = 0
   clearance: number
   effort: number
+  usedUnconstrainedDelaunayFallback = false
 
   constructor(public params: PolyHypergraphPortPointPathingSolverOptions) {
     super()
     this.effort = params.effort ?? 1
     this.clearance =
       params.srj.defaultObstacleMargin ?? params.srj.minTraceWidth
-    this.convexRegions = computeConvexRegions({
-      bounds: params.srj.bounds,
-      rects: getPolyGraphRectsFromSrj(params.srj),
-      polygons: getPolyGraphPolygonsFromSrj(params.srj),
-      clearance: this.clearance,
-      concavityTolerance: params.concavityTolerance ?? 0,
-      layerCount: params.srj.layerCount,
-      layerMergeMode: params.layerMergeMode ?? "same",
-      useConstrainedDelaunay: params.useConstrainedDelaunay ?? true,
-      usePolyanyaMerge: params.usePolyanyaMerge ?? false,
-      viaSegments: params.viaSegments ?? 8,
-    })
+    const computeRegions = (useConstrainedDelaunay: boolean) =>
+      computeConvexRegions({
+        bounds: params.srj.bounds,
+        rects: getPolyGraphRectsFromSrj(params.srj),
+        polygons: getPolyGraphPolygonsFromSrj(params.srj),
+        clearance: this.clearance,
+        concavityTolerance: params.concavityTolerance ?? 0,
+        layerCount: params.srj.layerCount,
+        layerMergeMode: params.layerMergeMode ?? "same",
+        useConstrainedDelaunay,
+        usePolyanyaMerge: params.usePolyanyaMerge ?? false,
+        viaSegments: params.viaSegments ?? 8,
+      })
+    const useConstrainedDelaunay = params.useConstrainedDelaunay ?? true
+    try {
+      this.convexRegions = computeRegions(useConstrainedDelaunay)
+    } catch (error) {
+      if (!useConstrainedDelaunay) throw error
+      this.usedUnconstrainedDelaunayFallback = true
+      this.convexRegions = computeRegions(false)
+    }
     this.serializedGraph = buildPolyHyperGraphFromRegions({
       regions: this.convexRegions.regions,
       availableZ: this.convexRegions.availableZ,
@@ -290,6 +300,7 @@ export class PolyHypergraphPortPointPathingSolver extends BaseSolver {
     this.stats = {
       ...(this.polySolver.stats ?? {}),
       reservedRegionCount: this.reservedRegionCount,
+      usedUnconstrainedDelaunayFallback: this.usedUnconstrainedDelaunayFallback,
       regionCount: this.loaded.topology.regionCount,
       portCount: this.loaded.topology.portCount,
       routeCount: this.loaded.problem.routeCount,

--- a/lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/geometry.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/geometry.ts
@@ -66,6 +66,8 @@ export const getPolygonSignedArea = (polygon: readonly Point[]) => {
 export const getPolygonArea = (polygon: readonly Point[]) =>
   Math.abs(getPolygonSignedArea(polygon))
 
+const getQuadArea = (quad: readonly Point[]) => getPolygonArea(quad)
+
 export const getPolygonCentroid = (polygon: readonly Point[]): Point => {
   const signedArea = getPolygonSignedArea(polygon)
   if (Math.abs(signedArea) < EPSILON) {
@@ -436,6 +438,25 @@ export const invertMatrix3x3 = (m: Matrix3x3): Matrix3x3 => {
   ]
 }
 
+const getRotationMatrixAroundPoint = (
+  center: Point,
+  ccwRotationRadians: number,
+): Matrix3x3 => {
+  const cos = Math.cos(ccwRotationRadians)
+  const sin = Math.sin(ccwRotationRadians)
+  return [
+    cos,
+    -sin,
+    center.x - cos * center.x + sin * center.y,
+    sin,
+    cos,
+    center.y - sin * center.x - cos * center.y,
+    0,
+    0,
+    1,
+  ]
+}
+
 export const applyMatrixToPoint = (matrix: Matrix3x3, point: Point): Point => {
   const denominator = matrix[6] * point.x + matrix[7] * point.y + matrix[8]
   if (Math.abs(denominator) < EPSILON) {
@@ -606,8 +627,27 @@ export const computeProjectedRect = (
     const hit = intersectRayWithPolygon(center, direction, workingPolygon)
     return hit ? { x: hit.x, y: hit.y } : corner
   }) as [Point, Point, Point, Point]
-  const rectToPolygonMatrix = computeHomography(rectCorners, targetQuad)
-  const polygonToRectMatrix = invertMatrix3x3(rectToPolygonMatrix)
+  let nonDegenerateTargetQuad =
+    getQuadArea(targetQuad) > EPSILON ? targetQuad : rotatedRectCorners
+  let rectToPolygonMatrix: Matrix3x3
+  let polygonToRectMatrix: Matrix3x3
+  try {
+    rectToPolygonMatrix = computeHomography(
+      rectCorners,
+      nonDegenerateTargetQuad,
+    )
+    polygonToRectMatrix = invertMatrix3x3(rectToPolygonMatrix)
+  } catch {
+    nonDegenerateTargetQuad = rotatedRectCorners
+    rectToPolygonMatrix = getRotationMatrixAroundPoint(
+      center,
+      ccwRotationRadians,
+    )
+    polygonToRectMatrix = getRotationMatrixAroundPoint(
+      center,
+      -ccwRotationRadians,
+    )
+  }
 
   return {
     center,
@@ -619,7 +659,7 @@ export const computeProjectedRect = (
     ccwRotationRadians,
     polygonArea,
     equivalentAreaExpansionFactor: expansionFactor,
-    targetQuad,
+    targetQuad: nonDegenerateTargetQuad,
     rectToPolygonMatrix,
     polygonToRectMatrix,
   }

--- a/tests/features/pipeline6-poly-hypergraph.test.ts
+++ b/tests/features/pipeline6-poly-hypergraph.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test"
 import { AutoroutingPipelineSolver6 } from "lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/AutoroutingPipelineSolver6_PolyHypergraph"
+import { PolyHypergraphPortPointPathingSolver } from "lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/PolyHypergraphPortPointPathingSolver"
 import { PolySingleIntraNodeSolver } from "lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/PolySingleIntraNodeSolver"
 import { ProjectHighDensityToPolygonSolver } from "lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/ProjectHighDensityToPolygonSolver"
 import {
@@ -12,6 +13,7 @@ import {
 import type { PolyNodeWithPortPoints } from "lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/types"
 import type { SimpleRouteJson } from "lib/types"
 import { convertSrjToGraphicsObject } from "lib/utils/convertSrjToGraphicsObject"
+import { loadScenarios } from "scripts/benchmark/scenarios"
 
 const expectClose = (actual: number, expected: number, tolerance = 1e-6) => {
   expect(Math.abs(actual - expected)).toBeLessThanOrEqual(tolerance)
@@ -60,6 +62,33 @@ test("Pipeline6 projectedRect area expansion preserves center and reaches polygo
   )
   expectClose(distortedTopCorner.x, rotatedSquare[0]!.x)
   expectClose(distortedTopCorner.y, rotatedSquare[0]!.y)
+})
+
+test("Pipeline6 projectedRect handles sliver polygons without a singular homography", () => {
+  const sliverPolygon = [
+    { x: 4.349999, y: 10.45 },
+    { x: 4.3500000000000005, y: 11.450000999999999 },
+    { x: 4.349997, y: 10.5 },
+  ]
+
+  const projectedRect = computeProjectedRect(sliverPolygon, 0.25)
+
+  expect(projectedRect.targetQuad).toHaveLength(4)
+  expect(projectedRect.rectToPolygonMatrix.every(Number.isFinite)).toBe(true)
+  expect(projectedRect.polygonToRectMatrix.every(Number.isFinite)).toBe(true)
+})
+
+test("Pipeline6 falls back when constrained triangulation fails", async () => {
+  const scenarios = await loadScenarios("dataset01")
+  const circuit100 = scenarios.find(([name]) => name === "circuit100")?.[1]
+  expect(circuit100).toBeDefined()
+
+  const solver = new PolyHypergraphPortPointPathingSolver({
+    srj: circuit100!,
+  })
+
+  expect(solver.usedUnconstrainedDelaunayFallback).toBe(true)
+  expect(solver.convexRegions.regions.length).toBeGreaterThan(0)
 })
 
 test("PolySingleIntraNodeSolver solves in rect space before projection back to polygon", () => {


### PR DESCRIPTION
## Summary
- Add `--pipeline 6` support to `benchmark.sh` and document the new alias.
- Make pipeline 6 more resilient by falling back when constrained triangulation fails and by avoiding singular homography errors for sliver projected rects.
- Add regression tests for the pipeline 6 fallback path and degenerate projection handling.

## Testing
- `bun test tests/features/pipeline6-poly-hypergraph.test.ts`
- `bunx tsc --noEmit`
- `./benchmark.sh --pipeline 6`