### PR TITLE
Add test for bugreport02-bc4361

### DIFF
--- a/tests/bugs/bugreport01-be84eb.test.ts
+++ b/tests/bugs/bugreport01-be84eb.test.ts
@@ -1,0 +1,15 @@
+import { test, expect } from "bun:test"
+import { AutoroutingPipeline1_OriginalUnravel } from "lib/autorouter-pipelines/AutoroutingPipeline1_OriginalUnravel/AutoroutingPipeline1_OriginalUnravel"
+import bugReport from "../../fixtures/bug-reports/bugreport01-be84eb/bugreport01-be84eb.json"
+import type { SimpleRouteJson } from "lib/types"
+import { getLastStepSvg } from "tests/fixtures/getLastStepSvg"
+
+const srj = bugReport.simple_route_json as SimpleRouteJson
+
+test("bugreport01-be84eb.json-AutoroutingPipeline1_OriginalUnravel", () => {
+  const solver = new AutoroutingPipeline1_OriginalUnravel(srj)
+  solver.solve()
+  expect(getLastStepSvg(solver.visualize())).toMatchSvgSnapshot(
+    import.meta.path,
+  )
+})

--- a/tests/bugs/bugreport02-bc4361.test.ts
+++ b/tests/bugs/bugreport02-bc4361.test.ts
@@ -1,0 +1,15 @@
+import { test, expect } from "bun:test"
+import { AutoroutingPipeline1_OriginalUnravel } from "lib/autorouter-pipelines/AutoroutingPipeline1_OriginalUnravel/AutoroutingPipeline1_OriginalUnravel"
+import bugReport from "../../fixtures/bug-reports/bugreport02-bc4361/bugreport02-bc4361.json"
+import type { SimpleRouteJson } from "lib/types"
+import { getLastStepSvg } from "tests/fixtures/getLastStepSvg"
+
+const srj = bugReport.simple_route_json as SimpleRouteJson
+
+test("bugreport02-bc4361.json-AutoroutingPipeline1_OriginalUnravel", () => {
+  const solver = new AutoroutingPipeline1_OriginalUnravel(srj)
+  solver.solve()
+  expect(getLastStepSvg(solver.visualize())).toMatchSvgSnapshot(
+    import.meta.path,
+  )
+})


### PR DESCRIPTION
## Summary

Add snapshot test for `bugreport02-bc4361` using `AutoroutingPipeline1_OriginalUnravel`.

This bug report has:
- 16 connections
- 34 obstacles  
- Board size: 12.7mm x 17.78mm

## Testing

The test follows the same pattern as other bug report tests in `tests/bugs/`.

## Note

This is an entry PR to establish contributor status. After merging, I plan to work on issue #66 (Implement trace thickness as a parameter) which has a $150 bounty.