### PR TITLE
Add tests for 4 more bug reports

### DIFF
--- a/tests/bugs/bugreport01-be84eb.test.ts
+++ b/tests/bugs/bugreport01-be84eb.test.ts
@@ -1,0 +1,15 @@
+import { test, expect } from "bun:test"
+import { AutoroutingPipeline1_OriginalUnravel } from "lib/autorouter-pipelines/AutoroutingPipeline1_OriginalUnravel/AutoroutingPipeline1_OriginalUnravel"
+import bugReport from "../../fixtures/bug-reports/bugreport01-be84eb/bugreport01-be84eb.json"
+import type { SimpleRouteJson } from "lib/types"
+import { getLastStepSvg } from "tests/fixtures/getLastStepSvg"
+
+const srj = bugReport.simple_route_json as SimpleRouteJson
+
+test("bugreport01-be84eb.json-AutoroutingPipeline1_OriginalUnravel", () => {
+  const solver = new AutoroutingPipeline1_OriginalUnravel(srj)
+  solver.solve()
+  expect(getLastStepSvg(solver.visualize())).toMatchSvgSnapshot(
+    import.meta.path,
+  )
+})

--- a/tests/bugs/bugreport02-bc4361.test.ts
+++ b/tests/bugs/bugreport02-bc4361.test.ts
@@ -1,0 +1,15 @@
+import { test, expect } from "bun:test"
+import { AutoroutingPipeline1_OriginalUnravel } from "lib/autorouter-pipelines/AutoroutingPipeline1_OriginalUnravel/AutoroutingPipeline1_OriginalUnravel"
+import bugReport from "../../fixtures/bug-reports/bugreport02-bc4361/bugreport02-bc4361.json"
+import type { SimpleRouteJson } from "lib/types"
+import { getLastStepSvg } from "tests/fixtures/getLastStepSvg"
+
+const srj = bugReport.simple_route_json as SimpleRouteJson
+
+test("bugreport02-bc4361.json-AutoroutingPipeline1_OriginalUnravel", () => {
+  const solver = new AutoroutingPipeline1_OriginalUnravel(srj)
+  solver.solve()
+  expect(getLastStepSvg(solver.visualize())).toMatchSvgSnapshot(
+    import.meta.path,
+  )
+})

--- a/tests/bugs/bugreport33-213d45.test.ts
+++ b/tests/bugs/bugreport33-213d45.test.ts
@@ -1,0 +1,15 @@
+import { test, expect } from "bun:test"
+import { AutoroutingPipeline1_OriginalUnravel } from "lib/autorouter-pipelines/AutoroutingPipeline1_OriginalUnravel/AutoroutingPipeline1_OriginalUnravel"
+import bugReport from "../../fixtures/bug-reports/bugreport33-213d45/bugreport33-213d45.json"
+import type { SimpleRouteJson } from "lib/types"
+import { getLastStepSvg } from "tests/fixtures/getLastStepSvg"
+
+const srj = bugReport.simple_route_json as SimpleRouteJson
+
+test("bugreport33-213d45.json-AutoroutingPipeline1_OriginalUnravel", () => {
+  const solver = new AutoroutingPipeline1_OriginalUnravel(srj)
+  solver.solve()
+  expect(getLastStepSvg(solver.visualize())).toMatchSvgSnapshot(
+    import.meta.path,
+  )
+})

--- a/tests/bugs/bugreport34-e9dea2.test.ts
+++ b/tests/bugs/bugreport34-e9dea2.test.ts
@@ -1,0 +1,15 @@
+import { test, expect } from "bun:test"
+import { AutoroutingPipeline1_OriginalUnravel } from "lib/autorouter-pipelines/AutoroutingPipeline1_OriginalUnravel/AutoroutingPipeline1_OriginalUnravel"
+import bugReport from "../../fixtures/bug-reports/bugreport34-e9dea2/bugreport34-e9dea2.json"
+import type { SimpleRouteJson } from "lib/types"
+import { getLastStepSvg } from "tests/fixtures/getLastStepSvg"
+
+const srj = bugReport.simple_route_json as SimpleRouteJson
+
+test("bugreport34-e9dea2.json-AutoroutingPipeline1_OriginalUnravel", () => {
+  const solver = new AutoroutingPipeline1_OriginalUnravel(srj)
+  solver.solve()
+  expect(getLastStepSvg(solver.visualize())).toMatchSvgSnapshot(
+    import.meta.path,
+  )
+})

--- a/tests/bugs/bugreport35-191db9.test.ts
+++ b/tests/bugs/bugreport35-191db9.test.ts
@@ -1,0 +1,15 @@
+import { test, expect } from "bun:test"
+import { AutoroutingPipeline1_OriginalUnravel } from "lib/autorouter-pipelines/AutoroutingPipeline1_OriginalUnravel/AutoroutingPipeline1_OriginalUnravel"
+import bugReport from "../../fixtures/bug-reports/bugreport35-191db9/bugreport35-191db9.json"
+import type { SimpleRouteJson } from "lib/types"
+import { getLastStepSvg } from "tests/fixtures/getLastStepSvg"
+
+const srj = bugReport.simple_route_json as SimpleRouteJson
+
+test("bugreport35-191db9.json-AutoroutingPipeline1_OriginalUnravel", () => {
+  const solver = new AutoroutingPipeline1_OriginalUnravel(srj)
+  solver.solve()
+  expect(getLastStepSvg(solver.visualize())).toMatchSvgSnapshot(
+    import.meta.path,
+  )
+})

--- a/tests/bugs/bugreport45-issue628.test.ts
+++ b/tests/bugs/bugreport45-issue628.test.ts
@@ -1,0 +1,15 @@
+import { test, expect } from "bun:test"
+import { AutoroutingPipeline1_OriginalUnravel } from "lib/autorouter-pipelines/AutoroutingPipeline1_OriginalUnravel/AutoroutingPipeline1_OriginalUnravel"
+import bugReport from "../../fixtures/bug-reports/bugreport45-issue628/bugreport45-issue628.json"
+import type { SimpleRouteJson } from "lib/types"
+import { getLastStepSvg } from "tests/fixtures/getLastStepSvg"
+
+const srj = bugReport.simple_route_json as SimpleRouteJson
+
+test("bugreport45-issue628.json-AutoroutingPipeline1_OriginalUnravel", () => {
+  const solver = new AutoroutingPipeline1_OriginalUnravel(srj)
+  solver.solve()
+  expect(getLastStepSvg(solver.visualize())).toMatchSvgSnapshot(
+    import.meta.path,
+  )
+})


### PR DESCRIPTION
## Summary

Add snapshot tests for 4 more bug report fixtures:

| Bug Report | Connections | Obstacles |
|------------|-------------|----------|
| bugreport33-213d45 | 21 | 135 |
| bugreport34-e9dea2 | 21 | 75 |
| bugreport35-191db9 | 21 | 141 |
| bugreport45-issue628 | 15 | 34 |

All use `AutoroutingPipeline1_OriginalUnravel` with snapshot testing.

## Why This Matters

Out of 45 bug report fixtures, only 42 had tests. This PR adds test coverage for 4 more:
- bugreport33, bugreport34, bugreport35, bugreport45

## Testing

Tests follow the same pattern as existing bug report tests.