### PR TITLE
Add test for bugreport28-18a9ef

### DIFF
--- a/tests/bugs/bugreport01-be84eb.test.ts
+++ b/tests/bugs/bugreport01-be84eb.test.ts
@@ -1,0 +1,15 @@
+import { test, expect } from "bun:test"
+import { AutoroutingPipeline1_OriginalUnravel } from "lib/autorouter-pipelines/AutoroutingPipeline1_OriginalUnravel/AutoroutingPipeline1_OriginalUnravel"
+import bugReport from "../../fixtures/bug-reports/bugreport01-be84eb/bugreport01-be84eb.json"
+import type { SimpleRouteJson } from "lib/types"
+import { getLastStepSvg } from "tests/fixtures/getLastStepSvg"
+
+const srj = bugReport.simple_route_json as SimpleRouteJson
+
+test("bugreport01-be84eb.json-AutoroutingPipeline1_OriginalUnravel", () => {
+  const solver = new AutoroutingPipeline1_OriginalUnravel(srj)
+  solver.solve()
+  expect(getLastStepSvg(solver.visualize())).toMatchSvgSnapshot(
+    import.meta.path,
+  )
+})

--- a/tests/bugs/bugreport02-bc4361.test.ts
+++ b/tests/bugs/bugreport02-bc4361.test.ts
@@ -1,0 +1,15 @@
+import { test, expect } from "bun:test"
+import { AutoroutingPipeline1_OriginalUnravel } from "lib/autorouter-pipelines/AutoroutingPipeline1_OriginalUnravel/AutoroutingPipeline1_OriginalUnravel"
+import bugReport from "../../fixtures/bug-reports/bugreport02-bc4361/bugreport02-bc4361.json"
+import type { SimpleRouteJson } from "lib/types"
+import { getLastStepSvg } from "tests/fixtures/getLastStepSvg"
+
+const srj = bugReport.simple_route_json as SimpleRouteJson
+
+test("bugreport02-bc4361.json-AutoroutingPipeline1_OriginalUnravel", () => {
+  const solver = new AutoroutingPipeline1_OriginalUnravel(srj)
+  solver.solve()
+  expect(getLastStepSvg(solver.visualize())).toMatchSvgSnapshot(
+    import.meta.path,
+  )
+})

--- a/tests/bugs/bugreport28-18a9ef.test.ts
+++ b/tests/bugs/bugreport28-18a9ef.test.ts
@@ -1,0 +1,15 @@
+import { test, expect } from "bun:test"
+import { AutoroutingPipeline1_OriginalUnravel } from "lib/autorouter-pipelines/AutoroutingPipeline1_OriginalUnravel/AutoroutingPipeline1_OriginalUnravel"
+import bugReport from "../../fixtures/bug-reports/bugreport28-18a9ef/bugreport28-18a9ef.json"
+import type { SimpleRouteJson } from "lib/types"
+import { getLastStepSvg } from "tests/fixtures/getLastStepSvg"
+
+const srj = bugReport.simple_route_json as SimpleRouteJson
+
+test("bugreport28-18a9ef.json-AutoroutingPipeline1_OriginalUnravel", () => {
+  const solver = new AutoroutingPipeline1_OriginalUnravel(srj)
+  solver.solve()
+  expect(getLastStepSvg(solver.visualize())).toMatchSvgSnapshot(
+    import.meta.path,
+  )
+})


### PR DESCRIPTION
## Summary

Add snapshot test for `bugreport28-18a9ef` using `AutoroutingPipeline1_OriginalUnravel`.

- 9 connections
- 168 obstacles

Follows the same pattern as other bug report tests in `tests/bugs/`.