### PR TITLE
Add tests for bugreport46-ac4337-arduino-uno and bugreport22-2a75ce

### DIFF
--- a/tests/bugs/bugreport01-be84eb.test.ts
+++ b/tests/bugs/bugreport01-be84eb.test.ts
@@ -1,0 +1,15 @@
+import { test, expect } from "bun:test"
+import { AutoroutingPipeline1_OriginalUnravel } from "lib/autorouter-pipelines/AutoroutingPipeline1_OriginalUnravel/AutoroutingPipeline1_OriginalUnravel"
+import bugReport from "../../fixtures/bug-reports/bugreport01-be84eb/bugreport01-be84eb.json"
+import type { SimpleRouteJson } from "lib/types"
+import { getLastStepSvg } from "tests/fixtures/getLastStepSvg"
+
+const srj = bugReport.simple_route_json as SimpleRouteJson
+
+test("bugreport01-be84eb.json-AutoroutingPipeline1_OriginalUnravel", () => {
+  const solver = new AutoroutingPipeline1_OriginalUnravel(srj)
+  solver.solve()
+  expect(getLastStepSvg(solver.visualize())).toMatchSvgSnapshot(
+    import.meta.path,
+  )
+})

--- a/tests/bugs/bugreport22-2a75ce.test.ts
+++ b/tests/bugs/bugreport22-2a75ce.test.ts
@@ -1,12 +1,12 @@
 import { test, expect } from "bun:test"
 import { AutoroutingPipeline1_OriginalUnravel } from "lib/autorouter-pipelines/AutoroutingPipeline1_OriginalUnravel/AutoroutingPipeline1_OriginalUnravel"
-import bugReport from "../../fixtures/bug-reports/bugreport46-ac4337/bugreport46-ac4337-arduino-uno.json"
+import bugReport from "../../fixtures/bug-reports/bugreport22-2a75ce/bugreport22-2a75ce.json"
 import type { SimpleRouteJson } from "lib/types"
 import { getLastStepSvg } from "tests/fixtures/getLastStepSvg"
 
 const srj = bugReport.simple_route_json as SimpleRouteJson
 
-test("bugreport46-ac4337-arduino-uno.json-AutoroutingPipeline1_OriginalUnravel", () => {
+test("bugreport22-2a75ce.json-AutoroutingPipeline1_OriginalUnravel", () => {
   const solver = new AutoroutingPipeline1_OriginalUnravel(srj)
   solver.solve()
   expect(getLastStepSvg(solver.visualize())).toMatchSvgSnapshot(

--- a/tests/bugs/bugreport23-LGA15x4.test.ts
+++ b/tests/bugs/bugreport23-LGA15x4.test.ts
@@ -1,0 +1,15 @@
+import { test, expect } from "bun:test"
+import { AutoroutingPipeline1_OriginalUnravel } from "lib/autorouter-pipelines/AutoroutingPipeline1_OriginalUnravel/AutoroutingPipeline1_OriginalUnravel"
+import bugReport from "../../fixtures/bug-reports/bugreport23-LGA15x4/bugreport23-LGA15x4.srj.json"
+import type { SimpleRouteJson } from "lib/types"
+import { getLastStepSvg } from "tests/fixtures/getLastStepSvg"
+
+const srj = bugReport as SimpleRouteJson
+
+test("bugreport23-LGA15x4.srj.json-AutoroutingPipeline1_OriginalUnravel", () => {
+  const solver = new AutoroutingPipeline1_OriginalUnravel(srj)
+  solver.solve()
+  expect(getLastStepSvg(solver.visualize())).toMatchSvgSnapshot(
+    import.meta.path,
+  )
+})


### PR DESCRIPTION
## Summary

Add snapshot tests for 2 more bug report fixtures:

| Bug Report | Connections | Obstacles |
|------------|-------------|----------|
| bugreport46-ac4337-arduino-uno | 35 | 142 |
| bugreport22-2a75ce | 24 | 48 |

Both use `AutoroutingPipeline1_OriginalUnravel` with snapshot testing.