### PR TITLE
chore: update @tscircuit/checks to ^0.0.125

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@react-hook/resize-observer": "^2.0.2",
     "@resvg/resvg-js": "^2.6.2",
     "@tscircuit/autorouting-dataset-01": "^1.0.32",
-    "@tscircuit/checks": "^0.0.114",
+    "@tscircuit/checks": "^0.0.125",
     "@tscircuit/circuit-json-util": "^0.0.90",
     "@tscircuit/core": "^0.0.337",
     "@tscircuit/curvy-trace-solver": "^0.0.10",


### PR DESCRIPTION
### Motivation
- Update the devDependency `@tscircuit/checks` to the latest published release to pick up fixes and keep dependencies current.

### Description
- Bumped `@tscircuit/checks` in `devDependencies` in `package.json` from `^0.0.114` to `^0.0.125`.

### Testing
- Ran `npm view @tscircuit/checks version` which returned `0.0.125`, and inspected `git diff -- package.json` to verify only the intended dependency line changed; both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eff04523948327b46e22e2e50aee4f)