### PR TITLE
Add fixture for autorouting bug report 44d3c953

### DIFF
--- a/fixtures/bug-reports/bugreport56-44d3c9/bugreport56-44d3c9.fixture.tsx
+++ b/fixtures/bug-reports/bugreport56-44d3c9/bugreport56-44d3c9.fixture.tsx
@@ -1,0 +1,7 @@
+// @ts-nocheck
+import { AutoroutingPipelineDebugger } from "lib/testing/AutoroutingPipelineDebugger"
+import bugReportJson from "./bugreport56-44d3c9.json"
+
+export default () => {
+  return <AutoroutingPipelineDebugger srj={bugReportJson.simple_route_json} />
+}

--- a/fixtures/bug-reports/bugreport56-44d3c9/bugreport56-44d3c9.json
+++ b/fixtures/bug-reports/bugreport56-44d3c9/bugreport56-44d3c9.json
@@ -1,0 +1,2331 @@
+{
+  "autorouting_bug_report_id": "44d3c953-cdea-4d3b-9698-3fd69edad73c",
+  "reporter_account_id": "96f144ef-7dfe-4068-aac0-8753c8ab5f62",
+  "package_id": null,
+  "title": "<board#218 />",
+  "simple_route_json": {
+    "bounds": {
+      "maxX": 49.5,
+      "maxY": 34.5,
+      "minX": -49.5,
+      "minY": -34.5
+    },
+    "outline": [
+      {
+        "x": -34.29,
+        "y": 26.67
+      },
+      {
+        "x": 32.29,
+        "y": 26.67
+      },
+      {
+        "x": 34.29,
+        "y": 24.67
+      },
+      {
+        "x": 34.29,
+        "y": 13.89
+      },
+      {
+        "x": 36.83,
+        "y": 11.35
+      },
+      {
+        "x": 36.83,
+        "y": -21.35
+      },
+      {
+        "x": 34.29,
+        "y": -23.89
+      },
+      {
+        "x": 34.29,
+        "y": -26.67
+      },
+      {
+        "x": -34.29,
+        "y": -26.67
+      }
+    ],
+    "obstacles": [
+      {
+        "type": "rect",
+        "width": 1.025,
+        "center": {
+          "x": 22.9125,
+          "y": -14
+        },
+        "height": 1.4,
+        "layers": [
+          "top"
+        ],
+        "connectedTo": [
+          "pcb_smtpad_0",
+          "connectivity_net27",
+          "source_trace_10",
+          "source_port_66",
+          "source_trace_9",
+          "source_port_64",
+          "source_trace_8",
+          "source_port_46",
+          "source_trace_7",
+          "source_port_60",
+          "source_trace_1",
+          "source_port_6",
+          "source_net_1",
+          "pcb_plated_hole_6",
+          "pcb_port_6",
+          "pcb_plated_hole_46",
+          "pcb_port_46",
+          "pcb_plated_hole_60",
+          "pcb_port_60",
+          "pcb_smtpad_0",
+          "pcb_port_64",
+          "pcb_smtpad_2",
+          "pcb_port_66"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1.025,
+        "center": {
+          "x": 21.0875,
+          "y": -14
+        },
+        "height": 1.4,
+        "layers": [
+          "top"
+        ],
+        "connectedTo": [
+          "pcb_smtpad_1",
+          "connectivity_net39",
+          "source_trace_16",
+          "source_port_71",
+          "source_trace_15",
+          "source_port_67",
+          "source_trace_14",
+          "source_port_65",
+          "source_trace_13",
+          "source_port_61",
+          "source_trace_12",
+          "source_port_47",
+          "source_trace_11",
+          "source_port_44",
+          "source_trace_0",
+          "source_port_13",
+          "source_net_0",
+          "pcb_plated_hole_13",
+          "pcb_port_13",
+          "pcb_plated_hole_44",
+          "pcb_port_44",
+          "pcb_plated_hole_47",
+          "pcb_port_47",
+          "pcb_plated_hole_61",
+          "pcb_port_61",
+          "pcb_smtpad_1",
+          "pcb_port_65",
+          "pcb_smtpad_3",
+          "pcb_port_67",
+          "pcb_smtpad_7",
+          "pcb_port_71"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 0.8,
+        "center": {
+          "x": 22.825,
+          "y": -11
+        },
+        "height": 0.95,
+        "layers": [
+          "top"
+        ],
+        "connectedTo": [
+          "pcb_smtpad_2",
+          "connectivity_net27",
+          "source_trace_10",
+          "source_port_66",
+          "source_trace_9",
+          "source_port_64",
+          "source_trace_8",
+          "source_port_46",
+          "source_trace_7",
+          "source_port_60",
+          "source_trace_1",
+          "source_port_6",
+          "source_net_1",
+          "pcb_plated_hole_6",
+          "pcb_port_6",
+          "pcb_plated_hole_46",
+          "pcb_port_46",
+          "pcb_plated_hole_60",
+          "pcb_port_60",
+          "pcb_smtpad_0",
+          "pcb_port_64",
+          "pcb_smtpad_2",
+          "pcb_port_66"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 0.8,
+        "center": {
+          "x": 21.175,
+          "y": -11
+        },
+        "height": 0.95,
+        "layers": [
+          "top"
+        ],
+        "connectedTo": [
+          "pcb_smtpad_3",
+          "connectivity_net39",
+          "source_trace_16",
+          "source_port_71",
+          "source_trace_15",
+          "source_port_67",
+          "source_trace_14",
+          "source_port_65",
+          "source_trace_13",
+          "source_port_61",
+          "source_trace_12",
+          "source_port_47",
+          "source_trace_11",
+          "source_port_44",
+          "source_trace_0",
+          "source_port_13",
+          "source_net_0",
+          "pcb_plated_hole_13",
+          "pcb_port_13",
+          "pcb_plated_hole_44",
+          "pcb_port_44",
+          "pcb_plated_hole_47",
+          "pcb_port_47",
+          "pcb_plated_hole_61",
+          "pcb_port_61",
+          "pcb_smtpad_1",
+          "pcb_port_65",
+          "pcb_smtpad_3",
+          "pcb_port_67",
+          "pcb_smtpad_7",
+          "pcb_port_71"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 0.8,
+        "center": {
+          "x": -7.825,
+          "y": -14
+        },
+        "height": 0.95,
+        "layers": [
+          "top"
+        ],
+        "connectedTo": [
+          "pcb_smtpad_4",
+          "connectivity_net49",
+          "source_trace_20",
+          "source_port_43",
+          "source_port_68",
+          "pcb_plated_hole_43",
+          "pcb_port_43",
+          "pcb_smtpad_4",
+          "pcb_port_68"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 0.8,
+        "center": {
+          "x": -6.175,
+          "y": -14
+        },
+        "height": 0.95,
+        "layers": [
+          "top"
+        ],
+        "connectedTo": [
+          "pcb_smtpad_5",
+          "connectivity_net52",
+          "source_trace_21",
+          "source_port_69",
+          "source_port_70",
+          "pcb_smtpad_5",
+          "pcb_port_69",
+          "pcb_smtpad_6",
+          "pcb_port_70"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 0.8,
+        "center": {
+          "x": -2.825,
+          "y": -14
+        },
+        "height": 0.95,
+        "layers": [
+          "top"
+        ],
+        "connectedTo": [
+          "pcb_smtpad_6",
+          "connectivity_net52",
+          "source_trace_21",
+          "source_port_69",
+          "source_port_70",
+          "pcb_smtpad_5",
+          "pcb_port_69",
+          "pcb_smtpad_6",
+          "pcb_port_70"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 0.8,
+        "center": {
+          "x": -1.175,
+          "y": -14
+        },
+        "height": 0.95,
+        "layers": [
+          "top"
+        ],
+        "connectedTo": [
+          "pcb_smtpad_7",
+          "connectivity_net39",
+          "source_trace_16",
+          "source_port_71",
+          "source_trace_15",
+          "source_port_67",
+          "source_trace_14",
+          "source_port_65",
+          "source_trace_13",
+          "source_port_61",
+          "source_trace_12",
+          "source_port_47",
+          "source_trace_11",
+          "source_port_44",
+          "source_trace_0",
+          "source_port_13",
+          "source_net_0",
+          "pcb_plated_hole_13",
+          "pcb_port_13",
+          "pcb_plated_hole_44",
+          "pcb_port_44",
+          "pcb_plated_hole_47",
+          "pcb_port_47",
+          "pcb_plated_hole_61",
+          "pcb_port_61",
+          "pcb_smtpad_1",
+          "pcb_port_65",
+          "pcb_smtpad_3",
+          "pcb_port_67",
+          "pcb_smtpad_7",
+          "pcb_port_71"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 31.75,
+          "y": -23.99
+        },
+        "height": 1.88,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_0",
+          "connectivity_net199",
+          "source_port_0",
+          "pcb_plated_hole_0",
+          "pcb_port_0"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 29.19,
+          "y": -23.99
+        },
+        "height": 1.88,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_1",
+          "connectivity_net200",
+          "source_port_1",
+          "pcb_plated_hole_1",
+          "pcb_port_1"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 26.63,
+          "y": -23.99
+        },
+        "height": 1.88,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_2",
+          "connectivity_net201",
+          "source_port_2",
+          "pcb_plated_hole_2",
+          "pcb_port_2"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 24.07,
+          "y": -23.99
+        },
+        "height": 1.88,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_3",
+          "connectivity_net202",
+          "source_port_3",
+          "pcb_plated_hole_3",
+          "pcb_port_3"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 21.51,
+          "y": -23.99
+        },
+        "height": 1.88,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_4",
+          "connectivity_net203",
+          "source_port_4",
+          "pcb_plated_hole_4",
+          "pcb_port_4"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 18.95,
+          "y": -23.99
+        },
+        "height": 1.88,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_5",
+          "connectivity_net204",
+          "source_port_5",
+          "pcb_plated_hole_5",
+          "pcb_port_5"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 13.91,
+          "y": -23.99
+        },
+        "height": 1.88,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_6",
+          "connectivity_net27",
+          "source_trace_10",
+          "source_port_66",
+          "source_trace_9",
+          "source_port_64",
+          "source_trace_8",
+          "source_port_46",
+          "source_trace_7",
+          "source_port_60",
+          "source_trace_1",
+          "source_port_6",
+          "source_net_1",
+          "pcb_plated_hole_6",
+          "pcb_port_6",
+          "pcb_plated_hole_46",
+          "pcb_port_46",
+          "pcb_plated_hole_60",
+          "pcb_port_60",
+          "pcb_smtpad_0",
+          "pcb_port_64",
+          "pcb_smtpad_2",
+          "pcb_port_66"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 11.35,
+          "y": -23.99
+        },
+        "height": 1.88,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_7",
+          "connectivity_net205",
+          "source_port_7",
+          "pcb_plated_hole_7",
+          "pcb_port_7"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 8.79,
+          "y": -23.99
+        },
+        "height": 1.88,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_8",
+          "connectivity_net206",
+          "source_port_8",
+          "pcb_plated_hole_8",
+          "pcb_port_8"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 6.23,
+          "y": -23.99
+        },
+        "height": 1.88,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_9",
+          "connectivity_net207",
+          "source_port_9",
+          "pcb_plated_hole_9",
+          "pcb_port_9"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 3.67,
+          "y": -23.99
+        },
+        "height": 1.88,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_10",
+          "connectivity_net208",
+          "source_port_10",
+          "pcb_plated_hole_10",
+          "pcb_port_10"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 1.11,
+          "y": -23.99
+        },
+        "height": 1.88,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_11",
+          "connectivity_net41",
+          "source_trace_17",
+          "source_port_45",
+          "source_trace_2",
+          "source_port_11",
+          "source_net_2",
+          "pcb_plated_hole_11",
+          "pcb_port_11",
+          "pcb_plated_hole_45",
+          "pcb_port_45"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": -1.11,
+          "y": -23.99
+        },
+        "height": 1.88,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_12",
+          "connectivity_net209",
+          "source_port_12",
+          "pcb_plated_hole_12",
+          "pcb_port_12"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": -3.67,
+          "y": -23.99
+        },
+        "height": 1.88,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_13",
+          "connectivity_net39",
+          "source_trace_16",
+          "source_port_71",
+          "source_trace_15",
+          "source_port_67",
+          "source_trace_14",
+          "source_port_65",
+          "source_trace_13",
+          "source_port_61",
+          "source_trace_12",
+          "source_port_47",
+          "source_trace_11",
+          "source_port_44",
+          "source_trace_0",
+          "source_port_13",
+          "source_net_0",
+          "pcb_plated_hole_13",
+          "pcb_port_13",
+          "pcb_plated_hole_44",
+          "pcb_port_44",
+          "pcb_plated_hole_47",
+          "pcb_port_47",
+          "pcb_plated_hole_61",
+          "pcb_port_61",
+          "pcb_smtpad_1",
+          "pcb_port_65",
+          "pcb_smtpad_3",
+          "pcb_port_67",
+          "pcb_smtpad_7",
+          "pcb_port_71"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 31.75,
+          "y": 23.99
+        },
+        "height": 1.88,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_14",
+          "connectivity_net210",
+          "source_port_14",
+          "pcb_plated_hole_14",
+          "pcb_port_14"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 29.19,
+          "y": 23.99
+        },
+        "height": 1.88,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_15",
+          "connectivity_net211",
+          "source_port_15",
+          "pcb_plated_hole_15",
+          "pcb_port_15"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 26.63,
+          "y": 23.99
+        },
+        "height": 1.88,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_16",
+          "connectivity_net212",
+          "source_port_16",
+          "pcb_plated_hole_16",
+          "pcb_port_16"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 24.07,
+          "y": 23.99
+        },
+        "height": 1.88,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_17",
+          "connectivity_net213",
+          "source_port_17",
+          "pcb_plated_hole_17",
+          "pcb_port_17"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 21.51,
+          "y": 23.99
+        },
+        "height": 1.88,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_18",
+          "connectivity_net214",
+          "source_port_18",
+          "pcb_plated_hole_18",
+          "pcb_port_18"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 18.95,
+          "y": 23.99
+        },
+        "height": 1.88,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_19",
+          "connectivity_net215",
+          "source_port_19",
+          "pcb_plated_hole_19",
+          "pcb_port_19"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 16.39,
+          "y": 23.99
+        },
+        "height": 1.88,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_20",
+          "connectivity_net216",
+          "source_port_20",
+          "pcb_plated_hole_20",
+          "pcb_port_20"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 13.83,
+          "y": 23.99
+        },
+        "height": 1.88,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_21",
+          "connectivity_net217",
+          "source_port_21",
+          "pcb_plated_hole_21",
+          "pcb_port_21"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 9.96,
+          "y": 23.99
+        },
+        "height": 1.88,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_22",
+          "connectivity_net218",
+          "source_port_22",
+          "pcb_plated_hole_22",
+          "pcb_port_22"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 7.4,
+          "y": 23.99
+        },
+        "height": 1.88,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_23",
+          "connectivity_net219",
+          "source_port_23",
+          "pcb_plated_hole_23",
+          "pcb_port_23"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 4.84,
+          "y": 23.99
+        },
+        "height": 1.88,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_24",
+          "connectivity_net220",
+          "source_port_24",
+          "pcb_plated_hole_24",
+          "pcb_port_24"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": 2.28,
+          "y": 23.99
+        },
+        "height": 1.88,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_25",
+          "connectivity_net221",
+          "source_port_25",
+          "pcb_plated_hole_25",
+          "pcb_port_25"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": -0.28,
+          "y": 23.99
+        },
+        "height": 1.88,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_26",
+          "connectivity_net222",
+          "source_port_26",
+          "pcb_plated_hole_26",
+          "pcb_port_26"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": -2.82,
+          "y": 23.99
+        },
+        "height": 1.88,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_27",
+          "connectivity_net223",
+          "source_port_27",
+          "pcb_plated_hole_27",
+          "pcb_port_27"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": -5.36,
+          "y": 23.99
+        },
+        "height": 1.88,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_28",
+          "connectivity_net224",
+          "source_port_28",
+          "pcb_plated_hole_28",
+          "pcb_port_28"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": -7.9,
+          "y": 23.99
+        },
+        "height": 1.88,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_29",
+          "connectivity_net225",
+          "source_port_29",
+          "pcb_plated_hole_29",
+          "pcb_port_29"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": -10.46,
+          "y": 23.99
+        },
+        "height": 1.88,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_30",
+          "connectivity_net226",
+          "source_port_30",
+          "pcb_plated_hole_30",
+          "pcb_port_30"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.88,
+        "center": {
+          "x": -12.9,
+          "y": 23.99
+        },
+        "height": 1.88,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_31",
+          "connectivity_net227",
+          "source_port_31",
+          "pcb_plated_hole_31",
+          "pcb_port_31"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1.5,
+        "center": {
+          "x": -32.379999999999995,
+          "y": -7.62
+        },
+        "height": 1.5,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_32",
+          "connectivity_net228",
+          "source_port_32",
+          "pcb_plated_hole_32",
+          "pcb_port_32"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.5,
+        "center": {
+          "x": -32.379999999999995,
+          "y": -5.08
+        },
+        "height": 1.5,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_33",
+          "connectivity_net229",
+          "source_port_33",
+          "pcb_plated_hole_33",
+          "pcb_port_33"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.5,
+        "center": {
+          "x": -32.379999999999995,
+          "y": -2.54
+        },
+        "height": 1.5,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_34",
+          "connectivity_net230",
+          "source_port_34",
+          "pcb_plated_hole_34",
+          "pcb_port_34"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.5,
+        "center": {
+          "x": -32.379999999999995,
+          "y": 0
+        },
+        "height": 1.5,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_35",
+          "connectivity_net231",
+          "source_port_35",
+          "pcb_plated_hole_35",
+          "pcb_port_35"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.5,
+        "center": {
+          "x": -32.379999999999995,
+          "y": 2.54
+        },
+        "height": 1.5,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_36",
+          "connectivity_net232",
+          "source_port_36",
+          "pcb_plated_hole_36",
+          "pcb_port_36"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.5,
+        "center": {
+          "x": -32.379999999999995,
+          "y": 5.079999999999999
+        },
+        "height": 1.5,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_37",
+          "connectivity_net233",
+          "source_port_37",
+          "pcb_plated_hole_37",
+          "pcb_port_37"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.5,
+        "center": {
+          "x": -32.379999999999995,
+          "y": 7.62
+        },
+        "height": 1.5,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_38",
+          "connectivity_net234",
+          "source_port_38",
+          "pcb_plated_hole_38",
+          "pcb_port_38"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1.5,
+        "center": {
+          "x": -12.379999999999999,
+          "y": -7.62
+        },
+        "height": 1.5,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_39",
+          "connectivity_net18",
+          "source_trace_6",
+          "source_port_39",
+          "source_port_48",
+          "pcb_plated_hole_39",
+          "pcb_port_39",
+          "pcb_plated_hole_48",
+          "pcb_port_48"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.5,
+        "center": {
+          "x": -12.379999999999999,
+          "y": -5.08
+        },
+        "height": 1.5,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_40",
+          "connectivity_net9",
+          "source_trace_3",
+          "source_port_40",
+          "source_port_53",
+          "pcb_plated_hole_40",
+          "pcb_port_40",
+          "pcb_plated_hole_53",
+          "pcb_port_53"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.5,
+        "center": {
+          "x": -12.379999999999999,
+          "y": -2.54
+        },
+        "height": 1.5,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_41",
+          "connectivity_net15",
+          "source_trace_5",
+          "source_port_41",
+          "source_port_51",
+          "pcb_plated_hole_41",
+          "pcb_port_41",
+          "pcb_plated_hole_51",
+          "pcb_port_51"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.5,
+        "center": {
+          "x": -12.379999999999999,
+          "y": 0
+        },
+        "height": 1.5,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_42",
+          "connectivity_net12",
+          "source_trace_4",
+          "source_port_42",
+          "source_port_52",
+          "pcb_plated_hole_42",
+          "pcb_port_42",
+          "pcb_plated_hole_52",
+          "pcb_port_52"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.5,
+        "center": {
+          "x": -12.379999999999999,
+          "y": 2.54
+        },
+        "height": 1.5,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_43",
+          "connectivity_net49",
+          "source_trace_20",
+          "source_port_43",
+          "source_port_68",
+          "pcb_plated_hole_43",
+          "pcb_port_43",
+          "pcb_smtpad_4",
+          "pcb_port_68"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.5,
+        "center": {
+          "x": -12.379999999999999,
+          "y": 5.079999999999999
+        },
+        "height": 1.5,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_44",
+          "connectivity_net39",
+          "source_trace_16",
+          "source_port_71",
+          "source_trace_15",
+          "source_port_67",
+          "source_trace_14",
+          "source_port_65",
+          "source_trace_13",
+          "source_port_61",
+          "source_trace_12",
+          "source_port_47",
+          "source_trace_11",
+          "source_port_44",
+          "source_trace_0",
+          "source_port_13",
+          "source_net_0",
+          "pcb_plated_hole_13",
+          "pcb_port_13",
+          "pcb_plated_hole_44",
+          "pcb_port_44",
+          "pcb_plated_hole_47",
+          "pcb_port_47",
+          "pcb_plated_hole_61",
+          "pcb_port_61",
+          "pcb_smtpad_1",
+          "pcb_port_65",
+          "pcb_smtpad_3",
+          "pcb_port_67",
+          "pcb_smtpad_7",
+          "pcb_port_71"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.5,
+        "center": {
+          "x": -12.379999999999999,
+          "y": 7.62
+        },
+        "height": 1.5,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_45",
+          "connectivity_net41",
+          "source_trace_17",
+          "source_port_45",
+          "source_trace_2",
+          "source_port_11",
+          "source_net_2",
+          "pcb_plated_hole_11",
+          "pcb_port_11",
+          "pcb_plated_hole_45",
+          "pcb_port_45"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1.5,
+        "center": {
+          "x": -0.5000000000000006,
+          "y": -8.89
+        },
+        "height": 1.5,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_46",
+          "connectivity_net27",
+          "source_trace_10",
+          "source_port_66",
+          "source_trace_9",
+          "source_port_64",
+          "source_trace_8",
+          "source_port_46",
+          "source_trace_7",
+          "source_port_60",
+          "source_trace_1",
+          "source_port_6",
+          "source_net_1",
+          "pcb_plated_hole_6",
+          "pcb_port_6",
+          "pcb_plated_hole_46",
+          "pcb_port_46",
+          "pcb_plated_hole_60",
+          "pcb_port_60",
+          "pcb_smtpad_0",
+          "pcb_port_64",
+          "pcb_smtpad_2",
+          "pcb_port_66"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.5,
+        "center": {
+          "x": -0.5000000000000004,
+          "y": -6.3500000000000005
+        },
+        "height": 1.5,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_47",
+          "connectivity_net39",
+          "source_trace_16",
+          "source_port_71",
+          "source_trace_15",
+          "source_port_67",
+          "source_trace_14",
+          "source_port_65",
+          "source_trace_13",
+          "source_port_61",
+          "source_trace_12",
+          "source_port_47",
+          "source_trace_11",
+          "source_port_44",
+          "source_trace_0",
+          "source_port_13",
+          "source_net_0",
+          "pcb_plated_hole_13",
+          "pcb_port_13",
+          "pcb_plated_hole_44",
+          "pcb_port_44",
+          "pcb_plated_hole_47",
+          "pcb_port_47",
+          "pcb_plated_hole_61",
+          "pcb_port_61",
+          "pcb_smtpad_1",
+          "pcb_port_65",
+          "pcb_smtpad_3",
+          "pcb_port_67",
+          "pcb_smtpad_7",
+          "pcb_port_71"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.5,
+        "center": {
+          "x": -0.5000000000000002,
+          "y": -3.8100000000000005
+        },
+        "height": 1.5,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_48",
+          "connectivity_net18",
+          "source_trace_6",
+          "source_port_39",
+          "source_port_48",
+          "pcb_plated_hole_39",
+          "pcb_port_39",
+          "pcb_plated_hole_48",
+          "pcb_port_48"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.5,
+        "center": {
+          "x": -0.5000000000000001,
+          "y": -1.2700000000000005
+        },
+        "height": 1.5,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_49",
+          "connectivity_net235",
+          "source_port_49",
+          "pcb_plated_hole_49",
+          "pcb_port_49"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.5,
+        "center": {
+          "x": -0.49999999999999994,
+          "y": 1.2699999999999996
+        },
+        "height": 1.5,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_50",
+          "connectivity_net236",
+          "source_port_50",
+          "pcb_plated_hole_50",
+          "pcb_port_50"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.5,
+        "center": {
+          "x": -0.4999999999999998,
+          "y": 3.8099999999999987
+        },
+        "height": 1.5,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_51",
+          "connectivity_net15",
+          "source_trace_5",
+          "source_port_41",
+          "source_port_51",
+          "pcb_plated_hole_41",
+          "pcb_port_41",
+          "pcb_plated_hole_51",
+          "pcb_port_51"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.5,
+        "center": {
+          "x": -0.4999999999999996,
+          "y": 6.35
+        },
+        "height": 1.5,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_52",
+          "connectivity_net12",
+          "source_trace_4",
+          "source_port_42",
+          "source_port_52",
+          "pcb_plated_hole_42",
+          "pcb_port_42",
+          "pcb_plated_hole_52",
+          "pcb_port_52"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.5,
+        "center": {
+          "x": -0.49999999999999944,
+          "y": 8.89
+        },
+        "height": 1.5,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_53",
+          "connectivity_net9",
+          "source_trace_3",
+          "source_port_40",
+          "source_port_53",
+          "pcb_plated_hole_40",
+          "pcb_port_40",
+          "pcb_plated_hole_53",
+          "pcb_port_53"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1.5,
+        "center": {
+          "x": 16.5,
+          "y": -6.35
+        },
+        "height": 1.5,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_54",
+          "connectivity_net237",
+          "source_port_54",
+          "pcb_plated_hole_54",
+          "pcb_port_54"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.5,
+        "center": {
+          "x": 16.5,
+          "y": -3.8099999999999996
+        },
+        "height": 1.5,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_55",
+          "connectivity_net238",
+          "source_port_55",
+          "pcb_plated_hole_55",
+          "pcb_port_55"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.5,
+        "center": {
+          "x": 16.5,
+          "y": -1.2699999999999996
+        },
+        "height": 1.5,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_56",
+          "connectivity_net239",
+          "source_port_56",
+          "pcb_plated_hole_56",
+          "pcb_port_56"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.5,
+        "center": {
+          "x": 16.5,
+          "y": 1.2700000000000005
+        },
+        "height": 1.5,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_57",
+          "connectivity_net240",
+          "source_port_57",
+          "pcb_plated_hole_57",
+          "pcb_port_57"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.5,
+        "center": {
+          "x": 16.5,
+          "y": 3.8100000000000005
+        },
+        "height": 1.5,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_58",
+          "connectivity_net46",
+          "source_trace_19",
+          "source_port_63",
+          "source_port_58",
+          "pcb_plated_hole_58",
+          "pcb_port_58",
+          "pcb_plated_hole_63",
+          "pcb_port_63"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.5,
+        "center": {
+          "x": 16.5,
+          "y": 6.35
+        },
+        "height": 1.5,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_59",
+          "connectivity_net43",
+          "source_trace_18",
+          "source_port_62",
+          "source_port_59",
+          "pcb_plated_hole_59",
+          "pcb_port_59",
+          "pcb_plated_hole_62",
+          "pcb_port_62"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1.5,
+        "center": {
+          "x": 29,
+          "y": -14.54
+        },
+        "height": 1.5,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_60",
+          "connectivity_net27",
+          "source_trace_10",
+          "source_port_66",
+          "source_trace_9",
+          "source_port_64",
+          "source_trace_8",
+          "source_port_46",
+          "source_trace_7",
+          "source_port_60",
+          "source_trace_1",
+          "source_port_6",
+          "source_net_1",
+          "pcb_plated_hole_6",
+          "pcb_port_6",
+          "pcb_plated_hole_46",
+          "pcb_port_46",
+          "pcb_plated_hole_60",
+          "pcb_port_60",
+          "pcb_smtpad_0",
+          "pcb_port_64",
+          "pcb_smtpad_2",
+          "pcb_port_66"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.5,
+        "center": {
+          "x": 29,
+          "y": -9.46
+        },
+        "height": 1.5,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_61",
+          "connectivity_net39",
+          "source_trace_16",
+          "source_port_71",
+          "source_trace_15",
+          "source_port_67",
+          "source_trace_14",
+          "source_port_65",
+          "source_trace_13",
+          "source_port_61",
+          "source_trace_12",
+          "source_port_47",
+          "source_trace_11",
+          "source_port_44",
+          "source_trace_0",
+          "source_port_13",
+          "source_net_0",
+          "pcb_plated_hole_13",
+          "pcb_port_13",
+          "pcb_plated_hole_44",
+          "pcb_port_44",
+          "pcb_plated_hole_47",
+          "pcb_port_47",
+          "pcb_plated_hole_61",
+          "pcb_port_61",
+          "pcb_smtpad_1",
+          "pcb_port_65",
+          "pcb_smtpad_3",
+          "pcb_port_67",
+          "pcb_smtpad_7",
+          "pcb_port_71"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1.5,
+        "center": {
+          "x": 29,
+          "y": 5.46
+        },
+        "height": 1.5,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_62",
+          "connectivity_net43",
+          "source_trace_18",
+          "source_port_62",
+          "source_port_59",
+          "pcb_plated_hole_59",
+          "pcb_port_59",
+          "pcb_plated_hole_62",
+          "pcb_port_62"
+        ]
+      },
+      {
+        "type": "oval",
+        "width": 1.5,
+        "center": {
+          "x": 29,
+          "y": 10.54
+        },
+        "height": 1.5,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": [
+          "pcb_plated_hole_63",
+          "connectivity_net46",
+          "source_trace_19",
+          "source_port_63",
+          "source_port_58",
+          "pcb_plated_hole_58",
+          "pcb_port_58",
+          "pcb_plated_hole_63",
+          "pcb_port_63"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1,
+        "center": {
+          "x": -48,
+          "y": -33
+        },
+        "height": 1,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": []
+      },
+      {
+        "type": "rect",
+        "width": 1,
+        "center": {
+          "x": -48,
+          "y": 33
+        },
+        "height": 1,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": []
+      },
+      {
+        "type": "rect",
+        "width": 1,
+        "center": {
+          "x": 48,
+          "y": -33
+        },
+        "height": 1,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": []
+      },
+      {
+        "type": "rect",
+        "width": 1,
+        "center": {
+          "x": 48,
+          "y": 33
+        },
+        "height": 1,
+        "layers": [
+          "top",
+          "inner1",
+          "inner2",
+          "bottom"
+        ],
+        "connectedTo": []
+      }
+    ],
+    "layerCount": 2,
+    "connections": [
+      {
+        "name": "source_trace_3",
+        "width": 0.25,
+        "pointsToConnect": [
+          {
+            "x": -12.379999999999999,
+            "y": -5.08,
+            "layer": "top",
+            "pointId": "pcb_port_40",
+            "pcb_port_id": "pcb_port_40"
+          },
+          {
+            "x": -0.49999999999999944,
+            "y": 8.89,
+            "layer": "top",
+            "pointId": "pcb_port_53",
+            "pcb_port_id": "pcb_port_53"
+          }
+        ],
+        "source_trace_id": "source_trace_3",
+        "nominalTraceWidth": 0.25
+      },
+      {
+        "name": "source_trace_4",
+        "width": 0.25,
+        "pointsToConnect": [
+          {
+            "x": -12.379999999999999,
+            "y": 0,
+            "layer": "top",
+            "pointId": "pcb_port_42",
+            "pcb_port_id": "pcb_port_42"
+          },
+          {
+            "x": -0.4999999999999996,
+            "y": 6.35,
+            "layer": "top",
+            "pointId": "pcb_port_52",
+            "pcb_port_id": "pcb_port_52"
+          }
+        ],
+        "source_trace_id": "source_trace_4",
+        "nominalTraceWidth": 0.25
+      },
+      {
+        "name": "source_trace_5",
+        "width": 0.25,
+        "pointsToConnect": [
+          {
+            "x": -12.379999999999999,
+            "y": -2.54,
+            "layer": "top",
+            "pointId": "pcb_port_41",
+            "pcb_port_id": "pcb_port_41"
+          },
+          {
+            "x": -0.4999999999999998,
+            "y": 3.8099999999999987,
+            "layer": "top",
+            "pointId": "pcb_port_51",
+            "pcb_port_id": "pcb_port_51"
+          }
+        ],
+        "source_trace_id": "source_trace_5",
+        "nominalTraceWidth": 0.25
+      },
+      {
+        "name": "source_trace_6",
+        "width": 0.25,
+        "pointsToConnect": [
+          {
+            "x": -12.379999999999999,
+            "y": -7.62,
+            "layer": "top",
+            "pointId": "pcb_port_39",
+            "pcb_port_id": "pcb_port_39"
+          },
+          {
+            "x": -0.5000000000000002,
+            "y": -3.8100000000000005,
+            "layer": "top",
+            "pointId": "pcb_port_48",
+            "pcb_port_id": "pcb_port_48"
+          }
+        ],
+        "source_trace_id": "source_trace_6",
+        "nominalTraceWidth": 0.25
+      },
+      {
+        "name": "source_trace_18",
+        "width": 0.25,
+        "pointsToConnect": [
+          {
+            "x": 29,
+            "y": 5.46,
+            "layer": "top",
+            "pointId": "pcb_port_62",
+            "pcb_port_id": "pcb_port_62"
+          },
+          {
+            "x": 16.5,
+            "y": 6.35,
+            "layer": "top",
+            "pointId": "pcb_port_59",
+            "pcb_port_id": "pcb_port_59"
+          }
+        ],
+        "source_trace_id": "source_trace_18",
+        "nominalTraceWidth": 0.25
+      },
+      {
+        "name": "source_trace_19",
+        "width": 0.25,
+        "pointsToConnect": [
+          {
+            "x": 29,
+            "y": 10.54,
+            "layer": "top",
+            "pointId": "pcb_port_63",
+            "pcb_port_id": "pcb_port_63"
+          },
+          {
+            "x": 16.5,
+            "y": 3.8100000000000005,
+            "layer": "top",
+            "pointId": "pcb_port_58",
+            "pcb_port_id": "pcb_port_58"
+          }
+        ],
+        "source_trace_id": "source_trace_19",
+        "nominalTraceWidth": 0.25
+      },
+      {
+        "name": "source_trace_20",
+        "width": 0.25,
+        "pointsToConnect": [
+          {
+            "x": -12.379999999999999,
+            "y": 2.54,
+            "layer": "top",
+            "pointId": "pcb_port_43",
+            "pcb_port_id": "pcb_port_43"
+          },
+          {
+            "x": -7.825,
+            "y": -14,
+            "layer": "top",
+            "pointId": "pcb_port_68",
+            "pcb_port_id": "pcb_port_68"
+          }
+        ],
+        "source_trace_id": "source_trace_20",
+        "nominalTraceWidth": 0.25
+      },
+      {
+        "name": "source_trace_21",
+        "width": 0.25,
+        "pointsToConnect": [
+          {
+            "x": -6.175,
+            "y": -14,
+            "layer": "top",
+            "pointId": "pcb_port_69",
+            "pcb_port_id": "pcb_port_69"
+          },
+          {
+            "x": -2.825,
+            "y": -14,
+            "layer": "top",
+            "pointId": "pcb_port_70",
+            "pcb_port_id": "pcb_port_70"
+          }
+        ],
+        "source_trace_id": "source_trace_21",
+        "nominalTraceWidth": 0.25
+      },
+      {
+        "name": "source_net_0",
+        "width": 0.25,
+        "pointsToConnect": [
+          {
+            "x": -3.67,
+            "y": -23.99,
+            "layer": "top",
+            "pointId": "pcb_port_13",
+            "pcb_port_id": "pcb_port_13"
+          },
+          {
+            "x": -12.379999999999999,
+            "y": 5.079999999999999,
+            "layer": "top",
+            "pointId": "pcb_port_44",
+            "pcb_port_id": "pcb_port_44"
+          },
+          {
+            "x": -0.5000000000000004,
+            "y": -6.3500000000000005,
+            "layer": "top",
+            "pointId": "pcb_port_47",
+            "pcb_port_id": "pcb_port_47"
+          },
+          {
+            "x": 29,
+            "y": -9.46,
+            "layer": "top",
+            "pointId": "pcb_port_61",
+            "pcb_port_id": "pcb_port_61"
+          },
+          {
+            "x": 21.0875,
+            "y": -14,
+            "layer": "top",
+            "pointId": "pcb_port_65",
+            "pcb_port_id": "pcb_port_65"
+          },
+          {
+            "x": 21.175,
+            "y": -11,
+            "layer": "top",
+            "pointId": "pcb_port_67",
+            "pcb_port_id": "pcb_port_67"
+          },
+          {
+            "x": -1.175,
+            "y": -14,
+            "layer": "top",
+            "pointId": "pcb_port_71",
+            "pcb_port_id": "pcb_port_71"
+          }
+        ],
+        "nominalTraceWidth": 0.25
+      },
+      {
+        "name": "source_net_1",
+        "width": 0.25,
+        "pointsToConnect": [
+          {
+            "x": 13.91,
+            "y": -23.99,
+            "layer": "top",
+            "pointId": "pcb_port_6",
+            "pcb_port_id": "pcb_port_6"
+          },
+          {
+            "x": 29,
+            "y": -14.54,
+            "layer": "top",
+            "pointId": "pcb_port_60",
+            "pcb_port_id": "pcb_port_60"
+          },
+          {
+            "x": -0.5000000000000006,
+            "y": -8.89,
+            "layer": "top",
+            "pointId": "pcb_port_46",
+            "pcb_port_id": "pcb_port_46"
+          },
+          {
+            "x": 22.9125,
+            "y": -14,
+            "layer": "top",
+            "pointId": "pcb_port_64",
+            "pcb_port_id": "pcb_port_64"
+          },
+          {
+            "x": 22.825,
+            "y": -11,
+            "layer": "top",
+            "pointId": "pcb_port_66",
+            "pcb_port_id": "pcb_port_66"
+          }
+        ],
+        "nominalTraceWidth": 0.25
+      },
+      {
+        "name": "source_net_2",
+        "pointsToConnect": [
+          {
+            "x": 1.11,
+            "y": -23.99,
+            "layer": "top",
+            "pointId": "pcb_port_11",
+            "pcb_port_id": "pcb_port_11"
+          },
+          {
+            "x": -12.379999999999999,
+            "y": 7.62,
+            "layer": "top",
+            "pointId": "pcb_port_45",
+            "pcb_port_id": "pcb_port_45"
+          }
+        ]
+      }
+    ],
+    "minTraceWidth": 0.15,
+    "minViaDiameter": 2.5,
+    "minViaPadDiameter": 2.5,
+    "minViaHoleDiameter": 1.5,
+    "min_via_pad_diameter": 2.5,
+    "min_via_hole_diameter": 1.5
+  },
+  "circuit_json": null,
+  "subcircuit_id": null,
+  "created_at": "2026-04-29T18:00:44.292Z"
+}


### PR DESCRIPTION
### Motivation
- Provide a reproducible fixture for autorouting bug report `44d3c953-cdea-4d3b-9698-3fd69edad73c` to enable manual debugging and visualization in the dev environment.

### Description
- Added a raw bug report JSON at `fixtures/bug-reports/bugreport56-44d3c9/bugreport56-44d3c9.json` containing the downloaded `simple_route_json` payload.
- Added a minimal fixture component at `fixtures/bug-reports/bugreport56-44d3c9/bugreport56-44d3c9.fixture.tsx` that loads the SRJ into `AutoroutingPipelineDebugger` for interactive inspection.
- Applied repository formatting to keep code style consistent.

### Testing
- Ran `bun run bug-report "https://api.tscircuit.com/autorouting/bug_reports/view?autorouting_bug_report_id=44d3c953-cdea-4d3b-9698-3fd69edad73c"` to download and scaffold the fixture successfully.
- Ran `biome format --write .` to format files successfully.
- No snapshot or unit tests were added per request.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f24b3ef4f883278dee86074d3ef92d)