### PR TITLE
Fix Pipeline6 projection for constrained corridor nodes

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/AttachProjectedRectsSolver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/AttachProjectedRectsSolver.ts
@@ -3,18 +3,67 @@ import { BaseSolver } from "lib/solvers/BaseSolver"
 import { computeProjectedRect } from "./geometry"
 import type { PolyNodeWithPortPoints } from "./types"
 
+const getRequiredRoutingCorridorWidth = ({
+  traceWidth,
+  viaDiameter,
+  obstacleMargin,
+  minProjectedRectDimension,
+}: {
+  traceWidth?: number
+  viaDiameter?: number
+  obstacleMargin?: number
+  minProjectedRectDimension: number
+}) =>
+  Math.max(
+    minProjectedRectDimension,
+    viaDiameter ?? 0,
+    (traceWidth ?? 0) + 2 * (obstacleMargin ?? 0),
+  )
+
+const shouldClampProjectionExpansion = (
+  projectedRect: ReturnType<typeof computeProjectedRect>,
+  conservativeProjectedRect: ReturnType<typeof computeProjectedRect>,
+  requiredRoutingCorridorWidth: number,
+  traceWidth?: number,
+) => {
+  if (requiredRoutingCorridorWidth <= 0) return false
+
+  const minDimension = Math.min(projectedRect.width, projectedRect.height)
+  const conservativeMinDimension = Math.min(
+    conservativeProjectedRect.width,
+    conservativeProjectedRect.height,
+  )
+  const nextTraceLaneWidth = requiredRoutingCorridorWidth + (traceWidth ?? 0)
+  const expandedLanesAcross = Math.floor(
+    minDimension / requiredRoutingCorridorWidth,
+  )
+  const conservativeLanesAcross = Math.floor(
+    conservativeMinDimension / requiredRoutingCorridorWidth,
+  )
+
+  return (
+    expandedLanesAcross <= conservativeLanesAcross &&
+    minDimension <= nextTraceLaneWidth &&
+    projectedRect.equivalentAreaExpansionFactor > 1
+  )
+}
+
 export class AttachProjectedRectsSolver extends BaseSolver {
   override getSolverName(): string {
     return "AttachProjectedRectsSolver"
   }
 
   outputNodes: PolyNodeWithPortPoints[] = []
+  projectionAdjustmentByNodeId = new Map<string, string>()
 
   constructor(
     public params: {
       nodesWithPortPoints: PolyNodeWithPortPoints[]
       equivalentAreaExpansionFactor?: number
       minProjectedRectDimension?: number
+      traceWidth?: number
+      viaDiameter?: number
+      obstacleMargin?: number
     },
   ) {
     super()
@@ -22,12 +71,45 @@ export class AttachProjectedRectsSolver extends BaseSolver {
   }
 
   _step() {
+    this.projectionAdjustmentByNodeId.clear()
     this.outputNodes = this.params.nodesWithPortPoints.map((node) => {
-      const projectedRect = computeProjectedRect(
+      const requestedExpansionFactor =
+        this.params.equivalentAreaExpansionFactor ?? 0
+      const minProjectedRectDimension =
+        this.params.minProjectedRectDimension ?? 0
+      const requiredRoutingCorridorWidth = getRequiredRoutingCorridorWidth({
+        traceWidth: this.params.traceWidth,
+        viaDiameter: this.params.viaDiameter,
+        obstacleMargin: this.params.obstacleMargin,
+        minProjectedRectDimension,
+      })
+      let projectedRect = computeProjectedRect(
         node.polygon,
-        this.params.equivalentAreaExpansionFactor ?? 0,
-        this.params.minProjectedRectDimension ?? 0,
+        requestedExpansionFactor,
+        minProjectedRectDimension,
       )
+
+      const conservativeProjectedRect = computeProjectedRect(
+        node.polygon,
+        1,
+        minProjectedRectDimension,
+      )
+
+      if (
+        shouldClampProjectionExpansion(
+          projectedRect,
+          conservativeProjectedRect,
+          requiredRoutingCorridorWidth,
+          this.params.traceWidth,
+        )
+      ) {
+        projectedRect = conservativeProjectedRect
+        this.projectionAdjustmentByNodeId.set(
+          node.capacityMeshNodeId,
+          "corridor-expansion-factor-1",
+        )
+      }
+
       return {
         ...node,
         center: projectedRect.center,

--- a/lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/AttachProjectedRectsSolver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/AttachProjectedRectsSolver.ts
@@ -1,63 +1,11 @@
 import type { GraphicsObject } from "graphics-debug"
 import { BaseSolver } from "lib/solvers/BaseSolver"
 import { computeProjectedRect } from "./geometry"
+import {
+  getRequiredRoutingCorridorWidth,
+  shouldClampProjectionExpansion,
+} from "./shouldClampProjectionExpansion"
 import type { PolyNodeWithPortPoints } from "./types"
-
-const getRequiredRoutingCorridorWidth = ({
-  traceWidth,
-  viaDiameter,
-  obstacleMargin,
-  minProjectedRectDimension,
-}: {
-  traceWidth?: number
-  viaDiameter?: number
-  obstacleMargin?: number
-  minProjectedRectDimension: number
-}) =>
-  Math.max(
-    minProjectedRectDimension,
-    viaDiameter ?? 0,
-    (traceWidth ?? 0) + 2 * (obstacleMargin ?? 0),
-  )
-
-const shouldClampProjectionExpansion = (
-  node: PolyNodeWithPortPoints,
-  projectedRect: ReturnType<typeof computeProjectedRect>,
-  conservativeProjectedRect: ReturnType<typeof computeProjectedRect>,
-  requiredRoutingCorridorWidth: number,
-  traceWidth?: number,
-) => {
-  if (requiredRoutingCorridorWidth <= 0) return false
-
-  const minDimension = Math.min(projectedRect.width, projectedRect.height)
-  const conservativeMinDimension = Math.min(
-    conservativeProjectedRect.width,
-    conservativeProjectedRect.height,
-  )
-  const maxDimension = Math.max(projectedRect.width, projectedRect.height)
-  const conservativeMaxDimension = Math.max(
-    conservativeProjectedRect.width,
-    conservativeProjectedRect.height,
-  )
-  const nextTraceLaneWidth = requiredRoutingCorridorWidth + (traceWidth ?? 0)
-  const expandedLanesAcross = Math.floor(
-    minDimension / requiredRoutingCorridorWidth,
-  )
-  const conservativeLanesAcross = Math.floor(
-    conservativeMinDimension / requiredRoutingCorridorWidth,
-  )
-  const connectionCount = new Set(
-    node.portPoints.map((portPoint) => portPoint.connectionName),
-  ).size
-
-  return (
-    connectionCount > 1 &&
-    expandedLanesAcross <= conservativeLanesAcross &&
-    minDimension <= nextTraceLaneWidth &&
-    maxDimension - conservativeMaxDimension >= requiredRoutingCorridorWidth &&
-    projectedRect.equivalentAreaExpansionFactor > 1
-  )
-}
 
 export class AttachProjectedRectsSolver extends BaseSolver {
   override getSolverName(): string {
@@ -120,13 +68,13 @@ export class AttachProjectedRectsSolver extends BaseSolver {
       )
 
       if (
-        shouldClampProjectionExpansion(
+        shouldClampProjectionExpansion({
           node,
           projectedRect,
           conservativeProjectedRect,
           requiredRoutingCorridorWidth,
-          this.params.traceWidth,
-        )
+          traceWidth: this.params.traceWidth,
+        })
       ) {
         projectedRect = conservativeProjectedRect
         this.projectionAdjustmentByNodeId.set(

--- a/lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/AttachProjectedRectsSolver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/AttachProjectedRectsSolver.ts
@@ -21,6 +21,7 @@ const getRequiredRoutingCorridorWidth = ({
   )
 
 const shouldClampProjectionExpansion = (
+  node: PolyNodeWithPortPoints,
   projectedRect: ReturnType<typeof computeProjectedRect>,
   conservativeProjectedRect: ReturnType<typeof computeProjectedRect>,
   requiredRoutingCorridorWidth: number,
@@ -33,6 +34,11 @@ const shouldClampProjectionExpansion = (
     conservativeProjectedRect.width,
     conservativeProjectedRect.height,
   )
+  const maxDimension = Math.max(projectedRect.width, projectedRect.height)
+  const conservativeMaxDimension = Math.max(
+    conservativeProjectedRect.width,
+    conservativeProjectedRect.height,
+  )
   const nextTraceLaneWidth = requiredRoutingCorridorWidth + (traceWidth ?? 0)
   const expandedLanesAcross = Math.floor(
     minDimension / requiredRoutingCorridorWidth,
@@ -40,10 +46,15 @@ const shouldClampProjectionExpansion = (
   const conservativeLanesAcross = Math.floor(
     conservativeMinDimension / requiredRoutingCorridorWidth,
   )
+  const connectionCount = new Set(
+    node.portPoints.map((portPoint) => portPoint.connectionName),
+  ).size
 
   return (
+    connectionCount > 1 &&
     expandedLanesAcross <= conservativeLanesAcross &&
     minDimension <= nextTraceLaneWidth &&
+    maxDimension - conservativeMaxDimension >= requiredRoutingCorridorWidth &&
     projectedRect.equivalentAreaExpansionFactor > 1
   )
 }
@@ -89,6 +100,19 @@ export class AttachProjectedRectsSolver extends BaseSolver {
         minProjectedRectDimension,
       )
 
+      const minDimension = Math.min(projectedRect.width, projectedRect.height)
+      const nextTraceLaneWidth =
+        requiredRoutingCorridorWidth + (this.params.traceWidth ?? 0)
+      if (minDimension > nextTraceLaneWidth) {
+        return {
+          ...node,
+          center: projectedRect.center,
+          width: projectedRect.width,
+          height: projectedRect.height,
+          projectedRect,
+        }
+      }
+
       const conservativeProjectedRect = computeProjectedRect(
         node.polygon,
         1,
@@ -97,6 +121,7 @@ export class AttachProjectedRectsSolver extends BaseSolver {
 
       if (
         shouldClampProjectionExpansion(
+          node,
           projectedRect,
           conservativeProjectedRect,
           requiredRoutingCorridorWidth,

--- a/lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/AutoroutingPipelineSolver6_PolyHypergraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/AutoroutingPipelineSolver6_PolyHypergraph.ts
@@ -181,6 +181,9 @@ export class AutoroutingPipelineSolver6_PolyHypergraph extends BaseSolver {
           nodesWithPortPoints: cms.highDensityNodePortPoints ?? [],
           equivalentAreaExpansionFactor: cms.equivalentAreaExpansionFactor,
           minProjectedRectDimension: cms.minProjectedRectDimension,
+          traceWidth: cms.minTraceWidth,
+          viaDiameter: cms.viaDiameter,
+          obstacleMargin: cms.srj.defaultObstacleMargin ?? 0.15,
         },
       ],
       {

--- a/lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/shouldClampProjectionExpansion.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/shouldClampProjectionExpansion.ts
@@ -1,0 +1,64 @@
+import type { ProjectedRect } from "./geometry"
+import type { PolyNodeWithPortPoints } from "./types"
+
+export const getRequiredRoutingCorridorWidth = ({
+  traceWidth,
+  viaDiameter,
+  obstacleMargin,
+  minProjectedRectDimension,
+}: {
+  traceWidth?: number
+  viaDiameter?: number
+  obstacleMargin?: number
+  minProjectedRectDimension: number
+}) =>
+  Math.max(
+    minProjectedRectDimension,
+    viaDiameter ?? 0,
+    (traceWidth ?? 0) + 2 * (obstacleMargin ?? 0),
+  )
+
+export const shouldClampProjectionExpansion = ({
+  node,
+  projectedRect,
+  conservativeProjectedRect,
+  requiredRoutingCorridorWidth,
+  traceWidth,
+}: {
+  node: PolyNodeWithPortPoints
+  projectedRect: ProjectedRect
+  conservativeProjectedRect: ProjectedRect
+  requiredRoutingCorridorWidth: number
+  traceWidth?: number
+}) => {
+  if (requiredRoutingCorridorWidth <= 0) return false
+
+  const minDimension = Math.min(projectedRect.width, projectedRect.height)
+  const conservativeMinDimension = Math.min(
+    conservativeProjectedRect.width,
+    conservativeProjectedRect.height,
+  )
+  const maxDimension = Math.max(projectedRect.width, projectedRect.height)
+  const conservativeMaxDimension = Math.max(
+    conservativeProjectedRect.width,
+    conservativeProjectedRect.height,
+  )
+  const nextTraceLaneWidth = requiredRoutingCorridorWidth + (traceWidth ?? 0)
+  const expandedLanesAcross = Math.floor(
+    minDimension / requiredRoutingCorridorWidth,
+  )
+  const conservativeLanesAcross = Math.floor(
+    conservativeMinDimension / requiredRoutingCorridorWidth,
+  )
+  const connectionCount = new Set(
+    node.portPoints.map((portPoint) => portPoint.connectionName),
+  ).size
+
+  return (
+    connectionCount > 1 &&
+    expandedLanesAcross <= conservativeLanesAcross &&
+    minDimension <= nextTraceLaneWidth &&
+    maxDimension - conservativeMaxDimension >= requiredRoutingCorridorWidth &&
+    projectedRect.equivalentAreaExpansionFactor > 1
+  )
+}

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "high-density-dataset-z04": "git+https://github.com/tscircuit/high-density-dataset-z04.git#b9128ed52f5a50102b6526319be1d4ec33dca2c2",
     "kleur": "^4.1.5",
     "looks-same": "9",
-    "pcb-poly-hyper-graph": "https://codeload.github.com/tscircuit/pcb-poly-hyper-graph/tar.gz/867c15ad096393670d82625e9604e734c8acf4a2",
+    "pcb-poly-hyper-graph": "https://codeload.github.com/tscircuit/pcb-poly-hyper-graph/tar.gz/80db1463c4a47506eeda15b2c14d59679de900f8",
     "rbush": "^4.0.1",
     "react": "18",
     "react-cosmos": "^6.2.3",

--- a/tests/features/pipeline6-free6-repro.test.ts
+++ b/tests/features/pipeline6-free6-repro.test.ts
@@ -1,0 +1,170 @@
+import { expect, test } from "bun:test"
+import { AttachProjectedRectsSolver } from "lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/AttachProjectedRectsSolver"
+import { PolySingleIntraNodeSolver } from "lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/PolySingleIntraNodeSolver"
+
+test("pipeline6 free-6 extracted node uses conservative sliver projection", () => {
+  const polygon = [
+    { x: -3.2750030000000003, y: 2.625 },
+    { x: -3.2750000000000004, y: 1.999998 },
+    { x: -3.2749970000000004, y: 1.374999 },
+    { x: -2.7299990000000003, y: -4.087643169956141 },
+    { x: -2.7249969999999997, y: 1.375001 },
+    { x: -2.7249969999999997, y: 1.999998 },
+    { x: -2.725001, y: 2.624999 },
+    { x: -3.2700010000000024, y: 9.08764216995614 },
+  ]
+
+  const attachProjectedRectsSolver = new AttachProjectedRectsSolver({
+    equivalentAreaExpansionFactor: 2,
+    minProjectedRectDimension: 0.45,
+    traceWidth: 0.15,
+    viaDiameter: 0.6,
+    obstacleMargin: 0.15,
+    nodesWithPortPoints: [
+      {
+        capacityMeshNodeId: "free-6",
+        polygon,
+        center: { x: -3.006238873758835, y: 2.318894296998632 },
+        width: 0.5042195299138056,
+        height: 11.869310003953185,
+        availableZ: [0, 1],
+        portPoints: [
+          {
+            portPointId: "p1",
+            x: -3.256382871980899,
+            y: 1.188425249868615,
+            z: 0,
+            connectionName: "source_net_3_mst1",
+            rootConnectionName: "source_net_3",
+          },
+          {
+            portPointId: "p2",
+            x: -2.7251686887605406,
+            y: 1.1875010786054316,
+            z: 0,
+            connectionName: "source_net_3_mst1",
+            rootConnectionName: "source_net_3",
+          },
+          {
+            portPointId: "p3",
+            x: -3.2701461224892903,
+            y: 8.90014222611758,
+            z: 0,
+            connectionName: "source_net_12_mst2",
+            rootConnectionName: "source_net_12",
+          },
+          {
+            portPointId: "p4",
+            x: -3.254244898165465,
+            y: 8.900805355449524,
+            z: 0,
+            connectionName: "source_net_12_mst2",
+            rootConnectionName: "source_net_12",
+          },
+          {
+            portPointId: "p5",
+            x: -3.251382871980899,
+            y: 1.1934252498686149,
+            z: 1,
+            connectionName: "source_net_0_mst1",
+            rootConnectionName: "source_net_0",
+          },
+          {
+            portPointId: "p6",
+            x: -2.71999819999808,
+            y: 2.19249799999616,
+            z: 1,
+            connectionName: "source_net_0_mst1",
+            rootConnectionName: "source_net_0",
+          },
+          {
+            portPointId: "p7",
+            x: -2.861450848899501,
+            y: -2.770070604337339,
+            z: 0,
+            connectionName: "source_net_10_mst0",
+            rootConnectionName: "source_net_10",
+          },
+          {
+            portPointId: "p8",
+            x: -2.7282744370798198,
+            y: -2.204261806172571,
+            z: 0,
+            connectionName: "source_net_10_mst0",
+            rootConnectionName: "source_net_10",
+          },
+          {
+            portPointId: "p9",
+            x: -2.917869709339701,
+            y: -2.2045711965936325,
+            z: 0,
+            connectionName: "source_net_13",
+            rootConnectionName: "source_net_13",
+          },
+          {
+            portPointId: "p10",
+            x: -2.72775681235994,
+            y: -1.6389679920429034,
+            z: 0,
+            connectionName: "source_net_13",
+            rootConnectionName: "source_net_13",
+          },
+          {
+            portPointId: "p11",
+            x: -3.2749985000000006,
+            y: 1.6874985,
+            z: 0,
+            connectionName: "source_net_1_mst1",
+            rootConnectionName: "source_net_1",
+          },
+          {
+            portPointId: "p12",
+            x: -2.740757101834537,
+            y: 2.811835814506616,
+            z: 0,
+            connectionName: "source_net_1_mst1",
+            rootConnectionName: "source_net_1",
+          },
+          {
+            portPointId: "p13",
+            x: -3.2651461224892904,
+            y: 8.905142226117581,
+            z: 1,
+            connectionName: "source_net_15_mst0",
+            rootConnectionName: "source_net_15",
+          },
+          {
+            portPointId: "p14",
+            x: -3.249244898165465,
+            y: 8.905805355449525,
+            z: 1,
+            connectionName: "source_net_15_mst0",
+            rootConnectionName: "source_net_15",
+          },
+        ],
+      },
+    ],
+  })
+  attachProjectedRectsSolver.solve()
+
+  const nodeWithPortPoints = attachProjectedRectsSolver.outputNodes[0]!
+  const solver = new PolySingleIntraNodeSolver({
+    nodeWithPortPoints,
+    traceWidth: 0.15,
+    viaDiameter: 0.6,
+    obstacleMargin: 0.15,
+    effort: 1,
+  })
+
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(solver.solvedRoutes.length).toBeGreaterThan(0)
+  expect(
+    attachProjectedRectsSolver.projectionAdjustmentByNodeId.get("free-6"),
+  ).toBe("corridor-expansion-factor-1")
+  expect(nodeWithPortPoints.projectedRect?.equivalentAreaExpansionFactor).toBe(
+    1,
+  )
+})


### PR DESCRIPTION
 Updates Pipeline6 projected-rect selection to avoid over-expanding narrow routing corridors when expansion does not add usable cross-lane capacity. The projection clamp now uses trace width, via diameter, obstacle margin, and projected routing lanes, and records adjusted nodes for debugging.

  Also updates pcb-poly-hyper-graph to the latest upstream commit and adds a free-6 regression test that verifies the conservative projection routes successfully without retrying the high-density solver.

circuit 100 now solves with no drc:
<img width="838" height="1154" alt="image" src="https://github.com/user-attachments/assets/c18acaa8-84fc-4776-a80f-71260c2ed034" />
