### PR TITLE
expose sub solver of pipeline4_tinyhypergraph

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -55,3 +55,10 @@ export type {
   SimpleRouteJson,
   SimplifiedPcbTrace,
 } from "high-density-repair03/lib"
+
+export { EscapeViaLocationSolver } from "./solvers/EscapeViaLocationSolver/EscapeViaLocationSolver"
+export { NetToPointPairsSolver2_OffBoardConnection } from "./solvers/NetToPointPairsSolver2_OffBoardConnection/NetToPointPairsSolver2_OffBoardConnection"
+export { CapacityMeshEdgeSolver2_NodeTreeOptimization } from "./solvers/CapacityMeshSolver/CapacityMeshEdgeSolver2_NodeTreeOptimization"
+export { AvailableSegmentPointSolver } from "./solvers/AvailableSegmentPointSolver/AvailableSegmentPointSolver"
+export { NodeDimensionSubdivisionSolver } from "./solvers/NodeDimensionSubdivisionSolver/NodeDimensionSubdivisionSolver"
+export { MultiTargetNecessaryCrampedPortPointSolver } from "./solvers/NecessaryCrampedPortPointSolver/MultiTargetNecessaryCrampedPortPointSolver"


### PR DESCRIPTION
expose sub solver of pipeline4_tinyhypergraph

the idea is to expose the four Pipeline 4 sub-solvers from `index.ts`, then import them into `rectdiff` and build a custom pipeline there. This would let us skip the high-density solver during tests, making them faster.
