### PR TITLE
feat: implement trace thickness as autorouter parameter

### DIFF
--- a/lib/autorouter-pipelines/AssignableAutoroutingPipeline2/AssignableAutoroutingPipeline2.ts
+++ b/lib/autorouter-pipelines/AssignableAutoroutingPipeline2/AssignableAutoroutingPipeline2.ts
@@ -128,6 +128,7 @@ export class AssignableAutoroutingPipeline2 extends BaseSolver {
   multiSectionPortPointOptimizer?: MultiSectionPortPointOptimizer
   viaDiameter: number
   minTraceWidth: number
+  nominalTraceWidth?: number
   effort: number
 
   startTimeOfPhase: Record<string, number>
@@ -203,7 +204,7 @@ export class AssignableAutoroutingPipeline2 extends BaseSolver {
         {
           nodes: cms.capacityNodes!,
           edges: cms.capacityEdges || [],
-          traceWidth: cms.minTraceWidth,
+          traceWidth: cms.nominalTraceWidth ?? cms.minTraceWidth,
           colorMap: cms.colorMap,
           shouldReturnCrampedPortPoints: false,
         },
@@ -328,7 +329,7 @@ export class AssignableAutoroutingPipeline2 extends BaseSolver {
           [],
         colorMap: cms.colorMap,
         viaDiameter: cms.viaDiameter,
-        traceWidth: cms.minTraceWidth,
+        traceWidth: cms.nominalTraceWidth ?? cms.minTraceWidth,
         connMap: cms.connMap,
       },
     ]),
@@ -388,7 +389,12 @@ export class AssignableAutoroutingPipeline2 extends BaseSolver {
     definePipelineStep("traceWidthSolver", TraceWidthSolver, (cms) => [
       {
         hdRoutes: cms.traceKeepoutSolver?.redrawnHdRoutes ?? [],
-        connection: cms.srj.connections,
+        connection: cms.nominalTraceWidth
+          ? cms.srj.connections.map((c) => ({
+              ...c,
+              nominalTraceWidth: c.nominalTraceWidth ?? cms.nominalTraceWidth,
+            }))
+          : cms.srj.connections,
         obstacles: cms.srj.obstacles,
         connMap: cms.connMap,
         colorMap: cms.colorMap,
@@ -409,6 +415,7 @@ export class AssignableAutoroutingPipeline2 extends BaseSolver {
     this.MAX_ITERATIONS = 100e6
     this.viaDiameter = getViaDimensions(srj).padDiameter
     this.minTraceWidth = srj.minTraceWidth
+    this.nominalTraceWidth = srj.nominalTraceWidth
     const mutableOpts = this.opts
     this.effort = mutableOpts.effort ?? 1
 

--- a/lib/autorouter-pipelines/AutoroutingPipeline2_PortPointPathing/AutoroutingPipelineSolver2_PortPointPathing.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline2_PortPointPathing/AutoroutingPipelineSolver2_PortPointPathing.ts
@@ -120,6 +120,7 @@ export class AutoroutingPipelineSolver2_PortPointPathing extends BaseSolver {
   traceWidthSolver?: TraceWidthSolver
   viaDiameter: number
   minTraceWidth: number
+  nominalTraceWidth?: number
   effort: number
 
   startTimeOfPhase: Record<string, number>
@@ -229,7 +230,7 @@ export class AutoroutingPipelineSolver2_PortPointPathing extends BaseSolver {
         {
           nodes: cms.capacityNodes!,
           edges: cms.capacityEdges || [],
-          traceWidth: cms.minTraceWidth,
+          traceWidth: cms.nominalTraceWidth ?? cms.minTraceWidth,
           colorMap: cms.colorMap,
           shouldReturnCrampedPortPoints: false,
         },
@@ -351,7 +352,7 @@ export class AutoroutingPipelineSolver2_PortPointPathing extends BaseSolver {
         colorMap: cms.colorMap,
         connMap: cms.connMap,
         viaDiameter: cms.viaDiameter,
-        traceWidth: cms.minTraceWidth,
+        traceWidth: cms.nominalTraceWidth ?? cms.minTraceWidth,
         effort: cms.effort,
       },
     ]),
@@ -392,7 +393,12 @@ export class AutoroutingPipelineSolver2_PortPointPathing extends BaseSolver {
           connMap: cms.connMap,
           colorMap: cms.colorMap,
           minTraceWidth: cms.minTraceWidth,
-          connection: cms.srj.connections,
+          connection: cms.nominalTraceWidth
+            ? cms.srj.connections.map((c) => ({
+                ...c,
+                nominalTraceWidth: c.nominalTraceWidth ?? cms.nominalTraceWidth,
+              }))
+            : cms.srj.connections,
           layerCount: cms.srj.layerCount,
         },
       ]
@@ -409,6 +415,7 @@ export class AutoroutingPipelineSolver2_PortPointPathing extends BaseSolver {
     this.MAX_ITERATIONS = 100e6
     this.viaDiameter = getViaDimensions(srj).padDiameter
     this.minTraceWidth = srj.minTraceWidth
+    this.nominalTraceWidth = srj.nominalTraceWidth
     const mutableOpts = this.opts
     this.effort = mutableOpts.effort ?? 1
 

--- a/lib/autorouter-pipelines/AutoroutingPipeline3_HgPortPointPathing/AutoroutingPipelineSolver3_HgPortPointPathing.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline3_HgPortPointPathing/AutoroutingPipelineSolver3_HgPortPointPathing.ts
@@ -108,6 +108,7 @@ export class AutoroutingPipelineSolver3_HgPortPointPathing extends BaseSolver {
   hyperGraphSectionOptimizer?: HyperGraphSectionOptimizer
   viaDiameter: number
   minTraceWidth: number
+  nominalTraceWidth?: number
   effort: number
 
   startTimeOfPhase: Record<string, number>
@@ -164,7 +165,7 @@ export class AutoroutingPipelineSolver3_HgPortPointPathing extends BaseSolver {
         {
           nodes: cms.capacityNodes!,
           edges: cms.capacityEdges || [],
-          traceWidth: cms.minTraceWidth,
+          traceWidth: cms.nominalTraceWidth ?? cms.minTraceWidth,
           colorMap: cms.colorMap,
           shouldReturnCrampedPortPoints: true,
         },
@@ -318,7 +319,7 @@ export class AutoroutingPipelineSolver3_HgPortPointPathing extends BaseSolver {
         colorMap: cms.colorMap,
         connMap: cms.connMap,
         viaDiameter: cms.viaDiameter,
-        traceWidth: cms.minTraceWidth,
+        traceWidth: cms.nominalTraceWidth ?? cms.minTraceWidth,
       },
     ]),
     definePipelineStep(
@@ -357,7 +358,12 @@ export class AutoroutingPipelineSolver3_HgPortPointPathing extends BaseSolver {
         connMap: cms.connMap,
         colorMap: cms.colorMap,
         minTraceWidth: cms.minTraceWidth,
-        connection: cms.srj.connections,
+        connection: cms.nominalTraceWidth
+          ? cms.srj.connections.map((c) => ({
+              ...c,
+              nominalTraceWidth: c.nominalTraceWidth ?? cms.nominalTraceWidth,
+            }))
+          : cms.srj.connections,
         layerCount: cms.srj.layerCount,
       },
     ]),
@@ -373,6 +379,7 @@ export class AutoroutingPipelineSolver3_HgPortPointPathing extends BaseSolver {
     this.MAX_ITERATIONS = 100e6
     this.viaDiameter = getViaDimensions(srj).padDiameter
     this.minTraceWidth = srj.minTraceWidth
+    this.nominalTraceWidth = srj.nominalTraceWidth
     const mutableOpts = this.opts
     this.effort = mutableOpts.effort ?? 1
 

--- a/lib/autorouter-pipelines/AutoroutingPipeline4_TinyHypergraph/AutoroutingPipelineSolver4_TinyHypergraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline4_TinyHypergraph/AutoroutingPipelineSolver4_TinyHypergraph.ts
@@ -124,6 +124,7 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
   viaDiameter!: number
   viaHoleDiameter!: number
   minTraceWidth!: number
+  nominalTraceWidth?: number
   effort: number
   maxNodeDimension: number
   maxNodeRatio: number
@@ -232,7 +233,7 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
         {
           nodes: cms.capacityNodes!,
           edges: cms.capacityEdges || [],
-          traceWidth: cms.minTraceWidth,
+          traceWidth: cms.nominalTraceWidth ?? cms.minTraceWidth,
           colorMap: cms.colorMap,
           shouldReturnCrampedPortPoints: true,
         },
@@ -341,7 +342,7 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
           colorMap: cms.colorMap,
           connMap: cms.connMap,
           viaDiameter: cms.viaDiameter,
-          traceWidth: cms.minTraceWidth,
+          traceWidth: cms.nominalTraceWidth ?? cms.minTraceWidth,
           obstacleMargin: cms.srj.defaultObstacleMargin ?? 0.15,
           obstacles: cms.srj.obstacles,
           layerCount: cms.srj.layerCount,
@@ -416,7 +417,12 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
         connMap: cms.connMap,
         colorMap: cms.colorMap,
         minTraceWidth: cms.minTraceWidth,
-        connection: cms.srj.connections,
+        connection: cms.nominalTraceWidth
+          ? cms.srj.connections.map((c) => ({
+              ...c,
+              nominalTraceWidth: c.nominalTraceWidth ?? cms.nominalTraceWidth,
+            }))
+          : cms.srj.connections,
         obstacleMargin: cms.srj.minTraceToPadEdgeClearance ?? 0.15,
         layerCount: cms.srj.layerCount,
       },
@@ -477,6 +483,7 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
     this.viaDiameter = viaDimensions.padDiameter
     this.viaHoleDiameter = viaDimensions.holeDiameter
     this.minTraceWidth = this.srj.minTraceWidth
+    this.nominalTraceWidth = this.srj.nominalTraceWidth
     this.connMap = getConnectivityMapFromSimpleRouteJson(this.srj)
     this.colorMap = getColorMap(this.srj, this.connMap)
   }

--- a/lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/AutoroutingPipelineSolver6_PolyHypergraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/AutoroutingPipelineSolver6_PolyHypergraph.ts
@@ -102,6 +102,7 @@ export class AutoroutingPipelineSolver6_PolyHypergraph extends BaseSolver {
   viaDiameter!: number
   viaHoleDiameter!: number
   minTraceWidth!: number
+  nominalTraceWidth?: number
   effort: number
   maxNodeDimension: number
   maxNodeRatio: number
@@ -197,7 +198,7 @@ export class AutoroutingPipelineSolver6_PolyHypergraph extends BaseSolver {
           nodesWithPortPoints: cms.highDensityNodePortPoints ?? [],
           equivalentAreaExpansionFactor: cms.equivalentAreaExpansionFactor,
           minProjectedRectDimension: cms.minProjectedRectDimension,
-          traceWidth: cms.minTraceWidth,
+          traceWidth: cms.nominalTraceWidth ?? cms.minTraceWidth,
           viaDiameter: cms.viaDiameter,
           obstacleMargin: cms.srj.defaultObstacleMargin ?? 0.15,
         },
@@ -226,7 +227,7 @@ export class AutoroutingPipelineSolver6_PolyHypergraph extends BaseSolver {
           colorMap: cms.colorMap,
           connMap: cms.connMap,
           viaDiameter: cms.viaDiameter,
-          traceWidth: cms.minTraceWidth,
+          traceWidth: cms.nominalTraceWidth ?? cms.minTraceWidth,
           obstacleMargin: cms.srj.defaultObstacleMargin ?? 0.15,
           effort: cms.effort,
         },
@@ -279,7 +280,12 @@ export class AutoroutingPipelineSolver6_PolyHypergraph extends BaseSolver {
         connMap: cms.connMap,
         colorMap: cms.colorMap,
         minTraceWidth: cms.minTraceWidth,
-        connection: cms.srj.connections,
+        connection: cms.nominalTraceWidth
+          ? cms.srj.connections.map((c) => ({
+              ...c,
+              nominalTraceWidth: c.nominalTraceWidth ?? cms.nominalTraceWidth,
+            }))
+          : cms.srj.connections,
         layerCount: cms.srj.layerCount,
       },
     ]),
@@ -343,6 +349,7 @@ export class AutoroutingPipelineSolver6_PolyHypergraph extends BaseSolver {
     this.viaDiameter = viaDimensions.padDiameter
     this.viaHoleDiameter = viaDimensions.holeDiameter
     this.minTraceWidth = this.srj.minTraceWidth
+    this.nominalTraceWidth = this.srj.nominalTraceWidth
     this.connMap = getConnectivityMapFromSimpleRouteJson(this.srj)
     this.colorMap = getColorMap(this.srj, this.connMap)
   }

--- a/tests/autorouting-pipeline4-via-dimensions.test.ts
+++ b/tests/autorouting-pipeline4-via-dimensions.test.ts
@@ -187,7 +187,9 @@ test("pipeline4 applies top-level nominalTraceWidth to connections without overr
   const highDensityStep = solver.pipelineDef.find(
     (step) => step.solverName === "highDensityRouteSolver",
   )
-  const [highDensityParams] = highDensityStep!.getConstructorParams(solver) as any
+  const [highDensityParams] = highDensityStep!.getConstructorParams(
+    solver,
+  ) as any
 
   expect(highDensityParams.traceWidth).toBe(0.6)
 })

--- a/tests/autorouting-pipeline4-via-dimensions.test.ts
+++ b/tests/autorouting-pipeline4-via-dimensions.test.ts
@@ -153,3 +153,41 @@ test(
   },
   { timeout: 120_000 },
 )
+
+test("pipeline4 applies top-level nominalTraceWidth to connections without overrides", () => {
+  const solver = new AutoroutingPipelineSolver4({
+    ...srj,
+    nominalTraceWidth: 0.6,
+  })
+
+  expect(solver.nominalTraceWidth).toBe(0.6)
+
+  solver.traceSimplificationSolver = {
+    simplifiedHdRoutes: [
+      {
+        connectionName: "conn1",
+        traceThickness: solver.minTraceWidth,
+        viaDiameter: solver.viaDiameter,
+        route: [
+          { x: -0.5, y: 0, z: 0 },
+          { x: 0.5, y: 0, z: 0 },
+        ],
+        vias: [],
+      },
+    ],
+  } as any
+
+  const traceWidthStep = solver.pipelineDef.find(
+    (step) => step.solverName === "traceWidthSolver",
+  )
+  const [traceWidthParams] = traceWidthStep!.getConstructorParams(solver) as any
+
+  expect(traceWidthParams.connection[0].nominalTraceWidth).toBe(0.6)
+
+  const highDensityStep = solver.pipelineDef.find(
+    (step) => step.solverName === "highDensityRouteSolver",
+  )
+  const [highDensityParams] = highDensityStep!.getConstructorParams(solver) as any
+
+  expect(highDensityParams.traceWidth).toBe(0.6)
+})


### PR DESCRIPTION
/claim #66

Adds trace_thickness as a configurable parameter to the autorouter. Defaults to existing behavior when not specified.