### PR TITLE
fix(pipeline5): honor nominal trace width

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline5_HdCache/AutoroutingPipelineSolver5_HdCache.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline5_HdCache/AutoroutingPipelineSolver5_HdCache.ts
@@ -71,7 +71,7 @@ export class AutoroutingPipelineSolver5_HdCache extends AutoroutingPipelineSolve
             colorMap: cms.colorMap,
             connMap: cms.connMap as ConnectivityMap | undefined,
             viaDiameter: cms.viaDiameter,
-            traceWidth: cms.minTraceWidth,
+            traceWidth: cms.srj.nominalTraceWidth ?? cms.minTraceWidth,
             obstacleMargin: cms.srj.defaultObstacleMargin ?? 0.15,
             obstacles: cms.srj.obstacles,
             layerCount: cms.srj.layerCount,

--- a/lib/autorouter-pipelines/AutoroutingPipeline5_HdCache/Pipeline5HdCacheHighDensitySolver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline5_HdCache/Pipeline5HdCacheHighDensitySolver.ts
@@ -75,6 +75,9 @@ type NodeSolveMetadata = {
 }
 
 const DEFAULT_HD_CACHE_BASE_URL = "https://hd-cache.tscircuit.com"
+const DEFAULT_HD_CACHE_TRACE_WIDTH = 0.15
+const isDefaultHdCacheTraceWidth = (traceWidth: number) =>
+  Math.abs(traceWidth - DEFAULT_HD_CACHE_TRACE_WIDTH) < 1e-9
 
 const getHdCacheSolveUrl = (baseUrl: string) =>
   /\/solve\/?$/.test(baseUrl)
@@ -175,7 +178,14 @@ const getPercentile = (sortedValues: number[], percentile: number) => {
 const getNodePairCount = (node: NodeWithPortPoints) =>
   new Set(node.portPoints.map((point) => point.connectionName)).size
 
-const shouldSolveNodeViaHdCache = (node: NodeWithPortPoints) => {
+const shouldSolveNodeViaHdCache = (
+  node: NodeWithPortPoints,
+  traceWidth = DEFAULT_HD_CACHE_TRACE_WIDTH,
+) => {
+  if (!isDefaultHdCacheTraceWidth(traceWidth)) {
+    return false
+  }
+
   if (getNodePairCount(node) < 3) {
     return false
   }
@@ -570,7 +580,7 @@ export class Pipeline5HdCacheHighDensitySolver extends BaseSolver {
     const pendingEffects: PendingEffect[] = []
 
     this.unsolvedNodePortPoints.forEach((node, nodeIndex) => {
-      if (!shouldSolveNodeViaHdCache(node)) {
+      if (!shouldSolveNodeViaHdCache(node, this.traceWidth)) {
         this.solveNodeLocally(node, nodeIndex)
         return
       }
@@ -675,7 +685,10 @@ export class Pipeline5HdCacheHighDensitySolver extends BaseSolver {
         pairCount: getNodePairCount(failedResult.node),
         routeCount: 0,
         remoteAttempt: {
-          attempted: shouldSolveNodeViaHdCache(failedResult.node),
+          attempted: shouldSolveNodeViaHdCache(
+            failedResult.node,
+            this.traceWidth,
+          ),
           source: "error",
           error: failedResult.error,
         },

--- a/tests/features/pipeline5-nominal-trace-width.test.ts
+++ b/tests/features/pipeline5-nominal-trace-width.test.ts
@@ -1,0 +1,160 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver5 } from "lib/autorouter-pipelines/AutoroutingPipeline5_HdCache/AutoroutingPipelineSolver5_HdCache"
+import { Pipeline5HdCacheHighDensitySolver } from "lib/autorouter-pipelines/AutoroutingPipeline5_HdCache/Pipeline5HdCacheHighDensitySolver"
+import type { NodeWithPortPoints } from "lib/types/high-density-types"
+import type { SimpleRouteJson } from "lib/types"
+
+const srj: SimpleRouteJson = {
+  layerCount: 2,
+  minTraceWidth: 0.15,
+  nominalTraceWidth: 0.6,
+  minViaDiameter: 0.3,
+  obstacles: [],
+  connections: [
+    {
+      name: "conn1",
+      pointsToConnect: [
+        { x: -0.5, y: 0, layer: "top" },
+        { x: 0.5, y: 0, layer: "top" },
+      ],
+    },
+  ],
+  bounds: {
+    minX: -5,
+    maxX: 5,
+    minY: -5,
+    maxY: 5,
+  },
+}
+
+const nodeWithPortPoints: NodeWithPortPoints = {
+  capacityMeshNodeId: "cmn_1",
+  center: { x: 0, y: 0 },
+  width: 2,
+  height: 2,
+  portPoints: [
+    {
+      connectionName: "conn1",
+      x: -0.5,
+      y: 0,
+      z: 0,
+    },
+    {
+      connectionName: "conn1",
+      x: 0.5,
+      y: 0,
+      z: 0,
+    },
+  ],
+}
+
+const remoteEligibleNode: NodeWithPortPoints = {
+  capacityMeshNodeId: "cmn_remote_width",
+  center: { x: 0, y: 0 },
+  width: 4,
+  height: 3,
+  availableZ: [0, 1],
+  portPoints: [
+    { x: -2, y: -1.5, z: 0, connectionName: "A" },
+    { x: 2, y: -1.5, z: 0, connectionName: "A" },
+    { x: -2, y: 0, z: 1, connectionName: "B" },
+    { x: 2, y: 0, z: 1, connectionName: "B" },
+    { x: -2, y: 1.5, z: 0, connectionName: "C" },
+    { x: 2, y: 1.5, z: 0, connectionName: "C" },
+  ],
+}
+
+test("pipeline5 passes top-level nominalTraceWidth into the high-density step", () => {
+  const solver = new AutoroutingPipelineSolver5(structuredClone(srj))
+  solver.srjWithPointPairs = srj
+  solver.portPointPathingSolver = {
+    getOutput: () => ({
+      nodesWithPortPoints: [nodeWithPortPoints],
+      inputNodeWithPortPoints: [],
+    }),
+  } as any
+
+  const highDensityStep = solver.pipelineDef.find(
+    (step) => step.solverName === "highDensityRouteSolver",
+  )
+  const [highDensityParams] = highDensityStep!.getConstructorParams(
+    solver,
+  ) as any
+
+  expect(highDensityParams.traceWidth).toBe(0.6)
+})
+
+test("pipeline5 keeps non-default trace widths local because hd-cache is width agnostic", () => {
+  let fetchCallCount = 0
+  const fetchImpl = Object.assign(
+    async () => {
+      fetchCallCount += 1
+      throw new Error("non-default trace widths should not reach hd-cache")
+    },
+    {
+      preconnect: () => {},
+    },
+  ) as typeof fetch
+
+  const solver = new Pipeline5HdCacheHighDensitySolver({
+    nodePortPoints: [remoteEligibleNode],
+    traceWidth: 0.6,
+    fetchImpl,
+  })
+
+  const localSolveCalls: Array<{
+    node: NodeWithPortPoints
+    nodeIndex: number
+  }> = []
+  ;(solver as any).solveNodeLocally = (
+    node: NodeWithPortPoints,
+    nodeIndex: number,
+  ) => {
+    localSolveCalls.push({ node, nodeIndex })
+  }
+  ;(solver as any).launchRemoteSolves()
+
+  expect(fetchCallCount).toBe(0)
+  expect(localSolveCalls).toEqual([
+    {
+      node: remoteEligibleNode,
+      nodeIndex: 0,
+    },
+  ])
+  expect(solver.stats.remoteRequestsStarted).toBe(0)
+  expect(solver.pendingEffects).toEqual([])
+})
+
+test("pipeline5 still sends default-width eligible nodes to hd-cache", () => {
+  const solver = new Pipeline5HdCacheHighDensitySolver({
+    nodePortPoints: [remoteEligibleNode],
+    traceWidth: 0.15,
+  })
+
+  const localSolveCalls: Array<NodeWithPortPoints> = []
+  const remoteSolveCalls: Array<{
+    node: NodeWithPortPoints
+    nodeIndex: number
+  }> = []
+  ;(solver as any).solveNodeLocally = (node: NodeWithPortPoints) => {
+    localSolveCalls.push(node)
+  }
+  ;(solver as any).solveNodeViaHdCache = (
+    node: NodeWithPortPoints,
+    nodeIndex: number,
+  ) => {
+    remoteSolveCalls.push({ node, nodeIndex })
+    return Promise.resolve()
+  }
+  ;(solver as any).launchRemoteSolves()
+
+  expect(localSolveCalls).toEqual([])
+  expect(remoteSolveCalls).toEqual([
+    {
+      node: remoteEligibleNode,
+      nodeIndex: 0,
+    },
+  ])
+  expect(solver.stats.remoteRequestsStarted).toBe(1)
+  expect(solver.pendingEffects).toHaveLength(1)
+})


### PR DESCRIPTION
/claim #66

## What changed
- Pass top-level `nominalTraceWidth` into Pipeline5's cache-backed high-density step instead of always using `minTraceWidth`.
- Keep non-default trace widths on the local high-density solver path because the hd-cache request payload is width-agnostic.
- Add focused tests for top-level width propagation, non-default-width local routing, and unchanged default-width cache routing.
- Restore current main typecheck by adding a small `react-konva` module shim and explicit drag event annotations for the legacy 45-degree fixture.

## Why
Pipeline5 replaces Pipeline4's high-density step with `Pipeline5HdCacheHighDensitySolver`. Without this guard, a non-default requested trace width can be dropped before high-density routing, or a width-agnostic cached response can return default-width routes. The tiny legacy fixture typing fix keeps the PR CI-green on the current main branch.

## Validation
- `bun test tests/features/pipeline5-nominal-trace-width.test.ts`
- `bun run format:check`
- `bunx tsc --noEmit`
- `bun run build`

## Non-goals
- No changes to hd-cache service API.
- No changes to Pipeline2/3/4/6 routing behavior.