### PR TITLE
Fix TypeScript errors in legacy 45-degree path fixture

### DIFF
--- a/fixtures/legacy/construct-45-degree-path/construct45degreepath1.fixture.tsx
+++ b/fixtures/legacy/construct-45-degree-path/construct45degreepath1.fixture.tsx
@@ -1,6 +1,5 @@
 import { calculate45DegreePaths } from "lib/utils/calculate45DegreePaths"
 import React, { useState, useEffect, useRef } from "react"
-import type Konva from "konva"
 import { Stage, Layer, Circle, Line, Text } from "react-konva"
 
 interface Point {
@@ -22,10 +21,7 @@ const Construct45DegreePathFixture: React.FC = () => {
     setPaths(calculate45DegreePaths(pointA, pointB))
   }, [pointA, pointB])
 
-  const handleDragMove = (
-    e: Konva.KonvaEventObject<DragEvent>,
-    point: "A" | "B",
-  ) => {
+  const handleDragMove = (e: any, point: "A" | "B") => {
     const pos = e.target.position()
     if (point === "A") {
       setPointA({ x: pos.x, y: pos.y })
@@ -78,9 +74,7 @@ const Construct45DegreePathFixture: React.FC = () => {
             radius={8}
             fill="blue"
             draggable
-            onDragMove={(e: Konva.KonvaEventObject<DragEvent>) =>
-              handleDragMove(e, "A")
-            }
+            onDragMove={(e: any) => handleDragMove(e, "A")}
           />
           <Text
             x={pointA.x + 10}
@@ -97,9 +91,7 @@ const Construct45DegreePathFixture: React.FC = () => {
             radius={8}
             fill="red"
             draggable
-            onDragMove={(e: Konva.KonvaEventObject<DragEvent>) =>
-              handleDragMove(e, "B")
-            }
+            onDragMove={(e: any) => handleDragMove(e, "B")}
           />
           <Text
             x={pointB.x + 10}

--- a/fixtures/legacy/construct-45-degree-path/construct45degreepath1.fixture.tsx
+++ b/fixtures/legacy/construct-45-degree-path/construct45degreepath1.fixture.tsx
@@ -1,5 +1,6 @@
 import { calculate45DegreePaths } from "lib/utils/calculate45DegreePaths"
 import React, { useState, useEffect, useRef } from "react"
+import type Konva from "konva"
 import { Stage, Layer, Circle, Line, Text } from "react-konva"
 
 interface Point {
@@ -21,7 +22,10 @@ const Construct45DegreePathFixture: React.FC = () => {
     setPaths(calculate45DegreePaths(pointA, pointB))
   }, [pointA, pointB])
 
-  const handleDragMove = (e: any, point: "A" | "B") => {
+  const handleDragMove = (
+    e: Konva.KonvaEventObject<DragEvent>,
+    point: "A" | "B",
+  ) => {
     const pos = e.target.position()
     if (point === "A") {
       setPointA({ x: pos.x, y: pos.y })
@@ -74,7 +78,9 @@ const Construct45DegreePathFixture: React.FC = () => {
             radius={8}
             fill="blue"
             draggable
-            onDragMove={(e) => handleDragMove(e, "A")}
+            onDragMove={(e: Konva.KonvaEventObject<DragEvent>) =>
+              handleDragMove(e, "A")
+            }
           />
           <Text
             x={pointA.x + 10}
@@ -91,7 +97,9 @@ const Construct45DegreePathFixture: React.FC = () => {
             radius={8}
             fill="red"
             draggable
-            onDragMove={(e) => handleDragMove(e, "B")}
+            onDragMove={(e: Konva.KonvaEventObject<DragEvent>) =>
+              handleDragMove(e, "B")
+            }
           />
           <Text
             x={pointB.x + 10}

--- a/types/external-modules.d.ts
+++ b/types/external-modules.d.ts
@@ -11,3 +11,13 @@ declare module "cdt2d" {
   ): [number, number, number][]
   export = cdt2d
 }
+
+declare module "react-konva" {
+  import type * as React from "react"
+
+  export const Stage: React.ComponentType<any>
+  export const Layer: React.ComponentType<any>
+  export const Circle: React.ComponentType<any>
+  export const Line: React.ComponentType<any>
+  export const Text: React.ComponentType<any>
+}


### PR DESCRIPTION
  TypeScript was failing because one old demo file uses react-konva, and that
  package’s types were not being picked up correctly in this repo. Once that happened,
  the drag event values in the file also lost their types and triggered extra errors.
  The fix keeps everything local to the repo: add a small fallback type definition for
  react-konva and make the drag handler type explicit in the fixture. This removes the
  typecheck failure without changing runtime behavior.
  
```
fixtures/legacy/construct-45-degree-path/construct45degreepath1.fixture.tsx:3:50 - error TS7016: Could not find a declaration file for module 'react-konva'. '/home/ohmx/Documents/tscircuit-autorouter/node_modules/react-konva/es/ReactKonva.js' implicitly has an 'any' type.
  There are types at '/home/ohmx/Documents/tscircuit-autorouter/node_modules/react-konva/react-konva.d.ts', but this result could not be resolved when respecting package.json "exports". The 'react-konva' library may need to update its package.json or typings.

3 import { Stage, Layer, Circle, Line, Text } from "react-konva"
                                                   ~~~~~~~~~~~~~

fixtures/legacy/construct-45-degree-path/construct45degreepath1.fixture.tsx:77:26 - error TS7006: Parameter 'e' implicitly has an 'any' type.

77             onDragMove={(e) => handleDragMove(e, "A")}
                            ~

fixtures/legacy/construct-45-degree-path/construct45degreepath1.fixture.tsx:94:26 - error TS7006: Parameter 'e' implicitly has an 'any' type.

94             onDragMove={(e) => handleDragMove(e, "B")}
                            ~


Found 3 errors in the same file, starting at: fixtures/legacy/construct-45-degree-path/construct45degreepath1.fixture.tsx:3

```
