### PR TITLE
Add optional componentId to SRJ obstacles

### DIFF
--- a/lib/types/srj-types.ts
+++ b/lib/types/srj-types.ts
@@ -66,6 +66,8 @@ export interface SimpleRouteJson {
 
 export interface Obstacle {
   obstacleId?: string
+  /** Optional source component identifier associated with this obstacle. */
+  componentId?: string
   type: "rect"
   layers: string[]
   zLayers?: number[]

--- a/tests/srj-obstacle-component-id.test.ts
+++ b/tests/srj-obstacle-component-id.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test"
+import type { SimpleRouteJson } from "lib/types"
+import { addApproximatingRectsToSrj } from "lib/utils/addApproximatingRectsToSrj"
+import { createObjectsWithZLayers } from "lib/utils/createObjectsWithZLayers"
+
+const createSrjWithComponentObstacle = (): SimpleRouteJson => ({
+  layerCount: 2,
+  minTraceWidth: 0.1,
+  obstacles: [
+    {
+      obstacleId: "pad-1",
+      componentId: "U1",
+      type: "rect",
+      layers: ["top"],
+      center: { x: 0, y: 0 },
+      width: 1,
+      height: 0.5,
+      connectedTo: [],
+    },
+  ],
+  connections: [],
+  bounds: { minX: -1, maxX: 1, minY: -1, maxY: 1 },
+})
+
+test("SRJ obstacles can include an optional componentId", () => {
+  const srj = createSrjWithComponentObstacle()
+
+  expect(srj.obstacles[0]?.componentId).toBe("U1")
+})
+
+test("obstacle componentId is preserved by obstacle normalization helpers", () => {
+  const srj = createSrjWithComponentObstacle()
+  const withZLayers = createObjectsWithZLayers(srj.obstacles, srj.layerCount)
+  const approximated = addApproximatingRectsToSrj(srj)
+
+  expect(withZLayers[0]?.componentId).toBe("U1")
+  expect(approximated.obstacles[0]?.componentId).toBe("U1")
+})


### PR DESCRIPTION
### Motivation
- Allow SRJ obstacles to carry an optional source component identifier so downstream tooling and visualizations can attribute obstacle rectangles back to PCB components.

### Description
- Added an optional `componentId?: string` field to the `Obstacle` type in `lib/types/srj-types.ts` and added a unit test file `tests/srj-obstacle-component-id.test.ts` that verifies the field is accepted and preserved by `createObjectsWithZLayers` and `addApproximatingRectsToSrj`.

### Testing
- Ran `bun test tests/srj-obstacle-component-id.test.ts` which passed (2 tests).
- Ran `bunx tsc --noEmit`, which reported unrelated type errors in `node_modules/high-density-repair03` and is not caused by this change.
- Ran `bun run format` which formatted files successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a035a2195e4832e9ed7d944d7ba75a8)