### PR TITLE
regen bga dataset to include componentId

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@react-hook/resize-observer": "^2.0.2",
     "@resvg/resvg-js": "^2.6.2",
     "@tsci/seveibar.dataset-srj13": "git+https://github.com/tscircuit/dataset-srj13.git#56db70039aeb28a76540fe951b5a96be60f9e949",
-    "@tsci/tscircuit.dataset-srj16-bga-breakouts": "git+https://github.com/tscircuit/dataset-srj16-bga-breakouts.git",
+    "@tsci/tscircuit.dataset-srj16-bga-breakouts": "/home/ohmx/Documents/dataset-srj16-bga-breakouts",
     "@tsci/tscircuit.dataset-srj12-bus-routing": "git+https://github.com/tscircuit/dataset-srj12-bus-routing.git#ba82f86a7d1288566b7144eb8661ad2549c5f328",
     "@tscircuit/autorouting-dataset-01": "^1.0.32",
     "@tscircuit/checks": "^0.0.126",


### PR DESCRIPTION
- **Fix TypeScript errors in legacy 45-degree path fixture (#1153)**
- **v0.0.513 (#1154)**
- **Add componentId to SRJ obstacles (#1156)**
- **Fix incomplete route stitching caused by unstable island selection in the stitch  solver (#1151)**
- **v0.0.514 (#1157)**
- **regen dataset to include componentId**
