### PR TITLE
Support trace thickness routing parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ The input to the autorouter is a `SimpleRouteJson` object with the following str
 interface SimpleRouteJson {
   layerCount: number
   minTraceWidth: number
+  nominalTraceWidth?: number // Optional default output trace width, e.g. 0.6
+  traceWidthMultiplier?: number // Optional multiplier of minTraceWidth, e.g. 2, 4, 8
   obstacles: Obstacle[]
   connections: Array<SimpleRouteConnection>
   bounds: { minX: number; maxX: number; minY: number; maxY: number }
@@ -77,6 +79,8 @@ interface Obstacle {
 
 interface SimpleRouteConnection {
   name: string
+  nominalTraceWidth?: number // Optional per-connection output trace width
+  traceWidthMultiplier?: number // Optional per-connection multiplier of minTraceWidth
   pointsToConnect: Array<{ x: number; y: number; layer: string }>
 }
 ```

--- a/lib/autorouter-pipelines/AssignableAutoroutingPipeline2/AssignableAutoroutingPipeline2.ts
+++ b/lib/autorouter-pipelines/AssignableAutoroutingPipeline2/AssignableAutoroutingPipeline2.ts
@@ -19,6 +19,7 @@ import {
   getGraphicsLayerForObstacle,
 } from "lib/utils/getGraphicsObjectLayer"
 import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
+import { getDefaultTraceWidthForSimpleRouteJson } from "lib/utils/getTraceWidth"
 import { getViaDimensions } from "lib/utils/getViaDimensions"
 import { AvailableSegmentPointSolver } from "../../solvers/AvailableSegmentPointSolver/AvailableSegmentPointSolver"
 import { BaseSolver } from "../../solvers/BaseSolver"
@@ -203,7 +204,7 @@ export class AssignableAutoroutingPipeline2 extends BaseSolver {
         {
           nodes: cms.capacityNodes!,
           edges: cms.capacityEdges || [],
-          traceWidth: cms.minTraceWidth,
+          traceWidth: getDefaultTraceWidthForSimpleRouteJson(cms.srj),
           colorMap: cms.colorMap,
           shouldReturnCrampedPortPoints: false,
         },
@@ -328,7 +329,7 @@ export class AssignableAutoroutingPipeline2 extends BaseSolver {
           [],
         colorMap: cms.colorMap,
         viaDiameter: cms.viaDiameter,
-        traceWidth: cms.minTraceWidth,
+        traceWidth: getDefaultTraceWidthForSimpleRouteJson(cms.srj),
         connMap: cms.connMap,
       },
     ]),
@@ -393,6 +394,8 @@ export class AssignableAutoroutingPipeline2 extends BaseSolver {
         connMap: cms.connMap,
         colorMap: cms.colorMap,
         minTraceWidth: cms.minTraceWidth,
+        nominalTraceWidth: cms.srj.nominalTraceWidth,
+        traceWidthMultiplier: cms.srj.traceWidthMultiplier,
         obstacleMargin: cms.srj.defaultObstacleMargin ?? 0.15,
         layerCount: cms.srj.layerCount,
       },

--- a/lib/autorouter-pipelines/AssignableAutoroutingPipeline3/AssignableAutoroutingPipeline3.ts
+++ b/lib/autorouter-pipelines/AssignableAutoroutingPipeline3/AssignableAutoroutingPipeline3.ts
@@ -20,6 +20,7 @@ import {
   getGraphicsLayerForObstacle,
 } from "lib/utils/getGraphicsObjectLayer"
 import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
+import { getDefaultTraceWidthForSimpleRouteJson } from "lib/utils/getTraceWidth"
 import { getViaDimensions } from "lib/utils/getViaDimensions"
 import { AvailableSegmentPointSolver } from "../../solvers/AvailableSegmentPointSolver/AvailableSegmentPointSolver"
 import { BaseSolver } from "../../solvers/BaseSolver"
@@ -211,7 +212,7 @@ export class AssignableAutoroutingPipeline3 extends BaseSolver {
         {
           nodes: cms.capacityNodes!,
           edges: cms.capacityEdges || [],
-          traceWidth: cms.minTraceWidth,
+          traceWidth: getDefaultTraceWidthForSimpleRouteJson(cms.srj),
           colorMap: cms.colorMap,
           shouldReturnCrampedPortPoints: false,
         },
@@ -370,7 +371,7 @@ export class AssignableAutoroutingPipeline3 extends BaseSolver {
           [],
         colorMap: cms.colorMap,
         viaDiameter: cms.viaDiameter,
-        traceWidth: cms.minTraceWidth,
+        traceWidth: getDefaultTraceWidthForSimpleRouteJson(cms.srj),
         obstacleMargin: cms.srj.defaultObstacleMargin ?? 0.15,
         connMap: cms.connMap,
         capacityMeshNodes: cms.capacityNodes ?? [],

--- a/lib/autorouter-pipelines/AutoroutingPipeline1_OriginalUnravel/AutoroutingPipeline1_OriginalUnravel.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline1_OriginalUnravel/AutoroutingPipeline1_OriginalUnravel.ts
@@ -56,6 +56,7 @@ import {
   getGraphicsLayerForObstacle,
 } from "lib/utils/getGraphicsObjectLayer"
 import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
+import { getDefaultTraceWidthForSimpleRouteJson } from "lib/utils/getTraceWidth"
 import { getViaDimensions } from "lib/utils/getViaDimensions"
 import { calculateOptimalCapacityDepth } from "lib/utils/getTunedTotalCapacity1"
 import { mapLayerNameToZ } from "lib/utils/mapLayerNameToZ"
@@ -321,7 +322,7 @@ export class AutoroutingPipeline1_OriginalUnravel extends BaseSolver {
         colorMap: cms.colorMap,
         connMap: cms.connMap,
         viaDiameter: cms.viaDiameter,
-        traceWidth: cms.minTraceWidth,
+        traceWidth: getDefaultTraceWidthForSimpleRouteJson(cms.srj),
       },
     ]),
     definePipelineStep(

--- a/lib/autorouter-pipelines/AutoroutingPipeline2_PortPointPathing/AutoroutingPipelineSolver2_PortPointPathing.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline2_PortPointPathing/AutoroutingPipelineSolver2_PortPointPathing.ts
@@ -18,6 +18,7 @@ import {
   getGraphicsLayerForObstacle,
 } from "lib/utils/getGraphicsObjectLayer"
 import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
+import { getDefaultTraceWidthForSimpleRouteJson } from "lib/utils/getTraceWidth"
 import { getViaDimensions } from "lib/utils/getViaDimensions"
 import { AvailableSegmentPointSolver } from "../../solvers/AvailableSegmentPointSolver/AvailableSegmentPointSolver"
 import { BaseSolver } from "../../solvers/BaseSolver"
@@ -229,7 +230,7 @@ export class AutoroutingPipelineSolver2_PortPointPathing extends BaseSolver {
         {
           nodes: cms.capacityNodes!,
           edges: cms.capacityEdges || [],
-          traceWidth: cms.minTraceWidth,
+          traceWidth: getDefaultTraceWidthForSimpleRouteJson(cms.srj),
           colorMap: cms.colorMap,
           shouldReturnCrampedPortPoints: false,
         },
@@ -351,7 +352,7 @@ export class AutoroutingPipelineSolver2_PortPointPathing extends BaseSolver {
         colorMap: cms.colorMap,
         connMap: cms.connMap,
         viaDiameter: cms.viaDiameter,
-        traceWidth: cms.minTraceWidth,
+        traceWidth: getDefaultTraceWidthForSimpleRouteJson(cms.srj),
         effort: cms.effort,
       },
     ]),
@@ -392,6 +393,8 @@ export class AutoroutingPipelineSolver2_PortPointPathing extends BaseSolver {
           connMap: cms.connMap,
           colorMap: cms.colorMap,
           minTraceWidth: cms.minTraceWidth,
+          nominalTraceWidth: cms.srj.nominalTraceWidth,
+          traceWidthMultiplier: cms.srj.traceWidthMultiplier,
           connection: cms.srj.connections,
           layerCount: cms.srj.layerCount,
         },

--- a/lib/autorouter-pipelines/AutoroutingPipeline3_HgPortPointPathing/AutoroutingPipelineSolver3_HgPortPointPathing.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline3_HgPortPointPathing/AutoroutingPipelineSolver3_HgPortPointPathing.ts
@@ -30,6 +30,7 @@ import {
 } from "lib/utils/getGraphicsObjectLayer"
 import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
 import { getViaDimensions } from "lib/utils/getViaDimensions"
+import { getDefaultTraceWidthForSimpleRouteJson } from "lib/utils/getTraceWidth"
 import { calculateOptimalCapacityDepth } from "lib/utils/getTunedTotalCapacity1"
 import { AvailableSegmentPointSolver } from "../../solvers/AvailableSegmentPointSolver/AvailableSegmentPointSolver"
 import { BaseSolver } from "../../solvers/BaseSolver"
@@ -164,7 +165,7 @@ export class AutoroutingPipelineSolver3_HgPortPointPathing extends BaseSolver {
         {
           nodes: cms.capacityNodes!,
           edges: cms.capacityEdges || [],
-          traceWidth: cms.minTraceWidth,
+          traceWidth: getDefaultTraceWidthForSimpleRouteJson(cms.srj),
           colorMap: cms.colorMap,
           shouldReturnCrampedPortPoints: true,
         },
@@ -318,7 +319,7 @@ export class AutoroutingPipelineSolver3_HgPortPointPathing extends BaseSolver {
         colorMap: cms.colorMap,
         connMap: cms.connMap,
         viaDiameter: cms.viaDiameter,
-        traceWidth: cms.minTraceWidth,
+        traceWidth: getDefaultTraceWidthForSimpleRouteJson(cms.srj),
       },
     ]),
     definePipelineStep(
@@ -357,6 +358,8 @@ export class AutoroutingPipelineSolver3_HgPortPointPathing extends BaseSolver {
         connMap: cms.connMap,
         colorMap: cms.colorMap,
         minTraceWidth: cms.minTraceWidth,
+        nominalTraceWidth: cms.srj.nominalTraceWidth,
+        traceWidthMultiplier: cms.srj.traceWidthMultiplier,
         connection: cms.srj.connections,
         layerCount: cms.srj.layerCount,
       },

--- a/lib/autorouter-pipelines/AutoroutingPipeline4_TinyHypergraph/AutoroutingPipelineSolver4_TinyHypergraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline4_TinyHypergraph/AutoroutingPipelineSolver4_TinyHypergraph.ts
@@ -33,6 +33,7 @@ import {
   getGraphicsLayerForObstacle,
 } from "lib/utils/getGraphicsObjectLayer"
 import { getPresuppliedTraceVisualization } from "lib/utils/getPresuppliedTraceVisualization"
+import { getDefaultTraceWidthForSimpleRouteJson } from "lib/utils/getTraceWidth"
 import { calculateOptimalCapacityDepth } from "lib/utils/getTunedTotalCapacity1"
 import { getViaDimensions } from "lib/utils/getViaDimensions"
 import { AvailableSegmentPointSolver } from "../../solvers/AvailableSegmentPointSolver/AvailableSegmentPointSolver"
@@ -232,7 +233,7 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
         {
           nodes: cms.capacityNodes!,
           edges: cms.capacityEdges || [],
-          traceWidth: cms.minTraceWidth,
+          traceWidth: getDefaultTraceWidthForSimpleRouteJson(cms.srj),
           colorMap: cms.colorMap,
           shouldReturnCrampedPortPoints: true,
         },
@@ -341,7 +342,7 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
           colorMap: cms.colorMap,
           connMap: cms.connMap,
           viaDiameter: cms.viaDiameter,
-          traceWidth: cms.minTraceWidth,
+          traceWidth: getDefaultTraceWidthForSimpleRouteJson(cms.srj),
           obstacleMargin: cms.srj.defaultObstacleMargin ?? 0.15,
           obstacles: cms.srj.obstacles,
           layerCount: cms.srj.layerCount,
@@ -416,6 +417,8 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
         connMap: cms.connMap,
         colorMap: cms.colorMap,
         minTraceWidth: cms.minTraceWidth,
+        nominalTraceWidth: cms.srj.nominalTraceWidth,
+        traceWidthMultiplier: cms.srj.traceWidthMultiplier,
         connection: cms.srj.connections,
         obstacleMargin: cms.srj.minTraceToPadEdgeClearance ?? 0.15,
         layerCount: cms.srj.layerCount,

--- a/lib/autorouter-pipelines/AutoroutingPipeline5_HdCache/AutoroutingPipelineSolver5_HdCache.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline5_HdCache/AutoroutingPipelineSolver5_HdCache.ts
@@ -1,6 +1,7 @@
 import { ConnectivityMap } from "circuit-json-to-connectivity-map"
 import type { CapacityMeshNodeId } from "lib/types/capacity-mesh-types"
 import { getPendingEffectsFromSolverTree } from "lib/solvers/getPendingEffectsFromSolverTree"
+import { getDefaultTraceWidthForSimpleRouteJson } from "lib/utils/getTraceWidth"
 import {
   AutoroutingPipelineSolver4_TinyHypergraph,
   type AutoroutingPipelineSolverOptions,
@@ -71,7 +72,7 @@ export class AutoroutingPipelineSolver5_HdCache extends AutoroutingPipelineSolve
             colorMap: cms.colorMap,
             connMap: cms.connMap as ConnectivityMap | undefined,
             viaDiameter: cms.viaDiameter,
-            traceWidth: cms.minTraceWidth,
+            traceWidth: getDefaultTraceWidthForSimpleRouteJson(cms.srj),
             obstacleMargin: cms.srj.defaultObstacleMargin ?? 0.15,
             obstacles: cms.srj.obstacles,
             layerCount: cms.srj.layerCount,

--- a/lib/autorouter-pipelines/AutoroutingPipeline5_HdCache/Pipeline5HdCacheHighDensitySolver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline5_HdCache/Pipeline5HdCacheHighDensitySolver.ts
@@ -75,6 +75,10 @@ type NodeSolveMetadata = {
 }
 
 const DEFAULT_HD_CACHE_BASE_URL = "https://hd-cache.tscircuit.com"
+const DEFAULT_HD_CACHE_TRACE_WIDTH = 0.15
+
+const isDefaultHdCacheTraceWidth = (traceWidth: number) =>
+  Math.abs(traceWidth - DEFAULT_HD_CACHE_TRACE_WIDTH) < 1e-9
 
 const getHdCacheSolveUrl = (baseUrl: string) =>
   /\/solve\/?$/.test(baseUrl)
@@ -175,7 +179,14 @@ const getPercentile = (sortedValues: number[], percentile: number) => {
 const getNodePairCount = (node: NodeWithPortPoints) =>
   new Set(node.portPoints.map((point) => point.connectionName)).size
 
-const shouldSolveNodeViaHdCache = (node: NodeWithPortPoints) => {
+const shouldSolveNodeViaHdCache = (
+  node: NodeWithPortPoints,
+  traceWidth = DEFAULT_HD_CACHE_TRACE_WIDTH,
+) => {
+  if (!isDefaultHdCacheTraceWidth(traceWidth)) {
+    return false
+  }
+
   if (getNodePairCount(node) < 3) {
     return false
   }
@@ -570,7 +581,7 @@ export class Pipeline5HdCacheHighDensitySolver extends BaseSolver {
     const pendingEffects: PendingEffect[] = []
 
     this.unsolvedNodePortPoints.forEach((node, nodeIndex) => {
-      if (!shouldSolveNodeViaHdCache(node)) {
+      if (!shouldSolveNodeViaHdCache(node, this.traceWidth)) {
         this.solveNodeLocally(node, nodeIndex)
         return
       }
@@ -675,7 +686,10 @@ export class Pipeline5HdCacheHighDensitySolver extends BaseSolver {
         pairCount: getNodePairCount(failedResult.node),
         routeCount: 0,
         remoteAttempt: {
-          attempted: shouldSolveNodeViaHdCache(failedResult.node),
+          attempted: shouldSolveNodeViaHdCache(
+            failedResult.node,
+            this.traceWidth,
+          ),
           source: "error",
           error: failedResult.error,
         },

--- a/lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/AutoroutingPipelineSolver6_PolyHypergraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/AutoroutingPipelineSolver6_PolyHypergraph.ts
@@ -27,6 +27,7 @@ import {
   getGraphicsLayerForObstacle,
 } from "lib/utils/getGraphicsObjectLayer"
 import { getPresuppliedTraceVisualization } from "lib/utils/getPresuppliedTraceVisualization"
+import { getDefaultTraceWidthForSimpleRouteJson } from "lib/utils/getTraceWidth"
 import { calculateOptimalCapacityDepth } from "lib/utils/getTunedTotalCapacity1"
 import { getViaDimensions } from "lib/utils/getViaDimensions"
 import { AttachProjectedRectsSolver } from "./AttachProjectedRectsSolver"
@@ -197,7 +198,7 @@ export class AutoroutingPipelineSolver6_PolyHypergraph extends BaseSolver {
           nodesWithPortPoints: cms.highDensityNodePortPoints ?? [],
           equivalentAreaExpansionFactor: cms.equivalentAreaExpansionFactor,
           minProjectedRectDimension: cms.minProjectedRectDimension,
-          traceWidth: cms.minTraceWidth,
+          traceWidth: getDefaultTraceWidthForSimpleRouteJson(cms.srj),
           viaDiameter: cms.viaDiameter,
           obstacleMargin: cms.srj.defaultObstacleMargin ?? 0.15,
         },
@@ -226,7 +227,7 @@ export class AutoroutingPipelineSolver6_PolyHypergraph extends BaseSolver {
           colorMap: cms.colorMap,
           connMap: cms.connMap,
           viaDiameter: cms.viaDiameter,
-          traceWidth: cms.minTraceWidth,
+          traceWidth: getDefaultTraceWidthForSimpleRouteJson(cms.srj),
           obstacleMargin: cms.srj.defaultObstacleMargin ?? 0.15,
           effort: cms.effort,
         },
@@ -279,6 +280,8 @@ export class AutoroutingPipelineSolver6_PolyHypergraph extends BaseSolver {
         connMap: cms.connMap,
         colorMap: cms.colorMap,
         minTraceWidth: cms.minTraceWidth,
+        nominalTraceWidth: cms.srj.nominalTraceWidth,
+        traceWidthMultiplier: cms.srj.traceWidthMultiplier,
         connection: cms.srj.connections,
         layerCount: cms.srj.layerCount,
       },

--- a/lib/solvers/NetToPointPairsSolver/NetToPointPairsSolver.ts
+++ b/lib/solvers/NetToPointPairsSolver/NetToPointPairsSolver.ts
@@ -148,6 +148,8 @@ export class NetToPointPairsSolver extends BaseSolver {
         rootConnectionName: connection.name,
         mergedConnectionNames: connection.mergedConnectionNames,
         netConnectionName: connection.netConnectionName,
+        nominalTraceWidth: connection.nominalTraceWidth,
+        traceWidthMultiplier: connection.traceWidthMultiplier,
       })
     }
   }

--- a/lib/solvers/NetToPointPairsSolver/mergeConnections.ts
+++ b/lib/solvers/NetToPointPairsSolver/mergeConnections.ts
@@ -7,6 +7,7 @@ import {
 } from "lib/types"
 import { DSU } from "lib/utils/dsu"
 import { getPointKey } from "lib/utils/getPointKey"
+import { isFinitePositiveTraceWidth } from "lib/utils/getTraceWidth"
 
 /**
  * Merges SimpleRouteConnections that share common ConnectionPoints into single connections.
@@ -89,6 +90,7 @@ export function mergeConnections(
     const mergedExternallyConnectedPointIds: PointId[][] = []
     const mergedNetConnectionNames: Set<string> = new Set()
     let nominalTraceWidth: number | undefined = undefined
+    let traceWidthMultiplier: number | undefined = undefined
 
     simpleRouteConnectionGroup.forEach((simpleRouteConnection) => {
       // Collect unique points
@@ -119,13 +121,27 @@ export function mergeConnections(
         mergedNetConnectionNames.add(simpleRouteConnection.netConnectionName)
       }
 
-      // Take the nominalTraceWidth from the first connection for now
-      // A more robust solution might average or pick the max/min based on context
+      // When merged nets disagree, preserve the widest requested trace.
+      if (isFinitePositiveTraceWidth(simpleRouteConnection.nominalTraceWidth)) {
+        nominalTraceWidth =
+          nominalTraceWidth === undefined
+            ? simpleRouteConnection.nominalTraceWidth
+            : Math.max(
+                nominalTraceWidth,
+                simpleRouteConnection.nominalTraceWidth,
+              )
+      }
+
       if (
-        nominalTraceWidth === undefined &&
-        simpleRouteConnection.nominalTraceWidth !== undefined
+        isFinitePositiveTraceWidth(simpleRouteConnection.traceWidthMultiplier)
       ) {
-        nominalTraceWidth = simpleRouteConnection.nominalTraceWidth
+        traceWidthMultiplier =
+          traceWidthMultiplier === undefined
+            ? simpleRouteConnection.traceWidthMultiplier
+            : Math.max(
+                traceWidthMultiplier,
+                simpleRouteConnection.traceWidthMultiplier,
+              )
       }
     })
 
@@ -144,7 +160,8 @@ export function mergeConnections(
         mergedNetConnectionNames.size > 0
           ? Array.from(mergedNetConnectionNames).join("__") // Combine unique net connection names
           : undefined,
-      nominalTraceWidth: nominalTraceWidth, // Keep the first found nominalTraceWidth
+      nominalTraceWidth,
+      traceWidthMultiplier,
     }
 
     mergedSimpleRouteConnections.push(newSimpleRouteConnection)

--- a/lib/solvers/NetToPointPairsSolver2_OffBoardConnection/NetToPointPairsSolver2_OffBoardConnection.ts
+++ b/lib/solvers/NetToPointPairsSolver2_OffBoardConnection/NetToPointPairsSolver2_OffBoardConnection.ts
@@ -172,6 +172,8 @@ export class NetToPointPairsSolver2_OffBoardConnection extends NetToPointPairsSo
         rootConnectionName: currentConnection.name,
         mergedConnectionNames: currentConnection.mergedConnectionNames,
         netConnectionName: currentConnection.netConnectionName,
+        nominalTraceWidth: currentConnection.nominalTraceWidth,
+        traceWidthMultiplier: currentConnection.traceWidthMultiplier,
       })
     }
   }

--- a/lib/solvers/TraceWidthSolver/TraceWidthSolver.ts
+++ b/lib/solvers/TraceWidthSolver/TraceWidthSolver.ts
@@ -7,6 +7,11 @@ import { HighDensityRouteSpatialIndex } from "lib/data-structures/HighDensityRou
 import { GraphicsObject } from "graphics-debug"
 import { getJumpersGraphics } from "lib/utils/getJumperGraphics"
 import { createObjectsWithZLayers } from "lib/utils/createObjectsWithZLayers"
+import {
+  getConnectionRequestedTraceWidth,
+  getOptionalDefaultTraceWidth,
+  isFinitePositiveTraceWidth,
+} from "lib/utils/getTraceWidth"
 
 const CURSOR_STEP_DISTANCE = 0.1
 
@@ -26,6 +31,8 @@ export interface TraceWidthSolverInput {
   connMap?: ConnectivityMap
   colorMap?: Record<string, string>
   minTraceWidth: number
+  nominalTraceWidth?: number
+  traceWidthMultiplier?: number
   obstacleMargin?: number
   layerCount: number
 }
@@ -39,9 +46,10 @@ export interface TraceWidthSolverInput {
  * If clearance is insufficient for the current width, it tries the next
  * narrower width in the schedule.
  *
- * It only runs width adjustments for routes whose connection provides a
- * nominalTraceWidth; routes without one are passed through unchanged.
- * The schedule is built per-route from that connection's nominalTraceWidth.
+ * It only runs width adjustments for routes whose connection provides
+ * nominalTraceWidth/traceWidthMultiplier, or when the request has a top-level
+ * nominalTraceWidth/traceWidthMultiplier default. Per-connection values take
+ * precedence over the top-level default.
  */
 export class TraceWidthSolver extends BaseSolver {
   override getSolverName(): string {
@@ -52,6 +60,7 @@ export class TraceWidthSolver extends BaseSolver {
   hdRoutesWithWidths: HighDensityRoute[] = []
 
   nominalTraceWidth: number
+  defaultTraceWidth?: number
   minTraceWidth: number
   obstacleMargin: number
   TRACE_WIDTH_SCHEDULE: number[]
@@ -86,6 +95,11 @@ export class TraceWidthSolver extends BaseSolver {
 
     this.hdRoutes = [...input.hdRoutes]
     this.minTraceWidth = input.minTraceWidth
+    this.defaultTraceWidth = getOptionalDefaultTraceWidth({
+      minTraceWidth: input.minTraceWidth,
+      nominalTraceWidth: input.nominalTraceWidth,
+      traceWidthMultiplier: input.traceWidthMultiplier,
+    })
     this.obstacleMargin = input.obstacleMargin ?? 0.15
     this.nominalTraceWidth = 0
     this.TRACE_WIDTH_SCHEDULE = []
@@ -101,13 +115,29 @@ export class TraceWidthSolver extends BaseSolver {
     this.connectionNominalTraceWidthMap = new Map()
 
     for (const connection of input.connection) {
-      if (connection.nominalTraceWidth === undefined) {
+      const requestedTraceWidth = getConnectionRequestedTraceWidth(connection, {
+        minTraceWidth: this.minTraceWidth,
+      })
+      if (!isFinitePositiveTraceWidth(requestedTraceWidth)) {
         continue
       }
       this.connectionNominalTraceWidthMap.set(
         connection.name,
-        connection.nominalTraceWidth,
+        requestedTraceWidth,
       )
+      if (connection.rootConnectionName) {
+        this.connectionNominalTraceWidthMap.set(
+          connection.rootConnectionName,
+          requestedTraceWidth,
+        )
+      }
+      for (const mergedConnectionName of connection.mergedConnectionNames ??
+        []) {
+        this.connectionNominalTraceWidthMap.set(
+          mergedConnectionName,
+          requestedTraceWidth,
+        )
+      }
     }
 
     if (this.obstacles.length > 0) {
@@ -130,7 +160,7 @@ export class TraceWidthSolver extends BaseSolver {
     if (route.rootConnectionName) {
       return this.connectionNominalTraceWidthMap.get(route.rootConnectionName)
     }
-    return undefined
+    return this.defaultTraceWidth
   }
 
   _step() {

--- a/lib/solvers/TraceWidthSolver/TraceWidthSolver.ts
+++ b/lib/solvers/TraceWidthSolver/TraceWidthSolver.ts
@@ -158,7 +158,12 @@ export class TraceWidthSolver extends BaseSolver {
       return byName
     }
     if (route.rootConnectionName) {
-      return this.connectionNominalTraceWidthMap.get(route.rootConnectionName)
+      const byRootName = this.connectionNominalTraceWidthMap.get(
+        route.rootConnectionName,
+      )
+      if (byRootName !== undefined) {
+        return byRootName
+      }
     }
     return this.defaultTraceWidth
   }

--- a/lib/types/srj-types.ts
+++ b/lib/types/srj-types.ts
@@ -45,6 +45,7 @@ export interface SimpleRouteJson {
   layerCount: number
   minTraceWidth: number
   nominalTraceWidth?: number
+  traceWidthMultiplier?: number
   /** @deprecated Use `min_via_pad_diameter` / `minViaPadDiameter` instead. */
   minViaDiameter?: number
   minViaHoleDiameter?: number
@@ -89,6 +90,7 @@ export interface SimpleRouteConnection {
   isOffBoard?: boolean
   netConnectionName?: string
   nominalTraceWidth?: number
+  traceWidthMultiplier?: number
   pointsToConnect: Array<ConnectionPoint>
 
   /** @deprecated DO NOT USE **/

--- a/lib/utils/getTraceWidth.ts
+++ b/lib/utils/getTraceWidth.ts
@@ -1,0 +1,63 @@
+import type { SimpleRouteConnection, SimpleRouteJson } from "lib/types"
+
+export const isFinitePositiveTraceWidth = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value) && value > 0
+
+export const getTraceWidthFromMultiplier = (
+  minTraceWidth: number,
+  traceWidthMultiplier: unknown,
+): number | undefined => {
+  if (
+    !isFinitePositiveTraceWidth(minTraceWidth) ||
+    !isFinitePositiveTraceWidth(traceWidthMultiplier)
+  ) {
+    return undefined
+  }
+
+  return minTraceWidth * traceWidthMultiplier
+}
+
+export const getOptionalDefaultTraceWidth = ({
+  minTraceWidth,
+  nominalTraceWidth,
+  traceWidthMultiplier,
+}: {
+  minTraceWidth: number
+  nominalTraceWidth?: unknown
+  traceWidthMultiplier?: unknown
+}): number | undefined => {
+  if (isFinitePositiveTraceWidth(nominalTraceWidth)) {
+    return nominalTraceWidth
+  }
+
+  return getTraceWidthFromMultiplier(minTraceWidth, traceWidthMultiplier)
+}
+
+export const getDefaultTraceWidthForSimpleRouteJson = (
+  srj: Pick<
+    SimpleRouteJson,
+    "minTraceWidth" | "nominalTraceWidth" | "traceWidthMultiplier"
+  >,
+): number =>
+  getOptionalDefaultTraceWidth({
+    minTraceWidth: srj.minTraceWidth,
+    nominalTraceWidth: srj.nominalTraceWidth,
+    traceWidthMultiplier: srj.traceWidthMultiplier,
+  }) ?? srj.minTraceWidth
+
+export const getConnectionRequestedTraceWidth = (
+  connection: Pick<
+    SimpleRouteConnection,
+    "nominalTraceWidth" | "traceWidthMultiplier"
+  >,
+  { minTraceWidth }: { minTraceWidth: number },
+): number | undefined => {
+  if (isFinitePositiveTraceWidth(connection.nominalTraceWidth)) {
+    return connection.nominalTraceWidth
+  }
+
+  return getTraceWidthFromMultiplier(
+    minTraceWidth,
+    connection.traceWidthMultiplier,
+  )
+}

--- a/tests/features/trace-thickness-parameter.test.ts
+++ b/tests/features/trace-thickness-parameter.test.ts
@@ -96,6 +96,24 @@ test("TraceWidthSolver applies a connection multiplier through root connection n
   expect(solver.getHdRoutesWithWidths()[0]?.traceThickness).toBe(1.2)
 })
 
+test("TraceWidthSolver applies top-level defaults through root connection names", () => {
+  const solver = new TraceWidthSolver({
+    hdRoutes: [
+      makeRoute("power_mst0", {
+        rootConnectionName: "power",
+      }),
+    ],
+    connection: [makeConnection({ name: "power" })],
+    minTraceWidth: 0.15,
+    traceWidthMultiplier: 4,
+    layerCount: 2,
+  })
+
+  solver.solve()
+
+  expect(solver.getHdRoutesWithWidths()[0]?.traceThickness).toBe(0.6)
+})
+
 test("NetToPointPairsSolver preserves trace width settings when it splits a multi-point net", () => {
   const srj = makeSimpleSrj({
     connections: [

--- a/tests/features/trace-thickness-parameter.test.ts
+++ b/tests/features/trace-thickness-parameter.test.ts
@@ -1,0 +1,204 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver4 } from "lib/autorouter-pipelines/AutoroutingPipeline4_TinyHypergraph/AutoroutingPipelineSolver4_TinyHypergraph"
+import { Pipeline5HdCacheHighDensitySolver } from "lib/autorouter-pipelines/AutoroutingPipeline5_HdCache/Pipeline5HdCacheHighDensitySolver"
+import { NetToPointPairsSolver } from "lib/solvers/NetToPointPairsSolver/NetToPointPairsSolver"
+import { TraceWidthSolver } from "lib/solvers/TraceWidthSolver/TraceWidthSolver"
+import type { SimpleRouteConnection, SimpleRouteJson } from "lib/types"
+import type {
+  HighDensityRoute,
+  NodeWithPortPoints,
+} from "lib/types/high-density-types"
+
+const makeRoute = (
+  connectionName: string,
+  opts: { y?: number; rootConnectionName?: string } = {},
+): HighDensityRoute => ({
+  connectionName,
+  rootConnectionName: opts.rootConnectionName,
+  traceThickness: 0.15,
+  viaDiameter: 0.3,
+  route: [
+    { x: -1, y: opts.y ?? 0, z: 0 },
+    { x: 1, y: opts.y ?? 0, z: 0 },
+  ],
+  vias: [],
+})
+
+const makeConnection = (
+  connection: Partial<SimpleRouteConnection> &
+    Pick<SimpleRouteConnection, "name">,
+): SimpleRouteConnection => ({
+  ...connection,
+  pointsToConnect: connection.pointsToConnect ?? [
+    { x: -1, y: 0, layer: "top" },
+    { x: 1, y: 0, layer: "top" },
+  ],
+})
+
+const makeSimpleSrj = (
+  overrides: Partial<SimpleRouteJson> = {},
+): SimpleRouteJson => ({
+  layerCount: 2,
+  minTraceWidth: 0.15,
+  minViaDiameter: 0.3,
+  obstacles: [],
+  connections: [
+    makeConnection({
+      name: "net1",
+      pointsToConnect: [
+        { x: -1, y: 0, layer: "top" },
+        { x: 1, y: 0, layer: "top" },
+      ],
+    }),
+  ],
+  bounds: { minX: -5, maxX: 5, minY: -5, maxY: 5 },
+  ...overrides,
+})
+
+test("TraceWidthSolver uses top-level trace width defaults and per-connection overrides", () => {
+  const solver = new TraceWidthSolver({
+    hdRoutes: [makeRoute("net1"), makeRoute("net2", { y: 2 })],
+    connection: [
+      makeConnection({ name: "net1" }),
+      makeConnection({ name: "net2", nominalTraceWidth: 0.3 }),
+    ],
+    minTraceWidth: 0.15,
+    traceWidthMultiplier: 4,
+    layerCount: 2,
+  })
+
+  solver.solve()
+
+  const widthsByConnection = new Map(
+    solver
+      .getHdRoutesWithWidths()
+      .map((route) => [route.connectionName, route.traceThickness]),
+  )
+
+  expect(widthsByConnection.get("net1")).toBe(0.6)
+  expect(widthsByConnection.get("net2")).toBe(0.3)
+})
+
+test("TraceWidthSolver applies a connection multiplier through root connection names", () => {
+  const solver = new TraceWidthSolver({
+    hdRoutes: [
+      makeRoute("power_mst0", {
+        rootConnectionName: "power",
+      }),
+    ],
+    connection: [makeConnection({ name: "power", traceWidthMultiplier: 8 })],
+    minTraceWidth: 0.15,
+    layerCount: 2,
+  })
+
+  solver.solve()
+
+  expect(solver.getHdRoutesWithWidths()[0]?.traceThickness).toBe(1.2)
+})
+
+test("NetToPointPairsSolver preserves trace width settings when it splits a multi-point net", () => {
+  const srj = makeSimpleSrj({
+    connections: [
+      makeConnection({
+        name: "power",
+        nominalTraceWidth: 0.6,
+        traceWidthMultiplier: 4,
+        pointsToConnect: [
+          { x: -1, y: 0, layer: "top" },
+          { x: 0, y: 0, layer: "top" },
+          { x: 1, y: 0, layer: "top" },
+        ],
+      }),
+    ],
+  })
+
+  const solver = new NetToPointPairsSolver(srj)
+  solver.solve()
+
+  expect(solver.newConnections).toHaveLength(2)
+  expect(
+    solver.newConnections.every(
+      (connection) =>
+        connection.rootConnectionName === "power" &&
+        connection.nominalTraceWidth === 0.6 &&
+        connection.traceWidthMultiplier === 4,
+    ),
+  ).toBe(true)
+})
+
+test("AutoroutingPipelineSolver4 routes a top-level nominal trace width end to end", () => {
+  const solver = new AutoroutingPipelineSolver4(
+    makeSimpleSrj({ nominalTraceWidth: 0.6 }),
+    { cacheProvider: null },
+  )
+
+  solver.solve()
+
+  expect(solver.failed).toBe(false)
+  expect(solver.highDensityRouteSolver?.traceWidth).toBe(0.6)
+
+  const output = solver.getOutputSimpleRouteJson()
+  const wireWidths = (output.traces ?? []).flatMap((trace) =>
+    trace.route
+      .filter((point) => point.route_type === "wire")
+      .map((point) => point.width),
+  )
+
+  expect(wireWidths.length).toBeGreaterThan(0)
+  expect(new Set(wireWidths)).toEqual(new Set([0.6]))
+})
+
+test("Pipeline5 keeps non-default trace widths on the local path because hd-cache requests are width agnostic", () => {
+  const remoteEligibleNode: NodeWithPortPoints = {
+    capacityMeshNodeId: "cmn_remote_width",
+    center: { x: 0, y: 0 },
+    width: 4,
+    height: 3,
+    availableZ: [0, 1],
+    portPoints: [
+      { x: -2, y: -1.5, z: 0, connectionName: "A" },
+      { x: 2, y: -1.5, z: 0, connectionName: "A" },
+      { x: -2, y: 0, z: 1, connectionName: "B" },
+      { x: 2, y: 0, z: 1, connectionName: "B" },
+      { x: -2, y: 1.5, z: 0, connectionName: "C" },
+      { x: 2, y: 1.5, z: 0, connectionName: "C" },
+    ],
+  }
+
+  let fetchCallCount = 0
+  const fetchImpl = Object.assign(
+    async () => {
+      fetchCallCount += 1
+      throw new Error("non-default trace widths should not reach hd-cache")
+    },
+    { preconnect: () => {} },
+  ) as typeof fetch
+
+  const solver = new Pipeline5HdCacheHighDensitySolver({
+    nodePortPoints: [remoteEligibleNode],
+    traceWidth: 0.6,
+    fetchImpl,
+  })
+
+  const localSolveCalls: Array<{
+    node: NodeWithPortPoints
+    nodeIndex: number
+  }> = []
+  ;(solver as any).solveNodeLocally = (
+    node: NodeWithPortPoints,
+    nodeIndex: number,
+  ) => {
+    localSolveCalls.push({ node, nodeIndex })
+  }
+  ;(solver as any).launchRemoteSolves()
+
+  expect(fetchCallCount).toBe(0)
+  expect(localSolveCalls).toEqual([
+    {
+      node: remoteEligibleNode,
+      nodeIndex: 0,
+    },
+  ])
+  expect(solver.stats.remoteRequestsStarted).toBe(0)
+  expect(solver.pendingEffects).toEqual([])
+})


### PR DESCRIPTION
## Summary
- add top-level `nominalTraceWidth` support for SimpleRouteJson routing defaults
- preserve per-connection trace width overrides and multipliers through net splitting and routing pipelines
- add focused regression coverage for trace-width propagation across root routes and Pipeline 5 local routing

## Validation
- `bun test tests/features/trace-thickness-parameter.test.ts`
- `bun run format:check`
- `bun run build`

/claim #66