### PR TITLE
remove deprecated baseUrl from tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,16 +8,13 @@
     "jsx": "react-jsx",
     "allowJs": true,
 
-    "baseUrl": ".",
     "paths": {
-      "lib/*": ["lib/*"],
-      "examples/*": ["examples/*"],
-      "tests/*": ["tests/*"],
-      "@tscircuit/autorouting-dataset-01": ["types/dataset-module-shims"],
-      "@tscircuit/dataset-srj05": ["types/dataset-module-shims"],
-      "@tsci/seveibar.dataset-srj13": ["types/dataset-module-shims"],
-      "zdwiel-dataset": ["types/dataset-module-shims"],
-      "high-density-dataset-z04": ["types/dataset-module-shims"]
+      "*": ["./*"],
+      "@tscircuit/autorouting-dataset-01": ["./types/dataset-module-shims"],
+      "@tscircuit/dataset-srj05": ["./types/dataset-module-shims"],
+      "@tsci/seveibar.dataset-srj13": ["./types/dataset-module-shims"],
+      "zdwiel-dataset": ["./types/dataset-module-shims"],
+      "high-density-dataset-z04": ["./types/dataset-module-shims"]
     },
 
     // Bundler mode


### PR DESCRIPTION

<img width="780" height="314" alt="image" src="https://github.com/user-attachments/assets/d578167d-1689-463d-b89b-f81adf03a93f" />


## Summary

Removes the deprecated `baseUrl` compiler option from `tsconfig.json` and replaces it with the smallest explicit mapping needed to preserve current resolution behavior.

## What Changed

- removed `compilerOptions.baseUrl`
- added `"*": ["./*"]` so bare project-root imports continue to resolve without `baseUrl`
- kept the existing dataset shim mappings, updated to explicit `./...` targets as required without `baseUrl`

## Why

TypeScript 6.0 deprecates `baseUrl`, and TypeScript 7.0 removes it. This repo still relies on root-level bare imports like `"lib"` and `"scripts/..."`, so it needs one explicit fallback mapping after `baseUrl` is removed.

## Validation

- `timeout 30s npx tsc -p tsconfig.json --noEmit --pretty false`
