### PR TITLE
benchmark qol

### DIFF
--- a/benchmark.sh
+++ b/benchmark.sh
@@ -77,7 +77,7 @@ Options:
   --scenario-limit N   Run only first N scenarios (same as second positional arg)
   --concurrency N      Number of Bun workers used per solver, or "auto"
   --effort N           Override scenario effort multiplier
-  --sample-timeout D   Override per-sample timeout directly; otherwise timeout is 60s + 60s * effort
+  --sample-timeout D   Override isolated per-sample timeout; benchmark scales it by concurrency for wall-clock execution
   --dataset NAME       Dataset to benchmark: 1/dataset01 (default), zdwiel, 5/srj05, 11/srj11, 12/srj12, 13/srj13, 14/srj14, 15/srj15, or 16/srj16
   --include-assignable Include assignable pipelines (excluded by default)
   -h, --help           Show this help

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -77,7 +77,7 @@ Options:
   --scenario-limit N   Run only first N scenarios (same as second positional arg)
   --concurrency N      Number of Bun workers used per solver, or "auto"
   --effort N           Override scenario effort multiplier
-  --sample-timeout D   Override isolated per-sample timeout; benchmark scales it by concurrency for wall-clock execution
+  --sample-timeout D   Override per-sample timeout directly; otherwise timeout is 60s + 60s * effort
   --dataset NAME       Dataset to benchmark: 1/dataset01 (default), zdwiel, 5/srj05, 11/srj11, 12/srj12, 13/srj13, 14/srj14, 15/srj15, or 16/srj16
   --include-assignable Include assignable pipelines (excluded by default)
   -h, --help           Show this help

--- a/scripts/benchmark/benchmark-run-task.ts
+++ b/scripts/benchmark/benchmark-run-task.ts
@@ -97,6 +97,90 @@ const getErrorMessage = (error: unknown): string | undefined => {
   return error instanceof Error ? error.message : String(error)
 }
 
+const toErrorRecord = (error: object): Record<string, unknown> =>
+  error as unknown as Record<string, unknown>
+
+const normalizeDrcMessage = (message: unknown) =>
+  typeof message === "string" && message.trim().length > 0
+    ? message.replace(/\s+/g, " ").trim()
+    : "no message"
+
+const getDrcErrorType = (error: object) => {
+  const errorRecord = toErrorRecord(error)
+  const message = normalizeDrcMessage(errorRecord.message)
+  if (
+    message.includes("overlaps with pcb_smtpad") &&
+    message.includes("accidental contact")
+  ) {
+    return "trace_smtpad_accidental_contact"
+  }
+  if (
+    message.includes("overlaps with pcb_plated_hole") &&
+    message.includes("accidental contact")
+  ) {
+    return "trace_plated_hole_accidental_contact"
+  }
+  if (message.includes("is too close to pcb_smtpad")) {
+    return "trace_smtpad_clearance"
+  }
+  if (message.includes("is too close to pcb_plated_hole")) {
+    return "trace_plated_hole_clearance"
+  }
+  if (message.includes("overlaps with pcb_trace")) {
+    return "trace_trace_overlap"
+  }
+  if (message.includes("overlaps with pcb_via")) {
+    return "trace_via_overlap"
+  }
+
+  const explicitType = errorRecord.error_type ?? errorRecord.type
+  if (typeof explicitType === "string" && explicitType.length > 0) {
+    return explicitType
+  }
+
+  const errorId = errorRecord.pcb_error_id
+  if (typeof errorId === "string") {
+    if (errorId.startsWith("same_net_vias_close_")) {
+      return "same_net_vias_close"
+    }
+    if (errorId.startsWith("different_net_vias_close_")) {
+      return "different_net_vias_close"
+    }
+  }
+
+  return "unknown_drc_error"
+}
+
+const incrementCount = (counts: Record<string, number>, key: string) => {
+  counts[key] = (counts[key] ?? 0) + 1
+}
+
+const summarizeDrcErrors = (
+  errors: object[],
+): Pick<WorkerResult, "drcErrorCount" | "drcErrorTypes" | "drcErrorMessages"> => {
+  const drcErrorTypes: Record<string, number> = {}
+  const messageCounts: Record<string, number> = {}
+
+  for (const error of errors) {
+    incrementCount(drcErrorTypes, getDrcErrorType(error))
+    incrementCount(
+      messageCounts,
+      normalizeDrcMessage(toErrorRecord(error).message),
+    )
+  }
+
+  const drcErrorMessages = Object.entries(messageCounts)
+    .sort(([, countA], [, countB]) => countB - countA)
+    .slice(0, 5)
+    .map(([message, count]) => ({ message, count }))
+
+  return {
+    drcErrorCount: errors.length,
+    drcErrorTypes,
+    drcErrorMessages,
+  }
+}
+
 const getSolverInstanceName = (solver: SolverInstance | null | undefined) => {
   if (!solver) {
     return undefined
@@ -276,6 +360,7 @@ export const runTask = async (
     )
     const { errors } = getDrcErrors(circuitJson, RELAXED_DRC_OPTIONS)
     const relaxedDrcPassed = errors.length === 0
+    const drcSummary = summarizeDrcErrors(errors as object[])
 
     return {
       solverName: task.solverName,
@@ -285,6 +370,7 @@ export const runTask = async (
       didSolve,
       didTimeout: false,
       relaxedDrcPassed,
+      ...drcSummary,
     }
   } catch (error) {
     return {

--- a/scripts/benchmark/benchmark-run-task.ts
+++ b/scripts/benchmark/benchmark-run-task.ts
@@ -157,7 +157,10 @@ const incrementCount = (counts: Record<string, number>, key: string) => {
 
 const summarizeDrcErrors = (
   errors: object[],
-): Pick<WorkerResult, "drcErrorCount" | "drcErrorTypes" | "drcErrorMessages"> => {
+): Pick<
+  WorkerResult,
+  "drcErrorCount" | "drcErrorTypes" | "drcErrorMessages"
+> => {
   const drcErrorTypes: Record<string, number> = {}
   const messageCounts: Record<string, number> = {}
 

--- a/scripts/benchmark/benchmark-types.ts
+++ b/scripts/benchmark/benchmark-types.ts
@@ -80,6 +80,7 @@ export type BenchmarkReport = {
   effortLabel: string
   summary: SolverRunSummary[]
   solverFailureSummary: FailureSummary[]
+  timeoutSummary: FailureSummary[]
   failureSummary: FailureSummary[]
   tests: WorkerResult[]
 }

--- a/scripts/benchmark/benchmark-types.ts
+++ b/scripts/benchmark/benchmark-types.ts
@@ -33,9 +33,23 @@ export type WorkerResult = {
   didSolve: boolean
   didTimeout: boolean
   relaxedDrcPassed: boolean
+  drcErrorCount?: number
+  drcErrorTypes?: Record<string, number>
+  drcErrorMessages?: Array<{
+    message: string
+    count: number
+  }>
   errorPhaseName?: string
   errorSolverName?: string
   error?: string
+}
+
+export type FailureSummary = {
+  failureKind: string
+  failureKey: string
+  affectedSamples: number
+  occurrences: number
+  sampleNumbers: number[]
 }
 
 export type WorkerResultMessage = {
@@ -65,5 +79,7 @@ export type BenchmarkReport = {
   scenarioCount: number
   effortLabel: string
   summary: SolverRunSummary[]
+  solverFailureSummary: FailureSummary[]
+  failureSummary: FailureSummary[]
   tests: WorkerResult[]
 }

--- a/scripts/benchmark/index.ts
+++ b/scripts/benchmark/index.ts
@@ -53,12 +53,6 @@ type WorkerExecutionResult = {
   restartWorker: boolean
 }
 
-type TaskTimeoutBudget = {
-  effectiveTimeoutMs: number
-  baseTimeoutMs: number
-  concurrencyScale: number
-}
-
 const DEFAULT_TASK_TIMEOUT_PER_EFFORT_MS = 60 * 1000
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 30 * 1000
 const DEFAULT_TERMINATE_TIMEOUT_MS = 5 * 1000
@@ -348,7 +342,7 @@ const formatSampleNumbers = (sampleNumbers: number[]) => {
 const getFailureKeyForResult = (result: WorkerResult) => {
   if (result.didTimeout) {
     return {
-      failureKind: "timeout",
+      failureKind: "timeout at last observed phase",
       failureKeys: [
         [
           result.errorPhaseName ?? "unknown phase",
@@ -434,7 +428,12 @@ const summarizeFailures = (results: WorkerResult[]): FailureSummary[] => {
 }
 
 const summarizeSolverFailures = (results: WorkerResult[]): FailureSummary[] =>
-  summarizeFailures(results.filter((result) => !result.didSolve))
+  summarizeFailures(
+    results.filter((result) => !result.didSolve && !result.didTimeout),
+  )
+
+const summarizeTimeouts = (results: WorkerResult[]): FailureSummary[] =>
+  summarizeFailures(results.filter((result) => result.didTimeout))
 
 const formatFailureSummary = (failureSummary: FailureSummary[]) => {
   if (failureSummary.length === 0) {
@@ -570,26 +569,13 @@ const getTaskEffort = (task: BenchmarkTask) => {
   return rawEffort
 }
 
-const getConcurrencyTimeoutScale = (workerCount: number) =>
-  Math.max(1, workerCount)
-
-const getTaskTimeoutBudget = (
-  task: BenchmarkTask,
-  workerCount: number,
-  sampleTimeoutMs?: number,
-): TaskTimeoutBudget => {
-  const baseTimeoutMs =
-    sampleTimeoutMs !== undefined
-      ? sampleTimeoutMs
-      : getTaskTimeoutPerEffortMs() +
-        getTaskTimeoutPerEffortMs() * getTaskEffort(task)
-  const concurrencyScale = getConcurrencyTimeoutScale(workerCount)
-
-  return {
-    effectiveTimeoutMs: baseTimeoutMs * concurrencyScale,
-    baseTimeoutMs,
-    concurrencyScale,
+const getTaskTimeoutMs = (task: BenchmarkTask, sampleTimeoutMs?: number) => {
+  if (sampleTimeoutMs !== undefined) {
+    return sampleTimeoutMs
   }
+
+  const baseTimeoutMs = getTaskTimeoutPerEffortMs()
+  return baseTimeoutMs + baseTimeoutMs * getTaskEffort(task)
 }
 
 const formatEffortLabel = (efforts: number[]) => {
@@ -649,15 +635,10 @@ const formatProgressDetails = (progress?: WorkerProgress) => {
 const executeTaskOnWorker = (
   slot: WorkerSlot,
   request: WorkerTaskMessage,
-  workerCount: number,
   sampleTimeoutMs?: number,
 ): Promise<WorkerExecutionResult> => {
   return new Promise((resolve) => {
-    const taskTimeoutBudget = getTaskTimeoutBudget(
-      request.task,
-      workerCount,
-      sampleTimeoutMs,
-    )
+    const taskTimeoutMs = getTaskTimeoutMs(request.task, sampleTimeoutMs)
     const startedAtMs = performance.now()
     let settled = false
 
@@ -734,21 +715,17 @@ const executeTaskOnWorker = (
 
     const timeout = setTimeout(() => {
       const latestProgress = slot.currentTask?.latestProgress
-      const timeoutLabel =
-        taskTimeoutBudget.concurrencyScale === 1
-          ? formatDurationLabel(taskTimeoutBudget.effectiveTimeoutMs)
-          : `${formatDurationLabel(taskTimeoutBudget.effectiveTimeoutMs)} (base ${formatDurationLabel(taskTimeoutBudget.baseTimeoutMs)} x ${taskTimeoutBudget.concurrencyScale} concurrency scale)`
       finish(
         createFailedResult(
           request.task,
-          taskTimeoutBudget.effectiveTimeoutMs,
-          `Timed out after ${timeoutLabel}${formatProgressDetails(latestProgress)}`,
+          taskTimeoutMs,
+          `Timed out after ${formatDurationLabel(taskTimeoutMs)}${formatProgressDetails(latestProgress)}`,
           true,
           latestProgress,
         ),
         true,
       )
-    }, taskTimeoutBudget.effectiveTimeoutMs)
+    }, taskTimeoutMs)
 
     slot.currentTask = {
       request,
@@ -856,7 +833,6 @@ const runBenchmarkTasks = async (
       const { result, restartWorker } = await executeTaskOnWorker(
         slot,
         request,
-        workerCount,
         sampleTimeoutMs,
       )
       results[request.taskId - 1] = result
@@ -1002,9 +978,11 @@ const main = async () => {
   const table = formatTable(rows)
   const solverFailureSummary = summarizeSolverFailures(results)
   const solverFailureSummaryText = formatFailureSummary(solverFailureSummary)
+  const timeoutSummary = summarizeTimeouts(results)
+  const timeoutSummaryText = formatFailureSummary(timeoutSummary)
   const failureSummary = summarizeFailures(results)
   const failureSummaryText = formatFailureSummary(failureSummary)
-  const output = `Benchmark Results (${effortLabel})\n\n${table}\n\nDataset: ${datasetName}\nScenarios: ${scenarios.length}\n\nTop solver failure buckets:\n${solverFailureSummaryText}\n\nTop failure buckets:\n${failureSummaryText}\n`
+  const output = `Benchmark Results (${effortLabel})\n\n${table}\n\nDataset: ${datasetName}\nScenarios: ${scenarios.length}\n\nTop solver failure buckets:\n${solverFailureSummaryText}\n\nTop timeout buckets:\n${timeoutSummaryText}\n\nTop failure buckets:\n${failureSummaryText}\n`
   const report: BenchmarkReport = {
     version: 1,
     datasetName,
@@ -1012,6 +990,7 @@ const main = async () => {
     effortLabel,
     summary: rows,
     solverFailureSummary,
+    timeoutSummary,
     failureSummary,
     tests: results,
   }
@@ -1024,6 +1003,8 @@ const main = async () => {
   console.log(`\nScenarios: ${scenarios.length}`)
   console.log("\nTop solver failure buckets:")
   console.log(solverFailureSummaryText)
+  console.log("\nTop timeout buckets:")
+  console.log(timeoutSummaryText)
   console.log("\nTop failure buckets:")
   console.log(failureSummaryText)
   console.log(

--- a/scripts/benchmark/index.ts
+++ b/scripts/benchmark/index.ts
@@ -402,14 +402,12 @@ const summarizeFailures = (results: WorkerResult[]): FailureSummary[] => {
 
     for (const failureKey of failure.failureKeys) {
       const bucketKey = `${failure.failureKind}\0${failureKey}`
-      const bucket =
-        buckets.get(bucketKey) ??
-        {
-          failureKind: failure.failureKind,
-          failureKey,
-          occurrences: 0,
-          sampleNumbers: new Set<number>(),
-        }
+      const bucket = buckets.get(bucketKey) ?? {
+        failureKind: failure.failureKind,
+        failureKey,
+        occurrences: 0,
+        sampleNumbers: new Set<number>(),
+      }
       bucket.sampleNumbers.add(result.sampleNumber)
       bucket.occurrences +=
         failure.failureKind === "relaxed DRC"

--- a/scripts/benchmark/index.ts
+++ b/scripts/benchmark/index.ts
@@ -9,6 +9,7 @@ import type { SimpleRouteJson } from "../../lib/types/srj-types"
 import type {
   BenchmarkReport,
   BenchmarkTask,
+  FailureSummary,
   SolverRunSummary,
   WorkerChildMessage,
   WorkerProgress,
@@ -50,6 +51,12 @@ type WorkerSlot = {
 type WorkerExecutionResult = {
   result: WorkerResult
   restartWorker: boolean
+}
+
+type TaskTimeoutBudget = {
+  effectiveTimeoutMs: number
+  baseTimeoutMs: number
+  concurrencyScale: number
 }
 
 const DEFAULT_TASK_TIMEOUT_PER_EFFORT_MS = 60 * 1000
@@ -333,6 +340,118 @@ const formatTable = (rows: SolverRunSummary[]) => {
   return [separator, headerLine, separator, ...bodyLines, separator].join("\n")
 }
 
+const formatSampleNumbers = (sampleNumbers: number[]) => {
+  const shown = sampleNumbers.slice(0, 8).join(", ")
+  return sampleNumbers.length > 8 ? `${shown}, ...` : shown
+}
+
+const getFailureKeyForResult = (result: WorkerResult) => {
+  if (result.didTimeout) {
+    return {
+      failureKind: "timeout",
+      failureKeys: [
+        [
+          result.errorPhaseName ?? "unknown phase",
+          result.errorSolverName ?? "unknown solver",
+        ].join(" / "),
+      ],
+    }
+  }
+
+  if (!result.didSolve) {
+    return {
+      failureKind: "solver failure",
+      failureKeys: [
+        [
+          result.errorPhaseName ?? "unknown phase",
+          result.errorSolverName ?? "unknown solver",
+          result.error ?? "unknown error",
+        ].join(" / "),
+      ],
+    }
+  }
+
+  if (!result.relaxedDrcPassed) {
+    const drcErrorTypes = result.drcErrorTypes ?? {}
+    const failureKeys = Object.keys(drcErrorTypes)
+    return {
+      failureKind: "relaxed DRC",
+      failureKeys: failureKeys.length > 0 ? failureKeys : ["unknown DRC error"],
+    }
+  }
+
+  return null
+}
+
+const summarizeFailures = (results: WorkerResult[]): FailureSummary[] => {
+  const buckets = new Map<
+    string,
+    {
+      failureKind: string
+      failureKey: string
+      occurrences: number
+      sampleNumbers: Set<number>
+    }
+  >()
+
+  for (const result of results) {
+    const failure = getFailureKeyForResult(result)
+    if (!failure) {
+      continue
+    }
+
+    for (const failureKey of failure.failureKeys) {
+      const bucketKey = `${failure.failureKind}\0${failureKey}`
+      const bucket =
+        buckets.get(bucketKey) ??
+        {
+          failureKind: failure.failureKind,
+          failureKey,
+          occurrences: 0,
+          sampleNumbers: new Set<number>(),
+        }
+      bucket.sampleNumbers.add(result.sampleNumber)
+      bucket.occurrences +=
+        failure.failureKind === "relaxed DRC"
+          ? (result.drcErrorTypes?.[failureKey] ?? 1)
+          : 1
+      buckets.set(bucketKey, bucket)
+    }
+  }
+
+  return [...buckets.values()]
+    .map((bucket) => ({
+      failureKind: bucket.failureKind,
+      failureKey: bucket.failureKey,
+      affectedSamples: bucket.sampleNumbers.size,
+      occurrences: bucket.occurrences,
+      sampleNumbers: [...bucket.sampleNumbers].sort((a, b) => a - b),
+    }))
+    .sort((a, b) => {
+      if (b.affectedSamples !== a.affectedSamples) {
+        return b.affectedSamples - a.affectedSamples
+      }
+      return b.occurrences - a.occurrences
+    })
+}
+
+const summarizeSolverFailures = (results: WorkerResult[]): FailureSummary[] =>
+  summarizeFailures(results.filter((result) => !result.didSolve))
+
+const formatFailureSummary = (failureSummary: FailureSummary[]) => {
+  if (failureSummary.length === 0) {
+    return "No failures recorded."
+  }
+
+  return failureSummary
+    .slice(0, 10)
+    .map(
+      (failure, index) =>
+        `${index + 1}. ${failure.failureKind}: ${failure.failureKey} - ${failure.affectedSamples} sample${failure.affectedSamples === 1 ? "" : "s"}, ${failure.occurrences} occurrence${failure.occurrences === 1 ? "" : "s"} (samples: ${formatSampleNumbers(failure.sampleNumbers)})`,
+    )
+    .join("\n")
+}
+
 const createChildProcess = () =>
   spawn(process.execPath, ["scripts/benchmark/benchmark.child.ts"], {
     cwd: process.cwd(),
@@ -453,13 +572,26 @@ const getTaskEffort = (task: BenchmarkTask) => {
   return rawEffort
 }
 
-const getTaskTimeoutMs = (task: BenchmarkTask, sampleTimeoutMs?: number) => {
-  if (sampleTimeoutMs !== undefined) {
-    return sampleTimeoutMs
-  }
+const getConcurrencyTimeoutScale = (workerCount: number) =>
+  Math.max(1, workerCount)
 
-  const baseTimeoutMs = getTaskTimeoutPerEffortMs()
-  return baseTimeoutMs + baseTimeoutMs * getTaskEffort(task)
+const getTaskTimeoutBudget = (
+  task: BenchmarkTask,
+  workerCount: number,
+  sampleTimeoutMs?: number,
+): TaskTimeoutBudget => {
+  const baseTimeoutMs =
+    sampleTimeoutMs !== undefined
+      ? sampleTimeoutMs
+      : getTaskTimeoutPerEffortMs() +
+        getTaskTimeoutPerEffortMs() * getTaskEffort(task)
+  const concurrencyScale = getConcurrencyTimeoutScale(workerCount)
+
+  return {
+    effectiveTimeoutMs: baseTimeoutMs * concurrencyScale,
+    baseTimeoutMs,
+    concurrencyScale,
+  }
 }
 
 const formatEffortLabel = (efforts: number[]) => {
@@ -519,10 +651,15 @@ const formatProgressDetails = (progress?: WorkerProgress) => {
 const executeTaskOnWorker = (
   slot: WorkerSlot,
   request: WorkerTaskMessage,
+  workerCount: number,
   sampleTimeoutMs?: number,
 ): Promise<WorkerExecutionResult> => {
   return new Promise((resolve) => {
-    const taskTimeoutMs = getTaskTimeoutMs(request.task, sampleTimeoutMs)
+    const taskTimeoutBudget = getTaskTimeoutBudget(
+      request.task,
+      workerCount,
+      sampleTimeoutMs,
+    )
     const startedAtMs = performance.now()
     let settled = false
 
@@ -599,17 +736,21 @@ const executeTaskOnWorker = (
 
     const timeout = setTimeout(() => {
       const latestProgress = slot.currentTask?.latestProgress
+      const timeoutLabel =
+        taskTimeoutBudget.concurrencyScale === 1
+          ? formatDurationLabel(taskTimeoutBudget.effectiveTimeoutMs)
+          : `${formatDurationLabel(taskTimeoutBudget.effectiveTimeoutMs)} (base ${formatDurationLabel(taskTimeoutBudget.baseTimeoutMs)} x ${taskTimeoutBudget.concurrencyScale} concurrency scale)`
       finish(
         createFailedResult(
           request.task,
-          taskTimeoutMs,
-          `Timed out after ${formatDurationLabel(taskTimeoutMs)}${formatProgressDetails(latestProgress)}`,
+          taskTimeoutBudget.effectiveTimeoutMs,
+          `Timed out after ${timeoutLabel}${formatProgressDetails(latestProgress)}`,
           true,
           latestProgress,
         ),
         true,
       )
-    }, taskTimeoutMs)
+    }, taskTimeoutBudget.effectiveTimeoutMs)
 
     slot.currentTask = {
       request,
@@ -717,6 +858,7 @@ const runBenchmarkTasks = async (
       const { result, restartWorker } = await executeTaskOnWorker(
         slot,
         request,
+        workerCount,
         sampleTimeoutMs,
       )
       results[request.taskId - 1] = result
@@ -860,13 +1002,19 @@ const main = async () => {
     ),
   )
   const table = formatTable(rows)
-  const output = `Benchmark Results (${effortLabel})\n\n${table}\n\nDataset: ${datasetName}\nScenarios: ${scenarios.length}\n`
+  const solverFailureSummary = summarizeSolverFailures(results)
+  const solverFailureSummaryText = formatFailureSummary(solverFailureSummary)
+  const failureSummary = summarizeFailures(results)
+  const failureSummaryText = formatFailureSummary(failureSummary)
+  const output = `Benchmark Results (${effortLabel})\n\n${table}\n\nDataset: ${datasetName}\nScenarios: ${scenarios.length}\n\nTop solver failure buckets:\n${solverFailureSummaryText}\n\nTop failure buckets:\n${failureSummaryText}\n`
   const report: BenchmarkReport = {
     version: 1,
     datasetName,
     scenarioCount: scenarios.length,
     effortLabel,
     summary: rows,
+    solverFailureSummary,
+    failureSummary,
     tests: results,
   }
   await Bun.write("benchmark-result.txt", output)
@@ -876,6 +1024,10 @@ const main = async () => {
   console.log(table)
   console.log(`\nDataset: ${datasetName}`)
   console.log(`\nScenarios: ${scenarios.length}`)
+  console.log("\nTop solver failure buckets:")
+  console.log(solverFailureSummaryText)
+  console.log("\nTop failure buckets:")
+  console.log(failureSummaryText)
   console.log(
     "Results written to benchmark-result.txt and benchmark-result.json",
   )


### PR DESCRIPTION
Adds structured benchmark failure summaries so solver failures are separated from relaxed DRC failures. Records DRC error counts/types/messages per sample, adds top solver failure buckets to text/JSON output, and scales sample timeouts by concurrency to avoid misattributing parallel wall-clock contention as phase failures.