### PR TITLE
fix: Increasing the effort level was preventing globalDrcForceImprovementSolver to use the preplaced via's

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline8/AutoroutingPipelineSolver8.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline8/AutoroutingPipelineSolver8.ts
@@ -38,6 +38,7 @@ import { getPresuppliedTraceVisualization } from "lib/utils/getPresuppliedTraceV
 import { calculateOptimalCapacityDepth } from "lib/utils/getTunedTotalCapacity1"
 import { getViaDimensions } from "lib/utils/getViaDimensions"
 import { getAssignableViaPointKeys } from "./assignableViaUtils"
+import { getXyPointKey } from "./getXyPointKey"
 import { AvailableSegmentPointSolver } from "../../solvers/AvailableSegmentPointSolver/AvailableSegmentPointSolver"
 import { BaseSolver } from "../../solvers/BaseSolver"
 import { CapacityMeshEdgeSolver } from "../../solvers/CapacityMeshSolver/CapacityMeshEdgeSolver"
@@ -764,13 +765,30 @@ export class AutoroutingPipelineSolver8 extends BaseSolver {
   }
 
   _getOutputHdRoutes(): HighDensityRoute[] {
+    const globalDrcRoutes = this.globalDrcForceImproveSolver?.getOutput()
+    if (globalDrcRoutes && this.routesOnlyUsePreplacedVias(globalDrcRoutes)) {
+      return globalDrcRoutes
+    }
+
     return (
-      this.globalDrcForceImproveSolver?.getOutput() ??
       this.traceWidthSolver?.getHdRoutesWithWidths() ??
       this.traceSimplificationSolver?.simplifiedHdRoutes ??
       this.highDensityRepairRoutes ??
       this.highDensityForceImproveRoutes ??
       this.highDensityStitchSolver!.mergedHdRoutes
+    )
+  }
+
+  private routesOnlyUsePreplacedVias(routes: HighDensityRoute[]) {
+    const allowedLayerTransitionPointKeys = getAssignableViaPointKeys(
+      this.originalSrj.obstacles,
+    )
+    if (allowedLayerTransitionPointKeys.size === 0) return true
+
+    return routes.every((route) =>
+      route.vias.every((via) =>
+        allowedLayerTransitionPointKeys.has(getXyPointKey(via)),
+      ),
     )
   }
 

--- a/tests/bugs/bugreport59-82431e.test.ts
+++ b/tests/bugs/bugreport59-82431e.test.ts
@@ -5,6 +5,8 @@ import bugReport from "../../fixtures/bug-reports/bugreport59-82431e/bugreport59
 }
 import type { SimpleRouteJson } from "lib/types"
 import { getLastStepSvg } from "../fixtures/getLastStepSvg"
+import { getAssignableViaPointKeys } from "lib/autorouter-pipelines/AutoroutingPipeline8/assignableViaUtils"
+import { getXyPointKey } from "lib/autorouter-pipelines/AutoroutingPipeline8/getXyPointKey"
 
 const srj = bugReport.simple_route_json as SimpleRouteJson
 
@@ -17,4 +19,21 @@ test("bugreport59-82431e.json", () => {
       : import.meta.path
 
   expect(getLastStepSvg(solver.visualize())).toMatchSvgSnapshot(snapshotPath)
+}, 30_000)
+
+test("bugreport59-82431e keeps effort 2 vias on preplaced assignable vias", () => {
+  const solver = new AutoroutingPipelineSolver8(srj, { effort: 2 })
+  solver.solve()
+
+  const allowedViaPointKeys = getAssignableViaPointKeys(srj.obstacles)
+  const outputVias = solver
+    .getOutputSimplifiedPcbTraces()
+    .flatMap((trace) =>
+      trace.route.filter((segment) => segment.route_type === "via"),
+    )
+
+  expect(outputVias.length).toBeGreaterThan(0)
+  expect(
+    outputVias.filter((via) => !allowedViaPointKeys.has(getXyPointKey(via))),
+  ).toEqual([])
 }, 30_000)


### PR DESCRIPTION
Increasing the effort is causing the `globalDrcForceImprovementSolver` to find a better drc score layer change transition at different position and not using the pre placed via.

Another solution for this could be to pass optional constraint which will guard `globalDrcForceImprovementSolver` to use only the passed layer change positions. Is that a better solution? @seveibar 