### PR TITLE
Switch welcome page KiCad import to jscdn.tscircuit.com

### DIFF
--- a/fixtures/_welcome/welcome.fixture.tsx
+++ b/fixtures/_welcome/welcome.fixture.tsx
@@ -4,7 +4,7 @@ import { convertSrjTracesToObstacles } from "lib/utils/convertSrjTracesToObstacl
 import { useState } from "react"
 
 const KICAD_TO_CIRCUIT_JSON_ESM_URL =
-  "https://cdnjs.tscircuit.com/npm/kicad-to-circuit-json@latest/+esm"
+  "https://jscdn.tscircuit.com/kicad-to-circuit-json/latest/+esm"
 
 type CircuitJsonElement = Record<string, any>
 type SrjConnection = SimpleRouteJson["connections"][number]

--- a/fixtures/_welcome/welcome.fixture.tsx
+++ b/fixtures/_welcome/welcome.fixture.tsx
@@ -4,7 +4,7 @@ import { convertSrjTracesToObstacles } from "lib/utils/convertSrjTracesToObstacl
 import { useState } from "react"
 
 const KICAD_TO_CIRCUIT_JSON_ESM_URL =
-  "https://cdn.jsdelivr.net/npm/kicad-to-circuit-json@latest/+esm"
+  "https://cdnjs.tscircuit.com/npm/kicad-to-circuit-json@latest/+esm"
 
 type CircuitJsonElement = Record<string, any>
 type SrjConnection = SimpleRouteJson["connections"][number]


### PR DESCRIPTION
## Summary
- Update the welcome fixture to load `kicad-to-circuit-json` from `jscdn.tscircuit.com` instead of jsDelivr.
- Use the CDN's package/version path format: `https://jscdn.tscircuit.com/kicad-to-circuit-json/latest/+esm`.

## Testing
- Verified the new URL returns JavaScript and exposes `KicadToCircuitJsonConverter`.
- Verified the module and its nested imports resolve successfully from `jscdn.tscircuit.com`.
- Confirmed the repo still typechecks after the change.