### PR TITLE
Add dataset-srj18 to benchmark fixtures and scenario loading

### DIFF
--- a/benchmark.sh
+++ b/benchmark.sh
@@ -80,7 +80,7 @@ Options:
   --effort N           Override scenario effort multiplier
   --sample-timeout D   Override per-sample timeout directly; otherwise timeout is 60s + 60s * effort
   --sample-numbers L   Run comma-separated 1-based sample numbers from the dataset order
-  --dataset NAME       Dataset to benchmark: 1/dataset01 (default), zdwiel, 5/srj05, 11/srj11, 12/srj12, 13/srj13, 14/srj14, 15/srj15, or 16/srj16
+  --dataset NAME       Dataset to benchmark: 1/dataset01 (default), zdwiel, 5/srj05, 11/srj11, 12/srj12, 13/srj13, 14/srj14, 15/srj15, 16/srj16, or 18/srj18
   --include-assignable Include assignable pipelines (excluded by default)
   -h, --help           Show this help
 
@@ -109,6 +109,7 @@ Examples:
   ./benchmark.sh --dataset 14
   ./benchmark.sh --dataset 15
   ./benchmark.sh --dataset 16
+  ./benchmark.sh --dataset 18
   ./benchmark.sh --include-assignable
 EOF
 

--- a/fixtures/benchmarks/dataset-srj18.fixture.tsx
+++ b/fixtures/benchmarks/dataset-srj18.fixture.tsx
@@ -1,0 +1,24 @@
+import {
+  DatasetBenchmarkFixture,
+  type DatasetCircuit,
+} from "./DatasetBenchmarkFixture"
+import { dataset as datasetSrj18 } from "dataset-srj18"
+
+const sampleKeyPattern = /^sample(\d{3})$/
+
+const circuits = Object.entries(datasetSrj18)
+  .map(([key, srj]) => {
+    const sampleMatch = key.match(sampleKeyPattern)
+    if (!sampleMatch) return null
+
+    return {
+      id: sampleMatch[1],
+      srj,
+    }
+  })
+  .filter((circuit): circuit is DatasetCircuit => circuit !== null)
+  .sort((a, b) => Number(a.id) - Number(b.id))
+
+export default () => (
+  <DatasetBenchmarkFixture datasetLabel="dataset-srj18" circuits={circuits} />
+)

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "circuit-to-svg": "^0.0.220",
     "clsx": "^2.1.1",
     "dataset-srj11-45-degree": "git+https://github.com/tscircuit/dataset-srj11-45-degree.git#0add61e6a0e6b59f6defc36f257052f773e2d685",
+    "dataset-srj18": "git+https://github.com/tscircuit/dataset-srj18.git#de0a8db80288715382857da7d5558096ca786cb6",
     "flatbush": "^4.4.0",
     "graphics-debug": "0.0.94",
     "high-density-dataset-z04": "git+https://github.com/tscircuit/high-density-dataset-z04.git#b9128ed52f5a50102b6526319be1d4ec33dca2c2",

--- a/scripts/benchmark/scenarios.ts
+++ b/scripts/benchmark/scenarios.ts
@@ -10,6 +10,7 @@ export const DATASET_NAMES = [
   "srj14",
   "srj15",
   "srj16",
+  "srj18",
 ] as const
 
 export type DatasetName = (typeof DATASET_NAMES)[number]
@@ -17,7 +18,7 @@ export type DatasetName = (typeof DATASET_NAMES)[number]
 type DatasetModule = Record<string, unknown>
 
 export const DATASET_OPTIONS_LABEL =
-  "1/dataset01, zdwiel, 5/srj05, 11/srj11, 12/srj12, 13/srj13, 14/srj14, 15/srj15, 16/srj16"
+  "1/dataset01, zdwiel, 5/srj05, 11/srj11, 12/srj12, 13/srj13, 14/srj14, 15/srj15, 16/srj16, 18/srj18"
 
 const datasetAliases: Record<string, DatasetName> = {
   "1": "dataset01",
@@ -57,6 +58,10 @@ const datasetAliases: Record<string, DatasetName> = {
   "dataset-srj16": "srj16",
   "dataset-srj16-bga-breakouts": "srj16",
   "@tsci/tscircuit.dataset-srj16-bga-breakouts": "srj16",
+  "18": "srj18",
+  dataset18: "srj18",
+  srj18: "srj18",
+  "dataset-srj18": "srj18",
   zdwiel: "zdwiel",
 }
 
@@ -148,6 +153,12 @@ const datasetLoaders: Record<DatasetName, () => Promise<DatasetModule>> = {
       getSpecifier: (sampleId) =>
         `@tsci/tscircuit.dataset-srj16-bga-breakouts/circuits/sample${sampleId}/sample${sampleId}.circuit.simple-route.json`,
     }),
+  srj18: async () =>
+    loadNumberedJsonDatasetModule({
+      sampleCount: 16,
+      getSpecifier: (sampleId) =>
+        `dataset-srj18/samples/sample${sampleId}.json`,
+    }),
 }
 
 const datasetScenarioKeyPatterns: Record<DatasetName, RegExp> = {
@@ -160,6 +171,7 @@ const datasetScenarioKeyPatterns: Record<DatasetName, RegExp> = {
   srj14: /^sample\d{3}Circuit$/,
   srj15: /^sample\d{3}Circuit$/,
   srj16: /^sample\d{3}Circuit$/,
+  srj18: /^sample\d{3}Circuit$/,
 }
 
 export const toSimpleRouteJson = (value: unknown): SimpleRouteJson | null => {


### PR DESCRIPTION
## Summary
- Add `dataset-srj18` as a pinned dev dependency at the current upstream commit hash
- Create a new benchmark fixture page for `dataset-srj18` using the package’s exported `dataset`
- Wire `srj18` into benchmark dataset parsing, loaders, and scenario filtering
- Update `benchmark.sh` help and examples to include dataset 18

## Testing
- `bun install`
- `bunx tsc --noEmit`
- Verified `parseDatasetName()` accepts `18`, `srj18`, and `dataset-srj18`
- Ran a bounded benchmark invocation against `--dataset 18` to confirm the dataset loads and dispatches into the benchmark runner