### PR TITLE
Add bug report fixture for autorouting case 2936e12e

### DIFF
--- a/fixtures/bug-reports/bugreport61-2936e1/bugreport61-2936e1.fixture.tsx
+++ b/fixtures/bug-reports/bugreport61-2936e1/bugreport61-2936e1.fixture.tsx
@@ -1,0 +1,7 @@
+// @ts-nocheck
+import { AutoroutingPipelineDebugger } from "lib/testing/AutoroutingPipelineDebugger"
+import bugReportJson from "./bugreport61-2936e1.json"
+
+export default () => {
+  return <AutoroutingPipelineDebugger srj={bugReportJson.simple_route_json} />
+}

--- a/fixtures/bug-reports/bugreport61-2936e1/bugreport61-2936e1.json
+++ b/fixtures/bug-reports/bugreport61-2936e1/bugreport61-2936e1.json
@@ -1,0 +1,438 @@
+{
+  "autorouting_bug_report_id": "2936e12e-a609-4090-9619-9d7d20820b46",
+  "reporter_account_id": "9f398687-69d0-4ef4-a48c-bb6dc990e7df",
+  "package_id": null,
+  "title": "<board#2664 />",
+  "simple_route_json": {
+    "bounds": {
+      "maxX": 4.6499999999999995,
+      "maxY": 10.75,
+      "minX": -5.249158560811657,
+      "minY": -4.205
+    },
+    "obstacles": [
+      {
+        "type": "rect",
+        "width": 1,
+        "center": {
+          "x": -2.15,
+          "y": 1.905
+        },
+        "height": 0.6,
+        "layers": [
+          "top"
+        ],
+        "componentId": "pcb_component_0",
+        "connectedTo": [
+          "pcb_smtpad_0",
+          "connectivity_net3",
+          "source_trace_1",
+          "source_port_15",
+          "source_port_0",
+          "pcb_smtpad_0",
+          "pcb_port_0",
+          "pcb_smtpad_15",
+          "pcb_port_15"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1,
+        "center": {
+          "x": -2.15,
+          "y": 0.635
+        },
+        "height": 0.6,
+        "layers": [
+          "top"
+        ],
+        "componentId": "pcb_component_0",
+        "connectedTo": [
+          "pcb_smtpad_1",
+          "connectivity_net6",
+          "source_trace_2",
+          "source_port_11",
+          "source_port_1",
+          "pcb_smtpad_1",
+          "pcb_port_1",
+          "pcb_smtpad_11",
+          "pcb_port_11"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1,
+        "center": {
+          "x": -2.15,
+          "y": -0.635
+        },
+        "height": 0.6,
+        "layers": [
+          "top"
+        ],
+        "componentId": "pcb_component_0",
+        "connectedTo": [
+          "pcb_smtpad_2",
+          "connectivity_net41",
+          "source_port_2",
+          "pcb_smtpad_2",
+          "pcb_port_2"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1,
+        "center": {
+          "x": -2.15,
+          "y": -1.905
+        },
+        "height": 0.6,
+        "layers": [
+          "top"
+        ],
+        "componentId": "pcb_component_0",
+        "connectedTo": [
+          "pcb_smtpad_3",
+          "connectivity_net42",
+          "source_port_3",
+          "pcb_smtpad_3",
+          "pcb_port_3"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1,
+        "center": {
+          "x": 2.15,
+          "y": -1.905
+        },
+        "height": 0.6,
+        "layers": [
+          "top"
+        ],
+        "componentId": "pcb_component_0",
+        "connectedTo": [
+          "pcb_smtpad_4",
+          "connectivity_net43",
+          "source_port_4",
+          "pcb_smtpad_4",
+          "pcb_port_4"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1,
+        "center": {
+          "x": 2.15,
+          "y": -0.635
+        },
+        "height": 0.6,
+        "layers": [
+          "top"
+        ],
+        "componentId": "pcb_component_0",
+        "connectedTo": [
+          "pcb_smtpad_5",
+          "connectivity_net44",
+          "source_port_5",
+          "pcb_smtpad_5",
+          "pcb_port_5"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1,
+        "center": {
+          "x": 2.15,
+          "y": 0.635
+        },
+        "height": 0.6,
+        "layers": [
+          "top"
+        ],
+        "componentId": "pcb_component_0",
+        "connectedTo": [
+          "pcb_smtpad_6",
+          "connectivity_net45",
+          "source_port_6",
+          "pcb_smtpad_6",
+          "pcb_port_6"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1,
+        "center": {
+          "x": 2.15,
+          "y": 1.905
+        },
+        "height": 0.6,
+        "layers": [
+          "top"
+        ],
+        "componentId": "pcb_component_0",
+        "connectedTo": [
+          "pcb_smtpad_7",
+          "connectivity_net0",
+          "source_trace_0",
+          "source_port_8",
+          "source_port_7",
+          "pcb_smtpad_7",
+          "pcb_port_7",
+          "pcb_smtpad_8",
+          "pcb_port_8"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1,
+        "center": {
+          "x": 1.5508414391883418,
+          "y": 4.64
+        },
+        "height": 0.6,
+        "layers": [
+          "top"
+        ],
+        "componentId": "pcb_component_1",
+        "connectedTo": [
+          "pcb_smtpad_8",
+          "connectivity_net0",
+          "source_trace_0",
+          "source_port_8",
+          "source_port_7",
+          "pcb_smtpad_7",
+          "pcb_port_7",
+          "pcb_smtpad_8",
+          "pcb_port_8"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1,
+        "center": {
+          "x": 1.5508414391883423,
+          "y": 5.91
+        },
+        "height": 0.6,
+        "layers": [
+          "top"
+        ],
+        "componentId": "pcb_component_1",
+        "connectedTo": [
+          "pcb_smtpad_9",
+          "connectivity_net46",
+          "source_port_9",
+          "pcb_smtpad_9",
+          "pcb_port_9"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1,
+        "center": {
+          "x": 1.5508414391883423,
+          "y": 7.18
+        },
+        "height": 0.6,
+        "layers": [
+          "top"
+        ],
+        "componentId": "pcb_component_1",
+        "connectedTo": [
+          "pcb_smtpad_10",
+          "connectivity_net47",
+          "source_port_10",
+          "pcb_smtpad_10",
+          "pcb_port_10"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1,
+        "center": {
+          "x": 1.5508414391883427,
+          "y": 8.45
+        },
+        "height": 0.6,
+        "layers": [
+          "top"
+        ],
+        "componentId": "pcb_component_1",
+        "connectedTo": [
+          "pcb_smtpad_11",
+          "connectivity_net6",
+          "source_trace_2",
+          "source_port_11",
+          "source_port_1",
+          "pcb_smtpad_1",
+          "pcb_port_1",
+          "pcb_smtpad_11",
+          "pcb_port_11"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1,
+        "center": {
+          "x": -2.749158560811657,
+          "y": 8.45
+        },
+        "height": 0.6,
+        "layers": [
+          "top"
+        ],
+        "componentId": "pcb_component_1",
+        "connectedTo": [
+          "pcb_smtpad_12",
+          "connectivity_net48",
+          "source_port_12",
+          "pcb_smtpad_12",
+          "pcb_port_12"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1,
+        "center": {
+          "x": -2.7491585608116575,
+          "y": 7.18
+        },
+        "height": 0.6,
+        "layers": [
+          "top"
+        ],
+        "componentId": "pcb_component_1",
+        "connectedTo": [
+          "pcb_smtpad_13",
+          "connectivity_net49",
+          "source_port_13",
+          "pcb_smtpad_13",
+          "pcb_port_13"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1,
+        "center": {
+          "x": -2.7491585608116575,
+          "y": 5.91
+        },
+        "height": 0.6,
+        "layers": [
+          "top"
+        ],
+        "componentId": "pcb_component_1",
+        "connectedTo": [
+          "pcb_smtpad_14",
+          "connectivity_net50",
+          "source_port_14",
+          "pcb_smtpad_14",
+          "pcb_port_14"
+        ]
+      },
+      {
+        "type": "rect",
+        "width": 1,
+        "center": {
+          "x": -2.749158560811658,
+          "y": 4.640000000000001
+        },
+        "height": 0.6,
+        "layers": [
+          "top"
+        ],
+        "componentId": "pcb_component_1",
+        "connectedTo": [
+          "pcb_smtpad_15",
+          "connectivity_net3",
+          "source_trace_1",
+          "source_port_15",
+          "source_port_0",
+          "pcb_smtpad_0",
+          "pcb_port_0",
+          "pcb_smtpad_15",
+          "pcb_port_15"
+        ]
+      }
+    ],
+    "layerCount": 2,
+    "connections": [
+      {
+        "name": "source_trace_0",
+        "pointsToConnect": [
+          {
+            "x": 1.5508414391883418,
+            "y": 4.64,
+            "layer": "top",
+            "pointId": "pcb_port_8",
+            "pcb_port_id": "pcb_port_8"
+          },
+          {
+            "x": 2.15,
+            "y": 1.905,
+            "layer": "top",
+            "pointId": "pcb_port_7",
+            "pcb_port_id": "pcb_port_7"
+          }
+        ],
+        "source_trace_id": "source_trace_0"
+      },
+      {
+        "name": "source_trace_1",
+        "pointsToConnect": [
+          {
+            "x": -2.749158560811658,
+            "y": 4.640000000000001,
+            "layer": "top",
+            "pointId": "pcb_port_15",
+            "pcb_port_id": "pcb_port_15"
+          },
+          {
+            "x": -2.15,
+            "y": 1.905,
+            "layer": "top",
+            "pointId": "pcb_port_0",
+            "pcb_port_id": "pcb_port_0"
+          }
+        ],
+        "source_trace_id": "source_trace_1"
+      },
+      {
+        "name": "source_trace_2",
+        "pointsToConnect": [
+          {
+            "x": 1.5508414391883427,
+            "y": 8.45,
+            "layer": "top",
+            "pointId": "pcb_port_11",
+            "pcb_port_id": "pcb_port_11"
+          },
+          {
+            "x": -2.15,
+            "y": 0.635,
+            "layer": "top",
+            "pointId": "pcb_port_1",
+            "pcb_port_id": "pcb_port_1"
+          }
+        ],
+        "source_trace_id": "source_trace_2"
+      }
+    ],
+    "minTraceWidth": 0.15,
+    "minViaDiameter": 0.3,
+    "minViaPadDiameter": 0.3,
+    "nominalTraceWidth": 0.15,
+    "minViaHoleDiameter": 0.2,
+    "min_via_pad_diameter": 0.3,
+    "minBoardEdgeClearance": 0.2,
+    "min_via_hole_diameter": 0.2,
+    "minTraceToPadEdgeClearance": 0.1,
+    "minPadEdgeToPadEdgeClearance": 0.1,
+    "minViaHoleEdgeToViaHoleEdgeClearance": 0.1,
+    "minPlatedHoleDrillEdgeToDrillEdgeClearance": 0.15
+  },
+  "circuit_json": null,
+  "subcircuit_id": null,
+  "created_at": "2026-05-23T20:27:42.049Z"
+}


### PR DESCRIPTION
## Summary
- Added a new autorouting bug report fixture under `fixtures/bug-reports/bugreport61-2936e1`
- Included the downloaded bug report JSON and a matching debugger fixture for replaying the case in the app

## Testing
- Verified the bug report ID is present in the downloaded JSON
- Confirmed the fixture imports the `simple_route_json` payload correctly
- `bun run bug-report` downloaded the report successfully; the repo formatter step failed because the local Biome config is incompatible with the installed Biome version