### PR TITLE
Display rootConnectionName in high-density hover labels

### DIFF
--- a/lib/solvers/HighDensitySolver/HighDensitySolver.ts
+++ b/lib/solvers/HighDensitySolver/HighDensitySolver.ts
@@ -24,6 +24,21 @@ type HighDensityIntraNodeSolver =
   | HyperSingleIntraNodeSolver
   | GrowShrinkHighDensityIntraNodeSolver
 
+const connectionLabel = (
+  connectionName: string,
+  rootConnectionName?: string,
+  extraLines: string[] = [],
+) =>
+  [
+    connectionName,
+    rootConnectionName
+      ? `rootConnectionName: ${rootConnectionName}`
+      : undefined,
+    ...extraLines,
+  ]
+    .filter(Boolean)
+    .join("\n")
+
 export class HighDensitySolver extends BaseSolver {
   override getSolverName(): string {
     return "HighDensitySolver"
@@ -341,7 +356,10 @@ export class HighDensitySolver extends BaseSolver {
       for (const segment of mergedSegments) {
         graphics.lines!.push({
           points: segment.points,
-          label: segment.connectionName,
+          label: connectionLabel(
+            route.connectionName,
+            route.rootConnectionName,
+          ),
           strokeColor:
             segment.z === 0
               ? segment.color
@@ -357,7 +375,11 @@ export class HighDensitySolver extends BaseSolver {
           layer: "z0,1",
           radius: route.viaDiameter / 2,
           fill: this.colorMap[route.connectionName],
-          label: `${route.connectionName} via`,
+          label: connectionLabel(
+            route.connectionName,
+            route.rootConnectionName,
+            ["via"],
+          ),
         })
       }
     }

--- a/lib/solvers/HighDensitySolver/IntraNodeSolver.ts
+++ b/lib/solvers/HighDensitySolver/IntraNodeSolver.ts
@@ -17,6 +17,21 @@ import { SingleHighDensityRouteSolver6_VertHorzLayer_FutureCost } from "./Single
 
 type ConnectionPoint = { x: number; y: number; z: number }
 
+const connectionLabel = (
+  connectionName: string,
+  rootConnectionName?: string,
+  extraLines: string[] = [],
+) =>
+  [
+    connectionName,
+    rootConnectionName
+      ? `rootConnectionName: ${rootConnectionName}`
+      : undefined,
+    ...extraLines,
+  ]
+    .filter(Boolean)
+    .join("\n")
+
 const pointKey = (point: ConnectionPoint) =>
   `${point.x.toFixed(6)},${point.y.toFixed(6)},${point.z}`
 
@@ -43,9 +58,11 @@ export class IntraNodeRouteSolver extends BaseSolver {
   colorMap: Record<string, string>
   unsolvedConnections: {
     connectionName: string
+    rootConnectionName?: string
     points: { x: number; y: number; z: number }[]
   }[]
   originalConnectionPointsByName: Map<string, ConnectionPoint[]>
+  rootConnectionNameByConnectionName: Map<string, string>
 
   totalConnections: number
   solvedRoutes: HighDensityIntraNodeRoute[]
@@ -96,7 +113,20 @@ export class IntraNodeRouteSolver extends BaseSolver {
     this.traceWidth = params.traceWidth ?? 0.15
     this.obstacleMargin = params.obstacleMargin ?? 0.15
     const unsolvedConnectionsMap: Map<string, ConnectionPoint[]> = new Map()
-    for (const { connectionName, x, y, z } of nodeWithPortPoints.portPoints) {
+    this.rootConnectionNameByConnectionName = new Map()
+    for (const {
+      connectionName,
+      rootConnectionName,
+      x,
+      y,
+      z,
+    } of nodeWithPortPoints.portPoints) {
+      if (rootConnectionName) {
+        this.rootConnectionNameByConnectionName.set(
+          connectionName,
+          rootConnectionName,
+        )
+      }
       unsolvedConnectionsMap.set(connectionName, [
         ...(unsolvedConnectionsMap.get(connectionName) ?? []),
         { x, y, z: z ?? 0 },
@@ -113,6 +143,8 @@ export class IntraNodeRouteSolver extends BaseSolver {
     this.unsolvedConnections = Array.from(
       unsolvedConnectionsMap.entries().map(([connectionName, points]) => ({
         connectionName,
+        rootConnectionName:
+          this.rootConnectionNameByConnectionName.get(connectionName),
         points: dedupeConnectionPoints(points),
       })),
     )
@@ -188,11 +220,13 @@ export class IntraNodeRouteSolver extends BaseSolver {
 
   private getSingleRouteSolverOpts(unsolvedConnection: {
     connectionName: string
+    rootConnectionName?: string
     points: { x: number; y: number; z: number }[]
   }) {
-    const { connectionName, points } = unsolvedConnection
+    const { connectionName, rootConnectionName, points } = unsolvedConnection
     return {
       connectionName,
+      rootConnectionName,
       minDistBetweenEnteringPoints: this.minDistBetweenEnteringPoints,
       bounds: getBoundsFromNodeWithPortPoints(this.nodeWithPortPoints),
       A: { x: points[0].x, y: points[0].y, z: points[0].z },
@@ -231,6 +265,7 @@ export class IntraNodeRouteSolver extends BaseSolver {
 
   private trySolveSamePointLayerChange(unsolvedConnection: {
     connectionName: string
+    rootConnectionName?: string
     points: { x: number; y: number; z: number }[]
   }) {
     const opts = this.getSingleRouteSolverOpts(unsolvedConnection)
@@ -258,6 +293,7 @@ export class IntraNodeRouteSolver extends BaseSolver {
 
     this.solvedRoutes.push({
       connectionName: unsolvedConnection.connectionName,
+      rootConnectionName: unsolvedConnection.rootConnectionName,
       traceThickness: this.traceWidth,
       viaDiameter: this.viaDiameter,
       route,
@@ -268,6 +304,7 @@ export class IntraNodeRouteSolver extends BaseSolver {
 
   private queueExtraBranchesForMultiPointConnection(unsolvedConnection: {
     connectionName: string
+    rootConnectionName?: string
     points: { x: number; y: number; z: number }[]
   }) {
     const [origin, ...extraPoints] = dedupeConnectionPoints(
@@ -279,6 +316,7 @@ export class IntraNodeRouteSolver extends BaseSolver {
     for (const point of extraPoints) {
       this.unsolvedConnections.push({
         connectionName: unsolvedConnection.connectionName,
+        rootConnectionName: unsolvedConnection.rootConnectionName,
         points: [origin, point],
       })
     }
@@ -354,6 +392,8 @@ export class IntraNodeRouteSolver extends BaseSolver {
     )
     this.unsolvedConnections.push({
       connectionName,
+      rootConnectionName:
+        this.rootConnectionNameByConnectionName.get(connectionName),
       points: points.map((point) => ({ ...point })),
     })
     this.rerouteAttemptsByConnection.set(
@@ -469,7 +509,9 @@ export class IntraNodeRouteSolver extends BaseSolver {
       graphics.points!.push({
         x: pt.x,
         y: pt.y,
-        label: [pt.connectionName, `layer: ${pt.z}`].join("\n"),
+        label: connectionLabel(pt.connectionName, pt.rootConnectionName, [
+          `layer: ${pt.z}`,
+        ]),
         color: this.colorMap[pt.connectionName] ?? "blue",
       })
     }
@@ -483,6 +525,9 @@ export class IntraNodeRouteSolver extends BaseSolver {
       const route = this.solvedRoutes[routeIndex]
       if (route.route.length > 0) {
         const routeColor = this.colorMap[route.connectionName] ?? "blue"
+        const rootConnectionName =
+          route.rootConnectionName ??
+          this.rootConnectionNameByConnectionName.get(route.connectionName)
 
         // Draw route segments between points
         for (let i = 0; i < route.route.length - 1; i++) {
@@ -491,6 +536,9 @@ export class IntraNodeRouteSolver extends BaseSolver {
 
           graphics.lines!.push({
             points: [p1, p2],
+            label: connectionLabel(route.connectionName, rootConnectionName, [
+              `layer: ${p1.z}`,
+            ]),
             strokeColor:
               p1.z === 0
                 ? safeTransparentize(routeColor, 0.2)
@@ -509,6 +557,9 @@ export class IntraNodeRouteSolver extends BaseSolver {
             fill: safeTransparentize(routeColor, 0.5),
             layer: "via",
             step: routeIndex,
+            label: connectionLabel(route.connectionName, rootConnectionName, [
+              "via",
+            ]),
           })
         }
       }

--- a/lib/solvers/HighDensitySolver/IntraNodeSolverWithJumpers.ts
+++ b/lib/solvers/HighDensitySolver/IntraNodeSolverWithJumpers.ts
@@ -1,17 +1,17 @@
-import type { GraphicsObject } from "graphics-debug"
-import type {
-  HighDensityIntraNodeRouteWithJumpers,
-  NodeWithPortPoints,
-  Jumper,
-} from "../../types/high-density-types"
-import { BaseSolver } from "../BaseSolver"
-import { SingleHighDensityRouteWithJumpersSolver } from "./SingleHighDensityRouteWithJumpersSolver"
-import { safeTransparentize } from "../colors"
-import { HighDensityHyperParameters } from "./HighDensityHyperParameters"
-import { cloneAndShuffleArray } from "lib/utils/cloneAndShuffleArray"
 import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import type { GraphicsObject } from "graphics-debug"
+import { cloneAndShuffleArray } from "lib/utils/cloneAndShuffleArray"
 import { getBoundsFromNodeWithPortPoints } from "lib/utils/getBoundsFromNodeWithPortPoints"
 import { getMinDistBetweenEnteringPoints } from "lib/utils/getMinDistBetweenEnteringPoints"
+import type {
+  HighDensityIntraNodeRouteWithJumpers,
+  Jumper,
+  NodeWithPortPoints,
+} from "../../types/high-density-types"
+import { BaseSolver } from "../BaseSolver"
+import { safeTransparentize } from "../colors"
+import { HighDensityHyperParameters } from "./HighDensityHyperParameters"
+import { SingleHighDensityRouteWithJumpersSolver } from "./SingleHighDensityRouteWithJumpersSolver"
 
 /**
  * 0603 footprint dimensions in mm for visualization
@@ -22,6 +22,21 @@ const JUMPER_0603 = {
   padLength: 0.8,
   padWidth: 0.95,
 }
+
+const connectionLabel = (
+  connectionName: string,
+  rootConnectionName?: string,
+  extraLines: string[] = [],
+) =>
+  [
+    connectionName,
+    rootConnectionName
+      ? `rootConnectionName: ${rootConnectionName}`
+      : undefined,
+    ...extraLines,
+  ]
+    .filter(Boolean)
+    .join("\n")
 
 /**
  * IntraNodeSolverWithJumpers is designed for single-layer nodes that use
@@ -236,6 +251,7 @@ export class IntraNodeSolverWithJumpers extends BaseSolver {
     jumper: Jumper,
     color: string,
     step?: number,
+    label?: string,
   ) {
     const dx = jumper.end.x - jumper.start.x
     const dy = jumper.end.y - jumper.start.y
@@ -261,6 +277,7 @@ export class IntraNodeSolverWithJumpers extends BaseSolver {
       fill: color,
       stroke: "rgba(0, 0, 0, 0.5)",
       layer: "jumper",
+      label,
     })
 
     // End pad
@@ -274,6 +291,7 @@ export class IntraNodeSolverWithJumpers extends BaseSolver {
       fill: color,
       stroke: "rgba(0, 0, 0, 0.5)",
       layer: "jumper",
+      label,
     })
 
     // Draw a line connecting the pads (representing the jumper body)
@@ -282,6 +300,7 @@ export class IntraNodeSolverWithJumpers extends BaseSolver {
       strokeColor: "rgba(100, 100, 100, 0.8)",
       strokeWidth: padWidth * 0.3,
       layer: "jumper-body",
+      label,
     })
   }
 
@@ -304,7 +323,9 @@ export class IntraNodeSolverWithJumpers extends BaseSolver {
       graphics.points!.push({
         x: pt.x,
         y: pt.y,
-        label: [pt.connectionName, "layer: 0 (single-layer)"].join("\n"),
+        label: connectionLabel(pt.connectionName, pt.rootConnectionName, [
+          "layer: 0 (single-layer)",
+        ]),
         color: this.colorMap[pt.connectionName] ?? "blue",
       })
     }
@@ -329,6 +350,11 @@ export class IntraNodeSolverWithJumpers extends BaseSolver {
             strokeColor: safeTransparentize(routeColor, 0.2),
             layer: "route-layer-0",
             strokeWidth: route.traceThickness,
+            label: connectionLabel(
+              route.connectionName,
+              route.rootConnectionName,
+              ["layer: 0"],
+            ),
           })
         }
 
@@ -339,6 +365,9 @@ export class IntraNodeSolverWithJumpers extends BaseSolver {
             jumper,
             safeTransparentize(routeColor, 0.5),
             routeIndex,
+            connectionLabel(route.connectionName, route.rootConnectionName, [
+              "jumper",
+            ]),
           )
         }
       }

--- a/lib/solvers/HighDensitySolver/SingleHighDensityRouteSolver.ts
+++ b/lib/solvers/HighDensitySolver/SingleHighDensityRouteSolver.ts
@@ -16,8 +16,24 @@ import { HighDensityHyperParameters } from "./HighDensityHyperParameters"
 
 export type FutureConnection = {
   connectionName: string
+  rootConnectionName?: string
   points: { x: number; y: number; z: number }[]
 }
+
+const connectionLabel = (
+  connectionName: string,
+  rootConnectionName?: string,
+  extraLines: string[] = [],
+) =>
+  [
+    connectionName,
+    rootConnectionName
+      ? `rootConnectionName: ${rootConnectionName}`
+      : undefined,
+    ...extraLines,
+  ]
+    .filter(Boolean)
+    .join("\n")
 
 export class SingleHighDensityRouteSolver extends BaseSolver {
   override getSolverName(): string {
@@ -51,6 +67,7 @@ export class SingleHighDensityRouteSolver extends BaseSolver {
   candidates: SingleRouteCandidatePriorityQueue
 
   connectionName: string
+  rootConnectionName?: string
   solvedPath: HighDensityIntraNodeRoute | null = null
 
   futureConnections: FutureConnection[]
@@ -74,6 +91,7 @@ export class SingleHighDensityRouteSolver extends BaseSolver {
 
   constructor(opts: {
     connectionName: string
+    rootConnectionName?: string
     obstacleRoutes: HighDensityIntraNodeRoute[]
     minDistBetweenEnteringPoints: number
     bounds: { minX: number; maxX: number; minY: number; maxY: number }
@@ -103,6 +121,7 @@ export class SingleHighDensityRouteSolver extends BaseSolver {
       y: (this.bounds.minY + this.bounds.maxY) / 2,
     }
     this.connectionName = opts.connectionName
+    this.rootConnectionName = opts.rootConnectionName
     this.obstacleRoutes = opts.obstacleRoutes
     this.A = opts.A
     this.B = opts.B
@@ -219,6 +238,7 @@ export class SingleHighDensityRouteSolver extends BaseSolver {
           ]
     this.solvedPath = {
       connectionName: this.connectionName,
+      rootConnectionName: this.rootConnectionName,
       route,
       traceThickness: this.traceThickness,
       viaDiameter: this.viaDiameter,
@@ -541,6 +561,7 @@ export class SingleHighDensityRouteSolver extends BaseSolver {
 
     this.solvedPath = {
       connectionName: this.connectionName,
+      rootConnectionName: this.rootConnectionName,
       traceThickness: this.traceThickness,
       viaDiameter: this.viaDiameter,
       route: path
@@ -631,13 +652,19 @@ export class SingleHighDensityRouteSolver extends BaseSolver {
     graphics.points!.push({
       x: this.A.x,
       y: this.A.y,
-      label: `Input A\nz: ${this.A.z}`,
+      label: connectionLabel(this.connectionName, this.rootConnectionName, [
+        "Input A",
+        `z: ${this.A.z}`,
+      ]),
       color: "orange",
     })
     graphics.points!.push({
       x: this.B.x,
       y: this.B.y,
-      label: `Input B\nz: ${this.B.z}`,
+      label: connectionLabel(this.connectionName, this.rootConnectionName, [
+        "Input B",
+        `z: ${this.B.z}`,
+      ]),
       color: "orange",
     })
 
@@ -680,7 +707,9 @@ export class SingleHighDensityRouteSolver extends BaseSolver {
     graphics.lines!.push({
       points: [this.A, this.B],
       strokeColor: "rgba(255, 0, 0, 0.5)",
-      label: "Direct Input Connection",
+      label: connectionLabel(this.connectionName, this.rootConnectionName, [
+        "Direct Input Connection",
+      ]),
     })
 
     // Show any obstacle routes as background references
@@ -697,7 +726,11 @@ export class SingleHighDensityRouteSolver extends BaseSolver {
           strokeColor:
             z === 0 ? "rgba(255, 0, 0, 0.75)" : "rgba(255, 128, 0, 0.25)",
           strokeWidth: route.traceThickness,
-          label: "Obstacle Route",
+          label: connectionLabel(
+            route.connectionName,
+            route.rootConnectionName,
+            ["Obstacle Route"],
+          ),
           layer: `obstacle${routeIndex.toString()}`,
         })
       }
@@ -758,14 +791,22 @@ export class SingleHighDensityRouteSolver extends BaseSolver {
       graphics.lines!.push({
         points: this.solvedPath.route,
         strokeColor: "green",
-        label: "Solved Route",
+        label: connectionLabel(
+          this.solvedPath.connectionName,
+          this.solvedPath.rootConnectionName,
+          ["Solved Route"],
+        ),
       })
       for (const via of this.solvedPath.vias) {
         graphics.circles!.push({
           center: via,
           radius: this.viaDiameter / 2,
           fill: "green",
-          label: "Via",
+          label: connectionLabel(
+            this.solvedPath.connectionName,
+            this.solvedPath.rootConnectionName,
+            ["Via"],
+          ),
         })
       }
     }

--- a/lib/solvers/HighDensitySolver/SingleHighDensityRouteWithJumpersSolver.ts
+++ b/lib/solvers/HighDensitySolver/SingleHighDensityRouteWithJumpersSolver.ts
@@ -1,25 +1,41 @@
-import { BaseSolver } from "../BaseSolver"
-import type {
-  HighDensityIntraNodeRouteWithJumpers,
-  Jumper,
-} from "lib/types/high-density-types"
 import {
   distance,
-  pointToSegmentDistance,
   doSegmentsIntersect,
+  pointToSegmentDistance,
 } from "@tscircuit/math-utils"
-import type { GraphicsObject } from "graphics-debug"
-import { HighDensityHyperParameters } from "./HighDensityHyperParameters"
 import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import type { GraphicsObject } from "graphics-debug"
 import {
   Node,
   SingleRouteCandidatePriorityQueue,
 } from "lib/data-structures/SingleRouteCandidatePriorityQueue"
+import type {
+  HighDensityIntraNodeRouteWithJumpers,
+  Jumper,
+} from "lib/types/high-density-types"
+import { BaseSolver } from "../BaseSolver"
+import { HighDensityHyperParameters } from "./HighDensityHyperParameters"
 
 export type FutureConnection = {
   connectionName: string
+  rootConnectionName?: string
   points: { x: number; y: number; z: number }[]
 }
+
+const connectionLabel = (
+  connectionName: string,
+  rootConnectionName?: string,
+  extraLines: string[] = [],
+) =>
+  [
+    connectionName,
+    rootConnectionName
+      ? `rootConnectionName: ${rootConnectionName}`
+      : undefined,
+    ...extraLines,
+  ]
+    .filter(Boolean)
+    .join("\n")
 
 /**
  * 0603 footprint dimensions in mm
@@ -1493,6 +1509,7 @@ export class SingleHighDensityRouteWithJumpersSolver extends BaseSolver {
     color: string,
     layer?: string,
     step?: number,
+    label?: string,
   ) {
     const dx = jumper.end.x - jumper.start.x
     const dy = jumper.end.y - jumper.start.y
@@ -1519,6 +1536,7 @@ export class SingleHighDensityRouteWithJumpersSolver extends BaseSolver {
       stroke: "rgba(0, 0, 0, 0.5)",
       layer: layer ?? "jumper",
       step,
+      label,
     })
 
     // End pad
@@ -1533,6 +1551,7 @@ export class SingleHighDensityRouteWithJumpersSolver extends BaseSolver {
       stroke: "rgba(0, 0, 0, 0.5)",
       layer: layer ?? "jumper",
       step,
+      label,
     })
 
     // Draw a line connecting the pads (representing the jumper body)
@@ -1542,6 +1561,7 @@ export class SingleHighDensityRouteWithJumpersSolver extends BaseSolver {
       strokeWidth: padWidth * 0.3,
       layer: layer ?? "jumper-body",
       step,
+      label,
     })
   }
 
@@ -1557,13 +1577,19 @@ export class SingleHighDensityRouteWithJumpersSolver extends BaseSolver {
     graphics.points!.push({
       x: this.A.x,
       y: this.A.y,
-      label: `Input A\nz: ${this.A.z}`,
+      label: connectionLabel(this.connectionName, this.rootConnectionName, [
+        "Input A",
+        `z: ${this.A.z}`,
+      ]),
       color: "orange",
     })
     graphics.points!.push({
       x: this.B.x,
       y: this.B.y,
-      label: `Input B\nz: ${this.B.z}`,
+      label: connectionLabel(this.connectionName, this.rootConnectionName, [
+        "Input B",
+        `z: ${this.B.z}`,
+      ]),
       color: "orange",
     })
 
@@ -1571,7 +1597,9 @@ export class SingleHighDensityRouteWithJumpersSolver extends BaseSolver {
     graphics.lines!.push({
       points: [this.A, this.B],
       strokeColor: "rgba(255, 0, 0, 0.5)",
-      label: "Direct Input Connection",
+      label: connectionLabel(this.connectionName, this.rootConnectionName, [
+        "Direct Input Connection",
+      ]),
     })
 
     // Show obstacle routes
@@ -1586,7 +1614,11 @@ export class SingleHighDensityRouteWithJumpersSolver extends BaseSolver {
           points: [route.route[i], route.route[i + 1]],
           strokeColor: "rgba(255, 0, 0, 0.75)",
           strokeWidth: route.traceThickness,
-          label: "Obstacle Route",
+          label: connectionLabel(
+            route.connectionName,
+            route.rootConnectionName,
+            ["Obstacle Route"],
+          ),
           layer: `obstacle${routeIndex.toString()}`,
         })
       }
@@ -1598,6 +1630,10 @@ export class SingleHighDensityRouteWithJumpersSolver extends BaseSolver {
           jumper,
           "rgba(255, 0, 0, 0.5)",
           `obstacle-jumper-${routeIndex}`,
+          undefined,
+          connectionLabel(route.connectionName, route.rootConnectionName, [
+            "Obstacle Jumper",
+          ]),
         )
       }
     }
@@ -1612,7 +1648,9 @@ export class SingleHighDensityRouteWithJumpersSolver extends BaseSolver {
         points: [start, end],
         strokeColor: "rgba(0, 100, 255, 0.6)",
         strokeWidth: this.traceThickness,
-        label: `Future: ${fc.connectionName}`,
+        label: connectionLabel(fc.connectionName, fc.rootConnectionName, [
+          "Future",
+        ]),
         layer: `future-connection-${i}`,
       })
     }
@@ -1770,7 +1808,11 @@ export class SingleHighDensityRouteWithJumpersSolver extends BaseSolver {
       graphics.lines!.push({
         points: this.solvedPath.route,
         strokeColor: "green",
-        label: "Solved Route",
+        label: connectionLabel(
+          this.solvedPath.connectionName,
+          this.solvedPath.rootConnectionName,
+          ["Solved Route"],
+        ),
         strokeWidth: this.traceThickness,
       })
 
@@ -1781,6 +1823,12 @@ export class SingleHighDensityRouteWithJumpersSolver extends BaseSolver {
           jumper,
           "rgba(0, 200, 0, 0.8)",
           "solved-jumper",
+          undefined,
+          connectionLabel(
+            this.solvedPath.connectionName,
+            this.solvedPath.rootConnectionName,
+            ["Solved Jumper"],
+          ),
         )
       }
     }

--- a/lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver/GrowShrinkHighDensityIntraNodeSolver.ts
+++ b/lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver/GrowShrinkHighDensityIntraNodeSolver.ts
@@ -4,13 +4,13 @@ import type {
   NodeWithPortPoints,
   PortPoint,
 } from "lib/types/high-density-types"
+import { BaseSolver } from "../../BaseSolver"
+import { HyperSingleIntraNodeSolver } from "../HyperSingleIntraNodeSolver"
 import {
   createInvalidDirectConnectionRoutes,
   createInvalidSameLayerCrossingRoutes,
   hasImpossibleSameLayerCrossingGeometry,
 } from "./invalidSameLayerCrossingGeometry"
-import { BaseSolver } from "../../BaseSolver"
-import { HyperSingleIntraNodeSolver } from "../HyperSingleIntraNodeSolver"
 
 type HyperSingleIntraNodeSolverParams = ConstructorParameters<
   typeof HyperSingleIntraNodeSolver
@@ -80,6 +80,21 @@ const routeColors = [
   "#9333ea",
   "#0891b2",
 ]
+
+const connectionLabel = (
+  connectionName: string,
+  rootConnectionName?: string,
+  extraLines: string[] = [],
+) =>
+  [
+    connectionName,
+    rootConnectionName
+      ? `rootConnectionName: ${rootConnectionName}`
+      : undefined,
+    ...extraLines,
+  ]
+    .filter(Boolean)
+    .join("\n")
 
 export class GrowShrinkHighDensityIntraNodeSolver extends BaseSolver {
   override getSolverName(): string {
@@ -230,14 +245,16 @@ export class GrowShrinkHighDensityIntraNodeSolver extends BaseSolver {
               strokeColor: routeColors[routeIndex % routeColors.length],
               strokeWidth: route.traceThickness,
               layer: `z${point.z}`,
-              label: [
+              label: connectionLabel(
                 route.connectionName,
-                this.stats.invalidGeometryFallback
-                  ? "invalid fallback route"
-                  : undefined,
-              ]
-                .filter(Boolean)
-                .join("\n"),
+                route.rootConnectionName,
+                [
+                  `z${point.z}`,
+                  this.stats.invalidGeometryFallback
+                    ? "invalid fallback route"
+                    : undefined,
+                ].filter(Boolean) as string[],
+              ),
             }
           }),
         ),
@@ -253,7 +270,11 @@ export class GrowShrinkHighDensityIntraNodeSolver extends BaseSolver {
                 ),
               ) % routeColors.length
             ],
-          label: `${point.connectionName}\nz${point.z}`,
+          label: connectionLabel(
+            point.connectionName,
+            point.rootConnectionName,
+            [`z${point.z}`],
+          ),
         })),
         rects: [
           {


### PR DESCRIPTION
## Summary
- Propagate `rootConnectionName` through high-density routing outputs so solved routes keep the original root net metadata.
- Update trace, via, port, and jumper hover labels in the high-density visualizers to show `rootConnectionName` when present.
- Apply the same labeling pattern across the standard, jumper-based, and grow/shrink high-density debug views so hover text stays consistent in the high-density phase.

## Testing
- `biome format` on the touched files
- `biome check` still reports pre-existing repo issues unrelated to this change: filename convention on `IntraNodeSolver.ts` and an older optional-chain lint in `SingleHighDensityRouteWithJumpersSolver.ts`
- Full TypeScript validation was not completed in this worktree because project dependencies are not installed here