### PR TITLE
feat: implement trace thickness multiples 2x, 4x, and 8x as a parameter

### DIFF
--- a/lib/solvers/TraceWidthSolver/TraceWidthSolver.ts
+++ b/lib/solvers/TraceWidthSolver/TraceWidthSolver.ts
@@ -155,8 +155,19 @@ export class TraceWidthSolver extends BaseSolver {
 
       this.currentTrace = nextTrace
       this.nominalTraceWidth = nominalTraceWidth
-      const midWidth = (this.nominalTraceWidth + this.minTraceWidth) / 2
-      this.TRACE_WIDTH_SCHEDULE = [this.nominalTraceWidth, midWidth]
+      
+      // Seve ki condition: 2x, 4x, aur 8x multiples (0.3mm, 0.6mm, 1.2mm) ka support
+      const schedule: number[] = []
+      if (this.nominalTraceWidth >= 1.2) schedule.push(1.2)
+      if (this.nominalTraceWidth >= 0.6) schedule.push(0.6)
+      if (this.nominalTraceWidth >= 0.3) schedule.push(0.3)
+      
+      // Agar user ne koi alag nominal width di hai, toh use schedule mein sabse pehle rakhenge
+      if (!schedule.includes(this.nominalTraceWidth)) {
+        schedule.unshift(this.nominalTraceWidth)
+      }
+      
+      this.TRACE_WIDTH_SCHEDULE = schedule
       if (this.currentTrace.route.length < 2) {
         // Trace is too short to process, just pass it through with minTraceWidth
         this.processedRoutes.push({
@@ -525,12 +536,12 @@ export class TraceWidthSolver extends BaseSolver {
       if (route.route.length === 0) continue
 
       const isNominalWidth = route.traceThickness === this.nominalTraceWidth
-      const isMidWidth = route.traceThickness === this.TRACE_WIDTH_SCHEDULE[1]
-      const strokeColor = isNominalWidth
-        ? "green"
-        : isMidWidth
-          ? "yellow"
-          : "orange"
+        const isAlternativeWidth = this.TRACE_WIDTH_SCHEDULE.includes(route.traceThickness ?? 0) && route.traceThickness !== this.minTraceWidth
+        const strokeColor = isNominalWidth
+          ? "green"
+          : isAlternativeWidth
+            ? "yellow"
+            : "orange"
 
       for (let i = 0; i < route.route.length - 1; i++) {
         const current = route.route[i]!

--- a/lib/solvers/TraceWidthSolver/TraceWidthSolver.ts
+++ b/lib/solvers/TraceWidthSolver/TraceWidthSolver.ts
@@ -155,18 +155,18 @@ export class TraceWidthSolver extends BaseSolver {
 
       this.currentTrace = nextTrace
       this.nominalTraceWidth = nominalTraceWidth
-      
+
       // Seve ki condition: 2x, 4x, aur 8x multiples (0.3mm, 0.6mm, 1.2mm) ka support
       const schedule: number[] = []
       if (this.nominalTraceWidth >= 1.2) schedule.push(1.2)
       if (this.nominalTraceWidth >= 0.6) schedule.push(0.6)
       if (this.nominalTraceWidth >= 0.3) schedule.push(0.3)
-      
+
       // Agar user ne koi alag nominal width di hai, toh use schedule mein sabse pehle rakhenge
       if (!schedule.includes(this.nominalTraceWidth)) {
         schedule.unshift(this.nominalTraceWidth)
       }
-      
+
       this.TRACE_WIDTH_SCHEDULE = schedule
       if (this.currentTrace.route.length < 2) {
         // Trace is too short to process, just pass it through with minTraceWidth
@@ -536,12 +536,14 @@ export class TraceWidthSolver extends BaseSolver {
       if (route.route.length === 0) continue
 
       const isNominalWidth = route.traceThickness === this.nominalTraceWidth
-        const isAlternativeWidth = this.TRACE_WIDTH_SCHEDULE.includes(route.traceThickness ?? 0) && route.traceThickness !== this.minTraceWidth
-        const strokeColor = isNominalWidth
-          ? "green"
-          : isAlternativeWidth
-            ? "yellow"
-            : "orange"
+      const isAlternativeWidth =
+        this.TRACE_WIDTH_SCHEDULE.includes(route.traceThickness ?? 0) &&
+        route.traceThickness !== this.minTraceWidth
+      const strokeColor = isNominalWidth
+        ? "green"
+        : isAlternativeWidth
+          ? "yellow"
+          : "orange"
 
       for (let i = 0; i < route.route.length - 1; i++) {
         const current = route.route[i]!

--- a/lib/types/srj-types.ts
+++ b/lib/types/srj-types.ts
@@ -91,6 +91,7 @@ export interface SimpleRouteConnection {
   isOffBoard?: boolean
   netConnectionName?: string
   nominalTraceWidth?: number
+  traceThickness?: number // <-- YEH HUMNE NAYA JODHA 🚀
   pointsToConnect: Array<ConnectionPoint>
 
   /** @deprecated DO NOT USE **/


### PR DESCRIPTION
Fixes #66
/claim #66

### Description
Added support for 2x, 4x, and 8x trace thickness multiples (0.3mm, 0.6mm, 1.2mm) in the `TraceWidthSolver` schedule. Updated the dynamic schedule builder to automatically include these standard multiples based on the requested nominal width. Also updated the visualization helper to support the new generic schedule indexing.

All 302 tests are passing successfully.