### PR TITLE
[codex] Fix srj18 port-point timeout prepass

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -548,7 +548,8 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
           defaultViaDiameter: cms.viaDiameter,
           layerCount: cms.srj.layerCount,
           minTraceToPadEdgeClearance: cms.srj.minTraceToPadEdgeClearance,
-          iterations: 2,
+          iterations:
+            cms.highDensityStitchSolver!.mergedHdRoutes.length > 150 ? 1 : 2,
         },
       ],
     ),

--- a/lib/solvers/PortPointPathingSolver/hgportpointpathingsolver/buildHyperGraph.ts
+++ b/lib/solvers/PortPointPathingSolver/hgportpointpathingsolver/buildHyperGraph.ts
@@ -162,15 +162,14 @@ export function buildHyperGraph(params: {
       ports: [],
     })
   }
+  const regionById = new Map(
+    graph.regions.map((region) => [region.regionId, region]),
+  )
 
   for (const spp of params.segmentPortPoints) {
     const [region1Id, region2Id] = spp.nodeIds
-    const region1 = graph.regions.find(
-      (region) => region.regionId === region1Id,
-    )
-    const region2 = graph.regions.find(
-      (region) => region.regionId === region2Id,
-    )
+    const region1 = regionById.get(region1Id)
+    const region2 = regionById.get(region2Id)
 
     assertDefined(
       region1,

--- a/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
+++ b/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
@@ -111,6 +111,7 @@ const TINY_SECTION_SOLVER_BASE_OPTIONS: TinyHyperGraphSectionSolverOptions = {
 }
 const DUPLICATE_PORT_TRAVERSAL_PENALTY = 150
 const CRAMPED_PORT_TRAVERSAL_PENALTY = 150
+const MAX_DUPLICATE_CONGESTED_PORT_ROUTE_PORT_PRODUCT = 1_000_000
 
 const getEffortScale = (effort: number) => Math.max(effort, 1e-2)
 
@@ -737,28 +738,37 @@ export class TinyHypergraphPortPointPathingSolver extends BaseSolver {
   constructor(private params: HgPortPointPathingSolverParams) {
     super()
     const serializedGraph = buildSerializedTinyGraph(params)
-    const duplicateCongestedPortSolver = new DuplicateCongestedPortSolver(
-      serializedGraph,
-      {
-        duplicatePortProximity: 0.05,
-        routeSolveOptions: {
-          ...getTinyViaSizeOptions(params.minViaPadDiameter),
-          ACCEPT_BEST_SOLUTION_ON_TIMEOUT: true,
-          GREEDY_FINAL_ROUTE_ITERS: 4,
-          MAX_ITERATIONS: Math.ceil(2_000_000 * getEffortScale(params.effort)),
-          RIP_THRESHOLD_RAMP_ATTEMPTS: 0,
-          STATIC_REACHABILITY_PRECHECK: false,
-        },
-      },
-    )
-    duplicateCongestedPortSolver.solve()
     let graphForTiny = serializedGraph
-    if (duplicateCongestedPortSolver.failed) {
-      this.duplicateCongestedPortError =
-        duplicateCongestedPortSolver.error ?? "unknown error"
-    } else {
-      this.duplicateCongestedPortReport = duplicateCongestedPortSolver.report
-      graphForTiny = duplicateCongestedPortSolver.getOutput()
+    const duplicateRoutePortProduct =
+      params.connections.length * serializedGraph.ports.length
+    if (
+      duplicateRoutePortProduct <=
+      MAX_DUPLICATE_CONGESTED_PORT_ROUTE_PORT_PRODUCT
+    ) {
+      const duplicateCongestedPortSolver = new DuplicateCongestedPortSolver(
+        serializedGraph,
+        {
+          duplicatePortProximity: 0.05,
+          routeSolveOptions: {
+            ...getTinyViaSizeOptions(params.minViaPadDiameter),
+            ACCEPT_BEST_SOLUTION_ON_TIMEOUT: true,
+            GREEDY_FINAL_ROUTE_ITERS: 4,
+            MAX_ITERATIONS: Math.ceil(
+              2_000_000 * getEffortScale(params.effort),
+            ),
+            RIP_THRESHOLD_RAMP_ATTEMPTS: 0,
+            STATIC_REACHABILITY_PRECHECK: true,
+          },
+        },
+      )
+      duplicateCongestedPortSolver.solve()
+      if (duplicateCongestedPortSolver.failed) {
+        this.duplicateCongestedPortError =
+          duplicateCongestedPortSolver.error ?? "unknown error"
+      } else {
+        this.duplicateCongestedPortReport = duplicateCongestedPortSolver.report
+        graphForTiny = duplicateCongestedPortSolver.getOutput()
+      }
     }
     this.duplicatedPortCount =
       this.duplicateCongestedPortReport?.duplicatedPorts.reduce(

--- a/lib/solvers/TraceSimplificationSolver/TraceSimplificationSolver.ts
+++ b/lib/solvers/TraceSimplificationSolver/TraceSimplificationSolver.ts
@@ -83,6 +83,7 @@ export class TraceSimplificationSolver extends BaseSolver {
       readonly defaultViaDiameter: number
       readonly layerCount: number
       readonly minTraceToPadEdgeClearance?: number
+      readonly iterations?: number
     },
   ) {
     super()
@@ -95,6 +96,10 @@ export class TraceSimplificationSolver extends BaseSolver {
     }
     this.hdRoutes = this.markThroughObstacleSegments(
       simplificationConfig.hdRoutes,
+    )
+    this.MAX_SIMPLIFICATION_PIPELINE_LOOPS = Math.max(
+      0,
+      Math.floor(simplificationConfig.iterations ?? 2),
     )
     this.MAX_ITERATIONS = 100e6
   }


### PR DESCRIPTION
## Summary
- use a region lookup map while building the port-point hypergraph
- skip the duplicate congested port prepass on large route/port products
- keep static reachability enabled inside that duplicate-port prepass so impossible routes fail fast
- honor the trace simplification `iterations` option and run one loop for large Pipeline7 stitched route sets

## Root cause
The port-point phase could appear stuck at 0% because `TinyHypergraphPortPointPathingSolver` ran `DuplicateCongestedPortSolver.solve()` synchronously in its constructor. On srj18 timeout samples, that prepass could spend the whole budget before the real tiny-hypergraph pipeline reported progress or surfaced the static reachability failure.

The benchmark rerun showed completed % was still flat because the port-point samples became fast failures rather than successful routes. The next isolated timeout bucket was sample010 timing out in `TraceSimplificationSolver`; Pipeline7 already passed an `iterations` setting, but the solver ignored it and always ran two simplification loops.

## Validation
- `bunx tsc --noEmit`
- local srj18 probes: sample004 now fails fast in ~0.26s instead of ~37s; sample006 constructor drops from >60s to ~28ms and fails fast with the underlying reachability error; sample009 and sample013 also fail fast instead of timing out in the prepass
- local sample010 completes with one trace-simplification loop; trace simplification dropped from ~2.4s to ~0.65s on the local probe
