### PR TITLE
feat: add traceThickness parameter to SimpleRouteJson

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline1_OriginalUnravel/AutoroutingPipeline1_OriginalUnravel.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline1_OriginalUnravel/AutoroutingPipeline1_OriginalUnravel.ts
@@ -122,6 +122,7 @@ export class AutoroutingPipeline1_OriginalUnravel extends BaseSolver {
   traceSimplificationSolver?: TraceSimplificationSolver
   viaDiameter: number
   minTraceWidth: number
+  traceWidth: number
 
   startTimeOfPhase: Record<string, number>
   endTimeOfPhase: Record<string, number>
@@ -321,7 +322,7 @@ export class AutoroutingPipeline1_OriginalUnravel extends BaseSolver {
         colorMap: cms.colorMap,
         connMap: cms.connMap,
         viaDiameter: cms.viaDiameter,
-        traceWidth: cms.minTraceWidth,
+        traceWidth: cms.traceWidth,
       },
     ]),
     definePipelineStep(
@@ -364,6 +365,7 @@ export class AutoroutingPipeline1_OriginalUnravel extends BaseSolver {
     this.MAX_ITERATIONS = 100e6
     this.viaDiameter = getViaDimensions(srj).padDiameter
     this.minTraceWidth = srj.minTraceWidth
+    this.traceWidth = srj.traceThickness ?? srj.minTraceWidth
     const mutableOpts = this.opts
 
     // If capacityDepth is not provided, calculate it automatically

--- a/lib/autorouter-pipelines/AutoroutingPipeline4_TinyHypergraph/AutoroutingPipelineSolver4_TinyHypergraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline4_TinyHypergraph/AutoroutingPipelineSolver4_TinyHypergraph.ts
@@ -124,6 +124,7 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
   viaDiameter!: number
   viaHoleDiameter!: number
   minTraceWidth!: number
+  traceWidth!: number
   effort: number
   maxNodeDimension: number
   maxNodeRatio: number
@@ -232,7 +233,7 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
         {
           nodes: cms.capacityNodes!,
           edges: cms.capacityEdges || [],
-          traceWidth: cms.minTraceWidth,
+          traceWidth: cms.traceWidth,
           colorMap: cms.colorMap,
           shouldReturnCrampedPortPoints: true,
         },
@@ -341,7 +342,7 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
           colorMap: cms.colorMap,
           connMap: cms.connMap,
           viaDiameter: cms.viaDiameter,
-          traceWidth: cms.minTraceWidth,
+          traceWidth: cms.traceWidth,
           obstacleMargin: cms.srj.defaultObstacleMargin ?? 0.15,
           obstacles: cms.srj.obstacles,
           layerCount: cms.srj.layerCount,
@@ -478,6 +479,7 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
     this.viaDiameter = viaDimensions.padDiameter
     this.viaHoleDiameter = viaDimensions.holeDiameter
     this.minTraceWidth = this.srj.minTraceWidth
+    this.traceWidth = this.srj.traceThickness ?? this.srj.minTraceWidth
     this.connMap = getConnectivityMapFromSimpleRouteJson(this.srj)
     this.colorMap = getColorMap(this.srj, this.connMap)
   }

--- a/lib/autorouter-pipelines/AutoroutingPipeline5_HdCache/AutoroutingPipelineSolver5_HdCache.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline5_HdCache/AutoroutingPipelineSolver5_HdCache.ts
@@ -71,7 +71,7 @@ export class AutoroutingPipelineSolver5_HdCache extends AutoroutingPipelineSolve
             colorMap: cms.colorMap,
             connMap: cms.connMap as ConnectivityMap | undefined,
             viaDiameter: cms.viaDiameter,
-            traceWidth: cms.minTraceWidth,
+            traceWidth: cms.traceWidth,
             obstacleMargin: cms.srj.defaultObstacleMargin ?? 0.15,
             obstacles: cms.srj.obstacles,
             layerCount: cms.srj.layerCount,

--- a/lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/AutoroutingPipelineSolver6_PolyHypergraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/AutoroutingPipelineSolver6_PolyHypergraph.ts
@@ -102,6 +102,7 @@ export class AutoroutingPipelineSolver6_PolyHypergraph extends BaseSolver {
   viaDiameter!: number
   viaHoleDiameter!: number
   minTraceWidth!: number
+  traceWidth!: number
   effort: number
   maxNodeDimension: number
   maxNodeRatio: number
@@ -197,7 +198,7 @@ export class AutoroutingPipelineSolver6_PolyHypergraph extends BaseSolver {
           nodesWithPortPoints: cms.highDensityNodePortPoints ?? [],
           equivalentAreaExpansionFactor: cms.equivalentAreaExpansionFactor,
           minProjectedRectDimension: cms.minProjectedRectDimension,
-          traceWidth: cms.minTraceWidth,
+          traceWidth: cms.traceWidth,
           viaDiameter: cms.viaDiameter,
           obstacleMargin: cms.srj.defaultObstacleMargin ?? 0.15,
         },
@@ -226,7 +227,7 @@ export class AutoroutingPipelineSolver6_PolyHypergraph extends BaseSolver {
           colorMap: cms.colorMap,
           connMap: cms.connMap,
           viaDiameter: cms.viaDiameter,
-          traceWidth: cms.minTraceWidth,
+          traceWidth: cms.traceWidth,
           obstacleMargin: cms.srj.defaultObstacleMargin ?? 0.15,
           effort: cms.effort,
         },
@@ -343,6 +344,7 @@ export class AutoroutingPipelineSolver6_PolyHypergraph extends BaseSolver {
     this.viaDiameter = viaDimensions.padDiameter
     this.viaHoleDiameter = viaDimensions.holeDiameter
     this.minTraceWidth = this.srj.minTraceWidth
+    this.traceWidth = this.srj.traceThickness ?? this.srj.minTraceWidth
     this.connMap = getConnectivityMapFromSimpleRouteJson(this.srj)
     this.colorMap = getColorMap(this.srj, this.connMap)
   }

--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -233,6 +233,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
   viaDiameter!: number
   viaHoleDiameter!: number
   minTraceWidth!: number
+  traceWidth!: number
   effort: number
   maxNodeDimension: number
   maxNodeRatio: number
@@ -358,7 +359,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
         {
           nodes: cms.capacityNodes!,
           edges: cms.capacityEdges || [],
-          traceWidth: cms.minTraceWidth,
+          traceWidth: cms.traceWidth,
           colorMap: cms.colorMap,
           shouldReturnCrampedPortPoints: true,
         },
@@ -499,7 +500,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
           colorMap: cms.colorMap,
           connMap: cms.connMap,
           viaDiameter: cms.viaDiameter,
-          traceWidth: cms.minTraceWidth,
+          traceWidth: cms.traceWidth,
           obstacleMargin: cms.srj.defaultObstacleMargin ?? 0.15,
           obstacles: cms.srj.obstacles,
           layerCount: cms.srj.layerCount,
@@ -641,6 +642,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
     this.viaDiameter = viaDimensions.padDiameter
     this.viaHoleDiameter = viaDimensions.holeDiameter
     this.minTraceWidth = this.srj.minTraceWidth
+    this.traceWidth = this.srj.traceThickness ?? this.srj.minTraceWidth
     this.connMap = getConnectivityMapFromSimpleRouteJson(this.srj)
     this.colorMap = getColorMap(this.srj, this.connMap)
   }

--- a/lib/autorouter-pipelines/AutoroutingPipeline8/AutoroutingPipelineSolver8.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline8/AutoroutingPipelineSolver8.ts
@@ -131,6 +131,7 @@ export class AutoroutingPipelineSolver8 extends BaseSolver {
   viaDiameter!: number
   viaHoleDiameter!: number
   minTraceWidth!: number
+  traceWidth!: number
   effort: number
   maxNodeDimension: number
   maxNodeRatio: number
@@ -239,7 +240,7 @@ export class AutoroutingPipelineSolver8 extends BaseSolver {
         {
           nodes: cms.capacityNodes!,
           edges: cms.capacityEdges || [],
-          traceWidth: cms.minTraceWidth,
+          traceWidth: cms.traceWidth,
           colorMap: cms.colorMap,
           shouldReturnCrampedPortPoints: true,
         },
@@ -366,7 +367,7 @@ export class AutoroutingPipelineSolver8 extends BaseSolver {
           colorMap: cms.colorMap,
           connMap: cms.connMap,
           viaDiameter: cms.viaDiameter,
-          traceWidth: cms.minTraceWidth,
+          traceWidth: cms.traceWidth,
           obstacleMargin: cms.srj.defaultObstacleMargin ?? 0.15,
           obstacles: cms.srj.obstacles,
           layerCount: cms.srj.layerCount,
@@ -534,6 +535,7 @@ export class AutoroutingPipelineSolver8 extends BaseSolver {
     this.viaDiameter = viaDimensions.padDiameter
     this.viaHoleDiameter = viaDimensions.holeDiameter
     this.minTraceWidth = this.srj.minTraceWidth
+    this.traceWidth = this.srj.traceThickness ?? this.srj.minTraceWidth
     this.connMap = getConnectivityMapFromSimpleRouteJson(this.srj)
     this.colorMap = getColorMap(this.srj, this.connMap)
   }

--- a/lib/types/srj-types.ts
+++ b/lib/types/srj-types.ts
@@ -46,6 +46,7 @@ export type JumperType = "1206x4" | "0603"
 export interface SimpleRouteJson {
   layerCount: number
   minTraceWidth: number
+  traceThickness?: number
   nominalTraceWidth?: number
   /** @deprecated Use `min_via_pad_diameter` / `minViaPadDiameter` instead. */
   minViaDiameter?: number


### PR DESCRIPTION
Add `traceThickness` as a global parameter to `SimpleRouteJson` for controlling default trace thickness.

## Summary

Right now every trace uses the industry standard data line thickness `0.15mm`. This PR adds a `traceThickness` parameter that allows users to specify thicker traces globally (e.g. `0.3mm` for 2x, `0.6mm` for 4x, `1.2mm` for 8x power traces).

## Changes

- Added `traceThickness?: number` to the `SimpleRouteJson` interface
- Added `traceWidth` property to all major pipelines (1, 4, 5, 6, 7, 8)
- Pipelines compute `traceWidth = srj.traceThickness ?? srj.minTraceWidth`
- Used `traceWidth` for actual routing width while keeping `minTraceWidth` as the DRC minimum
- The `traceWidth` flows through to `HighDensitySolver` which passes it to individual route solvers

## Usage

```typescript
const srj: SimpleRouteJson = {
  layerCount: 2,
  minTraceWidth: 0.15,
  traceThickness: 0.6, // 4x thickness for power traces
  obstacles: [...],
  connections: [...],
  bounds: { ... },
}

const solver = new AutoroutingPipelineSolver(srj)
solver.solve()
```

When `traceThickness` is not set, behavior is identical to before (uses `minTraceWidth` as the routing width). Per-connection `nominalTraceWidth` still takes precedence for individual nets.

/claim #66