### PR TITLE
repro: SameNetViaMergerSolver leaves a route-geometry stub when consolidating overlapping same-net vias

### DIFF
--- a/tests/repro/same-net-via-merger-phantom-copper-stub.test.ts
+++ b/tests/repro/same-net-via-merger-phantom-copper-stub.test.ts
@@ -11,9 +11,15 @@
  *
  * This stub is NOT cleaned up by the downstream path_simplification stage — it
  * survives into the final routed output (verified separately via
- * TraceSimplificationSolver). It is same-net copper, so it is not a net-to-net
- * short, but it is spurious/dangling copper (stub → antenna/reflection,
- * manufacturing) and means the output geometry does not match the intended route.
+ * TraceSimplificationSolver).
+ *
+ * This is a correctness/cleanliness issue, NOT an electrical/DRC hazard. The stub
+ * runs between the two via centers, and vias only merge when their pads overlap,
+ * so the stub sits inside the merged via-pad footprint (it only pokes out ~0.04-
+ * 0.06mm in a razor-thin band where vias are barely touching — within fab
+ * tolerance). It is same-net copper, so there is no net-to-net clearance effect.
+ * The defects are: (1) the route geometry no longer matches the intended route,
+ * and (2) route.vias disagrees with the actual copper in route.route.
  *
  * Per "no failing tests on merge", this test asserts the CURRENT (buggy) behavior:
  * the merge ADDS same-layer copper that did not exist in the input. A merge that

--- a/tests/repro/same-net-via-merger-phantom-copper-stub.test.ts
+++ b/tests/repro/same-net-via-merger-phantom-copper-stub.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Repro: SameNetViaMergerSolver leaves a phantom copper "stub" when consolidating
+ * overlapping same-net vias.
+ *
+ * When two same-net vias overlap, the merger relocates one via onto the other
+ * (correct). But `moveViaTo` does this by *inserting* a detour to the kept via's
+ * location into the route geometry without ever removing the original via point.
+ * The result is a there-and-back copper stub on BOTH layers: the trace runs from
+ * the kept location out to the removed via's old location and back. The `route.vias`
+ * list looks clean (it points at the kept location), which hides the extra copper.
+ *
+ * This stub is NOT cleaned up by the downstream path_simplification stage — it
+ * survives into the final routed output (verified separately via
+ * TraceSimplificationSolver). It is same-net copper, so it is not a net-to-net
+ * short, but it is spurious/dangling copper (stub → antenna/reflection,
+ * manufacturing) and means the output geometry does not match the intended route.
+ *
+ * Per "no failing tests on merge", this test asserts the CURRENT (buggy) behavior:
+ * the merge ADDS same-layer copper that did not exist in the input. A merge that
+ * only relocates a via must not change copper length. When the bug is fixed,
+ * `addedCopper` should be ~0 and the inverted assertion below should be used.
+ *
+ * To run: bun test tests/repro/same-net-via-merger-phantom-copper-stub.test.ts
+ */
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { SameNetViaMergerSolver } from "lib/solvers/SameNetViaMergerSolver/SameNetViaMergerSolver"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+
+// Total length of same-layer (copper) trace segments in a route. Layer changes
+// (z transitions, i.e. vias) are excluded — only physical copper is measured.
+const copperLength = (route: HighDensityRoute) => {
+  let length = 0
+  for (let i = 0; i < route.route.length - 1; i++) {
+    const a = route.route[i]
+    const b = route.route[i + 1]
+    if (a.z === b.z) length += Math.hypot(b.x - a.x, b.y - a.y)
+  }
+  return length
+}
+
+test("repro: SameNetViaMergerSolver adds phantom copper when merging overlapping same-net vias", () => {
+  // Two real traces on the same net (empty connMap => net "" for both). Each goes
+  // along z0, vias to z1, and continues. Their vias sit 0.2mm apart, which is less
+  // than the 0.3mm via diameter, so they overlap and must be consolidated.
+  const inputHdRoutes: HighDensityRoute[] = [
+    {
+      connectionName: "ra",
+      traceThickness: 0.15,
+      viaDiameter: 0.3,
+      route: [
+        { x: 0, y: 0, z: 0 },
+        { x: 5.0, y: 0, z: 0 },
+        { x: 5.0, y: 0, z: 1 },
+        { x: 10, y: 0, z: 1 },
+      ],
+      vias: [{ x: 5.0, y: 0 }],
+    },
+    {
+      connectionName: "rb",
+      traceThickness: 0.15,
+      viaDiameter: 0.3,
+      route: [
+        { x: 0, y: 0.5, z: 0 },
+        { x: 5.2, y: 0, z: 0 },
+        { x: 5.2, y: 0, z: 1 },
+        { x: 10, y: 0.5, z: 1 },
+      ],
+      vias: [{ x: 5.2, y: 0 }],
+    },
+  ]
+
+  const copperBefore = inputHdRoutes.reduce((n, r) => n + copperLength(r), 0)
+
+  const solver = new SameNetViaMergerSolver({
+    inputHdRoutes,
+    obstacles: [],
+    colorMap: {},
+    layerCount: 2,
+    connMap: new ConnectivityMap({}),
+  })
+  solver.solve()
+
+  expect(solver.failed).toBe(false)
+
+  const merged = solver.getMergedViaHdRoutes()
+  expect(merged).not.toBeNull()
+
+  // The vias are correctly consolidated to a single location (this part works).
+  const allVias = merged!.flatMap((r) => r.vias)
+  const uniqueViaLocations = new Set(allVias.map((v) => `${v.x}:${v.y}`))
+  expect(uniqueViaLocations.size).toBe(1)
+
+  const copperAfter = merged!.reduce((n, r) => n + copperLength(r), 0)
+  const addedCopper = copperAfter - copperBefore
+
+  // BUG: a pure via relocation must not add copper, but it does. The detour stub
+  // out to the removed via's old location (and back) adds same-layer copper on
+  // both layers. We assert the current (buggy) positive value to keep CI green
+  // and document the defect.
+  //
+  // When fixed, replace the two assertions below with:
+  //   expect(addedCopper).toBeLessThan(1e-9)
+  expect(addedCopper).toBeGreaterThan(0.1)
+
+  // The merged route still physically visits the removed via's old location (5.2,0)
+  // even though no via remains there — that is the dangling stub.
+  const visitsOldViaLocation = merged!.some((r) =>
+    r.route.some((p) => Math.hypot(p.x - 5.2, p.y - 0) < 1e-6),
+  )
+  expect(visitsOldViaLocation).toBe(true)
+})


### PR DESCRIPTION
### Summary
Adds a deterministic reproduction test in `tests/repro/same-net-via-merger-phantom-copper-stub.test.ts` documenting a **correctness/cleanliness** issue in `SameNetViaMergerSolver`: when consolidating overlapping same-net vias, it leaves a there-and-back "stub" in the route geometry.

**This is not an electrical/DRC hazard** (see geometry note below) — it is a correctness issue. The test asserts the *current* behavior so CI stays green ("no failing tests on merge"); no fix is included.

### What happens
When two same-net vias overlap, the merger correctly consolidates them to a single via. But `moveViaTo` (`lib/solvers/SameNetViaMergerSolver/SameNetViaMergerSolver.ts`) does this by *inserting* a detour to the kept via's location into the route geometry **without removing the original via point**. Result: the route runs from the kept location out to the removed via's old location and back, on both layers.

Two concrete inconsistencies this leaves behind:
- The route geometry no longer matches the intended route (an extra there-and-back excursion that was never routed).
- `route.vias` (consolidated, looks clean) disagrees with the actual copper in `route.route` — a footgun for any downstream code that trusts route geometry.

### Severity / scope (not a hazard)
The stub runs between the two via centers. Vias only merge when their pads overlap, so the stub sits **inside the merged via-pad footprint** for essentially the whole overlap range — it only pokes out by ~0.04–0.06 mm in a razor-thin band where vias are barely touching, which is within fab tolerance. It is same-net copper, so **no net-to-net clearance/electrical effect**. This is a correctness/cleanliness bug, not a DRC issue.

### To run
```
bun test tests/repro/same-net-via-merger-phantom-copper-stub.test.ts
```