### PR TITLE
break component topology generation

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -12,6 +12,7 @@ import { MultiTargetNecessaryCrampedPortPointSolver } from "lib/solvers/Necessar
 import { NodeDimensionSubdivisionSolver } from "lib/solvers/NodeDimensionSubdivisionSolver/NodeDimensionSubdivisionSolver"
 import { buildHyperGraph } from "lib/solvers/PortPointPathingSolver/hgportpointpathingsolver"
 import { TinyHypergraphPortPointPathingSolver } from "lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver"
+import { TopologyGeneratorForCompoents } from "lib/solvers/TopologyGeneratorForCompoents/TopologyGeneratorForCompoents"
 import { MultiGraphTopologyPlannerSolver } from "lib/solvers/TopologyPlanningSolver/MultiGraphTopologyPlannerSolver"
 import { UniformPortDistributionSolver } from "lib/solvers/UniformPortDistributionSolver/UniformPortDistributionSolver"
 import { getColorMap } from "lib/solvers/colors"
@@ -230,6 +231,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
   traceWidthSolver?: TraceWidthSolver
   necessaryCrampedPortPointSolver?: MultiTargetNecessaryCrampedPortPointSolver
   componentDetectionSolver?: ComponentDetectionSolver
+  topologyGeneratorForCompoents?: TopologyGeneratorForCompoents
   viaDiameter!: number
   viaHoleDiameter!: number
   minTraceWidth!: number
@@ -271,6 +273,16 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
       "componentDetectionSolver",
       ComponentDetectionSolver,
       (cms) => [{ inputSrj: cms.srj }],
+    ),
+    definePipelineStep(
+      "topologyGeneratorForCompoents",
+      TopologyGeneratorForCompoents,
+      (cms) => [
+        {
+          detectedComponents: cms.componentDetectionSolver!.getOutput(),
+          inputSrj: cms.srj,
+        },
+      ],
     ),
     definePipelineStep(
       "escapeViaLocationSolver",

--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -4,16 +4,12 @@ import { HighDensityForceImproveSolver } from "high-density-repair01/lib/HighDen
 import { GlobalDrcForceImproveSolver } from "high-density-repair03/lib"
 import { getGlobalInMemoryCache } from "lib/cache/setupGlobalCaches"
 import { CacheProvider } from "lib/cache/types"
-import {
-  ComponentDetectionSolver,
-  type ComponentDetectionSolverOutput,
-} from "lib/solvers/ComponentDetectionSolver/ComponentDetectionSolver"
+import { ComponentDetectionSolver } from "lib/solvers/ComponentDetectionSolver/ComponentDetectionSolver"
 import { MultiTargetNecessaryCrampedPortPointSolver } from "lib/solvers/NecessaryCrampedPortPointSolver/MultiTargetNecessaryCrampedPortPointSolver"
 import { NodeDimensionSubdivisionSolver } from "lib/solvers/NodeDimensionSubdivisionSolver/NodeDimensionSubdivisionSolver"
 import { buildHyperGraph } from "lib/solvers/PortPointPathingSolver/hgportpointpathingsolver"
 import { TinyHypergraphPortPointPathingSolver } from "lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver"
 import { TopologyGeneratorForCompoents } from "lib/solvers/TopologyGeneratorForCompoents/TopologyGeneratorForCompoents"
-import { MultiGraphTopologyPlannerSolver } from "lib/solvers/TopologyPlanningSolver/MultiGraphTopologyPlannerSolver"
 import { UniformPortDistributionSolver } from "lib/solvers/UniformPortDistributionSolver/UniformPortDistributionSolver"
 import { getColorMap } from "lib/solvers/colors"
 import {
@@ -82,20 +78,25 @@ type PipelineStep<T extends new (...args: any[]) => BaseSolver> = {
   onSolved?: (instance: AutoroutingPipelineSolver7_MultiGraph) => void
 }
 
+type LegacyTopologyPlanningSolverReference = {
+  getOutput(): {
+    componentMeshNodes: CapacityMeshNode[][]
+    mergedMeshNodes: CapacityMeshNode[]
+  }
+}
+
 /**
- * Collects the capacity mesh node ids that belong to component-local topology
- * regions.
+ * Collects the capacity mesh node ids produced by component-local topology
+ * generation.
  *
- * @param plannerOutput Output from the multi-graph topology planner.
+ * @param capacityMeshNodes Component-local capacity mesh nodes.
  * @returns A set of component-local capacity mesh node ids.
  */
 function getComponentCapacityMeshNodeIds(
-  plannerOutput: ReturnType<MultiGraphTopologyPlannerSolver["getOutput"]>,
+  capacityMeshNodes: CapacityMeshNode[] | null | undefined,
 ) {
   return new Set(
-    plannerOutput.componentMeshNodes
-      .flat()
-      .map((node) => node.capacityMeshNodeId),
+    (capacityMeshNodes ?? []).map((node) => node.capacityMeshNodeId),
   )
 }
 
@@ -169,22 +170,6 @@ function mergeComponentSharedEdgeSegments({
   })
 }
 
-const MAX_BGA_MEMBER_OBSTACLES_FOR_LOCAL_TOPOLOGY = 64
-
-function getTopologyComponentDetectionOutput(
-  componentDetectionOutput: ComponentDetectionSolverOutput,
-): ComponentDetectionSolverOutput {
-  return {
-    ...componentDetectionOutput,
-    components: componentDetectionOutput.components.filter(
-      (component) =>
-        component.componentKind !== "bga" ||
-        component.memberObstacles.length <=
-          MAX_BGA_MEMBER_OBSTACLES_FOR_LOCAL_TOPOLOGY,
-    ),
-  }
-}
-
 function definePipelineStep<
   T extends new (
     ...args: any[]
@@ -210,7 +195,8 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
   preprocessSimpleRouteJsonSolver?: PreprocessSimpleRouteJsonSolver
   escapeViaLocationSolver?: EscapeViaLocationSolver
   netToPointPairsSolver?: NetToPointPairsSolver
-  topologyPlanningSolver?: MultiGraphTopologyPlannerSolver
+  /** TODO: Remove after tests migrate to topologyGeneratorForCompoents. */
+  topologyPlanningSolver?: LegacyTopologyPlanningSolverReference
   nodeDimensionSubdivisionSolver?: NodeDimensionSubdivisionSolver
   nodeTargetMerger?: CapacityNodeTargetMerger
   edgeSolver?: CapacityMeshEdgeSolver
@@ -283,12 +269,19 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
           inputSrj: cms.srj,
         },
       ],
+      {
+        onSolved: (cms) => {
+          cms.capacityNodes = cms.topologyGeneratorForCompoents!.getOutput()
+        },
+      },
     ),
     definePipelineStep(
       "escapeViaLocationSolver",
       EscapeViaLocationSolver,
       (cms) => [
-        cms.componentDetectionSolver!.getOutput().componentsAsObstaclesSrj,
+        // TODO: Replace component obstacles in SRJ once ComponentDetectionSolver
+        // exposes the richer component-as-obstacle SRJ again.
+        cms.srj,
         {
           viaDiameter: cms.viaDiameter,
           minTraceWidth: cms.minTraceWidth,
@@ -314,26 +307,6 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
           cms.connMap = getConnectivityMapFromSimpleRouteJson(
             cms.srjWithPointPairs!,
           )
-        },
-      },
-    ),
-    definePipelineStep(
-      "topologyPlanningSolver",
-      MultiGraphTopologyPlannerSolver,
-      (cms) => [
-        {
-          inputSrj: cms.srjWithPointPairs!,
-          componentDetectionOutput: getTopologyComponentDetectionOutput(
-            cms.componentDetectionSolver!.getOutput(),
-          ),
-          viaDiameter: cms.viaDiameter,
-          obstacleMargin: cms.srj.defaultObstacleMargin ?? 0.15,
-        },
-      ],
-      {
-        onSolved: (cms) => {
-          const plannerOutput = cms.topologyPlanningSolver!.getOutput()
-          cms.capacityNodes = plannerOutput.mergedMeshNodes
         },
       },
     ),
@@ -380,9 +353,9 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
       "necessaryCrampedPortPointSolver",
       MultiTargetNecessaryCrampedPortPointSolver,
       (cms) => {
-        const plannerOutput = cms.topologyPlanningSolver!.getOutput()
-        const componentCapacityMeshNodeIds =
-          getComponentCapacityMeshNodeIds(plannerOutput)
+        const componentCapacityMeshNodeIds = getComponentCapacityMeshNodeIds(
+          cms.topologyGeneratorForCompoents?.getOutput(),
+        )
 
         return [
           {
@@ -404,9 +377,9 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
       },
       {
         onSolved: (cms) => {
-          const plannerOutput = cms.topologyPlanningSolver!.getOutput()
-          const componentCapacityMeshNodeIds =
-            getComponentCapacityMeshNodeIds(plannerOutput)
+          const componentCapacityMeshNodeIds = getComponentCapacityMeshNodeIds(
+            cms.topologyGeneratorForCompoents?.getOutput(),
+          )
 
           cms.sharedEdgeSegmentsWithNecessaryCrampedPortPoints =
             mergeComponentSharedEdgeSegments({
@@ -712,7 +685,8 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
     const escapeViaLocationViz = this.escapeViaLocationSolver?.visualize()
     const netToPPSolver = this.netToPointPairsSolver?.visualize()
     const componentDetectionViz = this.componentDetectionSolver?.visualize()
-    const topologyPlanningViz = this.topologyPlanningSolver?.visualize()
+    const topologyGeneratorForCompoentsViz =
+      this.topologyGeneratorForCompoents?.visualize()
     const nodeSubdivisionViz = this.nodeDimensionSubdivisionSolver?.visualize()
     const nodeTargetMergerViz = this.nodeTargetMerger?.visualize()
     const singleLayerNodeMergerViz = this.singleLayerNodeMerger?.visualize()
@@ -822,9 +796,9 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
       problemViz,
       processedProblemViz,
       componentDetectionViz,
+      topologyGeneratorForCompoentsViz,
       escapeViaLocationViz,
       netToPPSolver,
-      topologyPlanningViz,
       nodeSubdivisionViz,
       nodeTargetMergerViz,
       singleLayerNodeMergerViz,
@@ -883,8 +857,8 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
     if (this.escapeViaLocationSolver) {
       return this.escapeViaLocationSolver.visualize()
     }
-    if (this.topologyPlanningSolver) {
-      return this.topologyPlanningSolver.visualize()
+    if (this.topologyGeneratorForCompoents) {
+      return this.topologyGeneratorForCompoents.visualize()
     }
     if (this.componentDetectionSolver) {
       return this.componentDetectionSolver.visualize()

--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -6,11 +6,11 @@ import { GlobalDrcForceImproveSolver } from "high-density-repair03/lib"
 import { getGlobalInMemoryCache } from "lib/cache/setupGlobalCaches"
 import { CacheProvider } from "lib/cache/types"
 import { ComponentDetectionSolver } from "lib/solvers/ComponentDetectionSolver/ComponentDetectionSolver"
+import { ComponentTopologyGeneratorSolver } from "lib/solvers/ComponentTopologyGeneratorSolver/ComponentTopologyGeneratorSolver"
 import { MultiTargetNecessaryCrampedPortPointSolver } from "lib/solvers/NecessaryCrampedPortPointSolver/MultiTargetNecessaryCrampedPortPointSolver"
 import { NodeDimensionSubdivisionSolver } from "lib/solvers/NodeDimensionSubdivisionSolver/NodeDimensionSubdivisionSolver"
 import { buildHyperGraph } from "lib/solvers/PortPointPathingSolver/hgportpointpathingsolver"
 import { TinyHypergraphPortPointPathingSolver } from "lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver"
-import { TopologyGeneratorForCompoents } from "lib/solvers/TopologyGeneratorForCompoents/TopologyGeneratorForCompoents"
 import { UniformPortDistributionSolver } from "lib/solvers/UniformPortDistributionSolver/UniformPortDistributionSolver"
 import { getColorMap } from "lib/solvers/colors"
 import {
@@ -77,13 +77,6 @@ type PipelineStep<T extends new (...args: any[]) => BaseSolver> = {
     instance: AutoroutingPipelineSolver7_MultiGraph,
   ) => ConstructorParameters<T>
   onSolved?: (instance: AutoroutingPipelineSolver7_MultiGraph) => void
-}
-
-type LegacyTopologyPlanningSolverReference = {
-  getOutput(): {
-    componentMeshNodes: CapacityMeshNode[][]
-    mergedMeshNodes: CapacityMeshNode[]
-  }
 }
 
 /**
@@ -196,8 +189,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
   preprocessSimpleRouteJsonSolver?: PreprocessSimpleRouteJsonSolver
   escapeViaLocationSolver?: EscapeViaLocationSolver
   netToPointPairsSolver?: NetToPointPairsSolver
-  /** TODO: Remove after tests migrate to topologyGeneratorForCompoents. */
-  topologyPlanningSolver?: LegacyTopologyPlanningSolverReference
+  componentTopologyGeneratorSolver?: ComponentTopologyGeneratorSolver
   globalRectDiffSolver?: RectDiffPipeline
   nodeDimensionSubdivisionSolver?: NodeDimensionSubdivisionSolver
   nodeTargetMerger?: CapacityNodeTargetMerger
@@ -219,7 +211,6 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
   traceWidthSolver?: TraceWidthSolver
   necessaryCrampedPortPointSolver?: MultiTargetNecessaryCrampedPortPointSolver
   componentDetectionSolver?: ComponentDetectionSolver
-  topologyGeneratorForCompoents?: TopologyGeneratorForCompoents
   viaDiameter!: number
   viaHoleDiameter!: number
   minTraceWidth!: number
@@ -263,8 +254,8 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
       (cms) => [{ inputSrj: cms.srj }],
     ),
     definePipelineStep(
-      "topologyGeneratorForCompoents",
-      TopologyGeneratorForCompoents,
+      "componentTopologyGeneratorSolver",
+      ComponentTopologyGeneratorSolver,
       (cms) => [
         {
           detectedComponents: cms.componentDetectionSolver!.getOutput(),
@@ -273,7 +264,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
       ],
       {
         onSolved: (cms) => {
-          cms.capacityNodes = cms.topologyGeneratorForCompoents!.getOutput()
+          cms.capacityNodes = cms.componentTopologyGeneratorSolver!.getOutput()
         },
       },
     ),
@@ -281,8 +272,6 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
       "escapeViaLocationSolver",
       EscapeViaLocationSolver,
       (cms) => [
-        // TODO: Replace component obstacles in SRJ once ComponentDetectionSolver
-        // exposes the richer component-as-obstacle SRJ again.
         cms.srj,
         {
           viaDiameter: cms.viaDiameter,
@@ -318,7 +307,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
       (cms) => [
         {
           simpleRouteJson:
-            cms.topologyGeneratorForCompoents!.getComponentReplacedByObstacleSrj(
+            cms.componentTopologyGeneratorSolver!.createComponentObstacleSrj(
               cms.srjWithPointPairs!,
             ) as any,
         },
@@ -328,7 +317,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
           const globalMeshNodes =
             cms.globalRectDiffSolver?.getOutput().meshNodes ?? []
           const componentMeshNodes =
-            cms.topologyGeneratorForCompoents?.getOutput() ?? []
+            cms.componentTopologyGeneratorSolver?.getOutput() ?? []
 
           cms.capacityNodes = [...globalMeshNodes, ...componentMeshNodes]
         },
@@ -378,7 +367,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
       MultiTargetNecessaryCrampedPortPointSolver,
       (cms) => {
         const componentCapacityMeshNodeIds = getComponentCapacityMeshNodeIds(
-          cms.topologyGeneratorForCompoents?.getOutput(),
+          cms.componentTopologyGeneratorSolver?.getOutput(),
         )
 
         return [
@@ -402,7 +391,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
       {
         onSolved: (cms) => {
           const componentCapacityMeshNodeIds = getComponentCapacityMeshNodeIds(
-            cms.topologyGeneratorForCompoents?.getOutput(),
+            cms.componentTopologyGeneratorSolver?.getOutput(),
           )
 
           cms.sharedEdgeSegmentsWithNecessaryCrampedPortPoints =
@@ -709,8 +698,8 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
     const escapeViaLocationViz = this.escapeViaLocationSolver?.visualize()
     const netToPPSolver = this.netToPointPairsSolver?.visualize()
     const componentDetectionViz = this.componentDetectionSolver?.visualize()
-    const topologyGeneratorForCompoentsViz =
-      this.topologyGeneratorForCompoents?.visualize()
+    const componentTopologyGeneratorViz =
+      this.componentTopologyGeneratorSolver?.visualize()
     const globalRectDiffViz = this.globalRectDiffSolver?.visualize()
     const nodeSubdivisionViz = this.nodeDimensionSubdivisionSolver?.visualize()
     const nodeTargetMergerViz = this.nodeTargetMerger?.visualize()
@@ -821,7 +810,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
       problemViz,
       processedProblemViz,
       componentDetectionViz,
-      topologyGeneratorForCompoentsViz,
+      componentTopologyGeneratorViz,
       escapeViaLocationViz,
       netToPPSolver,
       globalRectDiffViz,
@@ -883,8 +872,8 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
     if (this.escapeViaLocationSolver) {
       return this.escapeViaLocationSolver.visualize()
     }
-    if (this.topologyGeneratorForCompoents) {
-      return this.topologyGeneratorForCompoents.visualize()
+    if (this.componentTopologyGeneratorSolver) {
+      return this.componentTopologyGeneratorSolver.visualize()
     }
     if (this.componentDetectionSolver) {
       return this.componentDetectionSolver.visualize()

--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -1,3 +1,4 @@
+import { RectDiffPipeline } from "@tscircuit/rectdiff"
 import { ConnectivityMap } from "circuit-json-to-connectivity-map"
 import type { GraphicsObject, Line } from "graphics-debug"
 import { HighDensityForceImproveSolver } from "high-density-repair01/lib/HighDensityForceImproveSolver"
@@ -197,6 +198,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
   netToPointPairsSolver?: NetToPointPairsSolver
   /** TODO: Remove after tests migrate to topologyGeneratorForCompoents. */
   topologyPlanningSolver?: LegacyTopologyPlanningSolverReference
+  globalRectDiffSolver?: RectDiffPipeline
   nodeDimensionSubdivisionSolver?: NodeDimensionSubdivisionSolver
   nodeTargetMerger?: CapacityNodeTargetMerger
   edgeSolver?: CapacityMeshEdgeSolver
@@ -307,6 +309,28 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
           cms.connMap = getConnectivityMapFromSimpleRouteJson(
             cms.srjWithPointPairs!,
           )
+        },
+      },
+    ),
+    definePipelineStep(
+      "globalRectDiffSolver",
+      RectDiffPipeline,
+      (cms) => [
+        {
+          simpleRouteJson:
+            cms.topologyGeneratorForCompoents!.getComponentReplacedByObstacleSrj(
+              cms.srjWithPointPairs!,
+            ) as any,
+        },
+      ],
+      {
+        onSolved: (cms) => {
+          const globalMeshNodes =
+            cms.globalRectDiffSolver?.getOutput().meshNodes ?? []
+          const componentMeshNodes =
+            cms.topologyGeneratorForCompoents?.getOutput() ?? []
+
+          cms.capacityNodes = [...globalMeshNodes, ...componentMeshNodes]
         },
       },
     ),
@@ -687,6 +711,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
     const componentDetectionViz = this.componentDetectionSolver?.visualize()
     const topologyGeneratorForCompoentsViz =
       this.topologyGeneratorForCompoents?.visualize()
+    const globalRectDiffViz = this.globalRectDiffSolver?.visualize()
     const nodeSubdivisionViz = this.nodeDimensionSubdivisionSolver?.visualize()
     const nodeTargetMergerViz = this.nodeTargetMerger?.visualize()
     const singleLayerNodeMergerViz = this.singleLayerNodeMerger?.visualize()
@@ -799,6 +824,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
       topologyGeneratorForCompoentsViz,
       escapeViaLocationViz,
       netToPPSolver,
+      globalRectDiffViz,
       nodeSubdivisionViz,
       nodeTargetMergerViz,
       singleLayerNodeMergerViz,

--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -190,7 +190,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
   escapeViaLocationSolver?: EscapeViaLocationSolver
   netToPointPairsSolver?: NetToPointPairsSolver
   componentTopologyGeneratorSolver?: ComponentTopologyGeneratorSolver
-  globalRectDiffSolver?: RectDiffPipeline
+  globalTopologyGeneratorSolver?: RectDiffPipeline
   nodeDimensionSubdivisionSolver?: NodeDimensionSubdivisionSolver
   nodeTargetMerger?: CapacityNodeTargetMerger
   edgeSolver?: CapacityMeshEdgeSolver
@@ -302,7 +302,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
       },
     ),
     definePipelineStep(
-      "globalRectDiffSolver",
+      "globalTopologyGeneratorSolver",
       RectDiffPipeline,
       (cms) => [
         {
@@ -315,7 +315,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
       {
         onSolved: (cms) => {
           const globalMeshNodes =
-            cms.globalRectDiffSolver?.getOutput().meshNodes ?? []
+            cms.globalTopologyGeneratorSolver?.getOutput().meshNodes ?? []
           const componentMeshNodes =
             cms.componentTopologyGeneratorSolver?.getOutput() ?? []
 
@@ -700,7 +700,8 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
     const componentDetectionViz = this.componentDetectionSolver?.visualize()
     const componentTopologyGeneratorViz =
       this.componentTopologyGeneratorSolver?.visualize()
-    const globalRectDiffViz = this.globalRectDiffSolver?.visualize()
+    const globalTopologyGeneratorViz =
+      this.globalTopologyGeneratorSolver?.visualize()
     const nodeSubdivisionViz = this.nodeDimensionSubdivisionSolver?.visualize()
     const nodeTargetMergerViz = this.nodeTargetMerger?.visualize()
     const singleLayerNodeMergerViz = this.singleLayerNodeMerger?.visualize()
@@ -813,7 +814,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
       componentTopologyGeneratorViz,
       escapeViaLocationViz,
       netToPPSolver,
-      globalRectDiffViz,
+      globalTopologyGeneratorViz,
       nodeSubdivisionViz,
       nodeTargetMergerViz,
       singleLayerNodeMergerViz,

--- a/lib/solvers/BgaTopologyGeneratorSolver/BgaTopologyGeneratorSolver.ts
+++ b/lib/solvers/BgaTopologyGeneratorSolver/BgaTopologyGeneratorSolver.ts
@@ -1,5 +1,5 @@
-import { BaseSolver } from "@tscircuit/solver-utils"
 import { doBoundsOverlap, getBoundingBox } from "@tscircuit/math-utils"
+import { BaseSolver } from "@tscircuit/solver-utils"
 import {
   TopologyGenerator,
   type TopologyGeneratorSolverOutput,
@@ -52,15 +52,20 @@ export class BgaTopologyGeneratorSolver extends BaseSolver {
       return
     }
 
-    const { bounds, layerCount, obstacles } = this.inputProblem.inputSrj
-    const topologyAxisObstacles = obstacles.filter((obstacle) =>
-      doBoundsOverlap(getBoundingBox(obstacle), bounds),
+    const { layerCount, obstacles } = this.inputProblem.inputSrj
+    const { bounds, componentId } = this.inputProblem.detectedComponent
+    const componentObstacles = obstacles.filter(
+      (obstacle) => obstacle.componentId === componentId,
     )
+    const topologyAxisObstacles =
+      componentObstacles.length > 0
+        ? componentObstacles
+        : obstacles.filter((obstacle) =>
+            doBoundsOverlap(getBoundingBox(obstacle), bounds),
+          )
     const availableZ = getLayerRange(layerCount)
     const nodeScopeId =
-      this.inputProblem.componentId ??
-      this.inputProblem.replacementObstacleId ??
-      "component"
+      componentId ?? this.inputProblem.replacementObstacleId ?? "component"
     const rowCount = clusterAxisValues(
       topologyAxisObstacles.map((obstacle) => obstacle.center.y),
     ).length
@@ -80,7 +85,7 @@ export class BgaTopologyGeneratorSolver extends BaseSolver {
       (node) => node.availableZ.length > 1,
     ).length
 
-    const clonedObstacles = obstacles.map((obstacle) =>
+    const clonedObstacles = topologyAxisObstacles.map((obstacle) =>
       structuredClone(obstacle),
     )
     this.output = {
@@ -88,7 +93,7 @@ export class BgaTopologyGeneratorSolver extends BaseSolver {
       routingRegions: meshNodes,
     }
     this.stats = {
-      componentId: this.inputProblem.componentId ?? null,
+      componentId: componentId ?? null,
       replacementObstacleId: this.inputProblem.replacementObstacleId ?? null,
       layerCount,
       inferredRowCount: rowCount,

--- a/lib/solvers/BgaTopologyGeneratorSolver/BgaTopologyGeneratorSolver.ts
+++ b/lib/solvers/BgaTopologyGeneratorSolver/BgaTopologyGeneratorSolver.ts
@@ -64,8 +64,7 @@ export class BgaTopologyGeneratorSolver extends BaseSolver {
             doBoundsOverlap(getBoundingBox(obstacle), bounds),
           )
     const availableZ = getLayerRange(layerCount)
-    const nodeScopeId =
-      componentId ?? this.inputProblem.replacementObstacleId ?? "component"
+    const nodeScopeId = componentId
     const rowCount = clusterAxisValues(
       topologyAxisObstacles.map((obstacle) => obstacle.center.y),
     ).length
@@ -93,8 +92,8 @@ export class BgaTopologyGeneratorSolver extends BaseSolver {
       routingRegions: meshNodes,
     }
     this.stats = {
-      componentId: componentId ?? null,
-      replacementObstacleId: this.inputProblem.replacementObstacleId ?? null,
+      componentId,
+      replacementObstacleId: this.inputProblem.replacementObstacleId,
       layerCount,
       inferredRowCount: rowCount,
       inferredColumnCount: colCount,

--- a/lib/solvers/ComponentDetectionSolver/ComponentDetectionSolver.ts
+++ b/lib/solvers/ComponentDetectionSolver/ComponentDetectionSolver.ts
@@ -13,19 +13,12 @@ export interface ComponentDetectionSolverParams {
 export interface DetectedComponent {
   componentId: string
   componentKind: ComponentKind
-  memberObstacleIds: string[]
-  memberObstacles: Obstacle[]
-  replacementObstacle: Obstacle
+  bounds: {
+    __type: "rect"
+  } & SimpleRouteJson["bounds"]
 }
 
-export interface ComponentDetectionSolverOutput {
-  /**
-   * Simple Route JSON where components are replaced with obstacles
-   * and component connection points are omitted.
-   */
-  componentsAsObstaclesSrj: SimpleRouteJson
-  components: DetectedComponent[]
-}
+export type ComponentDetectionSolverOutput = DetectedComponent[]
 
 const formatObstacleLabel = (obstacle: Obstacle) => {
   if (obstacle.componentId && obstacle.obstacleId) {

--- a/lib/solvers/ComponentDetectionSolver/RectBoundsComponentDetectionStage.ts
+++ b/lib/solvers/ComponentDetectionSolver/RectBoundsComponentDetectionStage.ts
@@ -1,4 +1,3 @@
-import { doBoundsOverlap, getBoundingBox } from "@tscircuit/math-utils"
 import { BaseSolver } from "@tscircuit/solver-utils"
 import type { GraphicsObject } from "graphics-debug"
 import { getStringColor, safeTransparentize } from "lib/solvers/colors"
@@ -11,31 +10,6 @@ import type {
 } from "./ComponentDetectionSolver"
 import { detectComponentKind, type ComponentKind } from "./detectors"
 
-const cloneObstacle = (obstacle: Obstacle): Obstacle => ({ ...obstacle })
-const cloneObstacles = (obstacles: Obstacle[]) => obstacles.map(cloneObstacle)
-/**
- * Checks whether an original obstacle intersects a detected component
- * replacement obstacle.
- *
- * @param params.obstacle - Candidate global obstacle that may need to be
- *   removed from the global no-connection SRJ.
- * @param params.replacementObstacle - Component-region obstacle that replaces
- *   the component's member pads in the global topology solve.
- * @returns `true` when the obstacle bounds overlap the replacement obstacle
- *   bounds; otherwise `false`.
- *
- * @note This uses bounding boxes so the global SRJ does not retain pass-through
- * obstacles underneath component-local routing regions.
- */
-const doObstaclesOverlap = ({
-  obstacle,
-  replacementObstacle,
-}: {
-  obstacle: Obstacle
-  replacementObstacle: Obstacle
-}) =>
-  doBoundsOverlap(getBoundingBox(obstacle), getBoundingBox(replacementObstacle))
-
 /**
  * Current detection stage: groups SRJ obstacles by component and replaces each
  * component's member pads with one rectangular bounds obstacle.
@@ -47,7 +21,6 @@ export class RectBoundsComponentDetectionStage extends BaseSolver {
   private groupedComponentObstacles: Record<string, Obstacle[]> = {}
   private groupedComponentKinds: Record<string, ComponentKind> = {}
   private unprocessedComponentIds: string[] = []
-  private passThroughObstacles: Obstacle[] = []
   private detectedComponents: DetectedComponent[] = []
   private currentComponentId: string | null = null
   private currentMemberObstacles: Obstacle[] = []
@@ -143,28 +116,16 @@ export class RectBoundsComponentDetectionStage extends BaseSolver {
 
     for (const component of this.detectedComponents) {
       const color = getStringColor(component.componentId)
-
-      rects.push(
-        ...component.memberObstacles.map((obstacle) => ({
-          center: obstacle.center,
-          width: obstacle.width,
-          height: obstacle.height,
-          fill: safeTransparentize(color, 0.7),
-          stroke: safeTransparentize(color, 0.25),
-          label: `${component.componentId} ${component.componentKind.toUpperCase()}`,
-          layer: obstacle.layers.join(","),
-          step: 1,
-        })),
-      )
-
       rects.push({
-        center: component.replacementObstacle.center,
-        width: component.replacementObstacle.width,
-        height: component.replacementObstacle.height,
+        center: {
+          x: (component.bounds.minX + component.bounds.maxX) / 2,
+          y: (component.bounds.minY + component.bounds.maxY) / 2,
+        },
+        width: component.bounds.maxX - component.bounds.minX,
+        height: component.bounds.maxY - component.bounds.minY,
         fill: safeTransparentize(color, 0.88),
         stroke: safeTransparentize(color, 0.1),
         label: `${component.componentId} ${component.componentKind.toUpperCase()} region`,
-        layer: component.replacementObstacle.layers.join(","),
         step: 2,
       })
     }
@@ -191,13 +152,6 @@ export class RectBoundsComponentDetectionStage extends BaseSolver {
     this.unprocessedComponentIds = Object.keys(
       this.groupedComponentObstacles,
     ).sort()
-    const componentIds = new Set(this.unprocessedComponentIds)
-    this.passThroughObstacles = this.inputSrj.obstacles
-      .filter(
-        (obstacle) =>
-          !obstacle.componentId || !componentIds.has(obstacle.componentId),
-      )
-      .map(cloneObstacle)
     this.detectedComponents = []
     this.currentComponentId = null
     this.currentMemberObstacles = []
@@ -238,33 +192,10 @@ export class RectBoundsComponentDetectionStage extends BaseSolver {
   }
 
   private finalizeOutput() {
-    const replacementObstacles = this.detectedComponents.map(
-      ({ replacementObstacle }) => replacementObstacle,
-    )
-    const globalObstacles = this.passThroughObstacles.filter(
-      (obstacle) =>
-        !replacementObstacles.some((replacementObstacle) =>
-          doObstaclesOverlap({ obstacle, replacementObstacle }),
-        ),
-    )
-
-    this.output = {
-      componentsAsObstaclesSrj: {
-        ...this.inputSrj,
-        obstacles: [
-          ...cloneObstacles(globalObstacles),
-          ...cloneObstacles(replacementObstacles),
-        ],
-      },
-      components: this.detectedComponents.map((component) => ({
-        ...component,
-        memberObstacleIds: [...component.memberObstacleIds],
-        memberObstacles: component.memberObstacles.map((obstacle) => ({
-          ...obstacle,
-        })),
-        replacementObstacle: { ...component.replacementObstacle },
-      })),
-    }
+    this.output = this.detectedComponents.map((component) => ({
+      ...component,
+      bounds: { ...component.bounds },
+    }))
 
     this.stats = {
       initialized: this.initialized,
@@ -293,11 +224,6 @@ export class RectBoundsComponentDetectionStage extends BaseSolver {
         .map((component) => component.componentId),
       remainingComponentCount: this.unprocessedComponentIds.length,
       hasActiveComponent: this.currentComponentId !== null,
-      replacedObstacleCount: this.detectedComponents.reduce(
-        (count, component) => count + component.memberObstacles.length,
-        0,
-      ),
-      passThroughObstacleCount: this.passThroughObstacles.length,
     }
   }
 
@@ -342,23 +268,15 @@ export class RectBoundsComponentDetectionStage extends BaseSolver {
     componentKind: ComponentKind
     memberObstacles: Obstacle[]
   }): DetectedComponent {
-    const copiedMemberObstacles = cloneObstacles(memberObstacles)
-    const bounds = getBoundsForObstacles(copiedMemberObstacles)
-    const replacementObstacle = this.createReplacementObstacle({
-      componentId,
-      memberObstacles: copiedMemberObstacles,
-      bounds,
-    })
+    const bounds = getBoundsForObstacles(memberObstacles)
 
     return {
       componentId,
       componentKind,
-      memberObstacleIds: copiedMemberObstacles.map(
-        (obstacle, index) =>
-          obstacle.obstacleId ?? `${componentId}:member:${index}`,
-      ),
-      memberObstacles: copiedMemberObstacles,
-      replacementObstacle,
+      bounds: {
+        __type: "rect",
+        ...bounds,
+      },
     }
   }
 
@@ -388,36 +306,5 @@ export class RectBoundsComponentDetectionStage extends BaseSolver {
     }
 
     return `Component Detection: finalizing ${completedCount}/${totalCount}`
-  }
-
-  private createReplacementObstacle({
-    componentId,
-    memberObstacles,
-    bounds,
-  }: {
-    componentId: string
-    memberObstacles: Obstacle[]
-    bounds: SimpleRouteJson["bounds"]
-  }): Obstacle {
-    const layers = Array.from(
-      new Set(memberObstacles.flatMap((obstacle) => obstacle.layers)),
-    )
-    const connectedTo = Array.from(
-      new Set(memberObstacles.flatMap((obstacle) => obstacle.connectedTo)),
-    )
-
-    return {
-      obstacleId: `component-region:${componentId}`,
-      componentId,
-      type: "rect",
-      layers,
-      center: {
-        x: (bounds.minX + bounds.maxX) / 2,
-        y: (bounds.minY + bounds.maxY) / 2,
-      },
-      width: bounds.maxX - bounds.minX,
-      height: bounds.maxY - bounds.minY,
-      connectedTo,
-    }
   }
 }

--- a/lib/solvers/ComponentTopologyGeneratorSolver/ComponentTopologyGeneratorSolver.ts
+++ b/lib/solvers/ComponentTopologyGeneratorSolver/ComponentTopologyGeneratorSolver.ts
@@ -12,14 +12,14 @@ import "lib/solvers/QfpThermalPadTopologyGeneratorSolver/QfpThermalPadTopologyGe
 import "lib/solvers/QfpTopologyGeneratorSolver/QfpTopologyGeneratorSolver"
 import "lib/solvers/SoicTopologyGeneratorSolver/SoicTopologyGeneratorSolver"
 
-export interface TopologyGeneratorForCompoentsParams {
+export interface ComponentTopologyGeneratorSolverParams {
   detectedComponents: DetectedComponent[]
   inputSrj: SimpleRouteJson
 }
 
-export type TopologyGeneratorForCompoentsOutput = CapacityMeshNode[]
+export type ComponentTopologyGeneratorSolverOutput = CapacityMeshNode[]
 
-function createReplacementObstacleForComponent({
+export function createReplacementObstacleForComponent({
   detectedComponent,
   inputSrj,
 }: {
@@ -56,6 +56,35 @@ function createReplacementObstacleForComponent({
   }
 }
 
+export function createComponentObstacleSrj({
+  detectedComponents,
+  inputSrj,
+}: {
+  detectedComponents: DetectedComponent[]
+  inputSrj: SimpleRouteJson
+}): SimpleRouteJson {
+  const detectedComponentIds = new Set(
+    detectedComponents.map((component) => component.componentId),
+  )
+
+  return {
+    ...structuredClone(inputSrj),
+    obstacles: [
+      ...inputSrj.obstacles.filter(
+        (obstacle) =>
+          !obstacle.componentId ||
+          !detectedComponentIds.has(obstacle.componentId),
+      ),
+      ...detectedComponents.map((detectedComponent) =>
+        createReplacementObstacleForComponent({
+          detectedComponent,
+          inputSrj,
+        }),
+      ),
+    ],
+  }
+}
+
 function isPointInsideComponentBounds(
   point: { x: number; y: number },
   detectedComponent: DetectedComponent,
@@ -79,14 +108,14 @@ function isObstacleInsideAnyComponentBounds(
   )
 }
 
-export class TopologyGeneratorForCompoents extends BaseSolver {
-  private output: TopologyGeneratorForCompoentsOutput = []
+export class ComponentTopologyGeneratorSolver extends BaseSolver {
+  private output: ComponentTopologyGeneratorSolverOutput = []
   private componentMeshNodes: CapacityMeshNode[][] = []
   private currentComponentIndex = 0
   private activeTopologyGenerator?: TopologyGeneratorSolver | null = null
 
   constructor(
-    public readonly inputProblem: TopologyGeneratorForCompoentsParams,
+    public readonly inputProblem: ComponentTopologyGeneratorSolverParams,
   ) {
     super()
   }
@@ -146,31 +175,13 @@ export class TopologyGeneratorForCompoents extends BaseSolver {
     }
   }
 
-  getComponentReplacedByObstacleSrj(
+  createComponentObstacleSrj(
     inputSrj: SimpleRouteJson = this.inputProblem.inputSrj,
   ): SimpleRouteJson {
-    const detectedComponentIds = new Set(
-      this.inputProblem.detectedComponents.map(
-        (component) => component.componentId,
-      ),
-    )
-
-    return {
-      ...structuredClone(inputSrj),
-      obstacles: [
-        ...inputSrj.obstacles.filter(
-          (obstacle) =>
-            !obstacle.componentId ||
-            !detectedComponentIds.has(obstacle.componentId),
-        ),
-        ...this.inputProblem.detectedComponents.map((detectedComponent) =>
-          createReplacementObstacleForComponent({
-            detectedComponent,
-            inputSrj,
-          }),
-        ),
-      ],
-    }
+    return createComponentObstacleSrj({
+      detectedComponents: this.inputProblem.detectedComponents,
+      inputSrj,
+    })
   }
 
   override visualize(): GraphicsObject {
@@ -242,9 +253,9 @@ export class TopologyGeneratorForCompoents extends BaseSolver {
     }
   }
 
-  getOutput(): TopologyGeneratorForCompoentsOutput {
+  getOutput(): ComponentTopologyGeneratorSolverOutput {
     if (!this.solved) {
-      throw new Error("TopologyGeneratorForCompoents has not solved yet")
+      throw new Error("ComponentTopologyGeneratorSolver has not solved yet")
     }
 
     return this.output

--- a/lib/solvers/ComponentTopologyGeneratorSolver/ComponentTopologyGeneratorSolver.ts
+++ b/lib/solvers/ComponentTopologyGeneratorSolver/ComponentTopologyGeneratorSolver.ts
@@ -25,7 +25,7 @@ export function createReplacementObstacleForComponent({
 }: {
   detectedComponent: DetectedComponent
   inputSrj: SimpleRouteJson
-}): Obstacle {
+}): Obstacle & { obstacleId: string } {
   const memberObstacles = inputSrj.obstacles.filter(
     (obstacle) => obstacle.componentId === detectedComponent.componentId,
   )
@@ -112,7 +112,7 @@ export class ComponentTopologyGeneratorSolver extends BaseSolver {
   private output: ComponentTopologyGeneratorSolverOutput = []
   private componentMeshNodes: CapacityMeshNode[][] = []
   private currentComponentIndex = 0
-  private activeTopologyGenerator?: TopologyGeneratorSolver | null = null
+  private activeTopologyGenerator: TopologyGeneratorSolver | null = null
 
   constructor(
     public readonly inputProblem: ComponentTopologyGeneratorSolverParams,
@@ -160,6 +160,8 @@ export class ComponentTopologyGeneratorSolver extends BaseSolver {
       {
         inputSrj: this.inputProblem.inputSrj,
         detectedComponent,
+        componentId: detectedComponent.componentId,
+        replacementObstacleId: `${detectedComponent.componentId}_component_bounds`,
       },
     )
   }

--- a/lib/solvers/QfpThermalPadTopologyGeneratorSolver/QfpThermalPadTopologyGeneratorSolver.ts
+++ b/lib/solvers/QfpThermalPadTopologyGeneratorSolver/QfpThermalPadTopologyGeneratorSolver.ts
@@ -740,13 +740,12 @@ export class QfpThermalPadTopologyGeneratorSolver extends BaseSolver {
       return
     }
 
-    const { bounds, layerCount, obstacles } = this.inputProblem.inputSrj
+    const { layerCount, obstacles } = this.inputProblem.inputSrj
+    const { bounds, componentId } = this.inputProblem.detectedComponent
     const availableZ = getLayerRange(layerCount)
-    const topologyObstacles = this.inputProblem.componentId
-      ? obstacles.filter(
-          (obstacle) => obstacle.componentId === this.inputProblem.componentId,
-        )
-      : obstacles
+    const topologyObstacles = obstacles.filter(
+      (obstacle) => obstacle.componentId === componentId,
+    )
     const componentObstacles =
       topologyObstacles.length > 0 ? topologyObstacles : obstacles
     const { padRingObstacles, thermalPadObstacles } =
@@ -762,9 +761,7 @@ export class QfpThermalPadTopologyGeneratorSolver extends BaseSolver {
     }
 
     const nodeScopeId =
-      this.inputProblem.componentId ??
-      this.inputProblem.replacementObstacleId ??
-      "component"
+      componentId ?? this.inputProblem.replacementObstacleId ?? "component"
     const viaDiameter =
       this.inputProblem.viaDiameter ??
       getViaDimensions(this.inputProblem.inputSrj).padDiameter
@@ -850,11 +847,13 @@ export class QfpThermalPadTopologyGeneratorSolver extends BaseSolver {
     )
 
     this.output = {
-      obstacles: obstacles.map((obstacle) => structuredClone(obstacle)),
+      obstacles: componentObstacles.map((obstacle) =>
+        structuredClone(obstacle),
+      ),
       routingRegions,
     }
     this.stats = {
-      componentId: this.inputProblem.componentId ?? null,
+      componentId: componentId ?? null,
       replacementObstacleId: this.inputProblem.replacementObstacleId ?? null,
       layerCount,
       viaDiameter,

--- a/lib/solvers/QfpThermalPadTopologyGeneratorSolver/QfpThermalPadTopologyGeneratorSolver.ts
+++ b/lib/solvers/QfpThermalPadTopologyGeneratorSolver/QfpThermalPadTopologyGeneratorSolver.ts
@@ -760,8 +760,7 @@ export class QfpThermalPadTopologyGeneratorSolver extends BaseSolver {
       return
     }
 
-    const nodeScopeId =
-      componentId ?? this.inputProblem.replacementObstacleId ?? "component"
+    const nodeScopeId = componentId
     const viaDiameter =
       this.inputProblem.viaDiameter ??
       getViaDimensions(this.inputProblem.inputSrj).padDiameter
@@ -853,8 +852,8 @@ export class QfpThermalPadTopologyGeneratorSolver extends BaseSolver {
       routingRegions,
     }
     this.stats = {
-      componentId: componentId ?? null,
-      replacementObstacleId: this.inputProblem.replacementObstacleId ?? null,
+      componentId,
+      replacementObstacleId: this.inputProblem.replacementObstacleId,
       layerCount,
       viaDiameter,
       obstacleMargin,

--- a/lib/solvers/QfpTopologyGeneratorSolver/QfpTopologyGeneratorSolver.ts
+++ b/lib/solvers/QfpTopologyGeneratorSolver/QfpTopologyGeneratorSolver.ts
@@ -452,21 +452,18 @@ export class QfpTopologyGeneratorSolver extends BaseSolver {
       return
     }
 
-    const { bounds, layerCount, obstacles } = this.inputProblem.inputSrj
+    const { layerCount, obstacles } = this.inputProblem.inputSrj
+    const { bounds, componentId } = this.inputProblem.detectedComponent
     const availableZ = getLayerRange(layerCount)
-    const topologyObstacles = this.inputProblem.componentId
-      ? obstacles.filter(
-          (obstacle) => obstacle.componentId === this.inputProblem.componentId,
-        )
-      : obstacles
+    const topologyObstacles = obstacles.filter(
+      (obstacle) => obstacle.componentId === componentId,
+    )
     const padRingObstacles =
       topologyObstacles.length > 0 ? topologyObstacles : obstacles
     const sideGroups = groupObstaclesBySide(padRingObstacles, bounds)
     const centralBounds = getInnerQfpBounds({ bounds, sideGroups })
     const nodeScopeId =
-      this.inputProblem.componentId ??
-      this.inputProblem.replacementObstacleId ??
-      "component"
+      componentId ?? this.inputProblem.replacementObstacleId ?? "component"
     const viaDiameter =
       this.inputProblem.viaDiameter ??
       getViaDimensions(this.inputProblem.inputSrj).padDiameter
@@ -523,11 +520,11 @@ export class QfpTopologyGeneratorSolver extends BaseSolver {
     )
 
     this.output = {
-      obstacles: obstacles.map((obstacle) => structuredClone(obstacle)),
+      obstacles: padRingObstacles.map((obstacle) => structuredClone(obstacle)),
       routingRegions,
     }
     this.stats = {
-      componentId: this.inputProblem.componentId ?? null,
+      componentId: componentId ?? null,
       replacementObstacleId: this.inputProblem.replacementObstacleId ?? null,
       layerCount,
       viaDiameter,

--- a/lib/solvers/QfpTopologyGeneratorSolver/QfpTopologyGeneratorSolver.ts
+++ b/lib/solvers/QfpTopologyGeneratorSolver/QfpTopologyGeneratorSolver.ts
@@ -462,8 +462,7 @@ export class QfpTopologyGeneratorSolver extends BaseSolver {
       topologyObstacles.length > 0 ? topologyObstacles : obstacles
     const sideGroups = groupObstaclesBySide(padRingObstacles, bounds)
     const centralBounds = getInnerQfpBounds({ bounds, sideGroups })
-    const nodeScopeId =
-      componentId ?? this.inputProblem.replacementObstacleId ?? "component"
+    const nodeScopeId = componentId
     const viaDiameter =
       this.inputProblem.viaDiameter ??
       getViaDimensions(this.inputProblem.inputSrj).padDiameter
@@ -524,8 +523,8 @@ export class QfpTopologyGeneratorSolver extends BaseSolver {
       routingRegions,
     }
     this.stats = {
-      componentId: componentId ?? null,
-      replacementObstacleId: this.inputProblem.replacementObstacleId ?? null,
+      componentId,
+      replacementObstacleId: this.inputProblem.replacementObstacleId,
       layerCount,
       viaDiameter,
       obstacleMargin,

--- a/lib/solvers/SoicTopologyGeneratorSolver/SoicTopologyGeneratorSolver.ts
+++ b/lib/solvers/SoicTopologyGeneratorSolver/SoicTopologyGeneratorSolver.ts
@@ -304,13 +304,12 @@ export class SoicTopologyGeneratorSolver extends BaseSolver {
       return
     }
 
-    const { bounds, layerCount, obstacles } = this.inputProblem.inputSrj
+    const { layerCount, obstacles } = this.inputProblem.inputSrj
+    const { bounds, componentId } = this.inputProblem.detectedComponent
     const availableZ = getLayerRange(layerCount)
-    const topologyObstacles = this.inputProblem.componentId
-      ? obstacles.filter(
-          (obstacle) => obstacle.componentId === this.inputProblem.componentId,
-        )
-      : obstacles
+    const topologyObstacles = obstacles.filter(
+      (obstacle) => obstacle.componentId === componentId,
+    )
     const soicObstacles =
       topologyObstacles.length > 0 ? topologyObstacles : obstacles
     const orientation = getSoicOrientation(soicObstacles)
@@ -324,9 +323,7 @@ export class SoicTopologyGeneratorSolver extends BaseSolver {
       sideGroups,
     })
     const nodeScopeId =
-      this.inputProblem.componentId ??
-      this.inputProblem.replacementObstacleId ??
-      "component"
+      componentId ?? this.inputProblem.replacementObstacleId ?? "component"
     const viaDiameter =
       this.inputProblem.viaDiameter ??
       getViaDimensions(this.inputProblem.inputSrj).padDiameter
@@ -361,11 +358,11 @@ export class SoicTopologyGeneratorSolver extends BaseSolver {
     )
 
     this.output = {
-      obstacles: obstacles.map((obstacle) => structuredClone(obstacle)),
+      obstacles: soicObstacles.map((obstacle) => structuredClone(obstacle)),
       routingRegions,
     }
     this.stats = {
-      componentId: this.inputProblem.componentId ?? null,
+      componentId: componentId ?? null,
       replacementObstacleId: this.inputProblem.replacementObstacleId ?? null,
       layerCount,
       orientation,

--- a/lib/solvers/SoicTopologyGeneratorSolver/SoicTopologyGeneratorSolver.ts
+++ b/lib/solvers/SoicTopologyGeneratorSolver/SoicTopologyGeneratorSolver.ts
@@ -322,8 +322,7 @@ export class SoicTopologyGeneratorSolver extends BaseSolver {
       orientation,
       sideGroups,
     })
-    const nodeScopeId =
-      componentId ?? this.inputProblem.replacementObstacleId ?? "component"
+    const nodeScopeId = componentId
     const viaDiameter =
       this.inputProblem.viaDiameter ??
       getViaDimensions(this.inputProblem.inputSrj).padDiameter
@@ -362,8 +361,8 @@ export class SoicTopologyGeneratorSolver extends BaseSolver {
       routingRegions,
     }
     this.stats = {
-      componentId: componentId ?? null,
-      replacementObstacleId: this.inputProblem.replacementObstacleId ?? null,
+      componentId,
+      replacementObstacleId: this.inputProblem.replacementObstacleId,
       layerCount,
       orientation,
       viaDiameter,

--- a/lib/solvers/TopologyGeneratorForCompoents/TopologyGeneratorForCompoents.ts
+++ b/lib/solvers/TopologyGeneratorForCompoents/TopologyGeneratorForCompoents.ts
@@ -1,6 +1,14 @@
 import { BaseSolver } from "lib/solvers/BaseSolver"
 import type { DetectedComponent } from "lib/solvers/ComponentDetectionSolver/ComponentDetectionSolver"
+import {
+  TopologyGenerator,
+  type TopologyGeneratorSolver,
+} from "lib/solvers/TopologyPlanningSolver/TopologyGenerator"
 import type { CapacityMeshNode, SimpleRouteJson } from "lib/types"
+import "lib/solvers/BgaTopologyGeneratorSolver/BgaTopologyGeneratorSolver"
+import "lib/solvers/QfpThermalPadTopologyGeneratorSolver/QfpThermalPadTopologyGeneratorSolver"
+import "lib/solvers/QfpTopologyGeneratorSolver/QfpTopologyGeneratorSolver"
+import "lib/solvers/SoicTopologyGeneratorSolver/SoicTopologyGeneratorSolver"
 
 export interface TopologyGeneratorForCompoentsParams {
   detectedComponents: DetectedComponent[]
@@ -11,6 +19,9 @@ export type TopologyGeneratorForCompoentsOutput = CapacityMeshNode[]
 
 export class TopologyGeneratorForCompoents extends BaseSolver {
   private output: TopologyGeneratorForCompoentsOutput = []
+  private componentMeshNodes: CapacityMeshNode[][] = []
+  private currentComponentIndex = 0
+  private activeTopologyGenerator?: TopologyGeneratorSolver | null = null
 
   constructor(
     public readonly inputProblem: TopologyGeneratorForCompoentsParams,
@@ -23,10 +34,54 @@ export class TopologyGeneratorForCompoents extends BaseSolver {
   }
 
   override _step() {
-    // TODO: Generate component-local topology capacity mesh nodes from detected
-    // components and the input SimpleRouteJson.
-    this.output = []
-    this.solved = true
+    if (this.activeTopologyGenerator) {
+      this.activeTopologyGenerator.step()
+
+      if (this.activeTopologyGenerator.failed) {
+        this.error = this.activeTopologyGenerator.error
+        this.failed = true
+        this.activeTopologyGenerator = null
+        return
+      }
+
+      if (!this.activeTopologyGenerator.solved) return
+
+      this.componentMeshNodes.push(
+        this.activeTopologyGenerator.getOutput().routingRegions,
+      )
+      this.currentComponentIndex += 1
+      this.activeTopologyGenerator = null
+      return
+    }
+
+    if (
+      this.currentComponentIndex >= this.inputProblem.detectedComponents.length
+    ) {
+      this.finalizeComponentTopology()
+      this.solved = true
+      return
+    }
+
+    const detectedComponent =
+      this.inputProblem.detectedComponents[this.currentComponentIndex]!
+    this.activeTopologyGenerator = TopologyGenerator.create(
+      detectedComponent.componentKind,
+      {
+        inputSrj: this.inputProblem.inputSrj,
+        detectedComponent,
+      },
+    )
+  }
+
+  private finalizeComponentTopology() {
+    this.output = this.componentMeshNodes.flat()
+    this.stats = {
+      detectedComponentCount: this.inputProblem.detectedComponents.length,
+      componentMeshNodeCount: this.output.length,
+      componentMeshNodeCounts: this.componentMeshNodes.map(
+        (nodes) => nodes.length,
+      ),
+    }
   }
 
   getOutput(): TopologyGeneratorForCompoentsOutput {

--- a/lib/solvers/TopologyGeneratorForCompoents/TopologyGeneratorForCompoents.ts
+++ b/lib/solvers/TopologyGeneratorForCompoents/TopologyGeneratorForCompoents.ts
@@ -1,0 +1,39 @@
+import { BaseSolver } from "lib/solvers/BaseSolver"
+import type { DetectedComponent } from "lib/solvers/ComponentDetectionSolver/ComponentDetectionSolver"
+import type { CapacityMeshNode, SimpleRouteJson } from "lib/types"
+
+export interface TopologyGeneratorForCompoentsParams {
+  detectedComponents: DetectedComponent[]
+  inputSrj: SimpleRouteJson
+}
+
+export type TopologyGeneratorForCompoentsOutput = CapacityMeshNode[]
+
+export class TopologyGeneratorForCompoents extends BaseSolver {
+  private output: TopologyGeneratorForCompoentsOutput = []
+
+  constructor(
+    public readonly inputProblem: TopologyGeneratorForCompoentsParams,
+  ) {
+    super()
+  }
+
+  override getConstructorParams() {
+    return [this.inputProblem] as const
+  }
+
+  override _step() {
+    // TODO: Generate component-local topology capacity mesh nodes from detected
+    // components and the input SimpleRouteJson.
+    this.output = []
+    this.solved = true
+  }
+
+  getOutput(): TopologyGeneratorForCompoentsOutput {
+    if (!this.solved) {
+      throw new Error("TopologyGeneratorForCompoents has not solved yet")
+    }
+
+    return this.output
+  }
+}

--- a/lib/solvers/TopologyGeneratorForCompoents/TopologyGeneratorForCompoents.ts
+++ b/lib/solvers/TopologyGeneratorForCompoents/TopologyGeneratorForCompoents.ts
@@ -1,10 +1,12 @@
+import type { GraphicsObject } from "graphics-debug"
 import { BaseSolver } from "lib/solvers/BaseSolver"
 import type { DetectedComponent } from "lib/solvers/ComponentDetectionSolver/ComponentDetectionSolver"
 import {
   TopologyGenerator,
   type TopologyGeneratorSolver,
 } from "lib/solvers/TopologyPlanningSolver/TopologyGenerator"
-import type { CapacityMeshNode, SimpleRouteJson } from "lib/types"
+import type { CapacityMeshNode, Obstacle, SimpleRouteJson } from "lib/types"
+import { createRectFromCapacityNode } from "lib/utils/createRectFromCapacityNode"
 import "lib/solvers/BgaTopologyGeneratorSolver/BgaTopologyGeneratorSolver"
 import "lib/solvers/QfpThermalPadTopologyGeneratorSolver/QfpThermalPadTopologyGeneratorSolver"
 import "lib/solvers/QfpTopologyGeneratorSolver/QfpTopologyGeneratorSolver"
@@ -16,6 +18,66 @@ export interface TopologyGeneratorForCompoentsParams {
 }
 
 export type TopologyGeneratorForCompoentsOutput = CapacityMeshNode[]
+
+function createReplacementObstacleForComponent({
+  detectedComponent,
+  inputSrj,
+}: {
+  detectedComponent: DetectedComponent
+  inputSrj: SimpleRouteJson
+}): Obstacle {
+  const memberObstacles = inputSrj.obstacles.filter(
+    (obstacle) => obstacle.componentId === detectedComponent.componentId,
+  )
+  const layers = Array.from(
+    new Set(memberObstacles.flatMap((obstacle) => obstacle.layers)),
+  )
+  const zLayers = Array.from(
+    new Set(memberObstacles.flatMap((obstacle) => obstacle.zLayers ?? [])),
+  )
+  const connectedTo = Array.from(
+    new Set(memberObstacles.flatMap((obstacle) => obstacle.connectedTo)),
+  )
+  const { bounds } = detectedComponent
+
+  return {
+    obstacleId: `${detectedComponent.componentId}_component_bounds`,
+    componentId: detectedComponent.componentId,
+    type: "rect",
+    layers: layers.length > 0 ? layers : ["top", "bottom"],
+    ...(zLayers.length > 0 ? { zLayers } : {}),
+    center: {
+      x: (bounds.minX + bounds.maxX) / 2,
+      y: (bounds.minY + bounds.maxY) / 2,
+    },
+    width: bounds.maxX - bounds.minX,
+    height: bounds.maxY - bounds.minY,
+    connectedTo,
+  }
+}
+
+function isPointInsideComponentBounds(
+  point: { x: number; y: number },
+  detectedComponent: DetectedComponent,
+) {
+  const { bounds } = detectedComponent
+
+  return (
+    point.x >= bounds.minX &&
+    point.x <= bounds.maxX &&
+    point.y >= bounds.minY &&
+    point.y <= bounds.maxY
+  )
+}
+
+function isObstacleInsideAnyComponentBounds(
+  obstacle: Obstacle,
+  detectedComponents: DetectedComponent[],
+) {
+  return detectedComponents.some((detectedComponent) =>
+    isPointInsideComponentBounds(obstacle.center, detectedComponent),
+  )
+}
 
 export class TopologyGeneratorForCompoents extends BaseSolver {
   private output: TopologyGeneratorForCompoentsOutput = []
@@ -81,6 +143,102 @@ export class TopologyGeneratorForCompoents extends BaseSolver {
       componentMeshNodeCounts: this.componentMeshNodes.map(
         (nodes) => nodes.length,
       ),
+    }
+  }
+
+  getComponentReplacedByObstacleSrj(
+    inputSrj: SimpleRouteJson = this.inputProblem.inputSrj,
+  ): SimpleRouteJson {
+    const detectedComponentIds = new Set(
+      this.inputProblem.detectedComponents.map(
+        (component) => component.componentId,
+      ),
+    )
+
+    return {
+      ...structuredClone(inputSrj),
+      obstacles: [
+        ...inputSrj.obstacles.filter(
+          (obstacle) =>
+            !obstacle.componentId ||
+            !detectedComponentIds.has(obstacle.componentId),
+        ),
+        ...this.inputProblem.detectedComponents.map((detectedComponent) =>
+          createReplacementObstacleForComponent({
+            detectedComponent,
+            inputSrj,
+          }),
+        ),
+      ],
+    }
+  }
+
+  override visualize(): GraphicsObject {
+    if (this.activeTopologyGenerator && !this.activeTopologyGenerator.solved) {
+      return this.activeTopologyGenerator.visualize()
+    }
+
+    const outputNodes = this.solved
+      ? this.output
+      : this.componentMeshNodes.flat()
+    const { bounds, outline, obstacles } = this.inputProblem.inputSrj
+    const boardOutlinePoints = outline?.length
+      ? [...outline, outline[0]!]
+      : [
+          { x: bounds.minX, y: bounds.minY },
+          { x: bounds.maxX, y: bounds.minY },
+          { x: bounds.maxX, y: bounds.maxY },
+          { x: bounds.minX, y: bounds.maxY },
+          { x: bounds.minX, y: bounds.minY },
+        ]
+    const nonComponentObstacles = obstacles.filter(
+      (obstacle) =>
+        !isObstacleInsideAnyComponentBounds(
+          obstacle,
+          this.inputProblem.detectedComponents,
+        ),
+    )
+
+    return {
+      title: `Component Topology Generator: ${outputNodes.length} mesh nodes`,
+      rects: [
+        ...nonComponentObstacles.map((obstacle) => ({
+          center: obstacle.center,
+          width: obstacle.width,
+          height: obstacle.height,
+          fill: "rgba(120, 120, 120, 0.12)",
+          stroke: "rgba(90, 90, 90, 0.45)",
+          layer: obstacle.layers.join(","),
+          label: obstacle.obstacleId ?? obstacle.componentId ?? "non-component",
+        })),
+        ...outputNodes.map((node) => ({
+          ...createRectFromCapacityNode(node, {
+            rectMargin: 0.01,
+            zOffset: 0.02,
+          }),
+          stroke: node._containsObstacle
+            ? "rgba(210, 50, 20, 0.75)"
+            : "rgba(20, 110, 210, 0.75)",
+          fill: node._containsObstacle
+            ? "rgba(255, 80, 40, 0.18)"
+            : "rgba(20, 130, 255, 0.16)",
+          label: [
+            node.capacityMeshNodeId,
+            `availableZ: ${node.availableZ.join(",")}`,
+            node._containsObstacle ? "containsObstacle" : "",
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        })),
+      ],
+      lines: [
+        {
+          points: boardOutlinePoints,
+          strokeColor: "rgba(40, 40, 40, 0.8)",
+        },
+      ],
+      points: [],
+      circles: [],
     }
   }
 

--- a/lib/solvers/TopologyPlanningSolver/MultiGraphTopologyPlannerSolver.ts
+++ b/lib/solvers/TopologyPlanningSolver/MultiGraphTopologyPlannerSolver.ts
@@ -2,7 +2,7 @@ import { RectDiffPipeline } from "@tscircuit/rectdiff"
 import { BasePipelineSolver, definePipelineStep } from "@tscircuit/solver-utils"
 import type { BaseSolver, PipelineStep } from "@tscircuit/solver-utils"
 import type { GraphicsObject } from "graphics-debug"
-import type { ComponentDetectionSolverOutput } from "lib/solvers/ComponentDetectionSolver/ComponentDetectionSolver"
+import type { DetectedComponent } from "lib/solvers/ComponentDetectionSolver/ComponentDetectionSolver"
 import type { ComponentKind } from "lib/solvers/ComponentDetectionSolver/detectors/types"
 import { safeTransparentize } from "lib/solvers/colors"
 import type { CapacityMeshNode, Obstacle, SimpleRouteJson } from "lib/types"
@@ -32,7 +32,7 @@ export interface MultiGraphTopologyPlannerSolverParams {
   inputSrj: SimpleRouteJson
   globalNoConnectionSrj?: SimpleRouteJson
   components?: SerializedTopologyComponentInput[]
-  componentDetectionOutput?: ComponentDetectionSolverOutput
+  componentDetectionOutput?: DetectedComponent[]
   viaDiameter?: number
   obstacleMargin?: number
   brokenSrj?: {

--- a/lib/solvers/TopologyPlanningSolver/MultiGraphTopologyPlannerSolver.ts
+++ b/lib/solvers/TopologyPlanningSolver/MultiGraphTopologyPlannerSolver.ts
@@ -22,10 +22,10 @@ export type TopologyMeshMergeStrategy = "concat"
 
 export interface SerializedTopologyComponentInput {
   componentId: string
-  componentKind?: ComponentKind
+  componentKind: ComponentKind
   memberObstacleIds: string[]
   memberObstacles: Obstacle[]
-  replacementObstacle: Obstacle
+  replacementObstacle: Obstacle & { obstacleId: string }
 }
 
 export interface MultiGraphTopologyPlannerSolverParams {
@@ -156,10 +156,8 @@ export class MultiGraphTopologyPlannerSolver extends BasePipelineSolver<MultiGra
       rects: [
         ...componentObstacleRects,
         ...output.mergedMeshNodes.map((node) => {
-          const component = this.normalizedInput.components.find(
-            (candidate) =>
-              candidate.componentId &&
-              node.capacityMeshNodeId.includes(candidate.componentId),
+          const component = this.normalizedInput.components.find((candidate) =>
+            node.capacityMeshNodeId.includes(candidate.componentId),
           )
           const rect = createRectFromCapacityNode(node, { rectMargin: 0.01 })
           return {
@@ -171,7 +169,7 @@ export class MultiGraphTopologyPlannerSolver extends BasePipelineSolver<MultiGra
               ? safeTransparentize("red", 0.3)
               : "rgba(0, 120, 255, 0.55)",
             label: component
-              ? `${component.componentKind?.toUpperCase() ?? "BGA"} ${node.capacityMeshNodeId}`
+              ? `${component.componentKind.toUpperCase()} ${node.capacityMeshNodeId}`
               : node.capacityMeshNodeId,
           }
         }),

--- a/lib/solvers/TopologyPlanningSolver/TopologyGenerator.ts
+++ b/lib/solvers/TopologyPlanningSolver/TopologyGenerator.ts
@@ -1,10 +1,12 @@
 import type { BaseSolver } from "@tscircuit/solver-utils"
+import type { DetectedComponent } from "lib/solvers/ComponentDetectionSolver/ComponentDetectionSolver"
 import type { ComponentKind } from "lib/solvers/ComponentDetectionSolver/detectors/types"
 import type { CapacityMeshNode, Obstacle, SimpleRouteJson } from "lib/types"
 
 /** Shared input passed into each component-specific topology generator. */
 export interface TopologyGeneratorSolverParams {
   inputSrj: SimpleRouteJson
+  detectedComponent: DetectedComponent
   componentId?: string
   replacementObstacleId?: string
   viaDiameter?: number
@@ -26,6 +28,7 @@ export interface TopologyGeneratorClass {
   new (params: TopologyGeneratorSolverParams): TopologyGeneratorSolver
 }
 
+// biome-ignore lint/complexity/noStaticOnlyClass: Registry API used by topology generator classes.
 export class TopologyGenerator {
   private static readonly generators = new Map<
     ComponentKind,
@@ -40,7 +43,10 @@ export class TopologyGenerator {
    * @note Later registrations replace earlier ones for the same component kind.
    */
   static register(generatorClass: TopologyGeneratorClass) {
-    this.generators.set(generatorClass.componentKind, generatorClass)
+    TopologyGenerator.generators.set(
+      generatorClass.componentKind,
+      generatorClass,
+    )
   }
 
   /**
@@ -55,7 +61,7 @@ export class TopologyGenerator {
     componentKind: ComponentKind,
     params: TopologyGeneratorSolverParams,
   ): TopologyGeneratorSolver {
-    const generatorClass = this.generators.get(componentKind)
+    const generatorClass = TopologyGenerator.generators.get(componentKind)
 
     if (!generatorClass) {
       throw new Error(

--- a/lib/solvers/TopologyPlanningSolver/TopologyGenerator.ts
+++ b/lib/solvers/TopologyPlanningSolver/TopologyGenerator.ts
@@ -7,8 +7,8 @@ import type { CapacityMeshNode, Obstacle, SimpleRouteJson } from "lib/types"
 export interface TopologyGeneratorSolverParams {
   inputSrj: SimpleRouteJson
   detectedComponent: DetectedComponent
-  componentId?: string
-  replacementObstacleId?: string
+  componentId: string
+  replacementObstacleId: string
   viaDiameter?: number
   obstacleMargin?: number
 }

--- a/lib/solvers/TopologyPlanningSolver/topologyPlanningShared.ts
+++ b/lib/solvers/TopologyPlanningSolver/topologyPlanningShared.ts
@@ -8,6 +8,11 @@ import { BaseSolver } from "@tscircuit/solver-utils"
 import type { GraphicsObject } from "graphics-debug"
 import type { ComponentKind } from "lib/solvers/ComponentDetectionSolver/detectors/types"
 import {
+  createComponentObstacleSrj,
+  createReplacementObstacleForComponent,
+} from "lib/solvers/ComponentTopologyGeneratorSolver/ComponentTopologyGeneratorSolver"
+import type { DetectedComponent } from "lib/solvers/ComponentDetectionSolver/ComponentDetectionSolver"
+import {
   TopologyGenerator,
   type TopologyGeneratorSolver,
 } from "lib/solvers/TopologyPlanningSolver/TopologyGenerator"
@@ -114,19 +119,29 @@ export function createComponentSrj({
 export function normalizeInput(
   input: MultiGraphTopologyPlannerSolverParams,
 ): NormalizedTopologyPlannerInput {
+  const detectedComponents = input.componentDetectionOutput ?? []
+  const serializedDetectedComponents = serializeDetectedComponents({
+    detectedComponents,
+    inputSrj: input.inputSrj,
+  })
   const globalNoConnectionSrj =
     input.globalNoConnectionSrj ??
-    input.componentDetectionOutput?.componentsAsObstaclesSrj ??
+    (detectedComponents.length > 0
+      ? createComponentObstacleSrj({
+          detectedComponents,
+          inputSrj: input.inputSrj,
+        })
+      : undefined) ??
     input.brokenSrj?.componentsAsObstaclesSrj
   const components =
     input.components ??
-    input.componentDetectionOutput?.components ??
+    serializedDetectedComponents ??
     input.brokenSrj?.components ??
     []
 
   if (!globalNoConnectionSrj) {
     throw new Error(
-      "MultiGraphTopologyPlannerSolver requires globalNoConnectionSrj or componentDetectionOutput.componentsAsObstaclesSrj",
+      "MultiGraphTopologyPlannerSolver requires globalNoConnectionSrj or detected components",
     )
   }
 
@@ -134,6 +149,35 @@ export function normalizeInput(
     globalNoConnectionSrj,
     components,
   }
+}
+
+function serializeDetectedComponents({
+  detectedComponents,
+  inputSrj,
+}: {
+  detectedComponents: DetectedComponent[]
+  inputSrj: SimpleRouteJson
+}): SerializedTopologyComponentInput[] {
+  return detectedComponents.map((detectedComponent) => {
+    const memberObstacles = inputSrj.obstacles.filter(
+      (obstacle) => obstacle.componentId === detectedComponent.componentId,
+    )
+
+    return {
+      componentId: detectedComponent.componentId,
+      componentKind: detectedComponent.componentKind,
+      memberObstacleIds: memberObstacles.map(
+        (obstacle, index) =>
+          obstacle.obstacleId ??
+          `${detectedComponent.componentId}:member:${index}`,
+      ),
+      memberObstacles,
+      replacementObstacle: createReplacementObstacleForComponent({
+        detectedComponent,
+        inputSrj,
+      }),
+    }
+  })
 }
 
 /**

--- a/lib/solvers/TopologyPlanningSolver/topologyPlanningShared.ts
+++ b/lib/solvers/TopologyPlanningSolver/topologyPlanningShared.ts
@@ -446,9 +446,19 @@ export class ComponentTopologyBatchSolver extends BaseSolver {
 
     const componentKind =
       this.inputProblem.componentKinds[this.currentIndex] ?? "bga"
+    const componentSrj = this.inputProblem.componentSrjs[this.currentIndex]!
+    const componentId = this.inputProblem.componentIds[this.currentIndex]!
     const solverInput = {
-      inputSrj: this.inputProblem.componentSrjs[this.currentIndex]!,
-      componentId: this.inputProblem.componentIds[this.currentIndex],
+      inputSrj: componentSrj,
+      detectedComponent: {
+        componentId,
+        componentKind,
+        bounds: {
+          __type: "rect" as const,
+          ...componentSrj.bounds,
+        },
+      },
+      componentId,
       replacementObstacleId:
         this.inputProblem.replacementObstacleIds[this.currentIndex],
       viaDiameter: this.inputProblem.viaDiameter,

--- a/lib/solvers/TopologyPlanningSolver/topologyPlanningShared.ts
+++ b/lib/solvers/TopologyPlanningSolver/topologyPlanningShared.ts
@@ -36,8 +36,8 @@ export interface NormalizedTopologyPlannerInput {
 export interface ComponentTopologyBatchSolverParams {
   componentSrjs: SimpleRouteJson[]
   componentIds: string[]
-  componentKinds: Array<ComponentKind | undefined>
-  replacementObstacleIds: Array<string | undefined>
+  componentKinds: ComponentKind[]
+  replacementObstacleIds: string[]
   viaDiameter?: number
   obstacleMargin?: number
 }
@@ -447,7 +447,7 @@ function areBoundsInsideBounds({
 
 /** Runs one component-local topology solve per component SRJ and collects the routing regions. */
 export class ComponentTopologyBatchSolver extends BaseSolver {
-  activeSubSolver?: TopologyGeneratorSolver | null = null
+  activeSubSolver: TopologyGeneratorSolver | null = null
   currentIndex = 0
   componentMeshNodes: CapacityMeshNode[][] = []
 
@@ -488,10 +488,11 @@ export class ComponentTopologyBatchSolver extends BaseSolver {
       return
     }
 
-    const componentKind =
-      this.inputProblem.componentKinds[this.currentIndex] ?? "bga"
+    const componentKind = this.inputProblem.componentKinds[this.currentIndex]!
     const componentSrj = this.inputProblem.componentSrjs[this.currentIndex]!
     const componentId = this.inputProblem.componentIds[this.currentIndex]!
+    const replacementObstacleId =
+      this.inputProblem.replacementObstacleIds[this.currentIndex]!
     const solverInput = {
       inputSrj: componentSrj,
       detectedComponent: {
@@ -503,8 +504,7 @@ export class ComponentTopologyBatchSolver extends BaseSolver {
         },
       },
       componentId,
-      replacementObstacleId:
-        this.inputProblem.replacementObstacleIds[this.currentIndex],
+      replacementObstacleId,
       viaDiameter: this.inputProblem.viaDiameter,
       obstacleMargin: this.inputProblem.obstacleMargin,
     }

--- a/tests/component-detection-bga-only.test.ts
+++ b/tests/component-detection-bga-only.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test"
 import { ComponentDetectionSolver } from "lib/solvers/ComponentDetectionSolver/ComponentDetectionSolver"
+import { createComponentObstacleSrj } from "lib/solvers/ComponentTopologyGeneratorSolver/ComponentTopologyGeneratorSolver"
 import { AvailableSegmentPointSolver } from "lib/solvers/AvailableSegmentPointSolver/AvailableSegmentPointSolver"
 import { CapacityMeshEdgeSolver2_NodeTreeOptimization } from "lib/solvers/CapacityMeshSolver/CapacityMeshEdgeSolver2_NodeTreeOptimization"
 import { buildHyperGraph } from "lib/solvers/PortPointPathingSolver/hgportpointpathingsolver"
@@ -47,6 +48,13 @@ const createSrj = (obstacles: Obstacle[]): SimpleRouteJson => ({
   connections: [],
   bounds: { minX: -2, maxX: 4, minY: -2, maxY: 4 },
 })
+
+const countComponentObstacles = (
+  inputSrj: SimpleRouteJson,
+  componentId: string,
+) =>
+  inputSrj.obstacles.filter((obstacle) => obstacle.componentId === componentId)
+    .length
 
 const createGridPads = ({
   componentId,
@@ -195,23 +203,28 @@ test("component detection only creates regions for BGA-like components", () => {
 
   solver.solve()
 
-  const output = solver.getOutput()
-  expect(output.components.map((component) => component.componentId)).toEqual([
+  const detectedComponents = solver.getOutput()
+  const componentObstacleSrj = createComponentObstacleSrj({
+    detectedComponents,
+    inputSrj: createSrj([...passivePads, ...bgaPads]),
+  })
+
+  expect(detectedComponents.map((component) => component.componentId)).toEqual([
     "U_BGA",
   ])
   expect(
-    output.componentsAsObstaclesSrj.obstacles.some(
+    componentObstacleSrj.obstacles.some(
       (obstacle) => obstacle.obstacleId === "R1.1",
     ),
   ).toBe(true)
   expect(
-    output.componentsAsObstaclesSrj.obstacles.some(
-      (obstacle) => obstacle.obstacleId === "component-region:R1",
+    componentObstacleSrj.obstacles.some(
+      (obstacle) => obstacle.obstacleId === "R1.2_component_bounds",
     ),
   ).toBe(false)
   expect(
-    output.componentsAsObstaclesSrj.obstacles.some(
-      (obstacle) => obstacle.obstacleId === "component-region:U_BGA",
+    componentObstacleSrj.obstacles.some(
+      (obstacle) => obstacle.obstacleId === "U_BGA_component_bounds",
     ),
   ).toBe(true)
 })
@@ -228,9 +241,11 @@ test("component detection accepts two-row and two-column BGA-like components", (
 
   solver.solve()
 
-  expect(
-    solver.getOutput().components.map((component) => component.componentId),
-  ).toEqual(["U_2X4", "U_2X5", "U_4X2"])
+  expect(solver.getOutput().map((component) => component.componentId)).toEqual([
+    "U_2X4",
+    "U_2X5",
+    "U_4X2",
+  ])
 })
 
 test("component detection marks large-gap two-row and two-column grids as SOIC", () => {
@@ -261,10 +276,7 @@ test("component detection marks large-gap two-row and two-column grids as SOIC",
   expect(
     solver
       .getOutput()
-      .components.map((component) => [
-        component.componentId,
-        component.componentKind,
-      ]),
+      .map((component) => [component.componentId, component.componentKind]),
   ).toEqual([
     ["U_SOIC_COLUMNS", "soic"],
     ["U_SOIC_ROWS", "soic"],
@@ -288,12 +300,10 @@ test("component detection clearly labels QFP-like components", () => {
 
   solver.solve()
 
-  const output = solver.getOutput()
   expect(
-    output.components.map((component) => [
-      component.componentId,
-      component.componentKind,
-    ]),
+    solver
+      .getOutput()
+      .map((component) => [component.componentId, component.componentKind]),
   ).toEqual([
     ["U_BGA", "bga"],
     ["U_QFP", "qfp"],
@@ -323,9 +333,9 @@ test("component detection rejects grids with pad dimensions outside one percent"
 
   solver.solve()
 
-  expect(
-    solver.getOutput().components.map((component) => component.componentId),
-  ).toEqual(["U_BGA"])
+  expect(solver.getOutput().map((component) => component.componentId)).toEqual([
+    "U_BGA",
+  ])
 })
 
 test("component detection does not require at least eight pads", () => {
@@ -342,9 +352,9 @@ test("component detection does not require at least eight pads", () => {
 
   solver.solve()
 
-  expect(
-    solver.getOutput().components.map((component) => component.componentId),
-  ).toEqual(["U_SPARSE_2X4"])
+  expect(solver.getOutput().map((component) => component.componentId)).toEqual([
+    "U_SPARSE_2X4",
+  ])
 })
 
 test("topology planning creates BGA component mesh nodes for two-row components", () => {
@@ -546,9 +556,7 @@ test("topology planning creates SOIC central and pad-gap mesh nodes", () => {
     node.capacityMeshNodeId.includes("-gap-"),
   )
 
-  expect(
-    componentDetectionSolver.getOutput().components[0]?.componentKind,
-  ).toBe("soic")
+  expect(componentDetectionSolver.getOutput()[0]?.componentKind).toBe("soic")
   expect(centerNode?.availableZ).toEqual([0, 1, 2, 3])
   expect(sideGapNodes.length).toBeGreaterThan(0)
   expect(
@@ -564,10 +572,7 @@ test("bugreport61 SOIC8 footprints use SOIC topology planning", () => {
   expect(
     componentDetectionSolver
       .getOutput()
-      .components.map((component) => [
-        component.componentId,
-        component.componentKind,
-      ]),
+      .map((component) => [component.componentId, component.componentKind]),
   ).toEqual([
     ["pcb_component_0", "soic"],
     ["pcb_component_1", "soic"],
@@ -604,10 +609,10 @@ test("bugreport62 QFP footprints are clearly detected", () => {
   expect(
     componentDetectionSolver
       .getOutput()
-      .components.map((component) => [
+      .map((component) => [
         component.componentId,
         component.componentKind,
-        component.memberObstacles.length,
+        countComponentObstacles(inputSrj, component.componentId),
       ]),
   ).toEqual([
     ["pcb_component_0", "qfp", 12],
@@ -623,10 +628,10 @@ test("bugreport63 QFP thermal-pad footprints are detected as qfp_thermalpad", ()
   expect(
     componentDetectionSolver
       .getOutput()
-      .components.map((component) => [
+      .map((component) => [
         component.componentId,
         component.componentKind,
-        component.memberObstacles.length,
+        countComponentObstacles(inputSrj, component.componentId),
       ]),
   ).toEqual([
     ["pcb_component_0", "qfp_thermalpad", 13],

--- a/tests/repro/usb-c-power-adapter-pipeline7.test.ts
+++ b/tests/repro/usb-c-power-adapter-pipeline7.test.ts
@@ -10,29 +10,29 @@ test("usb-c power adapter pipeline7 creates only supported component regions", (
   const solver = new AutoroutingPipelineSolver7_MultiGraph(srj, {
     cacheProvider: null,
   })
-  const topologyPlanningStepIndex = solver.pipelineDef.findIndex(
-    (step) => step.solverName === "topologyPlanningSolver",
+  const componentTopologyStepIndex = solver.pipelineDef.findIndex(
+    (step) => step.solverName === "componentTopologyGeneratorSolver",
   )
 
   while (
     !solver.solved &&
     !solver.failed &&
-    solver.currentPipelineStepIndex <= topologyPlanningStepIndex
+    solver.currentPipelineStepIndex <= componentTopologyStepIndex
   ) {
     solver.step()
   }
 
   expect(solver.failed).toBe(false)
-  const componentDetectionOutput = solver.componentDetectionSolver!.getOutput()
-  const topologyOutput = solver.topologyPlanningSolver!.getOutput()
+  const detectedComponents = solver.componentDetectionSolver!.getOutput()
+  const componentMeshNodes =
+    solver.componentTopologyGeneratorSolver!.getOutput()
 
   expect(
-    componentDetectionOutput.components.map((component) => [
+    detectedComponents.map((component) => [
       component.componentId,
       component.componentKind,
-      component.memberObstacles.length,
     ]),
-  ).toEqual([["pcb_component_40", "qfp_thermalpad", 25]])
-  expect(topologyOutput.componentMeshNodes.flat().length).toBeGreaterThan(0)
-  expect(topologyOutput.mergedMeshNodes.length).toBeLessThan(2_000)
+  ).toEqual([["pcb_component_40", "qfp_thermalpad"]])
+  expect(componentMeshNodes.length).toBeGreaterThan(0)
+  expect(componentMeshNodes.length).toBeLessThan(2_000)
 })


### PR DESCRIPTION
We need to move Topology Generation to the top, right after component detection, because the solver below it, `escapeViaLocationSolver`, depends on `ComponentReplacedWithObstacleSrj`.

The problem is that these obstacles are 3D, meaning we know their layer, but with the current implementation, we do not know how many layers the component occupies OR NEED to solve.

It would be better to let the generator create the topology first, and then generate the SRJ based on real facts.

Also because how we did it last time we could not see the output of individual component topology
<img width="1350" height="622" alt="image" src="https://github.com/user-attachments/assets/3a9fb424-a460-47e6-b939-c462074929f3" />
<img width="1472" height="480" alt="image" src="https://github.com/user-attachments/assets/13b3fd40-877d-4432-b5c5-9db9290a728d" />

