### PR TITLE
Fix Pipeline 7 hang on invalid topology node dimensions

### DIFF
--- a/lib/solvers/NodeDimensionSubdivisionSolver/NodeDimensionSubdivisionSolver.ts
+++ b/lib/solvers/NodeDimensionSubdivisionSolver/NodeDimensionSubdivisionSolver.ts
@@ -65,6 +65,10 @@ export class NodeDimensionSubdivisionSolver extends BaseSolver {
     const hasMinAreaLimit =
       Number.isFinite(this.minNodeArea) && this.minNodeArea > 0
 
+    if (!Number.isFinite(node.width) || !Number.isFinite(node.height)) {
+      return true
+    }
+
     return hasMinAreaLimit && node.width * node.height < this.minNodeArea
   }
 
@@ -109,11 +113,18 @@ export class NodeDimensionSubdivisionSolver extends BaseSolver {
     const inputCount = this.nodes.length
     let subdividedNodeCount = 0
     let removedSmallNodeCount = 0
+    let removedInvalidNodeCount = 0
 
     for (const node of this.nodes) {
+      const hasInvalidDimensions =
+        !Number.isFinite(node.width) || !Number.isFinite(node.height)
       const subdividedNodes = this.subdivideNode(node)
       if (subdividedNodes.length === 0) {
-        removedSmallNodeCount++
+        if (hasInvalidDimensions) {
+          removedInvalidNodeCount++
+        } else {
+          removedSmallNodeCount++
+        }
         continue
       }
 
@@ -128,6 +139,7 @@ export class NodeDimensionSubdivisionSolver extends BaseSolver {
       outputNodeCount: this.outputNodes.length,
       subdividedNodeCount,
       removedSmallNodeCount,
+      removedInvalidNodeCount,
       maxNodeDimension: this.maxNodeDimension,
       maxNodeRatio: this.maxNodeRatio,
       minNodeArea: this.minNodeArea,

--- a/tests/node-dimension-subdivision-solver.test.ts
+++ b/tests/node-dimension-subdivision-solver.test.ts
@@ -78,3 +78,29 @@ test("NodeDimensionSubdivisionSolver allows overriding minNodeArea for tiny node
   expect(solver.outputNodes.every((node) => getNodeRatio(node) <= 2)).toBe(true)
   expect(solver.stats.minNodeArea).toBe(0.001)
 })
+
+test("NodeDimensionSubdivisionSolver removes nodes with infinite dimensions", () => {
+  const solver = new NodeDimensionSubdivisionSolver(
+    [createNode({ height: Number.POSITIVE_INFINITY })],
+    16,
+    6,
+  )
+
+  solver.solve()
+
+  expect(solver.outputNodes).toHaveLength(0)
+  expect(solver.stats.removedInvalidNodeCount).toBe(1)
+})
+
+test("NodeDimensionSubdivisionSolver removes nodes with NaN dimensions", () => {
+  const solver = new NodeDimensionSubdivisionSolver(
+    [createNode({ width: Number.NaN })],
+    16,
+    6,
+  )
+
+  solver.solve()
+
+  expect(solver.outputNodes).toHaveLength(0)
+  expect(solver.stats.removedInvalidNodeCount).toBe(1)
+})


### PR DESCRIPTION
Prunes non-finite capacity mesh node dimensions before node subdivision so the aspect-ratio loop cannot run forever. Adds regression coverage for Infinity and NaN node dimensions.