### PR TITLE
fix(autorouter): same-net via clearance + per-pour escape grouping

### DIFF
--- a/lib/solvers/EscapeViaLocationSolver/EscapeViaLocationSolver.ts
+++ b/lib/solvers/EscapeViaLocationSolver/EscapeViaLocationSolver.ts
@@ -78,7 +78,10 @@ const pointMatches = (
 
 // A pour is rasterised into many obstacle cells sharing the same layer + net;
 // key by (layer, net) so every cell of one pour groups into a single escape-via
-// target instead of one target per raster cell.
+// target instead of one target per raster cell. This assumes one contiguous
+// pour per (layer, net): two physically-disjoint same-net regions on one layer
+// are intentionally not split — supported boards pour one contiguous region per
+// (layer, net).
 const getPourKey = (pour: Obstacle) =>
   `${pour.layers[0]}:${[...new Set(pour.connectedTo)].sort().join(",")}`
 
@@ -135,6 +138,20 @@ export class EscapeViaLocationSolver extends BaseSolver {
     connectionNetIds: Set<string>,
   ): boolean {
     return obstacle.connectedTo.some((id) => connectionNetIds.has(id))
+  }
+
+  // A non-pour obstacle on the escape via's own net (an author-placed stitch
+  // via, or any same-net pad). It can never cause a clearance violation for the
+  // via's own net, so both clearance checks exempt it. The two checks ask this
+  // in different geometric contexts (see each call site), but share this core.
+  private isSameNetObstacle(
+    obstacle: Obstacle,
+    connectionNetIds: Set<string>,
+  ): boolean {
+    return (
+      !obstacle.isCopperPour &&
+      this.obstacleMatchesConnectionNet(obstacle, connectionNetIds)
+    )
   }
 
   private getObstacleZs(obstacle: Obstacle): number[] {
@@ -380,13 +397,13 @@ export class EscapeViaLocationSolver extends BaseSolver {
       if (obstacle === sourceObstacle) continue
       if (!obstacle.layers.includes(sourceLayer)) continue
 
-      // A same-net via that spans this layer (e.g. an author-placed stitch via
+      // A same-net obstacle on this layer (e.g. an author-placed stitch via
       // bonding a pad to its pour) is not a clearance blocker for an escape via
       // on the same net — skip it so the escape path isn't falsely rejected.
+      // The enclosing loop has already restricted to obstacles on sourceLayer.
       if (
         connectionNetIds &&
-        !obstacle.isCopperPour &&
-        this.obstacleMatchesConnectionNet(obstacle, connectionNetIds)
+        this.isSameNetObstacle(obstacle, connectionNetIds)
       ) {
         continue
       }
@@ -621,14 +638,14 @@ export class EscapeViaLocationSolver extends BaseSolver {
         continue
       }
 
-      // A same-net via spanning the full source→target layer pair is the kind
-      // of stitch the escape via is trying to land next to; it is not a
-      // clearance blocker for its own net.
+      // Same exemption as hasClearEscapePath, but this clearance is measured
+      // across the via's full source→target span, so we only exempt a same-net
+      // obstacle that itself spans that whole pair (e.g. the author stitch via
+      // the escape is landing next to) — not a same-net pad on a single layer.
       if (
-        !obstacle.isCopperPour &&
+        this.isSameNetObstacle(obstacle, connectionNetIds) &&
         obstacleZs.includes(sourceZ) &&
-        obstacleZs.includes(targetZ) &&
-        this.obstacleMatchesConnectionNet(obstacle, connectionNetIds)
+        obstacleZs.includes(targetZ)
       ) {
         continue
       }

--- a/lib/solvers/EscapeViaLocationSolver/EscapeViaLocationSolver.ts
+++ b/lib/solvers/EscapeViaLocationSolver/EscapeViaLocationSolver.ts
@@ -625,6 +625,18 @@ export class EscapeViaLocationSolver extends BaseSolver {
         continue
       }
 
+      // A same-net via spanning the full source→target layer pair is the kind
+      // of stitch the escape via is trying to land next to; it is not a
+      // clearance blocker for its own net.
+      if (
+        !obstacle.isCopperPour &&
+        obstacleZs.includes(sourceZ) &&
+        obstacleZs.includes(targetZ) &&
+        this.obstacleMatchesConnectionNet(obstacle, connectionNetIds)
+      ) {
+        continue
+      }
+
       const clearance = pointToBoxDistance(candidate, obstacle) - this.viaRadius
       minClearance = Math.min(minClearance, clearance)
 

--- a/lib/solvers/EscapeViaLocationSolver/EscapeViaLocationSolver.ts
+++ b/lib/solvers/EscapeViaLocationSolver/EscapeViaLocationSolver.ts
@@ -358,8 +358,15 @@ export class EscapeViaLocationSolver extends BaseSolver {
     candidate: Point2D
     sourceLayer: string
     sourceObstacle?: Obstacle
+    connectionNetIds?: Set<string>
   }): boolean {
-    const { sourcePoint, candidate, sourceLayer, sourceObstacle } = params
+    const {
+      sourcePoint,
+      candidate,
+      sourceLayer,
+      sourceObstacle,
+      connectionNetIds,
+    } = params
     if (this.ogSrj.outline && this.ogSrj.outline.length >= 3) {
       const crossesOutline = doesSegmentCrossPolygonBoundary({
         start: sourcePoint,
@@ -376,6 +383,17 @@ export class EscapeViaLocationSolver extends BaseSolver {
     for (const obstacle of this.ogSrj.obstacles) {
       if (obstacle === sourceObstacle) continue
       if (!obstacle.layers.includes(sourceLayer)) continue
+
+      // A same-net via that spans this layer (e.g. an author-placed stitch via
+      // bonding a pad to its pour) is not a clearance blocker for an escape via
+      // on the same net — skip it so the escape path isn't falsely rejected.
+      if (
+        connectionNetIds &&
+        !obstacle.isCopperPour &&
+        this.obstacleMatchesConnectionNet(obstacle, connectionNetIds)
+      ) {
+        continue
+      }
 
       if (isPointInRect(candidate, obstacle)) {
         return false
@@ -728,6 +746,7 @@ export class EscapeViaLocationSolver extends BaseSolver {
             candidate,
             sourceLayer,
             sourceObstacle,
+            connectionNetIds,
           })
         ) {
           continue

--- a/lib/solvers/EscapeViaLocationSolver/EscapeViaLocationSolver.ts
+++ b/lib/solvers/EscapeViaLocationSolver/EscapeViaLocationSolver.ts
@@ -70,16 +70,6 @@ interface PointPlacementPlan {
   candidateCount: number
 }
 
-const getObstacleKey = (obstacle: Obstacle) =>
-  obstacle.obstacleId ??
-  [
-    obstacle.layers.join("."),
-    obstacle.center.x.toFixed(4),
-    obstacle.center.y.toFixed(4),
-    obstacle.width.toFixed(4),
-    obstacle.height.toFixed(4),
-  ].join(":")
-
 const pointMatches = (
   a: Point2D,
   b: Point2D,
@@ -747,7 +737,10 @@ export class EscapeViaLocationSolver extends BaseSolver {
       if (!targetLayer || targetLayer === sourceLayer) continue
 
       const targetZ = mapLayerNameToZ(targetLayer, this.ogSrj.layerCount)
-      const targetPourKey = getObstacleKey(copperPour)
+      // A pour is rasterised into many obstacle cells sharing the same layer +
+      // net; key by (layer, net) so every cell of one pour groups into a single
+      // escape-via target instead of one target per raster cell.
+      const targetPourKey = `${targetLayer}:${[...new Set(copperPour.connectedTo)].sort().join(",")}`
 
       for (const candidate of candidates) {
         if (!this.isInsideBoard(candidate)) continue

--- a/lib/solvers/EscapeViaLocationSolver/EscapeViaLocationSolver.ts
+++ b/lib/solvers/EscapeViaLocationSolver/EscapeViaLocationSolver.ts
@@ -76,6 +76,12 @@ const pointMatches = (
   tolerance = GEOMETRIC_TOLERANCE,
 ) => distance(a, b) <= tolerance
 
+// A pour is rasterised into many obstacle cells sharing the same layer + net;
+// key by (layer, net) so every cell of one pour groups into a single escape-via
+// target instead of one target per raster cell.
+const getPourKey = (pour: Obstacle) =>
+  `${pour.layers[0]}:${[...new Set(pour.connectedTo)].sort().join(",")}`
+
 export class EscapeViaLocationSolver extends BaseSolver {
   override getSolverName(): string {
     return "EscapeViaLocationSolver"
@@ -737,10 +743,7 @@ export class EscapeViaLocationSolver extends BaseSolver {
       if (!targetLayer || targetLayer === sourceLayer) continue
 
       const targetZ = mapLayerNameToZ(targetLayer, this.ogSrj.layerCount)
-      // A pour is rasterised into many obstacle cells sharing the same layer +
-      // net; key by (layer, net) so every cell of one pour groups into a single
-      // escape-via target instead of one target per raster cell.
-      const targetPourKey = `${targetLayer}:${[...new Set(copperPour.connectedTo)].sort().join(",")}`
+      const targetPourKey = getPourKey(copperPour)
 
       for (const candidate of candidates) {
         if (!this.isInsideBoard(candidate)) continue

--- a/tests/features/pour-via-escape/pour-via-escape-pour-key-collapse.test.ts
+++ b/tests/features/pour-via-escape/pour-via-escape-pour-key-collapse.test.ts
@@ -1,0 +1,115 @@
+import { expect, test } from "bun:test"
+import { EscapeViaLocationSolver } from "../../../lib/solvers/EscapeViaLocationSolver/EscapeViaLocationSolver"
+import type { SimpleRouteJson } from "../../../lib/types"
+
+// One logical inner1 pour rasterised into two cells, with two pads — one over
+// each cell. Each pad's escape via lands in a different cell. Keyed per raster
+// cell (the old getObstacleKey) the two vias got different pour targets and were
+// never grouped, so the MST routed a redundant pad-to-pad trace. Keyed by
+// (layer, net) they share one target and group through externallyConnectedPointIds.
+function twoCellPourSrj(): SimpleRouteJson {
+  return {
+    layerCount: 4,
+    minTraceWidth: 0.15,
+    minViaDiameter: 0.3,
+    defaultObstacleMargin: 0.15,
+    bounds: { minX: -10, maxX: 10, minY: -10, maxY: 10 },
+    obstacles: [
+      {
+        obstacleId: "pad-a",
+        type: "rect",
+        layers: ["top"],
+        center: { x: -5, y: 0 },
+        width: 1,
+        height: 1,
+        connectedTo: ["source_net_0", "pcb_port_a"],
+      },
+      {
+        obstacleId: "pad-b",
+        type: "rect",
+        layers: ["top"],
+        center: { x: 5, y: 0 },
+        width: 1,
+        height: 1,
+        connectedTo: ["source_net_0", "pcb_port_b"],
+      },
+      {
+        obstacleId: "pour-cell-left",
+        type: "rect",
+        layers: ["inner1"],
+        center: { x: -5, y: 0 },
+        width: 8,
+        height: 8,
+        connectedTo: ["source_net_0"],
+        isCopperPour: true,
+      },
+      {
+        obstacleId: "pour-cell-right",
+        type: "rect",
+        layers: ["inner1"],
+        center: { x: 5, y: 0 },
+        width: 8,
+        height: 8,
+        connectedTo: ["source_net_0"],
+        isCopperPour: true,
+      },
+    ],
+    connections: [
+      {
+        name: "source_net_0",
+        pointsToConnect: [
+          {
+            x: -5,
+            y: 0,
+            layer: "top",
+            pointId: "pcb_port_a",
+            pcb_port_id: "pcb_port_a",
+          },
+          {
+            x: 5,
+            y: 0,
+            layer: "top",
+            pointId: "pcb_port_b",
+            pcb_port_id: "pcb_port_b",
+          },
+        ],
+      },
+    ],
+  }
+}
+
+test("escape vias landing in different cells of one pour group into one target", () => {
+  const solver = new EscapeViaLocationSolver(twoCellPourSrj())
+  solver.solve()
+
+  const output = solver.getOutputSimpleRouteJson()
+  const connection = output.connections.find(
+    (candidate) => candidate.name === "source_net_0",
+  )
+  const escapePoints =
+    connection?.pointsToConnect.filter((point) =>
+      point.pointId?.startsWith("escape-via:"),
+    ) ?? []
+  expect(escapePoints).toHaveLength(2)
+
+  // Both escape vias share the (layer, net) pour target, so they are grouped
+  // into a single externallyConnectedPointIds group and the MST links them
+  // through the pour instead of routing pad-to-pad.
+  const metadataByPointId = solver.getEscapeViaMetadataByPointId()
+  const targetPourKeys = new Set(
+    escapePoints.map((point) =>
+      point.pointId
+        ? metadataByPointId.get(point.pointId)?.targetPourKey
+        : null,
+    ),
+  )
+  expect(targetPourKeys).toEqual(new Set(["inner1:source_net_0"]))
+
+  expect(
+    connection?.externallyConnectedPointIds?.some(
+      (group) =>
+        group.length === 2 &&
+        group.every((pointId) => pointId.startsWith("escape-via:")),
+    ),
+  ).toBe(true)
+})

--- a/tests/features/pour-via-escape/pour-via-escape-pour-key-collapse.test.ts
+++ b/tests/features/pour-via-escape/pour-via-escape-pour-key-collapse.test.ts
@@ -2,11 +2,13 @@ import { expect, test } from "bun:test"
 import { EscapeViaLocationSolver } from "../../../lib/solvers/EscapeViaLocationSolver/EscapeViaLocationSolver"
 import type { SimpleRouteJson } from "../../../lib/types"
 
-// One logical inner1 pour rasterised into two cells, with two pads — one over
-// each cell. Each pad's escape via lands in a different cell. Keyed per raster
-// cell (the old getObstacleKey) the two vias got different pour targets and were
-// never grouped, so the MST routed a redundant pad-to-pad trace. Keyed by
-// (layer, net) they share one target and group through externallyConnectedPointIds.
+// One logical inner1 pour rasterised into two ADJACENT cells (touching at x=0),
+// with two pads — one over each cell. Each pad's escape via lands in a different
+// cell. Keyed per raster cell (the old getObstacleKey) the two vias got different
+// pour targets and were never grouped, so the MST routed a redundant pad-to-pad
+// trace. Keyed by (layer, net) they share one target and group through
+// externallyConnectedPointIds. The cells are contiguous on purpose — that is the
+// topology (layer, net) keying assumes (see getPourKey).
 function twoCellPourSrj(): SimpleRouteJson {
   return {
     layerCount: 4,
@@ -37,7 +39,7 @@ function twoCellPourSrj(): SimpleRouteJson {
         obstacleId: "pour-cell-left",
         type: "rect",
         layers: ["inner1"],
-        center: { x: -5, y: 0 },
+        center: { x: -4, y: 0 },
         width: 8,
         height: 8,
         connectedTo: ["source_net_0"],
@@ -47,7 +49,7 @@ function twoCellPourSrj(): SimpleRouteJson {
         obstacleId: "pour-cell-right",
         type: "rect",
         layers: ["inner1"],
-        center: { x: 5, y: 0 },
+        center: { x: 4, y: 0 },
         width: 8,
         height: 8,
         connectedTo: ["source_net_0"],

--- a/tests/features/pour-via-escape/pour-via-escape-same-net-via-clearance.test.ts
+++ b/tests/features/pour-via-escape/pour-via-escape-same-net-via-clearance.test.ts
@@ -1,0 +1,91 @@
+import { expect, test } from "bun:test"
+import { EscapeViaLocationSolver } from "../../../lib/solvers/EscapeViaLocationSolver/EscapeViaLocationSolver"
+import type { Obstacle, SimpleRouteJson } from "../../../lib/types"
+
+// A pad ringed by same-net spanning vias (the dense WSON-8 GND-cluster shape):
+// previously every escape-via candidate around the pad was rejected because a
+// same-net via sat in its path / clearance, so no escape via could be placed.
+// hasClearEscapePath and getMinBlockingClearance now skip same-net obstacles,
+// so the escape via still places. The skip only ever relaxes clearance for the
+// via's own net, so it can never reject a candidate that was previously valid.
+function srjWithRing(ring: Obstacle[]): SimpleRouteJson {
+  return {
+    layerCount: 4,
+    minTraceWidth: 0.15,
+    minViaDiameter: 0.3,
+    defaultObstacleMargin: 0.15,
+    bounds: { minX: -4, maxX: 4, minY: -4, maxY: 4 },
+    obstacles: [
+      {
+        obstacleId: "pad",
+        type: "rect",
+        layers: ["top"],
+        center: { x: 0, y: 0 },
+        width: 0.6,
+        height: 0.6,
+        connectedTo: ["source_net_0", "pcb_port_a"],
+      },
+      {
+        obstacleId: "pour",
+        type: "rect",
+        layers: ["inner1"],
+        center: { x: 0, y: 0 },
+        width: 7,
+        height: 7,
+        connectedTo: ["source_net_0"],
+        isCopperPour: true,
+      },
+      ...ring,
+    ],
+    connections: [
+      {
+        name: "source_net_0",
+        pointsToConnect: [
+          {
+            x: 0,
+            y: 0,
+            layer: "top",
+            pointId: "pcb_port_a",
+            pcb_port_id: "pcb_port_a",
+          },
+        ],
+      },
+    ],
+  }
+}
+
+const escapePoints = (srj: SimpleRouteJson) => {
+  const solver = new EscapeViaLocationSolver(srj)
+  solver.solve()
+  return (
+    solver
+      .getOutputSimpleRouteJson()
+      .connections.find((connection) => connection.name === "source_net_0")
+      ?.pointsToConnect.filter((point) =>
+        point.pointId?.startsWith("escape-via:"),
+      ) ?? []
+  )
+}
+
+test("same-net spanning vias do not block escape-via placement", () => {
+  const sameNetRing: Obstacle[] = [
+    [0.55, 0],
+    [-0.55, 0],
+    [0, 0.55],
+    [0, -0.55],
+  ].map(([dx, dy]) => ({
+    obstacleId: `via-${dx}-${dy}`,
+    type: "rect",
+    layers: ["top", "inner1"],
+    zLayers: [0, 1],
+    center: { x: dx, y: dy },
+    width: 0.3,
+    height: 0.3,
+    connectedTo: ["source_net_0"],
+  }))
+
+  // Without the ring an escape via places; with a same-net ring it must still
+  // place (the same-net vias are not clearance blockers for their own net).
+  expect(escapePoints(srjWithRing([]))).toHaveLength(1)
+  expect(escapePoints(srjWithRing(sameNetRing))).toHaveLength(1)
+})

--- a/tests/features/pour-via-escape/pour-via-escape-same-net-via-clearance.test.ts
+++ b/tests/features/pour-via-escape/pour-via-escape-same-net-via-clearance.test.ts
@@ -89,3 +89,27 @@ test("same-net spanning vias do not block escape-via placement", () => {
   expect(escapePoints(srjWithRing([]))).toHaveLength(1)
   expect(escapePoints(srjWithRing(sameNetRing))).toHaveLength(1)
 })
+
+test("a foreign-net via ring still blocks escape-via placement", () => {
+  // Same geometry, but the ring belongs to a different net. The skip is scoped
+  // to the connection's own net, so these vias must still block — otherwise the
+  // relaxation would be a blanket one and could place a via through foreign
+  // copper.
+  const foreignNetRing: Obstacle[] = [
+    [0.55, 0],
+    [-0.55, 0],
+    [0, 0.55],
+    [0, -0.55],
+  ].map(([dx, dy]) => ({
+    obstacleId: `foreign-via-${dx}-${dy}`,
+    type: "rect",
+    layers: ["top", "inner1"],
+    zLayers: [0, 1],
+    center: { x: dx, y: dy },
+    width: 0.3,
+    height: 0.3,
+    connectedTo: ["source_net_other"],
+  }))
+
+  expect(escapePoints(srjWithRing(foreignNetRing))).toHaveLength(0)
+})


### PR DESCRIPTION
## Summary

Two `EscapeViaLocationSolver` fixes for pads the author has already stitched to a copper pour with their own vias (e.g. GND pads stitched to an inner plane on a 4-layer board):

- **Same-net vias no longer block escape-via placement.** Both clearance checks (`hasClearEscapePath`, `getMinBlockingClearance`) treated every overlapping obstacle as a blocker — including a same-net stitch via sitting exactly where the escape via should land — so a pad ringed by its own stitch vias could get no escape via at all. They now share an `isSameNetObstacle` predicate that skips non-pour obstacles on the connection's own net (the span check additionally requires the obstacle to cover the full source→target layer pair, since it measures clearance across that span). The skip only ever *relaxes* clearance for the obstacle's own net, so no previously-valid candidate is rejected.
- **One contiguous pour now produces one escape-via target.** Rasterised pours were keyed per obstacle cell (`getObstacleKey`), so escape vias landing in different cells of the same pour were never grouped, and the router added a redundant pad-to-pad surface trace between pads that are already connected through the pour. Pours are now keyed by `(layer, net)` via a `getPourKey` helper; `getObstacleKey` had no other caller and is removed.

## Testing

- Two regression tests, each of which fails on the pre-change solver:
  - `pour-via-escape-same-net-via-clearance`: a pad ringed by same-net spanning vias still gets an escape via (without the skip, every candidate is blocked and no via is placed); a foreign-net ring still blocks (negative control).
  - `pour-via-escape-pour-key-collapse`: two pads over adjacent cells of one contiguous pour group into a single escape-via target (the old per-cell key left them ungrouped and the router routed pad-to-pad).
- Full `tests/features/pour-via-escape/` suite green; the existing `01–06` escape-via snapshots are unchanged.
- `bunx tsc --noEmit` clean; `biome format` clean.
- Benchmark (`./benchmark.sh AutoroutingPipelineSolver4 40 --dataset dataset01`): completion 92.5%, relaxed-DRC 87.5%, 0/40 timeouts, P50 2.2 s, P95 9.9 s — unchanged vs `main`, identical failure samples (all pre-existing). The solver only acts on nets that have a matching copper pour and no shipped dataset contains one, so the change is inert on the benchmark; the regression tests above carry the behavioural proof.
