### PR TITLE
fix broken git hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#db73a5f"
   },
   "dependencies": {
-    "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3dbc62d425c0459e6fc2fef7a656b448e9a0",
+    "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d",
     "fast-json-stable-stringify": "^2.1.0",
     "object-hash": "^3.0.0"
   }


### PR DESCRIPTION
<img width="2254" height="256" alt="image" src="https://github.com/user-attachments/assets/019b1436-1988-450d-94e6-fd986a93fb11" />


ref: https://discord.com/channels/1233487248129921135/1513862717226618923/1514233053218607115

fix the git hash issue by only passing the first 7 characters 

not sure why this works