### PR TITLE
Release HD candidate solver state earlier

### DIFF
--- a/lib/solvers/HighDensitySolver/CachedIntraNodeRouteSolver.ts
+++ b/lib/solvers/HighDensitySolver/CachedIntraNodeRouteSolver.ts
@@ -239,6 +239,13 @@ export class CachedIntraNodeRouteSolver
       console.error("Error saving solution to cache:", error)
     }
   }
+
+  release() {
+    super.release()
+    this.initialUnsolvedConnections = []
+    this.cacheProvider = null
+    this.hasAttemptedToUseCache = true
+  }
 }
 
 export type { CachedSolvedIntraNodeRouteSolver }

--- a/lib/solvers/HighDensitySolver/HighDensitySolver.ts
+++ b/lib/solvers/HighDensitySolver/HighDensitySolver.ts
@@ -24,6 +24,10 @@ type HighDensityIntraNodeSolver =
   | HyperSingleIntraNodeSolver
   | GrowShrinkHighDensityIntraNodeSolver
 
+type ReleasableHighDensityIntraNodeSolver = HighDensityIntraNodeSolver & {
+  release?: () => void
+}
+
 const connectionLabel = (
   connectionName: string,
   rootConnectionName?: string,
@@ -38,6 +42,10 @@ const connectionLabel = (
   ]
     .filter(Boolean)
     .join("\n")
+
+const releaseSolver = (solver: ReleasableHighDensityIntraNodeSolver | null) => {
+  solver?.release?.()
+}
 
 export class HighDensitySolver extends BaseSolver {
   override getSolverName(): string {
@@ -288,6 +296,9 @@ export class HighDensitySolver extends BaseSolver {
       } else if (this.activeSubSolver.failed) {
         this.recordNodeSolveMetadata(this.activeSubSolver, "failed")
         this.recordResizeStats(this.activeSubSolver)
+        // Drop the failed solver's candidate sub-solvers; keeps
+        // nodeWithPortPoints/error/iterations needed for error messages
+        releaseSolver(this.activeSubSolver)
         this.failedSolvers.push(this.activeSubSolver)
         this.activeSubSolver = null
       }

--- a/lib/solvers/HighDensitySolver/IntraNodeSolver.ts
+++ b/lib/solvers/HighDensitySolver/IntraNodeSolver.ts
@@ -16,6 +16,9 @@ import { SingleHighDensityRouteSolver } from "./SingleHighDensityRouteSolver"
 import { SingleHighDensityRouteSolver6_VertHorzLayer_FutureCost } from "./SingleHighDensityRouteSolver6_VertHorzLayer_FutureCost"
 
 type ConnectionPoint = { x: number; y: number; z: number }
+type ReleasableSingleHighDensityRouteSolver = SingleHighDensityRouteSolver & {
+  release?: () => void
+}
 
 const connectionLabel = (
   connectionName: string,
@@ -47,6 +50,12 @@ const dedupeConnectionPoints = (points: ConnectionPoint[]) => {
   }
 
   return deduped
+}
+
+const releaseSingleRouteSolver = (
+  solver: ReleasableSingleHighDensityRouteSolver | null,
+) => {
+  solver?.release?.()
 }
 
 export class IntraNodeRouteSolver extends BaseSolver {
@@ -484,6 +493,19 @@ export class IntraNodeRouteSolver extends BaseSolver {
       new SingleHighDensityRouteSolver6_VertHorzLayer_FutureCost(
         this.getSingleRouteSolverOpts(unsolvedConnection),
       )
+  }
+
+  release() {
+    releaseSingleRouteSolver(this.activeSubSolver)
+    for (const failedSubSolver of this.failedSubSolvers) {
+      releaseSingleRouteSolver(failedSubSolver)
+    }
+    this.activeSubSolver = null
+    this.failedSubSolvers = []
+    this.unsolvedConnections = []
+    this.originalConnectionPointsByName = new Map()
+    this.rootConnectionNameByConnectionName = new Map()
+    this.rerouteAttemptsByConnection = new Map()
   }
 
   visualize(): GraphicsObject {

--- a/lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver/GrowShrinkHighDensityIntraNodeSolver.ts
+++ b/lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver/GrowShrinkHighDensityIntraNodeSolver.ts
@@ -25,6 +25,10 @@ export type GrowShrinkHighDensityIntraNodeSolverParams =
     fallbackToInvalidGeometryOnFailure?: boolean
   }
 
+type ReleasableHyperSingleIntraNodeSolver = HyperSingleIntraNodeSolver & {
+  release?: () => void
+}
+
 const scalePoint = <T extends { x: number; y: number }>(
   point: T,
   center: { x: number; y: number },
@@ -95,6 +99,12 @@ const connectionLabel = (
   ]
     .filter(Boolean)
     .join("\n")
+
+const releaseHyperSingleSolver = (
+  solver: ReleasableHyperSingleIntraNodeSolver | null,
+) => {
+  solver?.release?.()
+}
 
 export class GrowShrinkHighDensityIntraNodeSolver extends BaseSolver {
   override getSolverName(): string {
@@ -196,6 +206,8 @@ export class GrowShrinkHighDensityIntraNodeSolver extends BaseSolver {
 
     this.failedSolvers.push(this.activeSubSolver!)
     this.error = this.activeSubSolver!.error
+    // Drop the failed attempt's candidate solvers (error/iterations kept)
+    releaseHyperSingleSolver(this.activeSubSolver)
     this.activeSubSolver = null
 
     if (this.growthAttempts >= this.maxGrowthAttempts) {
@@ -225,6 +237,18 @@ export class GrowShrinkHighDensityIntraNodeSolver extends BaseSolver {
 
     this.growthAttempts++
     this.scaleFactor *= 2
+  }
+
+  /**
+   * Drop candidate solvers held by failed growth attempts so they can be
+   * garbage collected. Keeps the `failedSolvers` entries themselves (their
+   * `error` is preserved) and `winningSolver`.
+   */
+  release() {
+    for (const failedSolver of this.failedSolvers) {
+      releaseHyperSingleSolver(failedSolver)
+    }
+    this.activeSubSolver = null
   }
 
   visualize(): GraphicsObject {

--- a/lib/solvers/HyperParameterSupervisorSolver.ts
+++ b/lib/solvers/HyperParameterSupervisorSolver.ts
@@ -14,6 +14,10 @@ export type HyperParameterDef = {
   possibleValues: Array<any>
 }
 
+type ReleasableSolver = {
+  release?: () => void
+}
+
 /**
  * The HyperParameterSupervisorSolver is a solver that solves a problem by
  * running competing solvers with different hyperparameters.
@@ -33,6 +37,10 @@ export class HyperParameterSupervisorSolver<
 
   supervisedSolvers?: Array<SupervisedSolver<T>>
   winningSolver?: T
+
+  private releaseSolver(solver: T | undefined) {
+    ;(solver as (T & ReleasableSolver) | undefined)?.release?.()
+  }
 
   getHyperParameterDefs(): Array<HyperParameterDef> {
     throw new Error("Not implemented")
@@ -168,12 +176,36 @@ export class HyperParameterSupervisorSolver<
       this.solved = true
       this.winningSolver = supervisedSolver.solver
       this.onSolve?.(supervisedSolver)
+      // Drop losing candidate solvers now that a winner is chosen
+      this.release()
+    } else if (supervisedSolver.solver.failed) {
+      // Free the failed candidate's heavy internals (error/iterations kept)
+      this.releaseSolver(supervisedSolver.solver)
     }
   }
 
   onSolve(solver: SupervisedSolver<T>) {}
 
+  /**
+   * Drop references to candidate solvers so they can be garbage collected.
+   * Keeps `winningSolver` (if any) and preserves `error`, `stats`,
+   * `iterations` and `progress`. Only call once this solver will no longer
+   * be stepped (any error message has already been computed by then).
+   */
+  release() {
+    for (const supervisedSolver of this.supervisedSolvers ?? []) {
+      if (supervisedSolver.solver !== this.winningSolver) {
+        this.releaseSolver(supervisedSolver.solver)
+      }
+    }
+    this.supervisedSolvers = undefined
+    this.activeSubSolver = null
+  }
+
   visualize(): GraphicsObject {
+    if (this.winningSolver) {
+      return this.winningSolver.visualize()
+    }
     const bestSupervisedSolver = this.getSupervisedSolverWithBestFitness()
     let graphics: GraphicsObject = {
       lines: [],

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#db73a5f"
   },
   "dependencies": {
-    "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d",
+    "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#73319f18998a9784b3777d8976572851201d9762",
     "fast-json-stable-stringify": "^2.1.0",
     "object-hash": "^3.0.0"
   }


### PR DESCRIPTION
## Summary

Release heavy high-density candidate solver state as soon as it is no longer needed.

This PR keeps the high-density solver behavior the same, but drops candidate sub-solvers
earlier on solve/fail paths so they can be garbage collected sooner.

Included here:

- add a base `release()` hook for solver implementations
- release losing candidates in `HyperParameterSupervisorSolver`
- release failed node solvers in `HighDensitySolver`
- release failed grow/shrink attempts in `GrowShrinkHighDensityIntraNodeSolver`
- release nested route-solver state in `IntraNodeRouteSolver` and `CachedIntraNodeRouteSolver`

Not included here:

- later cache snapshot / ordering-dedupe experiments
- non-HD tiny-hypergraph follow-up work
- `@tscircuit/high-density-a01` package-side changes

## Why

High-density nodes can fan out into many competing candidate solvers. Before this change,
those candidate graphs were often retained after a winner was chosen or after a failed
attempt had already yielded the only information we still needed (`error`, `iterations`,
`progress`).

This PR adds explicit cleanup points so those heavy references are dropped promptly.

## Verification

Focused tests:

```bash
bun test tests/bugs/bugreport25-4b1d55.test.ts tests/features/never-fail-growth-high-density/ tests/high-density-solver-stats.test.ts
```

Result:

- `13 pass, 0 fail`

Previously verified memory results for this release-path work (same optimization family):

- `s1` HD heap: `1087MB -> 209MB`
- `s2` HD heap: `2515MB -> 440MB`
- `s3` HD heap: `1416MB -> 738MB`

These were measured in the HD memory harness during the investigation and are the basis
for splitting this proven release-path work into its own PR.
