### PR TITLE
Bump tiny-hypergraph for duplicate-port memory follow-up

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "recharts": "^2.15.1",
     "tailwind-merge": "^3.2.0",
     "terser": "^5.43.1",
-    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#fa6549f85d2865895f5f1ca3534ad23686f46718",
+    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#6ee2a304c43f7966f21884fd4d5a3be1ba5e2605",
     "tiny-hypergraph-poly": "git+https://github.com/tscircuit/tiny-hypergraph.git#7b93b4c",
     "tsup": "^8.3.6",
     "typescript": "^5.9.3",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "recharts": "^2.15.1",
     "tailwind-merge": "^3.2.0",
     "terser": "^5.43.1",
-    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#c9aa5b7c9da5e007e2fff5d5c360490551fe3329",
+    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#fa6549f85d2865895f5f1ca3534ad23686f46718",
     "tiny-hypergraph-poly": "git+https://github.com/tscircuit/tiny-hypergraph.git#7b93b4c",
     "tsup": "^8.3.6",
     "typescript": "^5.9.3",


### PR DESCRIPTION
## Summary
- update the tiny-hypergraph dependency to [tiny-hypergraph#115](https://github.com/tscircuit/tiny-hypergraph/pull/115)
- this picks up the duplicate-port memory handling follow-up layer
- stacks on top of [tscircuit-autorouter#1382](https://github.com/tscircuit/tscircuit-autorouter/pull/1382)

## Testing
- not run locally; package.json-only dependency pin update