### PR TITLE
Update tiny-hypergraph for duplicate-port constructor memory reduction

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "recharts": "^2.15.1",
     "tailwind-merge": "^3.2.0",
     "terser": "^5.43.1",
-    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#c9aa5b7c9da5e007e2fff5d5c360490551fe3329",
+    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#fa6549f7a975b04bd9da24eec516902fa2796512",
     "tiny-hypergraph-poly": "git+https://github.com/tscircuit/tiny-hypergraph.git#7b93b4c",
     "tsup": "^8.3.6",
     "typescript": "^5.9.3",


### PR DESCRIPTION
## Summary
- update autorouters `tiny-hypergraph` dependency to include [tiny-hypergraph#114](https://github.com/tscircuit/tiny-hypergraph/pull/114)
- this brings in the duplicate-port constructor memory reduction changes
- based directly on the latest origin/main

## What changes in autorouter
- no autorouter source changes
- only the `tiny-hypergraph` dependency commit in `package.json` is updated

## Validation
- bun i
- bun run format