### PR TITLE
feat: track best via benchmark records

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -532,10 +532,10 @@ jobs:
                 `Scenarios: ${report.scenarioCount}`,
                 `Effort: ${report.effortLabel}`,
                 '',
-                '| Solver | Completed % | Relaxed DRC Pass % | Timed Out | P50 Time | P95 Time | Best Via |',
-                '| --- | --- | --- | --- | --- | --- | ---: |',
+                '| Solver | Completed % | Relaxed DRC Pass % | Timed Out | P50 Time | P95 Time |',
+                '| --- | --- | --- | --- | --- | --- |',
                 ...report.summary.map((row) =>
-                  `| ${formatSolverDisplayName(row.solverName, report.effortLabel)} | ${row.completedRateLabel} | ${row.relaxedDrcRateLabel} | ${row.timedOutLabel} | ${formatTime(row.p50TimeMs)} | ${formatTime(row.p95TimeMs)} | ${formatViaCount(row.bestVia)} |`,
+                  `| ${formatSolverDisplayName(row.solverName, report.effortLabel)} | ${row.completedRateLabel} | ${row.relaxedDrcRateLabel} | ${row.timedOutLabel} | ${formatTime(row.p50TimeMs)} | ${formatTime(row.p95TimeMs)} |`,
                 ),
               ]
             }
@@ -549,10 +549,10 @@ jobs:
                 return []
               }
               return [
-                '| Dataset | Scenarios | Solver | Completed % | Relaxed DRC Pass % | Timed Out | P50 Time | P95 Time | Best Via |',
-                '| --- | ---: | --- | --- | --- | --- | --- | --- | ---: |',
+                '| Dataset | Scenarios | Solver | Completed % | Relaxed DRC Pass % | Timed Out | P50 Time | P95 Time |',
+                '| --- | ---: | --- | --- | --- | --- | --- | --- |',
                 ...rows.map(({ report, row }) =>
-                  `| ${escapeHtml(report.datasetName ?? '')} | ${escapeHtml(report.scenarioCount ?? '')} | ${escapeHtml(formatSolverDisplayName(row.solverName, report.effortLabel))} | ${escapeHtml(row.completedRateLabel)} | ${escapeHtml(row.relaxedDrcRateLabel)} | ${escapeHtml(row.timedOutLabel)} | ${escapeHtml(formatTime(row.p50TimeMs))} | ${escapeHtml(formatTime(row.p95TimeMs))} | ${escapeHtml(formatViaCount(row.bestVia))} |`,
+                  `| ${escapeHtml(report.datasetName ?? '')} | ${escapeHtml(report.scenarioCount ?? '')} | ${escapeHtml(formatSolverDisplayName(row.solverName, report.effortLabel))} | ${escapeHtml(row.completedRateLabel)} | ${escapeHtml(row.relaxedDrcRateLabel)} | ${escapeHtml(row.timedOutLabel)} | ${escapeHtml(formatTime(row.p50TimeMs))} | ${escapeHtml(formatTime(row.p95TimeMs))} |`,
                 ),
               ]
             }
@@ -584,7 +584,7 @@ jobs:
                 mainTest.didSolve
               ) {
                 if (test.viaCount < mainTest.viaCount) {
-                  return `🏆 -${mainTest.viaCount - test.viaCount} via`
+                  return `-${mainTest.viaCount - test.viaCount} via`
                 }
                 if (test.viaCount > mainTest.viaCount) {
                   return `+${test.viaCount - mainTest.viaCount} via`
@@ -610,7 +610,7 @@ jobs:
                     : null
               const record = mainBestVia === null ? test.bestViaCount : Math.min(test.bestViaCount, mainBestVia)
               if (record === test.bestViaCount && (mainBestVia === null || test.bestViaCount < mainBestVia)) {
-                return `${record} 🏆`
+                return String(record)
               }
               return String(record)
             }
@@ -1042,10 +1042,10 @@ jobs:
                 `Scenarios: ${report.scenarioCount}`,
                 `Effort: ${report.effortLabel}`,
                 '',
-                '| Solver | Completed % | Relaxed DRC Pass % | Timed Out | P50 Time | P95 Time | Best Via |',
-                '| --- | --- | --- | --- | --- | --- | ---: |',
+                '| Solver | Completed % | Relaxed DRC Pass % | Timed Out | P50 Time | P95 Time |',
+                '| --- | --- | --- | --- | --- | --- |',
                 ...report.summary.map((row) =>
-                  `| ${formatSolverDisplayName(row.solverName, report.effortLabel)} | ${row.completedRateLabel} | ${row.relaxedDrcRateLabel} | ${row.timedOutLabel} | ${formatTime(row.p50TimeMs)} | ${formatTime(row.p95TimeMs)} | ${formatViaCount(row.bestVia)} |`,
+                  `| ${formatSolverDisplayName(row.solverName, report.effortLabel)} | ${row.completedRateLabel} | ${row.relaxedDrcRateLabel} | ${row.timedOutLabel} | ${formatTime(row.p50TimeMs)} | ${formatTime(row.p95TimeMs)} |`,
                 ),
               ]
             }
@@ -1059,10 +1059,10 @@ jobs:
                 return []
               }
               return [
-                '| Dataset | Scenarios | Solver | Completed % | Relaxed DRC Pass % | Timed Out | P50 Time | P95 Time | Best Via |',
-                '| --- | ---: | --- | --- | --- | --- | --- | --- | ---: |',
+                '| Dataset | Scenarios | Solver | Completed % | Relaxed DRC Pass % | Timed Out | P50 Time | P95 Time |',
+                '| --- | ---: | --- | --- | --- | --- | --- | --- |',
                 ...rows.map(({ report, row }) =>
-                  `| ${escapeHtml(report.datasetName ?? '')} | ${escapeHtml(report.scenarioCount ?? '')} | ${escapeHtml(formatSolverDisplayName(row.solverName, report.effortLabel))} | ${escapeHtml(row.completedRateLabel)} | ${escapeHtml(row.relaxedDrcRateLabel)} | ${escapeHtml(row.timedOutLabel)} | ${escapeHtml(formatTime(row.p50TimeMs))} | ${escapeHtml(formatTime(row.p95TimeMs))} | ${escapeHtml(formatViaCount(row.bestVia))} |`,
+                  `| ${escapeHtml(report.datasetName ?? '')} | ${escapeHtml(report.scenarioCount ?? '')} | ${escapeHtml(formatSolverDisplayName(row.solverName, report.effortLabel))} | ${escapeHtml(row.completedRateLabel)} | ${escapeHtml(row.relaxedDrcRateLabel)} | ${escapeHtml(row.timedOutLabel)} | ${escapeHtml(formatTime(row.p50TimeMs))} | ${escapeHtml(formatTime(row.p95TimeMs))} |`,
                 ),
               ]
             }
@@ -1094,7 +1094,7 @@ jobs:
                 mainTest.didSolve
               ) {
                 if (test.viaCount < mainTest.viaCount) {
-                  return `🏆 -${mainTest.viaCount - test.viaCount} via`
+                  return `-${mainTest.viaCount - test.viaCount} via`
                 }
                 if (test.viaCount > mainTest.viaCount) {
                   return `+${test.viaCount - mainTest.viaCount} via`
@@ -1120,7 +1120,7 @@ jobs:
                     : null
               const record = mainBestVia === null ? test.bestViaCount : Math.min(test.bestViaCount, mainBestVia)
               if (record === test.bestViaCount && (mainBestVia === null || test.bestViaCount < mainBestVia)) {
-                return `${record} 🏆`
+                return String(record)
               }
               return String(record)
             }

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -471,11 +471,11 @@ jobs:
               }
               return timeMs < 1000 ? `${Math.round(timeMs)}ms` : `${(timeMs / 1000).toFixed(1)}s`
             }
-            const formatAverage = (value) => {
+            const formatViaCount = (value) => {
               if (typeof value !== 'number' || !Number.isFinite(value)) {
                 return 'n/a'
               }
-              return value.toFixed(2)
+              return String(value)
             }
             const getStatus = (test) => {
               if (test.didTimeout) return '❌'
@@ -532,10 +532,10 @@ jobs:
                 `Scenarios: ${report.scenarioCount}`,
                 `Effort: ${report.effortLabel}`,
                 '',
-                '| Solver | Completed % | Relaxed DRC Pass % | Timed Out | P50 Time | P95 Time | Avg Via |',
-                '| --- | --- | --- | --- | --- | --- | --- |',
+                '| Solver | Completed % | Relaxed DRC Pass % | Timed Out | P50 Time | P95 Time | Best Via |',
+                '| --- | --- | --- | --- | --- | --- | ---: |',
                 ...report.summary.map((row) =>
-                  `| ${formatSolverDisplayName(row.solverName, report.effortLabel)} | ${row.completedRateLabel} | ${row.relaxedDrcRateLabel} | ${row.timedOutLabel} | ${formatTime(row.p50TimeMs)} | ${formatTime(row.p95TimeMs)} | ${formatAverage(row.avgVia)} |`,
+                  `| ${formatSolverDisplayName(row.solverName, report.effortLabel)} | ${row.completedRateLabel} | ${row.relaxedDrcRateLabel} | ${row.timedOutLabel} | ${formatTime(row.p50TimeMs)} | ${formatTime(row.p95TimeMs)} | ${formatViaCount(row.bestVia)} |`,
                 ),
               ]
             }
@@ -549,10 +549,10 @@ jobs:
                 return []
               }
               return [
-                '| Dataset | Scenarios | Solver | Completed % | Relaxed DRC Pass % | Timed Out | P50 Time | P95 Time | Avg Via |',
-                '| --- | ---: | --- | --- | --- | --- | --- | --- | --- |',
+                '| Dataset | Scenarios | Solver | Completed % | Relaxed DRC Pass % | Timed Out | P50 Time | P95 Time | Best Via |',
+                '| --- | ---: | --- | --- | --- | --- | --- | --- | ---: |',
                 ...rows.map(({ report, row }) =>
-                  `| ${escapeHtml(report.datasetName ?? '')} | ${escapeHtml(report.scenarioCount ?? '')} | ${escapeHtml(formatSolverDisplayName(row.solverName, report.effortLabel))} | ${escapeHtml(row.completedRateLabel)} | ${escapeHtml(row.relaxedDrcRateLabel)} | ${escapeHtml(row.timedOutLabel)} | ${escapeHtml(formatTime(row.p50TimeMs))} | ${escapeHtml(formatTime(row.p95TimeMs))} | ${escapeHtml(formatAverage(row.avgVia))} |`,
+                  `| ${escapeHtml(report.datasetName ?? '')} | ${escapeHtml(report.scenarioCount ?? '')} | ${escapeHtml(formatSolverDisplayName(row.solverName, report.effortLabel))} | ${escapeHtml(row.completedRateLabel)} | ${escapeHtml(row.relaxedDrcRateLabel)} | ${escapeHtml(row.timedOutLabel)} | ${escapeHtml(formatTime(row.p50TimeMs))} | ${escapeHtml(formatTime(row.p95TimeMs))} | ${escapeHtml(formatViaCount(row.bestVia))} |`,
                 ),
               ]
             }
@@ -575,11 +575,44 @@ jobs:
               const key = `${test.solverName}::${test.scenarioName}`
               const mainTest = mainIndex.get(key)
               if (!mainTest) return ''
+              if (
+                typeof test.viaCount === 'number' &&
+                Number.isFinite(test.viaCount) &&
+                typeof mainTest.viaCount === 'number' &&
+                Number.isFinite(mainTest.viaCount) &&
+                test.didSolve &&
+                mainTest.didSolve
+              ) {
+                if (test.viaCount < mainTest.viaCount) {
+                  return `🏆 -${mainTest.viaCount - test.viaCount} via`
+                }
+                if (test.viaCount > mainTest.viaCount) {
+                  return `+${test.viaCount - mainTest.viaCount} via`
+                }
+              }
               const prScore = getOutcomeScore(test)
               const mainScore = getOutcomeScore(mainTest)
               if (prScore > mainScore) return '✅'
               if (prScore < mainScore) return '❌'
               return ''
+            }
+            const getBestViaRecord = (test, mainIndex) => {
+              if (typeof test?.bestViaCount !== 'number' || !Number.isFinite(test.bestViaCount)) {
+                return 'n/a'
+              }
+              const key = `${test.solverName}::${test.scenarioName}`
+              const mainTest = mainIndex?.get(key)
+              const mainBestVia =
+                typeof mainTest?.bestViaCount === 'number' && Number.isFinite(mainTest.bestViaCount)
+                  ? mainTest.bestViaCount
+                  : typeof mainTest?.viaCount === 'number' && Number.isFinite(mainTest.viaCount)
+                    ? mainTest.viaCount
+                    : null
+              const record = mainBestVia === null ? test.bestViaCount : Math.min(test.bestViaCount, mainBestVia)
+              if (record === test.bestViaCount && (mainBestVia === null || test.bestViaCount < mainBestVia)) {
+                return `${record} 🏆`
+              }
+              return String(record)
             }
             const isUnchangedPassingTest = (test, mainIndex) => {
               if (!mainIndex) return false
@@ -607,12 +640,12 @@ jobs:
               const omittedCount = report.tests.length - tests.length
               const header = includeDelta
                 ? [
-                    '| Solver | Sample | Status | Time | Relaxed DRC | Error | Delta |',
-                    '| --- | --- | --- | --- | --- | --- | --- |',
+                    '| Solver | Sample | Status | Time | Relaxed DRC | Via | Best Via Record | Error | Delta |',
+                    '| --- | --- | --- | --- | --- | ---: | ---: | --- | --- |',
                   ]
                 : [
-                    '| Solver | Sample | Status | Time | Relaxed DRC | Error |',
-                    '| --- | --- | --- | --- | --- | --- |',
+                    '| Solver | Sample | Status | Time | Relaxed DRC | Via | Best Via Record | Error |',
+                    '| --- | --- | --- | --- | --- | ---: | ---: | --- |',
                   ]
               return [
                 ...(omittedCount > 0
@@ -621,8 +654,8 @@ jobs:
                 ...header,
                 ...tests.map((test) =>
                   includeDelta
-                    ? `| ${formatSolverName(test.solverName)} | ${getSampleLabel(test)} | ${getStatus(test)} | ${formatTime(test.elapsedTimeMs)} | ${getDrc(test)} | ${getErrorCell(test)} | ${getDelta(test, mainIndex)} |`
-                    : `| ${formatSolverName(test.solverName)} | ${getSampleLabel(test)} | ${getStatus(test)} | ${formatTime(test.elapsedTimeMs)} | ${getDrc(test)} | ${getErrorCell(test)} |`,
+                    ? `| ${formatSolverName(test.solverName)} | ${getSampleLabel(test)} | ${getStatus(test)} | ${formatTime(test.elapsedTimeMs)} | ${getDrc(test)} | ${formatViaCount(test.viaCount)} | ${getBestViaRecord(test, mainIndex)} | ${getErrorCell(test)} | ${getDelta(test, mainIndex)} |`
+                    : `| ${formatSolverName(test.solverName)} | ${getSampleLabel(test)} | ${getStatus(test)} | ${formatTime(test.elapsedTimeMs)} | ${getDrc(test)} | ${formatViaCount(test.viaCount)} | ${getBestViaRecord(test, mainIndex)} | ${getErrorCell(test)} |`,
                 ),
               ]
             }
@@ -948,11 +981,11 @@ jobs:
               }
               return timeMs < 1000 ? `${Math.round(timeMs)}ms` : `${(timeMs / 1000).toFixed(1)}s`
             }
-            const formatAverage = (value) => {
+            const formatViaCount = (value) => {
               if (typeof value !== 'number' || !Number.isFinite(value)) {
                 return 'n/a'
               }
-              return value.toFixed(2)
+              return String(value)
             }
             const getStatus = (test) => {
               if (test.didTimeout) return '❌'
@@ -1009,10 +1042,10 @@ jobs:
                 `Scenarios: ${report.scenarioCount}`,
                 `Effort: ${report.effortLabel}`,
                 '',
-                '| Solver | Completed % | Relaxed DRC Pass % | Timed Out | P50 Time | P95 Time | Avg Via |',
-                '| --- | --- | --- | --- | --- | --- | --- |',
+                '| Solver | Completed % | Relaxed DRC Pass % | Timed Out | P50 Time | P95 Time | Best Via |',
+                '| --- | --- | --- | --- | --- | --- | ---: |',
                 ...report.summary.map((row) =>
-                  `| ${formatSolverDisplayName(row.solverName, report.effortLabel)} | ${row.completedRateLabel} | ${row.relaxedDrcRateLabel} | ${row.timedOutLabel} | ${formatTime(row.p50TimeMs)} | ${formatTime(row.p95TimeMs)} | ${formatAverage(row.avgVia)} |`,
+                  `| ${formatSolverDisplayName(row.solverName, report.effortLabel)} | ${row.completedRateLabel} | ${row.relaxedDrcRateLabel} | ${row.timedOutLabel} | ${formatTime(row.p50TimeMs)} | ${formatTime(row.p95TimeMs)} | ${formatViaCount(row.bestVia)} |`,
                 ),
               ]
             }
@@ -1026,10 +1059,10 @@ jobs:
                 return []
               }
               return [
-                '| Dataset | Scenarios | Solver | Completed % | Relaxed DRC Pass % | Timed Out | P50 Time | P95 Time | Avg Via |',
-                '| --- | ---: | --- | --- | --- | --- | --- | --- | --- |',
+                '| Dataset | Scenarios | Solver | Completed % | Relaxed DRC Pass % | Timed Out | P50 Time | P95 Time | Best Via |',
+                '| --- | ---: | --- | --- | --- | --- | --- | --- | ---: |',
                 ...rows.map(({ report, row }) =>
-                  `| ${escapeHtml(report.datasetName ?? '')} | ${escapeHtml(report.scenarioCount ?? '')} | ${escapeHtml(formatSolverDisplayName(row.solverName, report.effortLabel))} | ${escapeHtml(row.completedRateLabel)} | ${escapeHtml(row.relaxedDrcRateLabel)} | ${escapeHtml(row.timedOutLabel)} | ${escapeHtml(formatTime(row.p50TimeMs))} | ${escapeHtml(formatTime(row.p95TimeMs))} | ${escapeHtml(formatAverage(row.avgVia))} |`,
+                  `| ${escapeHtml(report.datasetName ?? '')} | ${escapeHtml(report.scenarioCount ?? '')} | ${escapeHtml(formatSolverDisplayName(row.solverName, report.effortLabel))} | ${escapeHtml(row.completedRateLabel)} | ${escapeHtml(row.relaxedDrcRateLabel)} | ${escapeHtml(row.timedOutLabel)} | ${escapeHtml(formatTime(row.p50TimeMs))} | ${escapeHtml(formatTime(row.p95TimeMs))} | ${escapeHtml(formatViaCount(row.bestVia))} |`,
                 ),
               ]
             }
@@ -1052,11 +1085,44 @@ jobs:
               const key = `${test.solverName}::${test.scenarioName}`
               const mainTest = mainIndex.get(key)
               if (!mainTest) return ''
+              if (
+                typeof test.viaCount === 'number' &&
+                Number.isFinite(test.viaCount) &&
+                typeof mainTest.viaCount === 'number' &&
+                Number.isFinite(mainTest.viaCount) &&
+                test.didSolve &&
+                mainTest.didSolve
+              ) {
+                if (test.viaCount < mainTest.viaCount) {
+                  return `🏆 -${mainTest.viaCount - test.viaCount} via`
+                }
+                if (test.viaCount > mainTest.viaCount) {
+                  return `+${test.viaCount - mainTest.viaCount} via`
+                }
+              }
               const prScore = getOutcomeScore(test)
               const mainScore = getOutcomeScore(mainTest)
               if (prScore > mainScore) return '✅'
               if (prScore < mainScore) return '❌'
               return ''
+            }
+            const getBestViaRecord = (test, mainIndex) => {
+              if (typeof test?.bestViaCount !== 'number' || !Number.isFinite(test.bestViaCount)) {
+                return 'n/a'
+              }
+              const key = `${test.solverName}::${test.scenarioName}`
+              const mainTest = mainIndex?.get(key)
+              const mainBestVia =
+                typeof mainTest?.bestViaCount === 'number' && Number.isFinite(mainTest.bestViaCount)
+                  ? mainTest.bestViaCount
+                  : typeof mainTest?.viaCount === 'number' && Number.isFinite(mainTest.viaCount)
+                    ? mainTest.viaCount
+                    : null
+              const record = mainBestVia === null ? test.bestViaCount : Math.min(test.bestViaCount, mainBestVia)
+              if (record === test.bestViaCount && (mainBestVia === null || test.bestViaCount < mainBestVia)) {
+                return `${record} 🏆`
+              }
+              return String(record)
             }
             const isUnchangedPassingTest = (test, mainIndex) => {
               if (!mainIndex) return false
@@ -1084,12 +1150,12 @@ jobs:
               const omittedCount = report.tests.length - tests.length
               const header = includeDelta
                 ? [
-                    '| Solver | Sample | Status | Time | Relaxed DRC | Error | Delta |',
-                    '| --- | --- | --- | --- | --- | --- | --- |',
+                    '| Solver | Sample | Status | Time | Relaxed DRC | Via | Best Via Record | Error | Delta |',
+                    '| --- | --- | --- | --- | --- | ---: | ---: | --- | --- |',
                   ]
                 : [
-                    '| Solver | Sample | Status | Time | Relaxed DRC | Error |',
-                    '| --- | --- | --- | --- | --- | --- |',
+                    '| Solver | Sample | Status | Time | Relaxed DRC | Via | Best Via Record | Error |',
+                    '| --- | --- | --- | --- | --- | ---: | ---: | --- |',
                   ]
               return [
                 ...(omittedCount > 0
@@ -1098,8 +1164,8 @@ jobs:
                 ...header,
                 ...tests.map((test) =>
                   includeDelta
-                    ? `| ${formatSolverName(test.solverName)} | ${getSampleLabel(test)} | ${getStatus(test)} | ${formatTime(test.elapsedTimeMs)} | ${getDrc(test)} | ${getErrorCell(test)} | ${getDelta(test, mainIndex)} |`
-                    : `| ${formatSolverName(test.solverName)} | ${getSampleLabel(test)} | ${getStatus(test)} | ${formatTime(test.elapsedTimeMs)} | ${getDrc(test)} | ${getErrorCell(test)} |`,
+                    ? `| ${formatSolverName(test.solverName)} | ${getSampleLabel(test)} | ${getStatus(test)} | ${formatTime(test.elapsedTimeMs)} | ${getDrc(test)} | ${formatViaCount(test.viaCount)} | ${getBestViaRecord(test, mainIndex)} | ${getErrorCell(test)} | ${getDelta(test, mainIndex)} |`
+                    : `| ${formatSolverName(test.solverName)} | ${getSampleLabel(test)} | ${getStatus(test)} | ${formatTime(test.elapsedTimeMs)} | ${getDrc(test)} | ${formatViaCount(test.viaCount)} | ${getBestViaRecord(test, mainIndex)} | ${getErrorCell(test)} |`,
                 ),
               ]
             }

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -596,7 +596,7 @@ jobs:
               if (prScore < mainScore) return '❌'
               return ''
             }
-            const getBestViaRecord = (test, mainIndex) => {
+            const formatBestViaRecord = (test, mainIndex) => {
               if (typeof test?.bestViaCount !== 'number' || !Number.isFinite(test.bestViaCount)) {
                 return 'n/a'
               }
@@ -609,9 +609,6 @@ jobs:
                     ? mainTest.viaCount
                     : null
               const record = mainBestVia === null ? test.bestViaCount : Math.min(test.bestViaCount, mainBestVia)
-              if (record === test.bestViaCount && (mainBestVia === null || test.bestViaCount < mainBestVia)) {
-                return String(record)
-              }
               return String(record)
             }
             const isUnchangedPassingTest = (test, mainIndex) => {
@@ -654,8 +651,8 @@ jobs:
                 ...header,
                 ...tests.map((test) =>
                   includeDelta
-                    ? `| ${formatSolverName(test.solverName)} | ${getSampleLabel(test)} | ${getStatus(test)} | ${formatTime(test.elapsedTimeMs)} | ${getDrc(test)} | ${formatViaCount(test.viaCount)} | ${getBestViaRecord(test, mainIndex)} | ${getErrorCell(test)} | ${getDelta(test, mainIndex)} |`
-                    : `| ${formatSolverName(test.solverName)} | ${getSampleLabel(test)} | ${getStatus(test)} | ${formatTime(test.elapsedTimeMs)} | ${getDrc(test)} | ${formatViaCount(test.viaCount)} | ${getBestViaRecord(test, mainIndex)} | ${getErrorCell(test)} |`,
+                    ? `| ${formatSolverName(test.solverName)} | ${getSampleLabel(test)} | ${getStatus(test)} | ${formatTime(test.elapsedTimeMs)} | ${getDrc(test)} | ${formatViaCount(test.viaCount)} | ${formatBestViaRecord(test, mainIndex)} | ${getErrorCell(test)} | ${getDelta(test, mainIndex)} |`
+                    : `| ${formatSolverName(test.solverName)} | ${getSampleLabel(test)} | ${getStatus(test)} | ${formatTime(test.elapsedTimeMs)} | ${getDrc(test)} | ${formatViaCount(test.viaCount)} | ${formatBestViaRecord(test, mainIndex)} | ${getErrorCell(test)} |`,
                 ),
               ]
             }
@@ -1106,7 +1103,7 @@ jobs:
               if (prScore < mainScore) return '❌'
               return ''
             }
-            const getBestViaRecord = (test, mainIndex) => {
+            const formatBestViaRecord = (test, mainIndex) => {
               if (typeof test?.bestViaCount !== 'number' || !Number.isFinite(test.bestViaCount)) {
                 return 'n/a'
               }
@@ -1119,9 +1116,6 @@ jobs:
                     ? mainTest.viaCount
                     : null
               const record = mainBestVia === null ? test.bestViaCount : Math.min(test.bestViaCount, mainBestVia)
-              if (record === test.bestViaCount && (mainBestVia === null || test.bestViaCount < mainBestVia)) {
-                return String(record)
-              }
               return String(record)
             }
             const isUnchangedPassingTest = (test, mainIndex) => {
@@ -1164,8 +1158,8 @@ jobs:
                 ...header,
                 ...tests.map((test) =>
                   includeDelta
-                    ? `| ${formatSolverName(test.solverName)} | ${getSampleLabel(test)} | ${getStatus(test)} | ${formatTime(test.elapsedTimeMs)} | ${getDrc(test)} | ${formatViaCount(test.viaCount)} | ${getBestViaRecord(test, mainIndex)} | ${getErrorCell(test)} | ${getDelta(test, mainIndex)} |`
-                    : `| ${formatSolverName(test.solverName)} | ${getSampleLabel(test)} | ${getStatus(test)} | ${formatTime(test.elapsedTimeMs)} | ${getDrc(test)} | ${formatViaCount(test.viaCount)} | ${getBestViaRecord(test, mainIndex)} | ${getErrorCell(test)} |`,
+                    ? `| ${formatSolverName(test.solverName)} | ${getSampleLabel(test)} | ${getStatus(test)} | ${formatTime(test.elapsedTimeMs)} | ${getDrc(test)} | ${formatViaCount(test.viaCount)} | ${formatBestViaRecord(test, mainIndex)} | ${getErrorCell(test)} | ${getDelta(test, mainIndex)} |`
+                    : `| ${formatSolverName(test.solverName)} | ${getSampleLabel(test)} | ${getStatus(test)} | ${formatTime(test.elapsedTimeMs)} | ${getDrc(test)} | ${formatViaCount(test.viaCount)} | ${formatBestViaRecord(test, mainIndex)} | ${getErrorCell(test)} |`,
                 ),
               ]
             }

--- a/scripts/benchmark/benchmark-types.ts
+++ b/scripts/benchmark/benchmark-types.ts
@@ -34,6 +34,7 @@ export type WorkerResult = {
   didTimeout: boolean
   relaxedDrcPassed: boolean
   viaCount?: number
+  bestViaCount?: number
   drcErrorCount?: number
   drcErrorTypes?: Record<string, number>
   drcErrorMessages?: Array<{
@@ -72,7 +73,7 @@ export type SolverRunSummary = {
   timedOutLabel: string
   p50TimeMs: number | null
   p95TimeMs: number | null
-  avgVia: number | null
+  bestVia: number | null
 }
 
 export type BenchmarkReport = {

--- a/scripts/benchmark/index.ts
+++ b/scripts/benchmark/index.ts
@@ -66,11 +66,11 @@ const formatTime = (timeMs: number | null) => {
   return `${(timeMs / 1000).toFixed(1)}s`
 }
 
-const formatAverage = (value: number | null) => {
+const formatViaCount = (value: number | null) => {
   if (value === null) {
     return "n/a"
   }
-  return value.toFixed(2)
+  return String(value)
 }
 
 const formatDurationLabel = (timeMs: number) => {
@@ -338,7 +338,7 @@ const formatTable = (rows: SolverRunSummary[]) => {
     "Timed Out",
     "P50 Time",
     "P95 Time",
-    "Avg Via",
+    "Best Via",
   ]
 
   const body = rows.map((row) => [
@@ -348,7 +348,7 @@ const formatTable = (rows: SolverRunSummary[]) => {
     row.timedOutLabel,
     formatTime(row.p50TimeMs),
     formatTime(row.p95TimeMs),
-    formatAverage(row.avgVia),
+    formatViaCount(row.bestVia),
   ])
 
   const widths = headers.map((header, columnIndex) => {
@@ -933,11 +933,7 @@ const summarizeSolverResults = (
   const relaxedDrcPassed = succeeded.filter(
     (result) => result.relaxedDrcPassed,
   ).length
-  const avgVia =
-    viaCounts.length === 0
-      ? null
-      : viaCounts.reduce((sum, viaCount) => sum + viaCount, 0) /
-        viaCounts.length
+  const bestVia = viaCounts.length === 0 ? null : Math.min(...viaCounts)
 
   return {
     solverName,
@@ -954,8 +950,28 @@ const summarizeSolverResults = (
     timedOutLabel: `${timedOut.length}/${results.length}`,
     p50TimeMs: getPercentileMs(elapsedForSucceeded, 0.5),
     p95TimeMs: getPercentileMs(elapsedForSucceeded, 0.95),
-    avgVia,
+    bestVia,
   } satisfies SolverRunSummary
+}
+
+const annotateBestViaCounts = (results: WorkerResult[]): WorkerResult[] => {
+  const bestViaByScenario = new Map<string, number>()
+
+  for (const result of results) {
+    if (!result.didSolve || typeof result.viaCount !== "number") {
+      continue
+    }
+
+    const currentBest = bestViaByScenario.get(result.scenarioName)
+    if (currentBest === undefined || result.viaCount < currentBest) {
+      bestViaByScenario.set(result.scenarioName, result.viaCount)
+    }
+  }
+
+  return results.map((result) => ({
+    ...result,
+    bestViaCount: bestViaByScenario.get(result.scenarioName),
+  }))
 }
 
 const main = async () => {
@@ -1030,7 +1046,9 @@ const main = async () => {
     `Running ${tasks.length} benchmark tasks across ${concurrency} workers (${solvers.length} solver${solvers.length === 1 ? "" : "s"}, ${scenarios.length} scenario${scenarios.length === 1 ? "" : "s"}, dataset: ${datasetName})`,
   )
 
-  const results = await runBenchmarkTasks(tasks, concurrency, sampleTimeoutMs)
+  const results = annotateBestViaCounts(
+    await runBenchmarkTasks(tasks, concurrency, sampleTimeoutMs),
+  )
   const rows = solvers.map((solver) =>
     summarizeSolverResults(
       solver,

--- a/scripts/benchmark/index.ts
+++ b/scripts/benchmark/index.ts
@@ -338,7 +338,6 @@ const formatTable = (rows: SolverRunSummary[]) => {
     "Timed Out",
     "P50 Time",
     "P95 Time",
-    "Best Via",
   ]
 
   const body = rows.map((row) => [
@@ -348,7 +347,6 @@ const formatTable = (rows: SolverRunSummary[]) => {
     row.timedOutLabel,
     formatTime(row.p50TimeMs),
     formatTime(row.p95TimeMs),
-    formatViaCount(row.bestVia),
   ])
 
   const widths = headers.map((header, columnIndex) => {


### PR DESCRIPTION
## Summary
- add per-scenario best-via record data to benchmark results
- replace average via reporting with best via reporting in benchmark summaries
- surface via counts and best-via record deltas in benchmark PR comments

## Validation
- bun test tests/benchmark-datasets.test.ts
- bun x tsc --noEmit
- bun run format