### PR TITLE
reduce ts footprint so LSP take less memory

### DIFF
--- a/fixtures/tsconfig.json
+++ b/fixtures/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "resolveJsonModule": true
+  },
+  "include": ["./**/*.ts", "./**/*.tsx"],
+  "exclude": ["../dist", "./**/*.json"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,6 @@
     "module": "ESNext",
     "moduleDetection": "force",
     "jsx": "react-jsx",
-    "allowJs": true,
 
     "baseUrl": ".",
     "paths": {
@@ -37,5 +36,17 @@
     "noUnusedParameters": false,
     "noPropertyAccessFromIndexSignature": false
   },
-  "exclude": ["dist", "examples/legacy/assets/**/*.json"]
+  "include": [
+    "lib/**/*.ts",
+    "lib/**/*.tsx",
+    "scripts/**/*.ts",
+    "scripts/**/*.tsx",
+    "tests/**/*.ts",
+    "tests/**/*.tsx",
+    "types/**/*.d.ts",
+    "json-modules.d.ts",
+    "main.tsx",
+    "vite.config.ts"
+  ],
+  "exclude": ["dist", "fixtures", "examples/legacy/assets/**/*.json"]
 }


### PR DESCRIPTION
Currently, it increased free space from **8.5 GB to 9.5 GB**, so about **1 GB more with LSP on**.

Before these changes, my available RAM would drop to around **4–5 GB** while working. It is hard to simulate the exact case, but I think these changes are good. With the changes, it stays around **8–9 GB** of free space, which is much better.

LSP is the software that helps with indexing and code completion (non ai).

<img width="884" height="617" alt="image" src="https://github.com/user-attachments/assets/c78bf2cf-ccb2-4fb1-a97b-79399684e1f0" />

<img width="749" height="516" alt="image" src="https://github.com/user-attachments/assets/b93b5bc2-da17-4181-a94e-8d2ba547c240" />
