### PR TITLE
preprocessSimpleRouteJsonSolver: snap point to connect to nearest pad for rotated rect cases where the point is outside and enables STATIC_REACHABILITY_PRECHECK in DuplicateCongestedPortSolver

### DIFF
--- a/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
+++ b/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
@@ -758,7 +758,7 @@ export class TinyHypergraphPortPointPathingSolver extends BaseSolver {
               2_000_000 * getEffortScale(params.effort),
             ),
             RIP_THRESHOLD_RAMP_ATTEMPTS: 0,
-            STATIC_REACHABILITY_PRECHECK: false,
+            STATIC_REACHABILITY_PRECHECK: true,
           },
         },
       )

--- a/lib/utils/addApproximatingRectsToSrj.ts
+++ b/lib/utils/addApproximatingRectsToSrj.ts
@@ -1,6 +1,10 @@
 import { CONNECTION_REGION_SIZE } from "@tscircuit/fixed-via-hypergraph-solver/lib/FixedViaHypergraphSolver/via-graph-generator/createConnectionRegion"
 import type { ConnectionPoint, Obstacle, SimpleRouteJson } from "lib/types"
-import { getBoundFromCenteredRect } from "@tscircuit/math-utils"
+import {
+  getBoundFromCenteredRect,
+  distance as calculateDistance,
+} from "@tscircuit/math-utils"
+import { calculateMse } from "scripts/highdensity-benchmark/metrics/calculateMse"
 
 const normalizeRotation = (rotationDegrees: number) =>
   ((rotationDegrees % 360) + 360) % 360
@@ -477,8 +481,7 @@ export const addApproximatingRectsToSrj = (
 
         for (const obstacle of approximatedObstacles) {
           const clampedPoint = clampPointToObstacle(point, obstacle)
-          const distance =
-            (clampedPoint.x - point.x) ** 2 + (clampedPoint.y - point.y) ** 2
+          const distance = calculateDistance(clampedPoint, point)
 
           if (distance < nearestDistance) {
             nearestDistance = distance

--- a/lib/utils/addApproximatingRectsToSrj.ts
+++ b/lib/utils/addApproximatingRectsToSrj.ts
@@ -1,4 +1,5 @@
-import type { Obstacle, SimpleRouteJson } from "lib/types"
+import { CONNECTION_REGION_SIZE } from "@tscircuit/fixed-via-hypergraph-solver/lib/FixedViaHypergraphSolver/via-graph-generator/createConnectionRegion"
+import type { ConnectionPoint, Obstacle, SimpleRouteJson } from "lib/types"
 
 const normalizeRotation = (rotationDegrees: number) =>
   ((rotationDegrees % 360) + 360) % 360
@@ -81,6 +82,49 @@ interface Rect {
   width: number
   height: number
 }
+
+const getConnectionPointLayers = (point: ConnectionPoint): string[] =>
+  "layers" in point ? point.layers : [point.layer]
+
+const isPointInsideObstacle = (
+  point: ConnectionPoint,
+  obstacle: Pick<Obstacle, "center" | "width" | "height" | "layers">,
+) => {
+  if (
+    getConnectionPointLayers(point).length > 0 &&
+    !getConnectionPointLayers(point).some((layer) => obstacle.layers.includes(layer))
+  ) {
+    return false
+  }
+
+  const minX = obstacle.center.x - obstacle.width / 2
+  const maxX = obstacle.center.x + obstacle.width / 2
+  const minY = obstacle.center.y - obstacle.height / 2
+  const maxY = obstacle.center.y + obstacle.height / 2
+
+  return point.x >= minX && point.x <= maxX && point.y >= minY && point.y <= maxY
+}
+
+const clampPointToObstacle = (
+  point: ConnectionPoint,
+  obstacle: Pick<Obstacle, "center" | "width" | "height">,
+) => {
+  const minX = obstacle.center.x - obstacle.width / 2
+  const maxX = obstacle.center.x + obstacle.width / 2
+  const minY = obstacle.center.y - obstacle.height / 2
+  const maxY = obstacle.center.y + obstacle.height / 2
+
+  return {
+    x: Math.max(minX, Math.min(maxX, point.x)),
+    y: Math.max(minY, Math.min(maxY, point.y)),
+  }
+}
+
+const getObstacleKey = (obstacle: Obstacle, index: number) =>
+  obstacle.obstacleId ?? `${obstacle.componentId ?? "obstacle"}_${index}`
+
+const getPointConnectionIds = (point: ConnectionPoint) =>
+  [point.pointId, point.pcb_port_id].filter((id): id is string => Boolean(id))
 
 export function generateApproximatingRects(
   rotatedRect: RotatedRect,
@@ -362,6 +406,8 @@ export const addApproximatingRectsToSrj = (
   srj: SimpleRouteJson,
 ): SimpleRouteJson => {
   const obstaclesByRect = new Map<string, Obstacle>()
+  const approximatedObstaclesBySource = new Map<string, Obstacle[]>()
+  const originalObstaclesBySource = new Map<string, Obstacle>()
   const connectedRotatedObstacleCount = srj.obstacles.filter(
     (obstacle) =>
       obstacle.connectedTo.length > 0 &&
@@ -372,13 +418,17 @@ export const addApproximatingRectsToSrj = (
   const useSparseCenterlineApproximation =
     connectedRotatedObstacleCount > MANY_CONNECTED_ROTATED_OBSTACLES_THRESHOLD
 
-  for (const obstacle of srj.obstacles) {
+  for (const [obstacleIndex, obstacle] of srj.obstacles.entries()) {
     const convertedObstacle = convertObstacleToOldFormat(obstacle, {
       useSparseCenterlineApproximation:
         useSparseCenterlineApproximation &&
         obstacle.connectedTo.length > 0 &&
         !obstacle.obstacleId?.startsWith("trace_obstacle_"),
     })
+    const sourceKey = getObstacleKey(obstacle, obstacleIndex)
+    approximatedObstaclesBySource.set(sourceKey, convertedObstacle)
+    originalObstaclesBySource.set(sourceKey, obstacle)
+
     for (const converted of convertedObstacle) {
       const key = [
         converted.center.x.toFixed(6),
@@ -400,8 +450,58 @@ export const addApproximatingRectsToSrj = (
     }
   }
 
+  const repairedConnections = srj.connections.map((connection) => ({
+    ...connection,
+    pointsToConnect: connection.pointsToConnect.map((point) => {
+      const pointIds = getPointConnectionIds(point)
+      if (pointIds.length === 0) return point
+
+      for (const [sourceKey, originalObstacle] of originalObstaclesBySource) {
+        if (
+          !pointIds.some((pointId) => originalObstacle.connectedTo.includes(pointId))
+        ) {
+          continue
+        }
+
+        if (!isPointInsideObstacle(point, originalObstacle)) continue
+
+        const approximatedObstacles =
+          approximatedObstaclesBySource.get(sourceKey) ?? []
+        if (approximatedObstacles.length === 0) continue
+
+        if (
+          approximatedObstacles.some((obstacle) => isPointInsideObstacle(point, obstacle))
+        ) {
+          return point
+        }
+
+        let nearestObstacle = approximatedObstacles[0]!
+        let nearestDistance = Number.POSITIVE_INFINITY
+
+        for (const obstacle of approximatedObstacles) {
+          const clampedPoint = clampPointToObstacle(point, obstacle)
+          const distance =
+            (clampedPoint.x - point.x) ** 2 + (clampedPoint.y - point.y) ** 2
+
+          if (distance < nearestDistance) {
+            nearestDistance = distance
+            nearestObstacle = obstacle
+          }
+        }
+
+        return {
+          ...point,
+          ...clampPointToObstacle(point, nearestObstacle),
+        }
+      }
+
+      return point
+    }),
+  }))
+
   return {
     ...srj,
+    connections: repairedConnections,
     obstacles: [...obstaclesByRect.values()],
   }
 }

--- a/lib/utils/addApproximatingRectsToSrj.ts
+++ b/lib/utils/addApproximatingRectsToSrj.ts
@@ -1,5 +1,6 @@
 import { CONNECTION_REGION_SIZE } from "@tscircuit/fixed-via-hypergraph-solver/lib/FixedViaHypergraphSolver/via-graph-generator/createConnectionRegion"
 import type { ConnectionPoint, Obstacle, SimpleRouteJson } from "lib/types"
+import { getBoundFromCenteredRect } from "@tscircuit/math-utils"
 
 const normalizeRotation = (rotationDegrees: number) =>
   ((rotationDegrees % 360) + 360) % 360
@@ -86,33 +87,25 @@ interface Rect {
 const getConnectionPointLayers = (point: ConnectionPoint): string[] =>
   "layers" in point ? point.layers : [point.layer]
 
-const isPointInsideObstacle = (
-  point: ConnectionPoint,
-  obstacle: Pick<Obstacle, "center" | "width" | "height" | "layers">,
-) => {
+const isPointInsideObstacle = (point: ConnectionPoint, obstacle: Obstacle) => {
   if (
     getConnectionPointLayers(point).length > 0 &&
-    !getConnectionPointLayers(point).some((layer) => obstacle.layers.includes(layer))
+    !getConnectionPointLayers(point).some((layer) =>
+      obstacle.layers.includes(layer),
+    )
   ) {
     return false
   }
 
-  const minX = obstacle.center.x - obstacle.width / 2
-  const maxX = obstacle.center.x + obstacle.width / 2
-  const minY = obstacle.center.y - obstacle.height / 2
-  const maxY = obstacle.center.y + obstacle.height / 2
+  const { minX, maxX, minY, maxY } = getBoundFromCenteredRect(obstacle)
 
-  return point.x >= minX && point.x <= maxX && point.y >= minY && point.y <= maxY
+  return (
+    point.x >= minX && point.x <= maxX && point.y >= minY && point.y <= maxY
+  )
 }
 
-const clampPointToObstacle = (
-  point: ConnectionPoint,
-  obstacle: Pick<Obstacle, "center" | "width" | "height">,
-) => {
-  const minX = obstacle.center.x - obstacle.width / 2
-  const maxX = obstacle.center.x + obstacle.width / 2
-  const minY = obstacle.center.y - obstacle.height / 2
-  const maxY = obstacle.center.y + obstacle.height / 2
+const clampPointToObstacle = (point: ConnectionPoint, obstacle: Obstacle) => {
+  const { minX, maxX, minY, maxY } = getBoundFromCenteredRect(obstacle)
 
   return {
     x: Math.max(minX, Math.min(maxX, point.x)),
@@ -458,7 +451,9 @@ export const addApproximatingRectsToSrj = (
 
       for (const [sourceKey, originalObstacle] of originalObstaclesBySource) {
         if (
-          !pointIds.some((pointId) => originalObstacle.connectedTo.includes(pointId))
+          !pointIds.some((pointId) =>
+            originalObstacle.connectedTo.includes(pointId),
+          )
         ) {
           continue
         }
@@ -470,7 +465,9 @@ export const addApproximatingRectsToSrj = (
         if (approximatedObstacles.length === 0) continue
 
         if (
-          approximatedObstacles.some((obstacle) => isPointInsideObstacle(point, obstacle))
+          approximatedObstacles.some((obstacle) =>
+            isPointInsideObstacle(point, obstacle),
+          )
         ) {
           return point
         }

--- a/lib/utils/addApproximatingRectsToSrj.ts
+++ b/lib/utils/addApproximatingRectsToSrj.ts
@@ -3,6 +3,7 @@ import type { ConnectionPoint, Obstacle, SimpleRouteJson } from "lib/types"
 import {
   getBoundFromCenteredRect,
   distance as calculateDistance,
+  isPointInsideBounds,
 } from "@tscircuit/math-utils"
 import { calculateMse } from "scripts/highdensity-benchmark/metrics/calculateMse"
 
@@ -101,11 +102,7 @@ const isPointInsideObstacle = (point: ConnectionPoint, obstacle: Obstacle) => {
     return false
   }
 
-  const { minX, maxX, minY, maxY } = getBoundFromCenteredRect(obstacle)
-
-  return (
-    point.x >= minX && point.x <= maxX && point.y >= minY && point.y <= maxY
-  )
+  return isPointInsideBounds(point, getBoundFromCenteredRect(obstacle))
 }
 
 const clampPointToObstacle = (point: ConnectionPoint, obstacle: Obstacle) => {


### PR DESCRIPTION
origin
<img width="312" height="307" alt="image" src="https://github.com/user-attachments/assets/99f933d6-73db-444e-8fda-e096c99be6e0" />

after running preprocessSimpleRouteJsonSolver

before fix:
<img width="269" height="268" alt="image" src="https://github.com/user-attachments/assets/bb4d737e-bfa9-4162-920c-31fb044f61ff" />

after fix:
<img width="243" height="239" alt="image" src="https://github.com/user-attachments/assets/98c8b53a-2457-4f46-9345-29a04098a359" />
