### PR TITLE
add tolerance to the distance check

### DIFF
--- a/lib/solvers/PortPointPathingSolver/hgportpointpathingsolver/checkIfConnectionPointIsInRegion.ts
+++ b/lib/solvers/PortPointPathingSolver/hgportpointpathingsolver/checkIfConnectionPointIsInRegion.ts
@@ -4,13 +4,20 @@ import { mapLayerNameToZ } from "lib/utils/mapLayerNameToZ"
 import { sharedZLayers } from "./sharedZLayers"
 import type { RegionHg } from "./types"
 
+const CONNECTION_POINT_REGION_TOLERANCE = 1e-3
+
 /** Checks whether a connection endpoint lies inside a region on at least one shared layer. */
 export function checkIfConnectionPointIsInRegion(params: {
   point: ConnectionPoint
   region: RegionHg
   layerCount: number
 }): boolean {
-  if (pointToBoxDistance(params.point, params.region.d) === 0) {
+  // Treat near-boundary endpoints as inside the region to avoid false
+  // negatives from tiny coordinate drift between topology and connection data.
+  if (
+    pointToBoxDistance(params.point, params.region.d) <=
+    CONNECTION_POINT_REGION_TOLERANCE
+  ) {
     const layers =
       "layers" in params.point ? params.point.layers : [params.point.layer]
     const intLayers = layers.map((layer) => {


### PR DESCRIPTION
<img width="827" height="417" alt="image" src="https://github.com/user-attachments/assets/e9eb566f-a4a5-4828-b3eb-ecb307d8d4dc" />


Even though the points to connect were inside, it was causing the solver to fail. Add a tolerance, because before we were using `== 0`, which was too strict.
