### PR TITLE
Track best-known via count per benchmark circuit

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -326,6 +326,23 @@ jobs:
           echo "datasets_json=${DATASETS_JSON}" >> "$GITHUB_OUTPUT"
           echo "Main branch benchmark datasets: ${DATASETS_JSON}"
 
+      - name: Download previous best via counts
+        if: github.event_name == 'push' && github.ref_name == 'main'
+        env:
+          GH_TOKEN: ${{ secrets.TSCIRCUIT_BOT_GITHUB_TOKEN }}
+        run: |
+          RUN_ID=$(gh api "repos/${{ github.repository }}/actions/workflows/benchmark.yml/runs?branch=main&event=push&status=success&per_page=1" --jq '.workflow_runs[0].id' 2>/dev/null || echo "")
+          if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+            echo '{"version":1,"kind":"benchmark-best-vias","records":[]}' > benchmark-best-vias-previous.json
+            exit 0
+          fi
+          gh run download "$RUN_ID" --repo "${{ github.repository }}" --name benchmark-result --dir ./previous-main-artifact 2>/dev/null || true
+          if [ -f ./previous-main-artifact/benchmark-best-vias.json ]; then
+            cp ./previous-main-artifact/benchmark-best-vias.json benchmark-best-vias-previous.json
+          else
+            echo '{"version":1,"kind":"benchmark-best-vias","records":[]}' > benchmark-best-vias-previous.json
+          fi
+
       - name: Run benchmark
         env:
           BENCHMARK_ARGS_JSON: ${{ steps.parse.outputs.benchmark_args_json }}
@@ -430,6 +447,11 @@ jobs:
 
           process.exit(result.status ?? 1)
           NODE
+          if [ "${GITHUB_EVENT_NAME}" = "push" ] && [ "${GITHUB_REF_NAME}" = "main" ]; then
+            bun scripts/benchmark/best-via-counts.ts merge --previous benchmark-best-vias-previous.json --current benchmark-result.json --out benchmark-best-vias.json
+          else
+            bun scripts/benchmark/best-via-counts.ts write-from-report --report benchmark-result.json --out benchmark-best-vias.json
+          fi
           cp benchmark-result.txt benchmark-result-pr.txt
           cp benchmark-result.json benchmark-result-pr.json
 
@@ -442,6 +464,8 @@ jobs:
           if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
             echo "(no main branch benchmark result available)" > benchmark-result-main.txt
             echo "" > benchmark-result-main.json
+            echo "" > benchmark-best-vias-main.json
+            bun scripts/benchmark/best-via-counts.ts write-cells --best-vias benchmark-best-vias-main.json --report benchmark-result-pr.json --out benchmark-via-cells.json
             exit 0
           fi
           gh run download "$RUN_ID" --repo "${{ github.repository }}" --name benchmark-result --dir ./main-artifact 2>/dev/null || true
@@ -455,6 +479,12 @@ jobs:
           else
             echo "" > benchmark-result-main.json
           fi
+          if [ -f ./main-artifact/benchmark-best-vias.json ]; then
+            cp ./main-artifact/benchmark-best-vias.json benchmark-best-vias-main.json
+          else
+            echo "" > benchmark-best-vias-main.json
+          fi
+          bun scripts/benchmark/best-via-counts.ts write-cells --best-vias benchmark-best-vias-main.json --report benchmark-result-pr.json --out benchmark-via-cells.json
 
       - name: Post benchmark result comment before profile-solvers
         if: github.event_name == 'issue_comment' && steps.parse.outputs.status_comment_id != ''
@@ -570,6 +600,15 @@ jobs:
                 ]),
               )
             }
+            const buildViaCellIndex = (report) => {
+              if (!Array.isArray(report?.cells)) return new Map()
+              return new Map(
+                report.cells.map((cell) => [
+                  `${cell.datasetName}::${cell.solverName}::${cell.scenarioName}`,
+                  cell.label,
+                ]),
+              )
+            }
             const getDelta = (test, mainIndex) => {
               if (!mainIndex) return ''
               const key = `${test.solverName}::${test.scenarioName}`
@@ -581,21 +620,34 @@ jobs:
               if (prScore < mainScore) return '❌'
               return ''
             }
+            const getViaCell = (test, viaCellIndex, datasetName) => {
+              const key = `${datasetName}::${test.solverName}::${test.scenarioName}`
+              const viaCell = viaCellIndex?.get(key)
+              if (viaCell) return viaCell
+              return typeof test?.viaCount === 'number' ? String(test.viaCount) : ''
+            }
             const isUnchangedPassingTest = (test, mainIndex) => {
               if (!mainIndex) return false
               const key = `${test.solverName}::${test.scenarioName}`
               const mainTest = mainIndex.get(key)
+              const sameSolverViaUnchanged =
+                typeof test.viaCount === 'number' ||
+                typeof mainTest?.viaCount === 'number'
+                  ? test.viaCount === mainTest?.viaCount
+                  : true
               return (
                 Boolean(mainTest) &&
                 test.didSolve &&
                 test.relaxedDrcPassed &&
                 mainTest.didSolve &&
-                mainTest.relaxedDrcPassed
+                mainTest.relaxedDrcPassed &&
+                sameSolverViaUnchanged
               )
             }
             const renderTests = (report, options = {}) => {
               const includeDelta = Boolean(options.includeDelta)
               const mainIndex = options.mainIndex
+              const viaCellIndex = options.viaCellIndex
               if (!Array.isArray(report?.tests) || report.tests.length === 0) {
                 return ['Per-test results unavailable.']
               }
@@ -607,12 +659,12 @@ jobs:
               const omittedCount = report.tests.length - tests.length
               const header = includeDelta
                 ? [
-                    '| Solver | Sample | Status | Time | Relaxed DRC | Error | Delta |',
-                    '| --- | --- | --- | --- | --- | --- | --- |',
+                    '| Solver | Sample | Status | Via | Time | Relaxed DRC | Error | Delta |',
+                    '| --- | --- | --- | ---: | --- | --- | --- | --- |',
                   ]
                 : [
-                    '| Solver | Sample | Status | Time | Relaxed DRC | Error |',
-                    '| --- | --- | --- | --- | --- | --- |',
+                    '| Solver | Sample | Status | Via | Time | Relaxed DRC | Error |',
+                    '| --- | --- | --- | ---: | --- | --- | --- |',
                   ]
               return [
                 ...(omittedCount > 0
@@ -621,8 +673,8 @@ jobs:
                 ...header,
                 ...tests.map((test) =>
                   includeDelta
-                    ? `| ${formatSolverName(test.solverName)} | ${getSampleLabel(test)} | ${getStatus(test)} | ${formatTime(test.elapsedTimeMs)} | ${getDrc(test)} | ${getErrorCell(test)} | ${getDelta(test, mainIndex)} |`
-                    : `| ${formatSolverName(test.solverName)} | ${getSampleLabel(test)} | ${getStatus(test)} | ${formatTime(test.elapsedTimeMs)} | ${getDrc(test)} | ${getErrorCell(test)} |`,
+                    ? `| ${formatSolverName(test.solverName)} | ${getSampleLabel(test)} | ${getStatus(test)} | ${getViaCell(test, viaCellIndex, report.datasetName)} | ${formatTime(test.elapsedTimeMs)} | ${getDrc(test)} | ${getErrorCell(test)} | ${getDelta(test, mainIndex)} |`
+                    : `| ${formatSolverName(test.solverName)} | ${getSampleLabel(test)} | ${getStatus(test)} | ${getViaCell(test, viaCellIndex, report.datasetName)} | ${formatTime(test.elapsedTimeMs)} | ${getDrc(test)} | ${getErrorCell(test)} |`,
                 ),
               ]
             }
@@ -688,7 +740,10 @@ jobs:
             const mainText = readText('benchmark-result-main.txt') ?? '(not available)'
             const prReport = readJson('benchmark-result-pr.json') ?? readJson('benchmark-result.json')
             const mainReport = readJson('benchmark-result-main.json')
-            const mainIndex = buildMainIndex(getMainReportForDataset(mainReport, prReport?.datasetName))
+            const viaCellReport = readJson('benchmark-via-cells.json')
+            const mainDatasetReport = getMainReportForDataset(mainReport, prReport?.datasetName)
+            const mainIndex = buildMainIndex(mainDatasetReport)
+            const viaCellIndex = buildViaCellIndex(viaCellReport)
             const runUrl = `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`
             const profileEnabled = '${{ steps.parse.outputs.profile_solvers }}' === 'true'
 
@@ -715,6 +770,7 @@ jobs:
               ...renderReport(prReport, prText ?? '(benchmark results were not produced)', {
                 includeDelta: true,
                 mainIndex,
+                viaCellIndex,
                 omitUnchangedPassingSamples: Boolean(options.omitUnchangedPassingSamples),
               }),
               ...(profileEnabled
@@ -923,10 +979,13 @@ jobs:
           path: |
             ./benchmark-result.txt
             ./benchmark-result.json
+            ./benchmark-best-vias.json
             ./benchmark-result-pr.txt
             ./benchmark-result-pr.json
             ./benchmark-result-main.txt
             ./benchmark-result-main.json
+            ./benchmark-best-vias-main.json
+            ./benchmark-via-cells.json
             ./profile-solvers-pr.txt
             ./profile-solvers-pr.json
             ./profile-solvers-main.txt
@@ -1047,6 +1106,15 @@ jobs:
                 ]),
               )
             }
+            const buildViaCellIndex = (report) => {
+              if (!Array.isArray(report?.cells)) return new Map()
+              return new Map(
+                report.cells.map((cell) => [
+                  `${cell.datasetName}::${cell.solverName}::${cell.scenarioName}`,
+                  cell.label,
+                ]),
+              )
+            }
             const getDelta = (test, mainIndex) => {
               if (!mainIndex) return ''
               const key = `${test.solverName}::${test.scenarioName}`
@@ -1058,21 +1126,34 @@ jobs:
               if (prScore < mainScore) return '❌'
               return ''
             }
+            const getViaCell = (test, viaCellIndex, datasetName) => {
+              const key = `${datasetName}::${test.solverName}::${test.scenarioName}`
+              const viaCell = viaCellIndex?.get(key)
+              if (viaCell) return viaCell
+              return typeof test?.viaCount === 'number' ? String(test.viaCount) : ''
+            }
             const isUnchangedPassingTest = (test, mainIndex) => {
               if (!mainIndex) return false
               const key = `${test.solverName}::${test.scenarioName}`
               const mainTest = mainIndex.get(key)
+              const sameSolverViaUnchanged =
+                typeof test.viaCount === 'number' ||
+                typeof mainTest?.viaCount === 'number'
+                  ? test.viaCount === mainTest?.viaCount
+                  : true
               return (
                 Boolean(mainTest) &&
                 test.didSolve &&
                 test.relaxedDrcPassed &&
                 mainTest.didSolve &&
-                mainTest.relaxedDrcPassed
+                mainTest.relaxedDrcPassed &&
+                sameSolverViaUnchanged
               )
             }
             const renderTests = (report, options = {}) => {
               const includeDelta = Boolean(options.includeDelta)
               const mainIndex = options.mainIndex
+              const viaCellIndex = options.viaCellIndex
               if (!Array.isArray(report?.tests) || report.tests.length === 0) {
                 return ['Per-test results unavailable.']
               }
@@ -1084,12 +1165,12 @@ jobs:
               const omittedCount = report.tests.length - tests.length
               const header = includeDelta
                 ? [
-                    '| Solver | Sample | Status | Time | Relaxed DRC | Error | Delta |',
-                    '| --- | --- | --- | --- | --- | --- | --- |',
+                    '| Solver | Sample | Status | Via | Time | Relaxed DRC | Error | Delta |',
+                    '| --- | --- | --- | ---: | --- | --- | --- | --- |',
                   ]
                 : [
-                    '| Solver | Sample | Status | Time | Relaxed DRC | Error |',
-                    '| --- | --- | --- | --- | --- | --- |',
+                    '| Solver | Sample | Status | Via | Time | Relaxed DRC | Error |',
+                    '| --- | --- | --- | ---: | --- | --- | --- |',
                   ]
               return [
                 ...(omittedCount > 0
@@ -1098,8 +1179,8 @@ jobs:
                 ...header,
                 ...tests.map((test) =>
                   includeDelta
-                    ? `| ${formatSolverName(test.solverName)} | ${getSampleLabel(test)} | ${getStatus(test)} | ${formatTime(test.elapsedTimeMs)} | ${getDrc(test)} | ${getErrorCell(test)} | ${getDelta(test, mainIndex)} |`
-                    : `| ${formatSolverName(test.solverName)} | ${getSampleLabel(test)} | ${getStatus(test)} | ${formatTime(test.elapsedTimeMs)} | ${getDrc(test)} | ${getErrorCell(test)} |`,
+                    ? `| ${formatSolverName(test.solverName)} | ${getSampleLabel(test)} | ${getStatus(test)} | ${getViaCell(test, viaCellIndex, report.datasetName)} | ${formatTime(test.elapsedTimeMs)} | ${getDrc(test)} | ${getErrorCell(test)} | ${getDelta(test, mainIndex)} |`
+                    : `| ${formatSolverName(test.solverName)} | ${getSampleLabel(test)} | ${getStatus(test)} | ${getViaCell(test, viaCellIndex, report.datasetName)} | ${formatTime(test.elapsedTimeMs)} | ${getDrc(test)} | ${getErrorCell(test)} |`,
                 ),
               ]
             }
@@ -1268,7 +1349,10 @@ jobs:
             const mainProfileSolversReport = readJson('profile-solvers-main.json')
             const prReport = readJson('benchmark-result-pr.json') ?? readJson('benchmark-result.json')
             const mainReport = readJson('benchmark-result-main.json')
-            const mainIndex = buildMainIndex(getMainReportForDataset(mainReport, prReport?.datasetName))
+            const viaCellReport = readJson('benchmark-via-cells.json')
+            const mainDatasetReport = getMainReportForDataset(mainReport, prReport?.datasetName)
+            const mainIndex = buildMainIndex(mainDatasetReport)
+            const viaCellIndex = buildViaCellIndex(viaCellReport)
             const runUrl = `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`
             const jobStatus = '${{ job.status }}'
             const benchmarkFailed = jobStatus !== 'success'
@@ -1318,6 +1402,7 @@ jobs:
               ...renderReport(prReport, prText ?? '(benchmark results were not produced)', {
                 includeDelta: true,
                 mainIndex,
+                viaCellIndex,
                 omitUnchangedPassingSamples: Boolean(options.omitUnchangedPassingSamples),
               }),
               ...(hasProfileSolvers

--- a/scripts/benchmark/benchmark-types.ts
+++ b/scripts/benchmark/benchmark-types.ts
@@ -75,6 +75,34 @@ export type SolverRunSummary = {
   avgVia: number | null
 }
 
+export type BestViaCountRecord = {
+  datasetName: string
+  solverName: string
+  scenarioName: string
+  sampleNumber: number
+  viaCount: number
+  elapsedTimeMs: number
+}
+
+export type BenchmarkBestViasReport = {
+  version: 1
+  kind: "benchmark-best-vias"
+  records: BestViaCountRecord[]
+}
+
+export type BestViaCountCell = {
+  datasetName: string
+  solverName: string
+  scenarioName: string
+  label: string
+}
+
+export type BenchmarkBestViaCellsReport = {
+  version: 1
+  kind: "benchmark-best-via-cells"
+  cells: BestViaCountCell[]
+}
+
 export type BenchmarkReport = {
   version: 1
   datasetName: string

--- a/scripts/benchmark/best-via-counts.ts
+++ b/scripts/benchmark/best-via-counts.ts
@@ -1,0 +1,577 @@
+#!/usr/bin/env bun
+
+import { existsSync } from "node:fs"
+import type {
+  BenchmarkBestViaCellsReport,
+  BenchmarkBestViasReport,
+  BestViaCountCell,
+  BestViaCountRecord,
+  WorkerResult,
+} from "./benchmark-types"
+
+export type ParsedBenchmarkReport = {
+  version: 1
+  datasetName: string
+  tests: WorkerResult[]
+}
+
+export type BenchmarkReportCollection = {
+  version: number
+  kind: "benchmark-report-collection"
+  reports: ParsedBenchmarkReport[]
+}
+
+type WriteBestViasCommand = {
+  command: "write-from-report"
+  reportPath: string
+  outputPath: string
+}
+
+type MergeBestViasCommand = {
+  command: "merge"
+  previousPath: string
+  currentPath: string
+  outputPath: string
+}
+
+type WriteBestViaCellsCommand = {
+  command: "write-cells"
+  bestViasPath: string
+  reportPath: string
+  outputPath: string
+}
+
+type BestViasCommand =
+  | WriteBestViasCommand
+  | MergeBestViasCommand
+  | WriteBestViaCellsCommand
+
+export type BestViaCountComparison =
+  | {
+      kind: "missing_via_count"
+    }
+  | {
+      kind: "no_known_best"
+      viaCount: number
+    }
+  | {
+      kind: "better_than_best"
+      viaCount: number
+      deltaViaCount: number
+    }
+  | {
+      kind: "worse_than_best"
+      viaCount: number
+      deltaViaCount: number
+    }
+  | {
+      kind: "matches_best"
+      viaCount: number
+    }
+
+const emptyBestViasReport = (): BenchmarkBestViasReport => ({
+  version: 1,
+  kind: "benchmark-best-vias",
+  records: [],
+})
+
+const isObjectRecord = (input: unknown): input is Record<string, unknown> =>
+  typeof input === "object" && input !== null
+
+const isBestViaCountRecord = (input: unknown): input is BestViaCountRecord => {
+  if (!isObjectRecord(input)) {
+    return false
+  }
+
+  return (
+    typeof input.datasetName === "string" &&
+    typeof input.solverName === "string" &&
+    typeof input.scenarioName === "string" &&
+    typeof input.sampleNumber === "number" &&
+    typeof input.viaCount === "number" &&
+    typeof input.elapsedTimeMs === "number"
+  )
+}
+
+const isWorkerResult = (input: unknown): input is WorkerResult => {
+  if (!isObjectRecord(input)) {
+    return false
+  }
+
+  return (
+    typeof input.solverName === "string" &&
+    typeof input.scenarioName === "string" &&
+    typeof input.sampleNumber === "number" &&
+    typeof input.elapsedTimeMs === "number" &&
+    typeof input.didSolve === "boolean" &&
+    typeof input.didTimeout === "boolean" &&
+    typeof input.relaxedDrcPassed === "boolean"
+  )
+}
+
+const isBenchmarkBestViasReport = (
+  input: unknown,
+): input is BenchmarkBestViasReport => {
+  if (!isObjectRecord(input)) {
+    return false
+  }
+
+  return (
+    input.version === 1 &&
+    input.kind === "benchmark-best-vias" &&
+    Array.isArray(input.records) &&
+    input.records.every(isBestViaCountRecord)
+  )
+}
+
+const isParsedBenchmarkReport = (
+  input: unknown,
+): input is ParsedBenchmarkReport => {
+  if (!isObjectRecord(input)) {
+    return false
+  }
+
+  return (
+    input.version === 1 &&
+    typeof input.datasetName === "string" &&
+    Array.isArray(input.tests) &&
+    input.tests.every(isWorkerResult)
+  )
+}
+
+const isBenchmarkReportCollection = (
+  input: unknown,
+): input is BenchmarkReportCollection => {
+  if (!isObjectRecord(input)) {
+    return false
+  }
+
+  return (
+    input.kind === "benchmark-report-collection" &&
+    Array.isArray(input.reports) &&
+    input.reports.every(isParsedBenchmarkReport)
+  )
+}
+
+const hasBetterViaCount = ({
+  candidateRecord,
+  currentRecord,
+}: {
+  candidateRecord: BestViaCountRecord
+  currentRecord: BestViaCountRecord | undefined
+}) => {
+  if (!currentRecord) {
+    return true
+  }
+
+  if (candidateRecord.viaCount !== currentRecord.viaCount) {
+    return candidateRecord.viaCount < currentRecord.viaCount
+  }
+
+  return candidateRecord.elapsedTimeMs < currentRecord.elapsedTimeMs
+}
+
+export const makeBestViaCountsFromResults = ({
+  results,
+  datasetName,
+}: {
+  results: WorkerResult[]
+  datasetName: string
+}): BestViaCountRecord[] => {
+  const bestRecordByScenarioName = new Map<string, BestViaCountRecord>()
+
+  for (const result of results) {
+    if (
+      !result.didSolve ||
+      !result.relaxedDrcPassed ||
+      typeof result.viaCount !== "number"
+    ) {
+      continue
+    }
+
+    const candidateRecord: BestViaCountRecord = {
+      datasetName,
+      solverName: result.solverName,
+      scenarioName: result.scenarioName,
+      sampleNumber: result.sampleNumber,
+      viaCount: result.viaCount,
+      elapsedTimeMs: result.elapsedTimeMs,
+    }
+    const currentRecord = bestRecordByScenarioName.get(result.scenarioName)
+
+    if (hasBetterViaCount({ candidateRecord, currentRecord })) {
+      bestRecordByScenarioName.set(result.scenarioName, candidateRecord)
+    }
+  }
+
+  return [...bestRecordByScenarioName.values()].sort(
+    (firstRecord, secondRecord) =>
+      firstRecord.sampleNumber - secondRecord.sampleNumber,
+  )
+}
+
+const getBestViaRecordsFromReport = (
+  benchmarkReport: ParsedBenchmarkReport,
+): BestViaCountRecord[] => {
+  return makeBestViaCountsFromResults({
+    results: benchmarkReport.tests,
+    datasetName: benchmarkReport.datasetName,
+  })
+}
+
+export const getBestViaRecordsFromBenchmarkOutput = (
+  benchmarkOutput: ParsedBenchmarkReport | BenchmarkReportCollection,
+): BestViaCountRecord[] => {
+  if (isBenchmarkReportCollection(benchmarkOutput)) {
+    return benchmarkOutput.reports.flatMap((benchmarkReport) =>
+      getBestViaRecordsFromReport(benchmarkReport),
+    )
+  }
+
+  return getBestViaRecordsFromReport(benchmarkOutput)
+}
+
+export const mergeBestViasReports = ({
+  previousBestViasReport,
+  benchmarkOutput,
+}: {
+  previousBestViasReport: BenchmarkBestViasReport
+  benchmarkOutput: ParsedBenchmarkReport | BenchmarkReportCollection
+}): BenchmarkBestViasReport => {
+  const bestRecordByCircuitKey = new Map<string, BestViaCountRecord>()
+  const recordsToMerge = [
+    ...previousBestViasReport.records,
+    ...getBestViaRecordsFromBenchmarkOutput(benchmarkOutput),
+  ]
+
+  for (const candidateRecord of recordsToMerge) {
+    const circuitKey = `${candidateRecord.datasetName}::${candidateRecord.scenarioName}`
+    const currentRecord = bestRecordByCircuitKey.get(circuitKey)
+
+    if (hasBetterViaCount({ candidateRecord, currentRecord })) {
+      bestRecordByCircuitKey.set(circuitKey, candidateRecord)
+    }
+  }
+
+  return {
+    version: 1,
+    kind: "benchmark-best-vias",
+    records: [...bestRecordByCircuitKey.values()].sort(
+      (firstRecord, secondRecord) => {
+        if (firstRecord.datasetName !== secondRecord.datasetName) {
+          return firstRecord.datasetName.localeCompare(secondRecord.datasetName)
+        }
+
+        return firstRecord.sampleNumber - secondRecord.sampleNumber
+      },
+    ),
+  }
+}
+
+export const makeBestViasReportFromBenchmarkOutput = (
+  benchmarkOutput: ParsedBenchmarkReport | BenchmarkReportCollection,
+): BenchmarkBestViasReport => ({
+  version: 1,
+  kind: "benchmark-best-vias",
+  records: getBestViaRecordsFromBenchmarkOutput(benchmarkOutput),
+})
+
+export const buildBestViaCountIndex = ({
+  bestViasReport,
+  datasetName,
+}: {
+  bestViasReport: BenchmarkBestViasReport
+  datasetName: string
+}): Map<string, BestViaCountRecord> => {
+  const bestRecordByScenarioName = new Map<string, BestViaCountRecord>()
+
+  for (const candidateRecord of bestViasReport.records) {
+    if (candidateRecord.datasetName !== datasetName) {
+      continue
+    }
+
+    const currentRecord = bestRecordByScenarioName.get(
+      candidateRecord.scenarioName,
+    )
+
+    if (hasBetterViaCount({ candidateRecord, currentRecord })) {
+      bestRecordByScenarioName.set(
+        candidateRecord.scenarioName,
+        candidateRecord,
+      )
+    }
+  }
+
+  return bestRecordByScenarioName
+}
+
+const compareViaCountToBest = ({
+  workerResult,
+  bestViaCountIndex,
+}: {
+  workerResult: WorkerResult
+  bestViaCountIndex: Map<string, BestViaCountRecord>
+}): BestViaCountComparison => {
+  if (typeof workerResult.viaCount !== "number") {
+    return {
+      kind: "missing_via_count",
+    }
+  }
+
+  const bestRecord = bestViaCountIndex.get(workerResult.scenarioName)
+  if (!bestRecord) {
+    return {
+      kind: "no_known_best",
+      viaCount: workerResult.viaCount,
+    }
+  }
+
+  const deltaViaCount = workerResult.viaCount - bestRecord.viaCount
+  if (deltaViaCount < 0) {
+    return {
+      kind: "better_than_best",
+      viaCount: workerResult.viaCount,
+      deltaViaCount,
+    }
+  }
+
+  if (deltaViaCount > 0) {
+    return {
+      kind: "worse_than_best",
+      viaCount: workerResult.viaCount,
+      deltaViaCount,
+    }
+  }
+
+  return {
+    kind: "matches_best",
+    viaCount: workerResult.viaCount,
+  }
+}
+
+export const formatBestViaCountCell = ({
+  comparison,
+}: {
+  comparison: BestViaCountComparison
+}): string => {
+  switch (comparison.kind) {
+    case "missing_via_count":
+      return ""
+    case "no_known_best":
+      return String(comparison.viaCount)
+    case "better_than_best":
+      return `${comparison.viaCount} (${comparison.deltaViaCount}, better)`
+    case "worse_than_best":
+      return `${comparison.viaCount} (+${comparison.deltaViaCount}, worse)`
+    case "matches_best":
+      return `${comparison.viaCount} (=best)`
+  }
+}
+
+const makeBestViaCellsForReport = ({
+  benchmarkReport,
+  bestViasReport,
+}: {
+  benchmarkReport: ParsedBenchmarkReport
+  bestViasReport: BenchmarkBestViasReport
+}): BestViaCountCell[] => {
+  const bestViaCountIndex = buildBestViaCountIndex({
+    bestViasReport,
+    datasetName: benchmarkReport.datasetName,
+  })
+
+  return benchmarkReport.tests.map((workerResult) => ({
+    datasetName: benchmarkReport.datasetName,
+    solverName: workerResult.solverName,
+    scenarioName: workerResult.scenarioName,
+    label: formatBestViaCountCell({
+      comparison: compareViaCountToBest({
+        workerResult,
+        bestViaCountIndex,
+      }),
+    }),
+  }))
+}
+
+export const makeBestViaCellsReport = ({
+  benchmarkOutput,
+  bestViasReport,
+}: {
+  benchmarkOutput: ParsedBenchmarkReport | BenchmarkReportCollection
+  bestViasReport: BenchmarkBestViasReport
+}): BenchmarkBestViaCellsReport => ({
+  version: 1,
+  kind: "benchmark-best-via-cells",
+  cells: isBenchmarkReportCollection(benchmarkOutput)
+    ? benchmarkOutput.reports.flatMap((benchmarkReport) =>
+        makeBestViaCellsForReport({ benchmarkReport, bestViasReport }),
+      )
+    : makeBestViaCellsForReport({
+        benchmarkReport: benchmarkOutput,
+        bestViasReport,
+      }),
+})
+
+const readJsonFile = async (filePath: string): Promise<unknown> => {
+  if (!existsSync(filePath)) {
+    return null
+  }
+
+  const rawJson = await Bun.file(filePath).text()
+  if (!rawJson.trim()) {
+    return null
+  }
+
+  return JSON.parse(rawJson)
+}
+
+const readBestViasReport = async (
+  filePath: string,
+): Promise<BenchmarkBestViasReport> => {
+  const parsedJson = await readJsonFile(filePath)
+
+  if (!isBenchmarkBestViasReport(parsedJson)) {
+    return emptyBestViasReport()
+  }
+
+  return parsedJson
+}
+
+const readBenchmarkOutput = async (
+  filePath: string,
+): Promise<ParsedBenchmarkReport | BenchmarkReportCollection> => {
+  const parsedJson = await readJsonFile(filePath)
+
+  if (
+    isParsedBenchmarkReport(parsedJson) ||
+    isBenchmarkReportCollection(parsedJson)
+  ) {
+    return parsedJson
+  }
+
+  throw new Error(`Invalid benchmark report: ${filePath}`)
+}
+
+const getFlagValue = ({
+  args,
+  flagName,
+}: {
+  args: string[]
+  flagName: string
+}) => {
+  const flagIndex = args.indexOf(flagName)
+  return flagIndex === -1 ? undefined : args[flagIndex + 1]
+}
+
+const parseBestViasCommand = (args: string[]): BestViasCommand => {
+  const command = args[0]
+
+  if (command === "write-from-report") {
+    const reportPath = getFlagValue({ args, flagName: "--report" })
+    const outputPath = getFlagValue({ args, flagName: "--out" })
+
+    if (!reportPath || !outputPath) {
+      throw new Error("write-from-report requires --report and --out")
+    }
+
+    return {
+      command,
+      reportPath,
+      outputPath,
+    }
+  }
+
+  if (command === "merge") {
+    const previousPath = getFlagValue({ args, flagName: "--previous" })
+    const currentPath = getFlagValue({ args, flagName: "--current" })
+    const outputPath = getFlagValue({ args, flagName: "--out" })
+
+    if (!previousPath || !currentPath || !outputPath) {
+      throw new Error("merge requires --previous, --current, and --out")
+    }
+
+    return {
+      command,
+      previousPath,
+      currentPath,
+      outputPath,
+    }
+  }
+
+  if (command === "write-cells") {
+    const bestViasPath = getFlagValue({ args, flagName: "--best-vias" })
+    const reportPath = getFlagValue({ args, flagName: "--report" })
+    const outputPath = getFlagValue({ args, flagName: "--out" })
+
+    if (!bestViasPath || !reportPath || !outputPath) {
+      throw new Error("write-cells requires --best-vias, --report, and --out")
+    }
+
+    return {
+      command,
+      bestViasPath,
+      reportPath,
+      outputPath,
+    }
+  }
+
+  throw new Error(
+    "Usage: bun scripts/benchmark/best-via-counts.ts write-from-report --report benchmark-result.json --out benchmark-best-vias.json",
+  )
+}
+
+const runBestViasCommand = async (bestViasCommand: BestViasCommand) => {
+  if (bestViasCommand.command === "write-from-report") {
+    const benchmarkOutput = await readBenchmarkOutput(
+      bestViasCommand.reportPath,
+    )
+    const bestViasReport =
+      makeBestViasReportFromBenchmarkOutput(benchmarkOutput)
+    await Bun.write(
+      bestViasCommand.outputPath,
+      JSON.stringify(bestViasReport, null, 2),
+    )
+    return
+  }
+
+  if (bestViasCommand.command === "write-cells") {
+    const bestViasReport = await readBestViasReport(
+      bestViasCommand.bestViasPath,
+    )
+    const benchmarkOutput = await readBenchmarkOutput(
+      bestViasCommand.reportPath,
+    )
+    const bestViaCellsReport = makeBestViaCellsReport({
+      benchmarkOutput,
+      bestViasReport,
+    })
+
+    await Bun.write(
+      bestViasCommand.outputPath,
+      JSON.stringify(bestViaCellsReport, null, 2),
+    )
+    return
+  }
+
+  const previousBestViasReport = await readBestViasReport(
+    bestViasCommand.previousPath,
+  )
+  const benchmarkOutput = await readBenchmarkOutput(bestViasCommand.currentPath)
+  const mergedBestViasReport = mergeBestViasReports({
+    previousBestViasReport,
+    benchmarkOutput,
+  })
+
+  await Bun.write(
+    bestViasCommand.outputPath,
+    JSON.stringify(mergedBestViasReport, null, 2),
+  )
+}
+
+if (import.meta.main) {
+  runBestViasCommand(parseBestViasCommand(Bun.argv.slice(2))).catch((error) => {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(message)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
The workflow has two parts: one for `main` branch runs and another for PR runs triggered using `/benchmark`.

```mermaid
flowchart TD
  A[Main push starts] --> B[Download previous main artifact]
  B --> C[benchmark-best-vias-previous.json]
  A --> D[Run benchmark]
  D --> E[benchmark-result.json]
  C --> F[Merge best via counts]
  E --> F
  F --> G[benchmark-best-vias.json]
  G --> H[Upload benchmark artifact]

  I[PR benchmark starts] --> J[Run benchmark]
  J --> K[benchmark-result-pr.json]
  I --> L[Download main benchmark artifact]
  L --> M[benchmark-best-vias-main.json]
  K --> N[Generate via comparison cells]
  M --> N
  N --> O[benchmark-via-cells.json]
  O --> P[Render Via column in PR comment]
```

AI usage: I used AI for almost all of the implementation, but I designed the workflow myself and understand how it works.

Ouput exmaple ->
[benchmark-best-vias.json](https://github.com/user-attachments/files/29189711/benchmark-best-vias.json)


