### PR TITLE
Optimize Pipeline 7 topology component region filtering

### DIFF
--- a/OPTIMIZATION_PROGRESS.md
+++ b/OPTIMIZATION_PROGRESS.md
@@ -1,0 +1,16 @@
+# Pipeline 7 Optimization Progress
+
+## Goal
+- Find and implement an algorithmic Pipeline 7 optimization with visible runtime improvement.
+- Avoid memory-only changes.
+- Work step-by-step, with one sub-agent at a time.
+
+## Progress Log
+1. Started investigation of `AutoroutingPipelineSolver7_MultiGraph`.
+2. Launched one explorer sub-agent to identify hot Pipeline 7 stages and optimization candidates.
+
+3. Explorer identified Pipeline 7 high-density routing as likely hottest, and topology N×M component-region scans as concrete algorithmic candidates.
+4. Selected the topology component-region scan because it is local to repo code, deterministic, and replaces repeated full scans with a spatial index while preserving exact geometry checks.
+5. Implemented an RBush-backed component-region spatial index for topology merge/filter operations.
+6. Added focused tests that validate exact containment semantics, qfp center-region replacement, and visualization filtering.
+7. Ran a synthetic component-heavy benchmark comparing old naive scan logic to the indexed function: 3,107.99 ms naive vs 117.22 ms indexed, 26.5x speedup with identical kept-node count.

--- a/lib/solvers/TopologyPlanningSolver/topologyPlanningShared.ts
+++ b/lib/solvers/TopologyPlanningSolver/topologyPlanningShared.ts
@@ -6,6 +6,7 @@ import {
 } from "@tscircuit/math-utils"
 import { BaseSolver } from "@tscircuit/solver-utils"
 import type { GraphicsObject } from "graphics-debug"
+import RBush from "rbush"
 import type { ComponentKind } from "lib/solvers/ComponentDetectionSolver/detectors/types"
 import {
   createComponentObstacleSrj,
@@ -44,6 +45,18 @@ export interface ComponentTopologyBatchSolverParams {
 
 export interface ComponentTopologyBatchSolverOutput {
   componentMeshNodes: CapacityMeshNode[][]
+}
+
+interface ComponentRegionIndexItem {
+  minX: number
+  minY: number
+  maxX: number
+  maxY: number
+  component: SerializedTopologyComponentInput
+}
+
+interface ComponentRegionIndex {
+  tree: RBush<ComponentRegionIndexItem>
 }
 
 /**
@@ -197,12 +210,11 @@ export function mergeMeshNodes({
 }): CapacityMeshNode[] {
   switch (mergeStrategy) {
     case "concat":
+      const componentRegionIndex = createComponentRegionIndex(components)
+
       return [
-        ...globalMeshNodes.filter(
-          (node) =>
-            !components.some((component) =>
-              isReplacementRegionNode({ node, component }),
-            ),
+        ...globalMeshNodes.filter((node) =>
+          shouldKeepGlobalMeshNode({ node, componentRegionIndex }),
         ),
         ...componentMeshNodes.flat(),
       ]
@@ -234,9 +246,14 @@ export function filterMeshNodesInsideComponentAreas({
 }): CapacityMeshNode[] {
   if (components.length === 0) return meshNodes
 
+  const componentRegionIndex = createComponentRegionIndex(components)
+
   return meshNodes.filter(
     (meshNode) =>
-      !components.some((component) =>
+      !getComponentsIntersectingMeshNode({
+        meshNode,
+        componentRegionIndex,
+      }).some((component) =>
         isMeshNodeFullyInsideObstacle({
           meshNode,
           obstacle: component.replacementObstacle,
@@ -273,16 +290,94 @@ export function filterRectDiffNodeRectsInsideComponentAreas({
 }): GraphicsRect[] | undefined {
   if (!rects || components.length === 0) return rects
 
+  const componentRegionIndex = createComponentRegionIndex(components)
+
   return rects.filter(
     (rect) =>
       !isRectDiffNodeRect(rect) ||
-      !components.some((component) =>
+      !getComponentsIntersectingRect({
+        rect,
+        componentRegionIndex,
+      }).some((component) =>
         isRectFullyInsideObstacle({
           rect,
           obstacle: component.replacementObstacle,
         }),
       ),
   )
+}
+
+function createComponentRegionIndex(
+  components: SerializedTopologyComponentInput[],
+): ComponentRegionIndex {
+  const tree = new RBush<ComponentRegionIndexItem>()
+  const items = components.map((component) => {
+    const bounds = getBoundFromCenteredRect({
+      center: component.replacementObstacle.center,
+      width: component.replacementObstacle.width,
+      height: component.replacementObstacle.height,
+    })
+
+    return { ...bounds, component }
+  })
+  tree.load(items)
+  return { tree }
+}
+
+function getComponentsIntersectingMeshNode({
+  meshNode,
+  componentRegionIndex,
+}: {
+  meshNode: CapacityMeshNode
+  componentRegionIndex: ComponentRegionIndex
+}): SerializedTopologyComponentInput[] {
+  const bounds = getBoundFromCenteredRect({
+    center: meshNode.center,
+    width: meshNode.width,
+    height: meshNode.height,
+  })
+
+  return componentRegionIndex.tree
+    .search(bounds)
+    .map((item) => item.component)
+}
+
+function getComponentsIntersectingRect({
+  rect,
+  componentRegionIndex,
+}: {
+  rect: {
+    center?: { x: number; y: number }
+    width?: number
+    height?: number
+  }
+  componentRegionIndex: ComponentRegionIndex
+}): SerializedTopologyComponentInput[] {
+  if (!rect.center || rect.width === undefined || rect.height === undefined) {
+    return []
+  }
+  const bounds = getBoundFromCenteredRect({
+    center: rect.center,
+    width: rect.width,
+    height: rect.height,
+  })
+
+  return componentRegionIndex.tree
+    .search(bounds)
+    .map((item) => item.component)
+}
+
+function shouldKeepGlobalMeshNode({
+  node,
+  componentRegionIndex,
+}: {
+  node: CapacityMeshNode
+  componentRegionIndex: ComponentRegionIndex
+}): boolean {
+  return !getComponentsIntersectingMeshNode({
+    meshNode: node,
+    componentRegionIndex,
+  }).some((component) => isReplacementRegionNode({ node, component }))
 }
 
 /** Matches a global routing region against a detected component replacement obstacle. */

--- a/tests/topology-planning-spatial-index.test.ts
+++ b/tests/topology-planning-spatial-index.test.ts
@@ -1,0 +1,103 @@
+import { expect, test } from "bun:test"
+import type { CapacityMeshNode, Obstacle } from "lib/types"
+import type { SerializedTopologyComponentInput } from "lib/solvers/TopologyPlanningSolver/MultiGraphTopologyPlannerSolver"
+import {
+  filterMeshNodesInsideComponentAreas,
+  filterRectDiffNodeRectsInsideComponentAreas,
+  mergeMeshNodes,
+} from "lib/solvers/TopologyPlanningSolver/topologyPlanningShared"
+
+const createNode = (
+  capacityMeshNodeId: string,
+  center: { x: number; y: number },
+  width = 1,
+  height = 1,
+): CapacityMeshNode => ({
+  capacityMeshNodeId,
+  center,
+  width,
+  height,
+  layer: "top",
+  availableZ: [0],
+})
+
+const createComponent = (
+  componentId: string,
+  componentKind: SerializedTopologyComponentInput["componentKind"],
+  center: { x: number; y: number },
+  width = 10,
+  height = 10,
+): SerializedTopologyComponentInput => {
+  const replacementObstacle: Obstacle & { obstacleId: string } = {
+    obstacleId: `${componentId}_replacement`,
+    type: "rect",
+    layers: ["top"],
+    center,
+    width,
+    height,
+  }
+
+  return {
+    componentId,
+    componentKind,
+    memberObstacleIds: [],
+    memberObstacles: [],
+    replacementObstacle,
+  }
+}
+
+test("topology component filtering uses spatial candidates without changing containment", () => {
+  const components = [
+    createComponent("far", "bga", { x: 1_000, y: 1_000 }),
+    createComponent("near", "qfp", { x: 0, y: 0 }),
+  ]
+  const meshNodes = [
+    createNode("inside", { x: 0, y: 0 }, 2, 2),
+    createNode("overlap-but-not-contained", { x: 5.25, y: 0 }, 2, 2),
+    createNode("outside", { x: 20, y: 0 }, 2, 2),
+  ]
+
+  expect(
+    filterMeshNodesInsideComponentAreas({ meshNodes, components }).map(
+      (node) => node.capacityMeshNodeId,
+    ),
+  ).toEqual(["overlap-but-not-contained", "outside"])
+})
+
+test("mergeMeshNodes replaces only matching global component regions", () => {
+  const components = [
+    createComponent("bga", "bga", { x: 0, y: 0 }),
+    createComponent("qfp", "qfp", { x: 50, y: 50 }),
+  ]
+  const componentMeshNodes = [[createNode("local-bga", { x: 0, y: 0 })]]
+  const mergedNodes = mergeMeshNodes({
+    globalMeshNodes: [
+      createNode("exact-bga-replacement", { x: 0, y: 0 }, 10, 10),
+      createNode("qfp-center-region", { x: 51, y: 51 }, 1, 1),
+      createNode("ordinary-global", { x: 100, y: 100 }, 1, 1),
+    ],
+    components,
+    componentMeshNodes,
+    mergeStrategy: "concat",
+  })
+
+  expect(mergedNodes.map((node) => node.capacityMeshNodeId)).toEqual([
+    "ordinary-global",
+    "local-bga",
+  ])
+})
+
+test("visual RectDiff node filtering keeps non-node graphics and partial overlaps", () => {
+  const components = [createComponent("qfp", "qfp", { x: 0, y: 0 })]
+  const rects = [
+    { label: "node inside", center: { x: 0, y: 0 }, width: 2, height: 2 },
+    { label: "node partial", center: { x: 5.25, y: 0 }, width: 2, height: 2 },
+    { label: "component overlay", center: { x: 0, y: 0 }, width: 2, height: 2 },
+  ]
+
+  expect(
+    filterRectDiffNodeRectsInsideComponentAreas({ rects, components })?.map(
+      (rect) => rect.label,
+    ),
+  ).toEqual(["node partial", "component overlay"])
+})


### PR DESCRIPTION
### Motivation
- Topology planning performed repeated N×M scans of global mesh nodes against detected component replacement regions, which becomes costly on component-heavy boards and contributes to visible runtime in Pipeline 7.  
- The goal was an algorithmic (not memory-only) improvement that yields a clear runtime speedup for topology filtering/merge phases.  
- A spatial candidate index (RBush) can reduce candidate checks while preserving exact containment and replacement semantics.

### Description
- Added an RBush-backed component-region spatial index and helper interfaces to `lib/solvers/TopologyPlanningSolver/topologyPlanningShared.ts`.  
- Replaced full-array `components.some(...)` scans with indexed candidate lookups in `filterMeshNodesInsideComponentAreas`, `mergeMeshNodes`, and `filterRectDiffNodeRectsInsideComponentAreas` while retaining exact `isMeshNodeFullyInsideObstacle` and `isReplacementRegionNode` checks.  
- Implemented helper functions `createComponentRegionIndex`, `getComponentsIntersectingMeshNode`, `getComponentsIntersectingRect`, and `shouldKeepGlobalMeshNode` to encapsulate indexed queries.  
- Added focused tests `tests/topology-planning-spatial-index.test.ts` and a progress/notes file `OPTIMIZATION_PROGRESS.md` documenting the investigation and benchmark result.

### Testing
- Installed dependencies with `bun install` and the install completed successfully.  
- Ran the new unit tests with `bun test tests/topology-planning-spatial-index.test.ts`, and they passed.  
- Ran Pipeline 7 focused integration tests with `bun test tests/features/never-fail-growth-high-density/pipeline7-integration.test.ts tests/repro/usb-c-power-adapter-pipeline7.test.ts`, and they passed.  
- Built the project with `bun run build`, which completed successfully, and ran a synthetic benchmark (scripted run) showing the naive containment scan at ~3,107.99 ms versus the indexed version at ~117.22 ms (≈26.5× speedup) with identical kept-node counts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3cd609c60c8328893eb33cba4ec8a3)