### PR TITLE
Memoize future connection penalty

### DIFF
--- a/lib/solvers/HighDensitySolver/SingleHighDensityRouteSolver6_VertHorzLayer_FutureCost.ts
+++ b/lib/solvers/HighDensitySolver/SingleHighDensityRouteSolver6_VertHorzLayer_FutureCost.ts
@@ -10,6 +10,7 @@ export class SingleHighDensityRouteSolver6_VertHorzLayer_FutureCost extends Sing
   VIA_PENALTY_FACTOR_2 = 1
   FLIP_TRACE_ALIGNMENT_DIRECTION = false
   FUTURE_CONNECTION_VIA_TRACE_CLEARANCE = 0.1
+  futureConnectionPenaltyCache: Map<string, number> = new Map()
 
   constructor(
     opts: ConstructorParameters<typeof SingleHighDensityRouteSolver>[0],
@@ -133,12 +134,21 @@ export class SingleHighDensityRouteSolver6_VertHorzLayer_FutureCost extends Sing
   }
 
   getFutureConnectionPenalty(node: Node, isVia: boolean) {
+    const cacheKey = `${node.x},${node.y},${node.z},${isVia ? 1 : 0}`
+    const cachedPenalty = this.futureConnectionPenaltyCache.get(cacheKey)
+    if (cachedPenalty !== undefined) {
+      return cachedPenalty
+    }
+
     let futureConnectionPenalty = 0
     const closestFuturePoint = this.getClosestFutureConnectionPoint(node)
     const goalDist = distance(node, this.B)
     if (closestFuturePoint) {
       const distToFuturePoint = distance(node, closestFuturePoint)
-      if (goalDist <= distToFuturePoint) return 0
+      if (goalDist <= distToFuturePoint) {
+        this.futureConnectionPenaltyCache.set(cacheKey, 0)
+        return 0
+      }
       const maxDist = this.viaDiameter * this.FUTURE_CONNECTION_PROXIMITY_VD
       const distRatio = distToFuturePoint / maxDist
       const maxPenalty = isVia
@@ -148,6 +158,7 @@ export class SingleHighDensityRouteSolver6_VertHorzLayer_FutureCost extends Sing
           this.FUTURE_CONNECTION_PROX_TRACE_PENALTY_FACTOR
       futureConnectionPenalty = maxPenalty * Math.exp(-distRatio * 5)
     }
+    this.futureConnectionPenaltyCache.set(cacheKey, futureConnectionPenalty)
     return futureConnectionPenalty
   }
 


### PR DESCRIPTION
## Summary

- Memoize future-connection penalty lookups in `SingleHighDensityRouteSolver6_VertHorzLayer_FutureCost`.
- Avoid recomputing the same future-connection scan from both `computeG` and `computeH` for the same node state.
- Keep the cache instance-local and keyed by exact `x,y,z,isVia` inputs to preserve route ranking.

## Validation

- `bun run build`
- `bun test tests/single-high-density-route-solver.test.ts tests/features/high-density-future-cost-cmn3.test.ts tests/features/high-density-cmn159-investigation.test.ts`

## Benchmarks

- Local `dataset01 --concurrency 4`: 97.6% completed, 87.1% relaxed DRC, 0/85 timed out, P50 1.9s, P95 10.3s, Avg Via 50.55.
- Blacksmith cloud `srj18 --concurrency 4`: 81.3% completed, 1/16 timed out, P50 148.4s, P95 284.7s, Avg Via 241.69.
