### PR TITLE
Add via-trace clearance to debugger DRC

### DIFF
--- a/lib/testing/getDrcErrors.ts
+++ b/lib/testing/getDrcErrors.ts
@@ -2,7 +2,9 @@ import {
   checkDifferentNetViaSpacing,
   checkEachPcbTraceNonOverlapping,
   checkSameNetViaSpacing,
+  checkViaTraceClearance,
 } from "@tscircuit/checks"
+import type { PcbVia, PcbViaTraceClearanceError } from "circuit-json"
 import { Point } from "graphics-debug"
 
 type CircuitJson = Parameters<typeof checkEachPcbTraceNonOverlapping>[0]
@@ -13,13 +15,28 @@ type SameNetViaError = ReturnType<typeof checkSameNetViaSpacing>[number]
 type DifferentNetViaError = ReturnType<
   typeof checkDifferentNetViaSpacing
 >[number]
-type ViaError = SameNetViaError | DifferentNetViaError
+type ViaError =
+  | SameNetViaError
+  | DifferentNetViaError
+  | PcbViaTraceClearanceError
 
 type DrcError = TraceError | ViaError
 
 type DrcErrorWithCenter = DrcError & { center?: Point }
 
 type LocationAwareDrcError = DrcError & { center: Point }
+
+const getPoint = (
+  point: unknown,
+): Point | null => {
+  if (!point || typeof point !== "object") return null
+  if (!("x" in point) || !("y" in point)) return null
+
+  const { x, y } = point
+  if (typeof x !== "number" || typeof y !== "number") return null
+
+  return { x, y }
+}
 
 export const MIN_VIA_TO_VIA_CLEARANCE = 0.1
 export const PREFERRED_VIA_TO_VIA_CLEARANCE = 0.2
@@ -35,6 +52,21 @@ export interface GetDrcErrorsOptions {
   traceClearance?: number
 }
 
+const getPcbViasById = (
+  circuitJson: CircuitJson,
+): Map<string, PcbVia> => {
+  const vias = circuitJson.filter(
+    (element): element is PcbVia => element.type === "pcb_via",
+  )
+  const viasById = new Map<string, PcbVia>()
+
+  for (const via of vias) {
+    viasById.set(via.pcb_via_id, via)
+  }
+
+  return viasById
+}
+
 export const getDrcErrors = (
   circuitJson: CircuitJson,
   options: GetDrcErrorsOptions = {},
@@ -43,10 +75,19 @@ export const getDrcErrors = (
     options.viaClearance ?? MIN_VIA_TO_VIA_CLEARANCE,
     MIN_VIA_TO_VIA_CLEARANCE,
   )
-  const traceErrors = checkEachPcbTraceNonOverlapping(circuitJson, {
+  const viasById = getPcbViasById(circuitJson)
+  const circuitJsonWithoutVias = circuitJson.filter(
+    (element) => element.type !== "pcb_via",
+  )
+
+  const traceErrors = checkEachPcbTraceNonOverlapping(circuitJsonWithoutVias, {
+    minClearance: options.traceClearance,
+  })
+  const viaTraceErrors = checkViaTraceClearance(circuitJson, {
     minClearance: options.traceClearance,
   })
   const viaErrors = [
+    ...viaTraceErrors,
     ...checkSameNetViaSpacing(circuitJson, {
       minClearance: viaClearance,
     }),
@@ -55,30 +96,32 @@ export const getDrcErrors = (
     }),
   ]
 
-  const errors: DrcError[] = [...traceErrors, ...viaErrors]
+  const errors: DrcError[] = [
+    ...traceErrors,
+    ...viaErrors,
+  ]
 
-  const vias = circuitJson.filter(
-    (
-      element,
-    ): element is CircuitJsonElement & {
-      type: "pcb_via"
-      pcb_via_id: string
-      x: number
-      y: number
-    } => element.type === "pcb_via",
-  )
+  const errorsWithCenters: DrcErrorWithCenter[] = errors.map((error) => {
+    if ("center" in error) {
+      const center = getPoint(error.center)
+      if (center) {
+        return {
+          ...error,
+          center,
+        }
+      }
 
-  const viasById = new Map(vias.map((via) => [via.pcb_via_id, via]))
-
-  const errorsWithCenters = errors.map((error) => {
-    if ("center" in error && error.center) {
-      return error as DrcErrorWithCenter
+      const { center: _center, ...errorWithoutCenter } = error
+      return errorWithoutCenter
     }
 
     if ("pcb_center" in error && error.pcb_center) {
-      return {
-        ...error,
-        center: error.pcb_center,
+      const center = getPoint(error.pcb_center)
+      if (center) {
+        return {
+          ...error,
+          center,
+        }
       }
     }
 
@@ -127,8 +170,7 @@ export const getDrcErrors = (
     }
 
     return error
-  }) as DrcErrorWithCenter[]
-
+  })
   const locationAwareErrors = errorsWithCenters.filter(
     (error): error is LocationAwareDrcError => Boolean(error.center),
   )

--- a/tests/drc-via-spacing.test.ts
+++ b/tests/drc-via-spacing.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
 import {
   MIN_VIA_TO_VIA_CLEARANCE,
   getDrcErrors,
@@ -6,9 +7,11 @@ import {
 
 const VIA_OUTER_DIAMETER = 0.3
 const VIA_HOLE_DIAMETER = 0.15
+const TRACE_WIDTH = 0.1
+const VIA_TO_TRACE_CLEARANCE = 0.1
 
-const createViaPair = (centerDistance: number) =>
-  [
+const createViaPair = (centerDistance: number): AnyCircuitElement[] => {
+  return [
     {
       type: "pcb_via",
       pcb_via_id: "via_a",
@@ -27,7 +30,8 @@ const createViaPair = (centerDistance: number) =>
       hole_diameter: VIA_HOLE_DIAMETER,
       layers: ["top", "bottom"],
     },
-  ] as any[]
+  ]
+}
 
 test("getDrcErrors reports different-net vias that are too close", () => {
   const circuitJson = createViaPair(VIA_HOLE_DIAMETER + 0.1 - 0.01)
@@ -65,4 +69,71 @@ test("getDrcErrors allows vias at 0.1 clearance", () => {
   const { errors } = getDrcErrors(createViaPair(centerDistance))
 
   expect(errors).toHaveLength(0)
+})
+
+test("getDrcErrors reports vias too close to unrelated traces", () => {
+  const traceCenterX =
+    VIA_OUTER_DIAMETER / 2 + TRACE_WIDTH / 2 + VIA_TO_TRACE_CLEARANCE - 0.01
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "pcb_via",
+      pcb_via_id: "via_a",
+      x: 0,
+      y: 0,
+      outer_diameter: VIA_OUTER_DIAMETER,
+      hole_diameter: VIA_HOLE_DIAMETER,
+      layers: ["top", "bottom"],
+    },
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "trace_a",
+      source_trace_id: "source_trace_a",
+      route: [
+        {
+          route_type: "wire",
+          x: traceCenterX,
+          y: -1,
+          width: TRACE_WIDTH,
+          layer: "top",
+        },
+        {
+          route_type: "wire",
+          x: traceCenterX,
+          y: 1,
+          width: TRACE_WIDTH,
+          layer: "top",
+        },
+      ],
+    },
+  ]
+
+  const { errors, errorsWithCenters, locationAwareErrors } = getDrcErrors(
+    circuitJson,
+    {
+      traceClearance: VIA_TO_TRACE_CLEARANCE,
+      viaClearance: 0.05,
+    },
+  )
+
+  expect(errors).toHaveLength(1)
+  const viaTraceError = errors.find(
+    (error) => error.type === "pcb_via_trace_clearance_error",
+  )
+  expect(viaTraceError).toMatchObject({
+    type: "pcb_via_trace_clearance_error",
+    error_type: "pcb_via_trace_clearance_error",
+    pcb_via_id: "via_a",
+    pcb_trace_id: "trace_a",
+  })
+  expect(errorsWithCenters).toHaveLength(1)
+  expect(viaTraceError && "center" in viaTraceError).toBe(true)
+  expect(locationAwareErrors).toHaveLength(1)
+  expect(
+    locationAwareErrors.some(
+      (error) =>
+        error.type === "pcb_via_trace_clearance_error" &&
+        error.center.x === traceCenterX / 2 &&
+        error.center.y === 0,
+    ),
+  ).toBe(true)
 })


### PR DESCRIPTION
## Summary
- add `checkViaTraceClearance` to `getDrcErrors` so autorouter debugger DRC includes via-to-trace clearance violations
- prefer the specific `pcb_via_trace_clearance_error` over the generic trace/via overlap for the same structured via-trace pair
- add focused coverage for an unrelated trace passing too close to a via

## Flow
`AutoroutingPipelineDebugger` calls `getDrcErrors`; `getDrcErrors` now composes `checkEachPcbTraceNonOverlapping`, `checkViaTraceClearance`, same-net via spacing, and different-net via spacing, then maps valid centers into `locationAwareErrors`.

## Validation
- `bunx tsc --noEmit --pretty false`
- `bun test tests/drc-via-spacing.test.ts`
- `bun run build`