### PR TITLE
Include trace clearance checks in DRC helper

### DIFF
--- a/lib/testing/getDrcErrors.ts
+++ b/lib/testing/getDrcErrors.ts
@@ -1,21 +1,36 @@
 import {
   checkDifferentNetViaSpacing,
   checkEachPcbTraceNonOverlapping,
+  checkPadTraceClearance,
   checkSameNetViaSpacing,
+  checkViaTraceClearance,
 } from "@tscircuit/checks"
+import type {
+  AnyCircuitElement,
+  PcbPadTraceClearanceError,
+  PcbTraceError,
+  PcbViaClearanceError,
+  PcbViaTraceClearanceError,
+} from "circuit-json"
+import {
+  type ConnectivityMap,
+  getFullConnectivityMapFromCircuitJson,
+} from "circuit-json-to-connectivity-map"
 import { Point } from "graphics-debug"
 
-type CircuitJson = Parameters<typeof checkEachPcbTraceNonOverlapping>[0]
+type CircuitJson = AnyCircuitElement[]
 type CircuitJsonElement = CircuitJson[number]
+type PcbViaWithTraceId = CircuitJsonElement & {
+  type: "pcb_via"
+  pcb_via_id: string
+  pcb_trace_id: string
+}
 
-type TraceError = ReturnType<typeof checkEachPcbTraceNonOverlapping>[number]
-type SameNetViaError = ReturnType<typeof checkSameNetViaSpacing>[number]
-type DifferentNetViaError = ReturnType<
-  typeof checkDifferentNetViaSpacing
->[number]
-type ViaError = SameNetViaError | DifferentNetViaError
-
-type DrcError = TraceError | ViaError
+type DrcError =
+  | PcbTraceError
+  | PcbViaTraceClearanceError
+  | PcbPadTraceClearanceError
+  | PcbViaClearanceError
 
 type DrcErrorWithCenter = DrcError & { center?: Point }
 
@@ -35,27 +50,59 @@ export interface GetDrcErrorsOptions {
   traceClearance?: number
 }
 
+const createDrcConnectivityMap = (
+  circuitJson: CircuitJson,
+): ConnectivityMap => {
+  const connMap = getFullConnectivityMapFromCircuitJson(circuitJson)
+  const viaTraceConnections = circuitJson
+    .filter(
+      (element): element is PcbViaWithTraceId =>
+        element.type === "pcb_via" && typeof element.pcb_trace_id === "string",
+    )
+    .map((via) => [via.pcb_via_id, via.pcb_trace_id])
+
+  connMap.addConnections(viaTraceConnections)
+  return connMap
+}
+
 export const getDrcErrors = (
   circuitJson: CircuitJson,
   options: GetDrcErrorsOptions = {},
 ): GetDrcErrorsResult => {
+  const connMap = createDrcConnectivityMap(circuitJson)
   const viaClearance = Math.max(
     options.viaClearance ?? MIN_VIA_TO_VIA_CLEARANCE,
     MIN_VIA_TO_VIA_CLEARANCE,
   )
   const traceErrors = checkEachPcbTraceNonOverlapping(circuitJson, {
+    connMap,
+    minClearance: options.traceClearance,
+  })
+  const viaTraceErrors = checkViaTraceClearance(circuitJson, {
+    connMap,
+    minClearance: options.traceClearance,
+  })
+  const padTraceErrors = checkPadTraceClearance(circuitJson, {
+    connMap,
     minClearance: options.traceClearance,
   })
   const viaErrors = [
     ...checkSameNetViaSpacing(circuitJson, {
+      connMap,
       minClearance: viaClearance,
     }),
     ...checkDifferentNetViaSpacing(circuitJson, {
+      connMap,
       minClearance: viaClearance,
     }),
   ]
 
-  const errors: DrcError[] = [...traceErrors, ...viaErrors]
+  const errors: DrcError[] = [
+    ...traceErrors,
+    ...viaTraceErrors,
+    ...padTraceErrors,
+    ...viaErrors,
+  ]
 
   const vias = circuitJson.filter(
     (

--- a/tests/bugs/bugreport-b5b3b9d8-drc-count.test.ts
+++ b/tests/bugs/bugreport-b5b3b9d8-drc-count.test.ts
@@ -46,10 +46,12 @@ test("bugreport-b5b3b9d8 pipeline7 records current total DRC errors", () => {
     return acc
   }, {})
 
-  expect(errors).toHaveLength(9)
-  expect(locationAwareErrors).toHaveLength(9)
+  expect(errors).toHaveLength(17)
+  expect(locationAwareErrors).toHaveLength(17)
   expect(errorCountByType).toEqual({
     pcb_trace_error: 8,
+    pcb_via_trace_clearance_error: 7,
+    pcb_pad_trace_clearance_error: 1,
     pcb_via_clearance_error: 1,
   })
 })


### PR DESCRIPTION
## Summary

- include via-trace and pad-trace clearance checks in `getDrcErrors`
- update the merged `b5b3b9d8` bug-report DRC count baseline for the fixed helper
- keep via-via spacing controlled by `viaClearance` and trace-adjacent checks controlled by `traceClearance`
- use named `circuit-json` DRC error types instead of derived `ReturnType` aliases
- add `pcb_via_id -> pcb_trace_id` ownership edges to the helper connectivity map before running DRC checks

## Validation

- `bun test --timeout 60000 tests/bugs/bugreport-b5b3b9d8-drc-count.test.ts tests/drc-via-spacing.test.ts tests/bugs/repro01-highdensity-drc-failure.test.ts`
- `bun run format`
- `bun run build`
- `./node_modules/.bin/tsc --noEmit`

## Notes

- PR base is `main`
- PR diff is limited to `lib/testing/getDrcErrors.ts` and the merged `b5b3b9d8` DRC-count assertion
- Initial `178` helper errors were mostly false positives because `circuit-json-to-connectivity-map` does not connect `pcb_via.pcb_trace_id` ownership metadata.
- After adding via ownership edges locally in the helper, the `b5b3b9d8` board moves from 9 helper errors to 17 helper errors: 8 trace, 7 via-trace, 1 pad-trace, 1 via-via.
