### PR TITLE
[codex] add multi-graph tiny hyper search

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline4_TinyHypergraph/AutoroutingPipelineSolver4_TinyHypergraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline4_TinyHypergraph/AutoroutingPipelineSolver4_TinyHypergraph.ts
@@ -8,7 +8,8 @@ import { CacheProvider } from "lib/cache/types"
 import { MultiTargetNecessaryCrampedPortPointSolver } from "lib/solvers/NecessaryCrampedPortPointSolver/MultiTargetNecessaryCrampedPortPointSolver"
 import { NodeDimensionSubdivisionSolver } from "lib/solvers/NodeDimensionSubdivisionSolver/NodeDimensionSubdivisionSolver"
 import { buildHyperGraph } from "lib/solvers/PortPointPathingSolver/hgportpointpathingsolver"
-import { TinyHypergraphPortPointPathingSolver } from "lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver"
+import type { HgPortPointPathingSolverParams } from "lib/solvers/PortPointPathingSolver/hgportpointpathingsolver/types"
+import { HyperTinyHypergraphPortPointPathingSolver } from "lib/solvers/PortPointPathingSolver/tinyhypergraph/HyperTinyHypergraphPortPointPathingSolver"
 import { UniformPortDistributionSolver } from "lib/solvers/UniformPortDistributionSolver/UniformPortDistributionSolver"
 import { getColorMap } from "lib/solvers/colors"
 import {
@@ -62,6 +63,7 @@ interface CapacityMeshSolverOptions {
   maxNodeDimension?: number
   maxNodeRatio?: number
   minNodeArea?: number
+  useHyperTinyPortPointPathing?: boolean
 }
 export type AutoroutingPipelineSolverOptions = CapacityMeshSolverOptions
 
@@ -116,7 +118,7 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
   deadEndSolver?: DeadEndSolver
   traceSimplificationSolver?: TraceSimplificationSolver
   availableSegmentPointSolver?: AvailableSegmentPointSolver
-  portPointPathingSolver?: TinyHypergraphPortPointPathingSolver
+  portPointPathingSolver?: HyperTinyHypergraphPortPointPathingSolver
   multiSectionPortPointOptimizer?: MultiSectionPortPointOptimizer
   uniformPortDistributionSolver?: UniformPortDistributionSolver
   traceWidthSolver?: TraceWidthSolver
@@ -254,22 +256,27 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
     ),
     definePipelineStep(
       "portPointPathingSolver",
-      TinyHypergraphPortPointPathingSolver,
+      HyperTinyHypergraphPortPointPathingSolver,
       (cms) => {
-        const sharedEdgeSegments =
+        const baselineSharedEdgeSegments =
           cms.necessaryCrampedPortPointSolver?.getOutput() ??
           cms.availableSegmentPointSolver!.getOutput()
-        const { graph, connections } = buildHyperGraph({
-          capacityMeshNodes: cms.capacityNodes!,
-          layerCount: cms.srj.layerCount,
-          segmentPortPoints: sharedEdgeSegments.flatMap(
-            (seg) => seg.portPoints,
-          ),
-          simpleRouteJsonConnections: cms.srjWithPointPairs!.connections,
-        })
+        const availableSharedEdgeSegments =
+          cms.availableSegmentPointSolver!.getOutput()
 
-        return [
-          {
+        const buildTinyParams = (
+          segmentPortPoints: typeof baselineSharedEdgeSegments,
+        ): HgPortPointPathingSolverParams => {
+          const { graph, connections } = buildHyperGraph({
+            capacityMeshNodes: cms.capacityNodes!,
+            layerCount: cms.srj.layerCount,
+            segmentPortPoints: segmentPortPoints.flatMap(
+              (seg) => seg.portPoints,
+            ),
+            simpleRouteJsonConnections: cms.srjWithPointPairs!.connections,
+          })
+
+          return {
             graph,
             connections,
             layerCount: cms.srj.layerCount,
@@ -299,6 +306,26 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
               GREEDY_MULTIPLIER: 0.7,
               MIN_ALLOWED_BOARD_SCORE: -10000,
             },
+          }
+        }
+
+        const variants = [
+          {
+            name: "baseline-cramped-ports",
+            tinyParams: buildTinyParams(baselineSharedEdgeSegments),
+          },
+        ]
+
+        if (cms.opts.useHyperTinyPortPointPathing) {
+          variants.push({
+            name: "available-segment-ports",
+            tinyParams: buildTinyParams(availableSharedEdgeSegments),
+          })
+        }
+
+        return [
+          {
+            variants,
           },
         ]
       },

--- a/lib/solvers/PortPointPathingSolver/tinyhypergraph/HyperTinyHypergraphPortPointPathingSolver.ts
+++ b/lib/solvers/PortPointPathingSolver/tinyhypergraph/HyperTinyHypergraphPortPointPathingSolver.ts
@@ -1,0 +1,284 @@
+import type { GraphicsObject } from "graphics-debug"
+import {
+  HyperParameterSupervisorSolver,
+  type HyperParameterDef,
+  type SupervisedSolver,
+} from "lib/solvers/HyperParameterSupervisorSolver"
+import type { InputNodeWithPortPoints } from "lib/solvers/PortPointPathingSolver/PortPointPathingSolver"
+import type { NodeWithPortPoints } from "lib/types/high-density-types"
+import type { HgPortPointPathingSolverParams } from "../hgportpointpathingsolver/types"
+import {
+  TinyHypergraphPortPointPathingSolver,
+  type TinyHypergraphPortPointPathingSolverOptions,
+} from "./TinyHypergraphPortPointPathingSolver"
+
+export type TinyHypergraphSearchVariant = {
+  name: string
+  tinyParams: HgPortPointPathingSolverParams
+  options?: TinyHypergraphPortPointPathingSolverOptions
+}
+
+export interface HyperTinyHypergraphPortPointPathingSolverParams {
+  variants: TinyHypergraphSearchVariant[]
+}
+
+type TinyHypergraphPortPointPathingOutput = ReturnType<
+  TinyHypergraphPortPointPathingSolver["getOutput"]
+>
+
+const getNumericStat = (
+  stats: Record<string, unknown>,
+  key: string,
+): number | undefined => {
+  const value = stats[key]
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined
+}
+
+const getTinyRouteQualityCost = (
+  solver: TinyHypergraphPortPointPathingSolver,
+): number => {
+  const finalMaxRegionCost =
+    getNumericStat(solver.stats, "finalMaxRegionCost") ??
+    getNumericStat(solver.stats, "sectionSearchFinalMaxRegionCost")
+  const baselineMaxRegionCost = getNumericStat(
+    solver.stats,
+    "sectionSearchBaselineMaxRegionCost",
+  )
+  const sectionMaskPortCount = getNumericStat(
+    solver.stats,
+    "sectionMaskPortCount",
+  )
+  const duplicateCongestedPortCount = getNumericStat(
+    solver.stats,
+    "duplicateCongestedPortCount",
+  )
+
+  return (
+    (finalMaxRegionCost ?? baselineMaxRegionCost ?? 0) +
+    (sectionMaskPortCount ?? 0) * 1e-6 +
+    (duplicateCongestedPortCount ?? 0) * 1e-4
+  )
+}
+
+/**
+ * Searches across multiple tiny-hypergraph graph variants and returns the best
+ * solved port-point pathing result.
+ */
+export class HyperTinyHypergraphPortPointPathingSolver extends HyperParameterSupervisorSolver<TinyHypergraphPortPointPathingSolver> {
+  private readonly params: HyperTinyHypergraphPortPointPathingSolverParams
+  private nextSupervisedSolverIndex = 0
+
+  constructor(params: HyperTinyHypergraphPortPointPathingSolverParams) {
+    super()
+    if (params.variants.length === 0) {
+      throw new Error(
+        "HyperTinyHypergraphPortPointPathingSolver requires at least one variant",
+      )
+    }
+    this.params = params
+    this.MAX_ITERATIONS =
+      Math.max(
+        ...params.variants.map(
+          (variant) =>
+            (variant.options?.solveGraphOptions?.MAX_ITERATIONS ??
+              2_000_000 * Math.max(variant.tinyParams.effort, 1e-2)) +
+            (variant.options?.sectionSolverOptions?.MAX_ITERATIONS ??
+              1_000_000 * Math.max(variant.tinyParams.effort, 1e-2)),
+        ),
+      ) *
+      params.variants.length +
+      1_000_000
+    this.GREEDY_MULTIPLIER = 1
+    this.MIN_SUBSTEPS = 25
+  }
+
+  override getSolverName(): string {
+    return "HyperTinyHypergraphPortPointPathingSolver"
+  }
+
+  override getConstructorParams(): [HyperTinyHypergraphPortPointPathingSolverParams] {
+    return [this.params]
+  }
+
+  override getHyperParameterDefs(): Array<HyperParameterDef> {
+    return [
+      {
+        name: "TINY_VARIANT",
+        possibleValues: this.params.variants.map((variant) => ({
+          TINY_VARIANT: variant,
+        })),
+      },
+    ]
+  }
+
+  override getCombinationDefs(): Array<string[]> {
+    return [["TINY_VARIANT"]]
+  }
+
+  override generateSolver(hyperParameters: {
+    TINY_VARIANT: TinyHypergraphSearchVariant
+  }): TinyHypergraphPortPointPathingSolver {
+    return new TinyHypergraphPortPointPathingSolver(
+      hyperParameters.TINY_VARIANT.tinyParams,
+      hyperParameters.TINY_VARIANT.options,
+    )
+  }
+
+  override computeG(solver: TinyHypergraphPortPointPathingSolver): number {
+    if (solver.failed) {
+      return Number.POSITIVE_INFINITY
+    }
+
+    return getTinyRouteQualityCost(solver)
+  }
+
+  override computeH(solver: TinyHypergraphPortPointPathingSolver): number {
+    return Math.max(0, 1 - (solver.progress || 0))
+  }
+
+  override _step(): void {
+    if (!this.supervisedSolvers) {
+      this.initializeSolvers()
+    }
+
+    const supervisedSolver = this.getNextRunnableSupervisedSolver()
+
+    if (!supervisedSolver) {
+      this.finishSearch()
+      return
+    }
+
+    for (let i = 0; i < this.MIN_SUBSTEPS; i++) {
+      if (supervisedSolver.solver.solved || supervisedSolver.solver.failed) {
+        break
+      }
+      supervisedSolver.solver.step()
+    }
+
+    this.activeSubSolver = supervisedSolver.solver
+    supervisedSolver.g = this.computeG(supervisedSolver.solver)
+    supervisedSolver.h = this.computeH(supervisedSolver.solver)
+    supervisedSolver.f = this.computeF(supervisedSolver.g, supervisedSolver.h)
+  }
+
+  override getFailureMessage(): string {
+    return `All tiny hypergraph search variants failed. Example failures: ${this.supervisedSolvers
+      ?.slice(0, 5)
+      .map((supervisedSolver) => {
+        const variantName = this.getVariantName(supervisedSolver)
+        return `${variantName}: ${supervisedSolver.solver.error ?? "unknown error"}`
+      })
+      .join(", ")}`
+  }
+
+  override onSolve(
+    supervisedSolver: SupervisedSolver<TinyHypergraphPortPointPathingSolver>,
+  ): void {
+    this.stats = {
+      ...supervisedSolver.solver.stats,
+      winningTinyHypergraphVariant: this.getVariantName(supervisedSolver),
+    }
+  }
+
+  getOutput(): TinyHypergraphPortPointPathingOutput {
+    return this.getSelectedSolver().getOutput()
+  }
+
+  computeNodePf(node: InputNodeWithPortPoints): number | null {
+    return this.getSelectedSolver().computeNodePf(node)
+  }
+
+  getNodesWithPortPoints(): NodeWithPortPoints[] {
+    return this.getOutput().nodesWithPortPoints
+  }
+
+  override visualize(): GraphicsObject {
+    return this.getSelectedSolverOrNull()?.visualize() ?? super.visualize()
+  }
+
+  override preview(): GraphicsObject {
+    return this.visualize()
+  }
+
+  private getSelectedSolver(): TinyHypergraphPortPointPathingSolver {
+    const solver = this.getSelectedSolverOrNull()
+
+    if (solver) {
+      return solver
+    }
+
+    throw new Error(
+      `${this.getSolverName()}: no tiny hypergraph variant has been initialized`,
+    )
+  }
+
+  private getSelectedSolverOrNull(): TinyHypergraphPortPointPathingSolver | null {
+    if (this.winningSolver) {
+      return this.winningSolver
+    }
+
+    const bestSolver = this.getSupervisedSolverWithBestFitness()?.solver
+    if (bestSolver) {
+      return bestSolver
+    }
+
+    return null
+  }
+
+  private getVariantName(
+    supervisedSolver: SupervisedSolver<TinyHypergraphPortPointPathingSolver>,
+  ): string {
+    const variant = supervisedSolver.hyperParameters.TINY_VARIANT
+    return typeof variant?.name === "string" ? variant.name : "unknown"
+  }
+
+  private getNextRunnableSupervisedSolver():
+    | SupervisedSolver<TinyHypergraphPortPointPathingSolver>
+    | null {
+    const supervisedSolvers = this.supervisedSolvers ?? []
+
+    for (let offset = 0; offset < supervisedSolvers.length; offset++) {
+      const index =
+        (this.nextSupervisedSolverIndex + offset) % supervisedSolvers.length
+      const supervisedSolver = supervisedSolvers[index]
+
+      if (
+        supervisedSolver &&
+        !supervisedSolver.solver.solved &&
+        !supervisedSolver.solver.failed
+      ) {
+        this.nextSupervisedSolverIndex = (index + 1) % supervisedSolvers.length
+        return supervisedSolver
+      }
+    }
+
+    return null
+  }
+
+  private finishSearch(): void {
+    const solvedSupervisedSolvers = (this.supervisedSolvers ?? []).filter(
+      (supervisedSolver) =>
+        supervisedSolver.solver.solved && !supervisedSolver.solver.failed,
+    )
+
+    if (solvedSupervisedSolvers.length === 0) {
+      this.failed = true
+      this.error = this.getFailureMessage()
+      return
+    }
+
+    const winningSupervisedSolver = solvedSupervisedSolvers.reduce(
+      (bestSolver, supervisedSolver) =>
+        getTinyRouteQualityCost(supervisedSolver.solver) <
+        getTinyRouteQualityCost(bestSolver.solver)
+          ? supervisedSolver
+          : bestSolver,
+    )
+
+    this.solved = true
+    this.winningSolver = winningSupervisedSolver.solver
+    this.onSolve(winningSupervisedSolver)
+  }
+}

--- a/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
+++ b/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
@@ -25,6 +25,21 @@ import {
 } from "tiny-hypergraph/lib/index"
 import type { HgPortPointPathingSolverParams } from "../hgportpointpathingsolver/types"
 
+export type TinyHypergraphSectionMaskStrategy =
+  | { kind: "empty" }
+  | { kind: "automatic" }
+  | {
+      kind: "custom"
+      createSectionMask: TinyHyperGraphSectionPipelineInput["createSectionMask"]
+    }
+
+export interface TinyHypergraphPortPointPathingSolverOptions {
+  solveGraphOptions?: TinyHyperGraphSolverOptions
+  sectionSolverOptions?: TinyHyperGraphSectionSolverOptions
+  sectionMaskStrategy?: TinyHypergraphSectionMaskStrategy
+  sectionSearchConfig?: TinyHyperGraphSectionPipelineInput["sectionSearchConfig"]
+}
+
 type RouteMetadata = {
   connectionId: string
   mutuallyConnectedNetworkId?: string
@@ -139,6 +154,7 @@ const getTinyHyperGraphSolveGraphOptions = (
 const getTinyHyperGraphSectionSolverOptions = (
   effort: number,
   minViaPadDiameter?: number,
+  options: TinyHyperGraphSectionSolverOptions = {},
 ): TinyHyperGraphSectionSolverOptions => {
   const effortScale = getEffortScale(effort)
   return {
@@ -147,6 +163,7 @@ const getTinyHyperGraphSectionSolverOptions = (
     USE_SPARSE_CANDIDATE_STORAGE: true,
     RIP_THRESHOLD_RAMP_ATTEMPTS: Math.ceil(16 * effortScale),
     MAX_ITERATIONS: Math.ceil(1_000_000 * effortScale),
+    ...options,
   }
 }
 
@@ -154,18 +171,37 @@ const getTinyHyperGraphPipelineInput = (
   serializedHyperGraph: SerializedHyperGraph,
   effort: number,
   minViaPadDiameter?: number,
+  options: TinyHypergraphPortPointPathingSolverOptions = {},
 ): TinyHyperGraphSectionPipelineInput => ({
   serializedHyperGraph,
-  createSectionMask: ({ topology }) => new Int8Array(topology.portCount),
-  solveGraphOptions: getTinyHyperGraphSolveGraphOptions(
-    effort,
-    minViaPadDiameter,
-  ),
+  ...getTinyHyperGraphSectionMaskInput(options.sectionMaskStrategy),
+  solveGraphOptions: {
+    ...getTinyHyperGraphSolveGraphOptions(effort, minViaPadDiameter),
+    ...options.solveGraphOptions,
+  },
   sectionSolverOptions: getTinyHyperGraphSectionSolverOptions(
     effort,
     minViaPadDiameter,
+    options.sectionSolverOptions,
   ),
+  sectionSearchConfig: options.sectionSearchConfig,
 })
+
+const getTinyHyperGraphSectionMaskInput = (
+  sectionMaskStrategy: TinyHypergraphSectionMaskStrategy = { kind: "empty" },
+): Pick<TinyHyperGraphSectionPipelineInput, "createSectionMask"> => {
+  if (sectionMaskStrategy.kind === "automatic") {
+    return {}
+  }
+
+  if (sectionMaskStrategy.kind === "custom") {
+    return { createSectionMask: sectionMaskStrategy.createSectionMask }
+  }
+
+  return {
+    createSectionMask: ({ topology }) => new Int8Array(topology.portCount),
+  }
+}
 
 const getTinyHyperGraphPipelineMaxIterations = (
   inputProblem: TinyHyperGraphSectionPipelineInput,
@@ -737,7 +773,10 @@ export class TinyHypergraphPortPointPathingSolver extends BaseSolver {
   >
   private originalRegionIds: Set<CapacityMeshNodeId>
 
-  constructor(private params: HgPortPointPathingSolverParams) {
+  constructor(
+    private params: HgPortPointPathingSolverParams,
+    private options: TinyHypergraphPortPointPathingSolverOptions = {},
+  ) {
     super()
     const serializedGraph = buildSerializedTinyGraph(params)
     const shouldRunDuplicateCongestedPortPrepass =
@@ -785,6 +824,7 @@ export class TinyHypergraphPortPointPathingSolver extends BaseSolver {
       },
       params.effort,
       params.minViaPadDiameter,
+      this.options,
     )
     this.tinyPipelineSolver =
       new TinyHyperGraphSectionPipelineWithTerminalNetIds(tinyPipelineInput)
@@ -1009,7 +1049,7 @@ export class TinyHypergraphPortPointPathingSolver extends BaseSolver {
   tryFinalAcceptance() {}
 
   getConstructorParams() {
-    return [this.params] as const
+    return [this.params, this.options] as const
   }
 
   visualize(): GraphicsObject {

--- a/tests/features/tinyhypergraph-port-bridge-repro.test.ts
+++ b/tests/features/tinyhypergraph-port-bridge-repro.test.ts
@@ -1,7 +1,25 @@
 import { expect, test } from "bun:test"
 import { getSvgFromGraphicsObject } from "graphics-debug"
 import input from "../../fixtures/features/portpointpathing/tinyhypergraph-port-bridge-repro-input.json"
+import { HyperTinyHypergraphPortPointPathingSolver } from "lib/solvers/PortPointPathingSolver/tinyhypergraph/HyperTinyHypergraphPortPointPathingSolver"
 import { TinyHypergraphPortPointPathingSolver } from "lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver"
+
+test("HyperTinyHypergraphPortPointPathingSolver solves a tiny graph variant", () => {
+  const solver = new HyperTinyHypergraphPortPointPathingSolver({
+    variants: [
+      {
+        name: "bridge-repro",
+        tinyParams: input as any,
+      },
+    ],
+  })
+
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.stats.winningTinyHypergraphVariant).toBe("bridge-repro")
+  expect(solver.getOutput().nodesWithPortPoints.length).toBeGreaterThan(0)
+})
 
 test("TinyHypergraphPortPointPathingSolver does not respect inputSolvedRoutes", () => {
   const solver = new TinyHypergraphPortPointPathingSolver(input as any)


### PR DESCRIPTION
## Summary

Adds an opt-in multi-graph tiny-hypergraph search wrapper for pipeline4 port-point pathing.

- Adds `HyperTinyHypergraphPortPointPathingSolver`, which runs named tiny graph variants and selects the best solved variant.
- Adds tiny solver option injection for solve-graph, section-solver, section-mask, and section-search settings.
- Wires pipeline4 through the hyper wrapper with one baseline variant by default, and an additional full available-segment graph when `useHyperTinyPortPointPathing` is enabled.

## Notes

This is single-repo code. It does not require changes to the local `tiny-hypergraph` package.

## Validation

- `bun run build`
- `bun test tests/features/tinyhypergraph-port-bridge-repro.test.ts tests/features/pipeline4-dataset01-circuit015-cmn2-high-density-only.test.ts`
