### PR TITLE
[codex] Connect approximated obstacles through source ids

### DIFF
--- a/lib/utils/addApproximatingRectsToSrj.ts
+++ b/lib/utils/addApproximatingRectsToSrj.ts
@@ -389,7 +389,12 @@ const convertObstacleToOldFormat = (
           ? `${obstacleWithoutRotation.obstacleId}_approx_${index}`
           : undefined,
     connectedTo:
-      index === connectedRectIndex ? obstacleWithoutRotation.connectedTo : [],
+      index === connectedRectIndex
+        ? obstacleWithoutRotation.connectedTo
+        : obstacleWithoutRotation.obstacleId &&
+            obstacleWithoutRotation.connectedTo.length > 0
+          ? [obstacleWithoutRotation.obstacleId]
+          : [],
     center: rect.center,
     width: rect.width,
     height: rect.height,

--- a/tests/utils/addApproximatingRectsToSrj.test.ts
+++ b/tests/utils/addApproximatingRectsToSrj.test.ts
@@ -91,7 +91,7 @@ test("addApproximatingRectsToSrj slices slender rotated obstacles into compact r
   ).toBe(true)
 })
 
-test("addApproximatingRectsToSrj only keeps connectivity on one approximating rect", () => {
+test("addApproximatingRectsToSrj connects child approximations to the source obstacle", () => {
   const srj: SimpleRouteJson = {
     layerCount: 2,
     minTraceWidth: 0.15,
@@ -113,10 +113,17 @@ test("addApproximatingRectsToSrj only keeps connectivity on one approximating re
   }
 
   const converted = addApproximatingRectsToSrj(srj)
+  const directlyConnectedObstacles = converted.obstacles.filter((o) =>
+    o.connectedTo.includes("net_a"),
+  )
+  const sourceConnectedObstacles = converted.obstacles.filter((o) =>
+    o.connectedTo.includes("connected_rotated_pad"),
+  )
 
-  expect(
-    converted.obstacles.filter((o) => o.connectedTo.length > 0),
-  ).toHaveLength(1)
+  expect(directlyConnectedObstacles).toHaveLength(1)
+  expect(sourceConnectedObstacles).toHaveLength(
+    converted.obstacles.length - directlyConnectedObstacles.length,
+  )
   expect(
     converted.obstacles.filter((o) => o.obstacleId === "connected_rotated_pad"),
   ).toHaveLength(1)

--- a/tests/utils/getConnectivityMapFromSimpleRouteJson.test.ts
+++ b/tests/utils/getConnectivityMapFromSimpleRouteJson.test.ts
@@ -3,7 +3,7 @@ import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivity
 import type { SimpleRouteJson } from "lib/types"
 
 describe("getConnectivityMapFromSimpleRouteJson", () => {
-  test("includes off-board obstacle connections", () => {
+  test("includes obstacle-derived connections", () => {
     const srj: SimpleRouteJson = {
       layerCount: 2,
       minTraceWidth: 0.2,
@@ -20,12 +20,22 @@ describe("getConnectivityMapFromSimpleRouteJson", () => {
           offBoardConnectsTo: ["obstacle_b"],
         },
         {
+          obstacleId: "connected_rotated_pad",
           type: "rect",
           layers: ["top"],
-          center: { x: 2, y: 2 },
+          center: { x: 3, y: 3 },
           width: 1,
           height: 1,
-          connectedTo: ["obstacle_b"],
+          connectedTo: ["net_a"],
+        },
+        {
+          obstacleId: "connected_rotated_pad_approx_1",
+          type: "rect",
+          layers: ["top"],
+          center: { x: 4, y: 4 },
+          width: 1,
+          height: 1,
+          connectedTo: ["connected_rotated_pad"],
         },
       ],
     }
@@ -33,5 +43,14 @@ describe("getConnectivityMapFromSimpleRouteJson", () => {
     const connMap = getConnectivityMapFromSimpleRouteJson(srj)
 
     expect(connMap.areIdsConnected("obstacle_a", "obstacle_b")).toBe(true)
+    expect(
+      connMap.areIdsConnected(
+        "connected_rotated_pad_approx_1",
+        "connected_rotated_pad",
+      ),
+    ).toBe(true)
+    expect(
+      connMap.areIdsConnected("connected_rotated_pad_approx_1", "net_a"),
+    ).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- link approximation child obstacles to their source obstacle using normal SRJ connectedTo data
- keep connMap construction generic; no regex/string parsing of approximation ids
- update focused utility tests for approximation output and connMap behavior

## Why
PR #1477 exposed that approximated obstacle children can lose same-net identity. This keeps the fix in structured SRJ connectivity data instead of adding solver-specific route handling or parsing generated ids.

## Validation
- bun test tests/utils/addApproximatingRectsToSrj.test.ts tests/utils/getConnectivityMapFromSimpleRouteJson.test.ts tests/pipeline-preload-route-obstacles.test.ts
- bun run build