### PR TITLE
Clamp route distance lookup at final segment

### DIFF
--- a/lib/solvers/SimplifiedPathSolver/SingleSimplifiedPathSolver5_Deg45.ts
+++ b/lib/solvers/SimplifiedPathSolver/SingleSimplifiedPathSolver5_Deg45.ts
@@ -373,8 +373,12 @@ export class SingleSimplifiedPathSolver5 extends SingleSimplifiedPathSolver {
     // If closer to the end of the segment, return the next index
     const segment = this.pathSegments[segmentIndex]
     const midDistance = (segment.startDistance + segment.endDistance) / 2
-
-    return distance > midDistance ? segmentIndex + 1 : segmentIndex
+    const currentSegmentIndex = segmentIndex
+    let nextSegmentIndex = segmentIndex + 1
+    if (nextSegmentIndex >= this.pathSegments.length) {
+      nextSegmentIndex = currentSegmentIndex
+    }
+    return distance > midDistance ? nextSegmentIndex : currentSegmentIndex
   }
 
   // Check if a path segment is valid


### PR DESCRIPTION
## Summary

- Clamp the nearest-distance lookup so the final path segment does not return an index past the last segment.
- Keeps final-segment distance handling inside the available `pathSegments` range.

## What was going on

`getNearestIndexForDistance()` uses `pathSegments` to find the segment containing a distance, then chooses the nearer side of that segment.

For the final segment, `segmentIndex + 1` can equal `pathSegments.length`. That is valid as a route point index, but it is not valid as a `pathSegments` index. Code that uses this value for segment-based continuation can skip the terminal segment endpoint.

## Validation

- `bun run format`
- Tests not run by request.
