### PR TITLE
Fix route slice and final segment indexing

### DIFF
--- a/lib/solvers/SimplifiedPathSolver/SingleSimplifiedPathSolver5_Deg45.ts
+++ b/lib/solvers/SimplifiedPathSolver/SingleSimplifiedPathSolver5_Deg45.ts
@@ -520,7 +520,17 @@ export class SingleSimplifiedPathSolver5 extends SingleSimplifiedPathSolver {
     startDistance: number,
     endIndexInclusive: number,
   ) {
-    const startIndex = this.getNearestIndexForDistance(startDistance)
+    const containingSegmentIndex = this.pathSegments.findIndex(
+      (segment) =>
+        startDistance >= segment.startDistance &&
+        startDistance <= segment.endDistance,
+    )
+    if (containingSegmentIndex === -1) {
+      throw new Error(
+        `Could not find path segment containing distance ${startDistance}`,
+      )
+    }
+    const startIndex = containingSegmentIndex
 
     for (
       let routeIndex = startIndex + 1;

--- a/lib/solvers/SimplifiedPathSolver/SingleSimplifiedPathSolver5_Deg45.ts
+++ b/lib/solvers/SimplifiedPathSolver/SingleSimplifiedPathSolver5_Deg45.ts
@@ -373,8 +373,12 @@ export class SingleSimplifiedPathSolver5 extends SingleSimplifiedPathSolver {
     // If closer to the end of the segment, return the next index
     const segment = this.pathSegments[segmentIndex]
     const midDistance = (segment.startDistance + segment.endDistance) / 2
-
-    return distance > midDistance ? segmentIndex + 1 : segmentIndex
+    const currentSegmentIndex = segmentIndex
+    let nextSegmentIndex = segmentIndex + 1
+    if (nextSegmentIndex >= this.pathSegments.length) {
+      nextSegmentIndex = currentSegmentIndex
+    }
+    return distance > midDistance ? nextSegmentIndex : currentSegmentIndex
   }
 
   // Check if a path segment is valid


### PR DESCRIPTION
## Summary

- Preserve the original route tail by appending from the containing path segment instead of the nearest route point.
- Clamp final-segment nearest-distance lookup so it does not produce an index outside `pathSegments`.

## What was going on

`getNearestIndexForDistance()` uses `pathSegments` internally, but its returned value can represent a route point index. In the final segment, that means it can return the terminal route point index even though there is no matching terminal segment index.

`appendOriginalRouteSlice()` needs segment-start semantics so it can append from the next route point. When it received the terminal route point index, the loop started past the end and skipped the route endpoint.

## Validation

- Not run by request.
