### PR TITLE
Declare imported deps (transformation-matrix, connectivity-map, polished)

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,9 @@
   "dependencies": {
     "fast-json-stable-stringify": "^2.1.0",
     "object-hash": "^3.0.0",
-    "stack-svgs": "^0.0.1"
+    "stack-svgs": "^0.0.1",
+    "transformation-matrix": "^3.1.0",
+    "connectivity-map": "^1.0.0",
+    "polished": "^4.3.1"
   }
 }


### PR DESCRIPTION
`lib/` imports these three packages directly but they are not in `dependencies`:

- `transformation-matrix` - `lib/solvers/JumperPrepatternSolver/…`, `lib/solvers/UnravelSolver/…`
- `connectivity-map` - `lib/solvers/RouteStitchingSolver/…`, `lib/autorouter-pipelines/…`
- `polished` - `lib/solvers/colors.ts`, `lib/utils/getPresuppliedTraceVisualization.ts`

A standalone `bun install && bun run build` fails with `Could not resolve "transformation-matrix"` (and the other two). They currently only resolve when a consumer happens to hoist them. Adds the three to `dependencies`.