### PR TITLE
fix: connect same-region connections (direct segment for degenerate HD route)

### DIFF
--- a/lib/utils/convertHdRouteToSimplifiedRoute.ts
+++ b/lib/utils/convertHdRouteToSimplifiedRoute.ts
@@ -343,6 +343,54 @@ export const convertHdRouteToSimplifiedRoute = (
     }
   }
 
+  // Same-region connection fallback. When both endpoints of a connection fall in
+  // a single capacity node, no region boundary is crossed. The terminal port
+  // points are filtered out of the HD node graph (buildInputNodesWithPortPoints
+  // drops `_tinyTerminal` ports because they are normally attached only at route
+  // ends), so the HD solver returns a degenerate single-point route and the net
+  // is left unconnected - e.g. two adjacent same-net pads in one node. Emit the
+  // direct intra-node segment between the two endpoints so the connection is
+  // actually made.
+  const distinctWireXy = new Set(
+    result
+      .filter((seg) => seg.route_type === "wire")
+      .map((seg) => `${(seg as { x: number }).x},${(seg as { y: number }).y}`),
+  )
+  const cps = opts.connectionPoints
+  if (cps && cps.length >= 2 && distinctWireXy.size < 2) {
+    const a = cps[0]
+    const b = cps[cps.length - 1]
+    if (
+      isSingleLayerConnectionPoint(a) &&
+      isSingleLayerConnectionPoint(b) &&
+      (a.x !== b.x || a.y !== b.y)
+    ) {
+      const width = hdRoute.traceThickness
+      if (a.layer === b.layer) {
+        return [
+          { route_type: "wire", x: a.x, y: a.y, width, layer: a.layer },
+          { route_type: "wire", x: b.x, y: b.y, width, layer: b.layer },
+        ]
+      }
+      return [
+        { route_type: "wire", x: a.x, y: a.y, width, layer: a.layer },
+        { route_type: "wire", x: b.x, y: b.y, width, layer: a.layer },
+        {
+          route_type: "via",
+          x: b.x,
+          y: b.y,
+          from_layer: a.layer,
+          to_layer: b.layer,
+          via_diameter: hdRoute.viaDiameter,
+          ...(opts.defaultViaHoleDiameter !== undefined
+            ? { via_hole_diameter: opts.defaultViaHoleDiameter }
+            : {}),
+        },
+        { route_type: "wire", x: b.x, y: b.y, width, layer: b.layer },
+      ]
+    }
+  }
+
   return attachTerminalViasToSimplifiedRoute({
     route: result,
     hdRoute,

--- a/tests/utils/convertHdRouteToSimplifiedRoute.test.ts
+++ b/tests/utils/convertHdRouteToSimplifiedRoute.test.ts
@@ -428,4 +428,30 @@ describe("convertHdRouteToSimplifiedRoute", () => {
       ]
     `)
   })
+
+  test("completes a degenerate same-region route from the connection endpoints", () => {
+    // When both endpoints of a connection fall in a single capacity node, the HD
+    // solver returns a degenerate single-point route (the terminal ports are
+    // filtered out of the node graph), leaving the net unconnected. The converter
+    // must fall back to the direct segment between the two endpoints.
+    const input: HighDensityIntraNodeRoute = {
+      connectionName: "same-region",
+      traceThickness: 0.15,
+      viaDiameter: 0.6,
+      route: [{ x: -4.92, y: 4.4, z: 0 }],
+      vias: [],
+    }
+    const connectionPoints: ConnectionPoint[] = [
+      { x: -4.92, y: 5.2, layer: "top" },
+      { x: -4.92, y: 4.4, layer: "top" },
+    ] as ConnectionPoint[]
+
+    const result = convertHdRouteToSimplifiedRoute(input, 2, { connectionPoints })
+
+    expect(result).toEqual([
+      { route_type: "wire", x: -4.92, y: 5.2, width: 0.15, layer: "top" },
+      { route_type: "wire", x: -4.92, y: 4.4, width: 0.15, layer: "top" },
+    ])
+  })
+
 })

--- a/tests/utils/convertHdRouteToSimplifiedRoute.test.ts
+++ b/tests/utils/convertHdRouteToSimplifiedRoute.test.ts
@@ -446,12 +446,13 @@ describe("convertHdRouteToSimplifiedRoute", () => {
       { x: -4.92, y: 4.4, layer: "top" },
     ] as ConnectionPoint[]
 
-    const result = convertHdRouteToSimplifiedRoute(input, 2, { connectionPoints })
+    const result = convertHdRouteToSimplifiedRoute(input, 2, {
+      connectionPoints,
+    })
 
     expect(result).toEqual([
       { route_type: "wire", x: -4.92, y: 5.2, width: 0.15, layer: "top" },
       { route_type: "wire", x: -4.92, y: 4.4, width: 0.15, layer: "top" },
     ])
   })
-
 })


### PR DESCRIPTION
## Problem
When both endpoints of a connection fall inside a **single capacity node** (e.g. two adjacent same-net pads), no region boundary is crossed. `buildInputNodesWithPortPoints` filters out the `_tinyTerminal` port points (they are normally attached only at route ends), so the HD solver has nothing to route and returns a **degenerate single-point** `hdRoute`. The net is then left as a floating stub, unconnected.

Observed on a real board: net V3V3 -> U1 pin6 came out as two disconnected same-layer fragments; the intra-node edge between adjacent pins 5/6 (both on V3V3) never got a trace. Deterministic, effort-independent. (#1528)

## Fix
`convertHdRouteToSimplifiedRoute` already receives the connection's `connectionPoints`. When the produced route is degenerate (< 2 distinct wire points) and there are two distinct endpoints, emit the **direct segment** between them (same layer -> one wire pair; different layers -> wire + via + wire).

## Test
Added a unit test: a single-point `hdRoute` with two distinct same-layer `connectionPoints` now yields a 2-point connecting route. Fails on `main` (single-point output), passes with the fix.

Fixes #1528.