### PR TITLE
fix: guard getEffortScale against undefined/NaN effort (NaN iteration cap)

### DIFF
--- a/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
+++ b/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
@@ -113,7 +113,8 @@ const DUPLICATE_PORT_TRAVERSAL_PENALTY = 150
 const CRAMPED_PORT_TRAVERSAL_PENALTY = 150
 const MAX_CONNECTIONS_FOR_DUPLICATE_CONGESTED_PORT_PREPASS = 180
 
-export const getEffortScale = (effort: number) => Math.max(Number(effort) || 1, 1e-2)
+export const getEffortScale = (effort: number) =>
+  Math.max(Number(effort) || 1, 1e-2)
 
 const getTinyViaSizeOptions = (
   minViaPadDiameter?: number,

--- a/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
+++ b/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
@@ -113,7 +113,7 @@ const DUPLICATE_PORT_TRAVERSAL_PENALTY = 150
 const CRAMPED_PORT_TRAVERSAL_PENALTY = 150
 const MAX_CONNECTIONS_FOR_DUPLICATE_CONGESTED_PORT_PREPASS = 180
 
-const getEffortScale = (effort: number) => Math.max(effort, 1e-2)
+export const getEffortScale = (effort: number) => Math.max(Number(effort) || 1, 1e-2)
 
 const getTinyViaSizeOptions = (
   minViaPadDiameter?: number,

--- a/tests/solvers/getEffortScale-undefined.test.ts
+++ b/tests/solvers/getEffortScale-undefined.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "bun:test"
+import { getEffortScale } from "lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver"
+
+// Regression: effort is optional and reaches getEffortScale as `undefined` on
+// low-connection boards (the DuplicateCongestedPortSolver prepass passes
+// params.effort straight through). `Math.max(undefined, 1e-2)` is NaN, which
+// makes every `MAX_ITERATIONS = N * getEffortScale(effort)` NaN and the solver
+// reports "ran out of iterations" on the first step. getEffortScale must return
+// a finite, positive scale for undefined/NaN input.
+test("getEffortScale returns a finite positive scale for undefined effort", () => {
+  const scale = getEffortScale(undefined as unknown as number)
+  expect(Number.isFinite(scale)).toBe(true)
+  expect(scale).toBeGreaterThan(0)
+  expect(Number.isFinite(2_000_000 * scale)).toBe(true)
+})
+
+test("getEffortScale still honors an explicit effort", () => {
+  expect(getEffortScale(3)).toBe(3)
+  expect(getEffortScale(0.001)).toBe(1e-2)
+})


### PR DESCRIPTION
## Problem
`getEffortScale = (effort) => Math.max(effort, 1e-2)` returns **NaN** when `effort` is undefined (`Math.max(undefined, 1e-2) === NaN`). `effort` is optional and arrives undefined on boards that hit the `DuplicateCongestedPortSolver` prepass (`params.effort` is not threaded from the pipeline's `effort ?? 1` default). Every `MAX_ITERATIONS = N * getEffortScale(effort)` then becomes NaN, and the solver fails on the first step with `TinyHyperGraphSolver ran out of iterations`, producing 0 traces. Larger boards that skip the prepass are unaffected, which masks it. (#1525)

## Fix
Floor undefined/NaN to a real default: `Math.max(Number(effort) || 1, 1e-2)`. Exported for a regression test.

## Test
`getEffortScale(undefined)` is finite and positive (and the derived iteration cap is finite); explicit efforts are unchanged.

Fixes #1525.