### PR TITLE
Update dataset01 to include ACS37800 pad orientation fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@tsci/tscircuit.dataset-srj19-bga-passive-overlays": "git+https://github.com/tscircuit/dataset-srj19.git#5104d03ed72a9090d76ea1f42ae9f4bc439f7534",
     "@tsci/tscircuit.dataset-srj20-partial-bga-breakouts": "git+https://github.com/tscircuit/dataset-srj20.git#9384fb8f45fb479b97178ddfa42fc74c69afbbec",
     "@tsci/tscircuit.dataset-srj12-bus-routing": "git+https://github.com/tscircuit/dataset-srj12-bus-routing.git#ba82f86a7d1288566b7144eb8661ad2549c5f328",
-    "@tscircuit/autorouting-dataset-01": "git+https://github.com/tscircuit/autorouting-dataset-01.git#f9c0a8fe11e9bc05064bdafdf61f33eb38fa2b8e",
+    "@tscircuit/autorouting-dataset-01": "git+https://github.com/tscircuit/autorouting-dataset-01.git#68565d64307a31c92927f077539dba0829c3c63f",
     "@tscircuit/checks": "^0.0.141",
     "@tscircuit/circuit-json-util": "^0.0.94",
     "@tscircuit/core": "0.0.337",


### PR DESCRIPTION
The dataset had the ACS37800 side pads shaped the wrong way, which made them overlap before routing started. This caused extra DRC failures that were coming from bad input geometry, not from the autorouter itself.
<img width="3184" height="1704" alt="image" src="https://github.com/user-attachments/assets/e5b8ed16-7643-430d-8678-c5e905aa8a96" />


<img width="955" height="957" alt="Screenshot 2026-07-08 at 3 34 57 PM" src="https://github.com/user-attachments/assets/1916957b-a491-4522-9e92-477e6fd73036" />
<img width="1218" height="973" alt="Screenshot 2026-07-08 at 3 36 45 PM" src="https://github.com/user-attachments/assets/c242c3f1-2fb2-4e6b-a1bf-29eac2e7b581" />
