### PR TITLE
Add 45-degree-trace SRJ23 benchmark dataset 

### DIFF
--- a/.github/workflows/benchmark-instructions.yml
+++ b/.github/workflows/benchmark-instructions.yml
@@ -26,7 +26,7 @@ jobs:
               "",
               "```",
               "/benchmark [benchmark.sh args...]",
-              "/benchmark [solver-name|all] [scenario-limit] --concurrency <n> --effort <n> --dataset <dataset01|zdwiel|srj05|srj11|srj12|srj13|srj14|srj15|srj16|srj18> [--profile-solvers]",
+              "/benchmark [solver-name|all] [scenario-limit] --concurrency <n> --effort <n> --dataset <dataset01|zdwiel|srj05|srj11|srj12|srj13|srj14|srj15|srj16|srj18|srj19|srj20|srj23> [--profile-solvers]",
               "```",
               "",
               "Everything after `/benchmark` is forwarded directly to `./benchmark.sh`, except `--profile-solvers`, which adds main/PR profile comparison tables to the result comment.",

--- a/.github/workflows/benchmark-instructions.yml
+++ b/.github/workflows/benchmark-instructions.yml
@@ -26,7 +26,7 @@ jobs:
               "",
               "```",
               "/benchmark [benchmark.sh args...]",
-              "/benchmark [solver-name|all] [scenario-limit] --concurrency <n> --effort <n> --dataset <dataset01|zdwiel|srj05|srj11|srj12|srj13|srj14|srj15|srj16|srj18|srj19|srj20|srj23> [--profile-solvers]",
+              "/benchmark [solver-name|all] [scenario-limit] --concurrency <n> --effort <n> --dataset <dataset01|zdwiel|srj05|srj11|srj12|srj13|srj14|srj15|srj16|srj18|srj23> [--profile-solvers]",
               "```",
               "",
               "Everything after `/benchmark` is forwarded directly to `./benchmark.sh`, except `--profile-solvers`, which adds main/PR profile comparison tables to the result comment.",

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -33,7 +33,7 @@ on:
         default: false
         type: boolean
       dataset_name:
-        description: "Dataset to benchmark (optional: dataset01, zdwiel, srj05, srj11, srj12, srj13, srj14, srj15, srj16, or srj18)"
+        description: "Dataset to benchmark (optional: dataset01, zdwiel, srj05, srj11, srj12, srj13, srj14, srj15, srj16, srj18, srj19, srj20, or srj23)"
         required: false
         type: string
       profile_solvers:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -33,7 +33,7 @@ on:
         default: false
         type: boolean
       dataset_name:
-        description: "Dataset to benchmark (optional: dataset01, zdwiel, srj05, srj11, srj12, srj13, srj14, srj15, srj16, srj18, srj19, srj20, or srj23)"
+        description: "Dataset to benchmark (optional: dataset01, zdwiel, srj05, srj11, srj12, srj13, srj14, srj15, srj16, srj18, or srj23)"
         required: false
         type: string
       profile_solvers:

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -86,7 +86,7 @@ Options:
   --effort N           Override scenario effort multiplier
   --sample-timeout D   Override per-sample timeout directly; otherwise timeout is 300s + 60s * effort
   --sample-numbers L   Run comma-separated 1-based sample numbers from the dataset order
-  --dataset NAME       Dataset to benchmark: 1/dataset01 (default), zdwiel, 5/srj05, 11/srj11, 12/srj12, 13/srj13, 14/srj14, 15/srj15, 16/srj16, 18/srj18, 19/srj19, or 20/srj20
+  --dataset NAME       Dataset to benchmark: 1/dataset01 (default), zdwiel, 5/srj05, 11/srj11, 12/srj12, 13/srj13, 14/srj14, 15/srj15, 16/srj16, 18/srj18, 19/srj19, 20/srj20, or 23/srj23
   --include-assignable Include assignable pipelines (excluded by default)
   -h, --help           Show this help
 
@@ -118,6 +118,7 @@ Examples:
   ./benchmark.sh --dataset 18
   ./benchmark.sh --dataset 19
   ./benchmark.sh --dataset 20
+  ./benchmark.sh --dataset 23
   ./benchmark.sh --include-assignable
 EOF
 

--- a/fixtures/benchmarks/dataset-srj23.fixture.tsx
+++ b/fixtures/benchmarks/dataset-srj23.fixture.tsx
@@ -1,0 +1,191 @@
+import { AutoroutingPipelineDebugger } from "lib/testing/AutoroutingPipelineDebugger"
+import { SimpleRouteJson } from "lib/types"
+import { useEffect, useMemo, useState } from "react"
+
+type DatasetCircuit = {
+  id: string
+  srj: SimpleRouteJson
+}
+
+type ViewState = "loading" | "unavailable" | "ready"
+
+const circuitKeyRegex = /^circuit(\d{3})$/
+
+/** Normalize any user/query input into a 3-digit circuit id (e.g. "7" -> "007"). */
+const normalizeCircuitId = (value: string) => {
+  const digits = value.replace(/[^0-9]/g, "")
+  if (digits.length === 0) return null
+  return digits.padStart(3, "0").slice(-3)
+}
+
+export default () => {
+  const [circuits, setCircuits] = useState<DatasetCircuit[]>([])
+  const [currentId, setCurrentId] = useState<string>("")
+  const [inputId, setInputId] = useState<string>("")
+  const [error, setError] = useState<string>("")
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    // Prevent state updates after unmount while async import is still in flight.
+    let isMounted = true
+
+    /** Load and index all `circuitNNN` exports from the dataset package. */
+    const loadDataset = async () => {
+      try {
+        const datasetModule = await import("@tsci/0hmX.45-degree-trace-srj23")
+        const indexed = Object.entries(datasetModule)
+          .map(([key, value]) => {
+            const match = key.match(circuitKeyRegex)
+            if (!match) return null
+            return {
+              id: match[1],
+              srj: value as SimpleRouteJson,
+            } satisfies DatasetCircuit
+          })
+          .filter((entry): entry is DatasetCircuit => Boolean(entry))
+          .sort((a, b) => Number(a.id) - Number(b.id))
+
+        if (!isMounted) return
+        setCircuits(indexed)
+
+        if (indexed.length === 0) {
+          setError(
+            "No circuits were found in @tsci/0hmX.45-degree-trace-srj23.",
+          )
+          setIsLoading(false)
+          return
+        }
+
+        const params = new URLSearchParams(window.location.search)
+        const requested = normalizeCircuitId(params.get("circuit") ?? "")
+        const requestedExists = requested
+          ? indexed.some((entry) => entry.id === requested)
+          : false
+
+        // Keep a warning visible if URL requested a missing circuit,
+        // but still load the first available circuit so the page is usable.
+        if (requested && !requestedExists) {
+          setError(`Circuit ${requested} is missing from this dataset.`)
+        }
+
+        const initialId =
+          requested && requestedExists ? requested : indexed[0].id
+        setCurrentId(initialId)
+        setInputId(initialId)
+      } catch (err) {
+        if (!isMounted) return
+        setError(`Failed to load dataset: ${(err as Error).message}`)
+      } finally {
+        if (isMounted) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    loadDataset()
+
+    return () => {
+      isMounted = false
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!currentId) return
+    // Persist selected circuit in URL so refresh/share keeps same selection.
+    const params = new URLSearchParams(window.location.search)
+    params.set("circuit", currentId)
+    const nextSearch = params.toString()
+    window.history.replaceState(
+      null,
+      "",
+      `${window.location.pathname}${nextSearch ? `?${nextSearch}` : ""}`,
+    )
+  }, [currentId])
+
+  const circuitIndexMap = useMemo(() => {
+    // Fast id -> array index lookup for validation + current circuit retrieval.
+    const map = new Map<string, number>()
+    for (const [index, circuit] of circuits.entries()) {
+      map.set(circuit.id, index)
+    }
+    return map
+  }, [circuits])
+
+  const currentIndex = currentId ? (circuitIndexMap.get(currentId) ?? -1) : -1
+  const currentCircuit = currentIndex >= 0 ? circuits[currentIndex] : null
+
+  /** Validate user input, then switch to the requested circuit if it exists. */
+  const selectFromInputValue = (value: string) => {
+    setInputId(value)
+    const normalized = normalizeCircuitId(value)
+    if (!normalized) {
+      setError("Enter a valid circuit id.")
+      return
+    }
+
+    if (!circuitIndexMap.has(normalized)) {
+      setError(`Circuit ${normalized} is missing from this dataset.`)
+      return
+    }
+
+    setCurrentId(normalized)
+    setInputId(normalized)
+    setError("")
+  }
+
+  const viewState: ViewState = isLoading
+    ? "loading"
+    : currentCircuit
+      ? "ready"
+      : "unavailable"
+
+  switch (viewState) {
+    case "loading":
+      return <div>Loading dataset...</div>
+    case "unavailable":
+      return (
+        <div>
+          <div>Unable to display a circuit.</div>
+          {error && <div style={{ color: "red", marginTop: 8 }}>{error}</div>}
+        </div>
+      )
+    case "ready": {
+      if (!currentCircuit) {
+        return (
+          <div>
+            <div>Unable to display a circuit.</div>
+            {error && <div style={{ color: "red", marginTop: 8 }}>{error}</div>}
+          </div>
+        )
+      }
+
+      return (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+          <div>
+            <label>
+              Circuit ID:{" "}
+              <input
+                type="number"
+                min={Number(circuits[0]?.id ?? "1")}
+                max={Number(circuits[circuits.length - 1]?.id ?? "999")}
+                value={inputId === "" ? "" : Number(inputId)}
+                onChange={(e) => selectFromInputValue(e.currentTarget.value)}
+              />
+            </label>{" "}
+            <span>
+              (Current: {currentCircuit.id}, {currentIndex + 1} /{" "}
+              {circuits.length})
+            </span>
+          </div>
+
+          {error && <div style={{ color: "red" }}>{error}</div>}
+
+          <AutoroutingPipelineDebugger
+            key={`circuit-${currentCircuit.id}`}
+            srj={currentCircuit.srj}
+          />
+        </div>
+      )
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@react-hook/resize-observer": "^2.0.2",
     "@resvg/resvg-js": "^2.6.2",
     "@tsci/seveibar.dataset-srj13": "git+https://github.com/tscircuit/dataset-srj13.git#56db70039aeb28a76540fe951b5a96be60f9e949",
+    "@tsci/0hmX.45-degree-trace-srj23": "git+https://github.com/tscircuit/45-degree-trace-srj23.git#b4fb684",
     "@tsci/tscircuit.dataset-srj16-bga-breakouts": "git+https://github.com/tscircuit/dataset-srj16-bga-breakouts.git#e8b2e70e1f50a0dba3ad977e140766f53b9b75fb",
     "@tsci/tscircuit.dataset-srj19-bga-passive-overlays": "git+https://github.com/tscircuit/dataset-srj19.git#5104d03ed72a9090d76ea1f42ae9f4bc439f7534",
     "@tsci/tscircuit.dataset-srj20-partial-bga-breakouts": "git+https://github.com/tscircuit/dataset-srj20.git#9384fb8f45fb479b97178ddfa42fc74c69afbbec",

--- a/scripts/benchmark/scenarios.ts
+++ b/scripts/benchmark/scenarios.ts
@@ -13,6 +13,7 @@ export const DATASET_NAMES = [
   "srj18",
   "srj19",
   "srj20",
+  "srj23",
 ] as const
 
 export type DatasetName = (typeof DATASET_NAMES)[number]
@@ -20,7 +21,7 @@ export type DatasetName = (typeof DATASET_NAMES)[number]
 type DatasetModule = Record<string, unknown>
 
 export const DATASET_OPTIONS_LABEL =
-  "1/dataset01, zdwiel, 5/srj05, 11/srj11, 12/srj12, 13/srj13, 14/srj14, 15/srj15, 16/srj16, 18/srj18, 19/srj19, 20/srj20"
+  "1/dataset01, zdwiel, 5/srj05, 11/srj11, 12/srj12, 13/srj13, 14/srj14, 15/srj15, 16/srj16, 18/srj18, 19/srj19, 20/srj20, 23/srj23"
 
 const datasetAliases: Record<string, DatasetName> = {
   "1": "dataset01",
@@ -76,6 +77,12 @@ const datasetAliases: Record<string, DatasetName> = {
   "dataset-srj20": "srj20",
   "dataset-srj20-partial-bga-breakouts": "srj20",
   "@tsci/tscircuit.dataset-srj20-partial-bga-breakouts": "srj20",
+  "23": "srj23",
+  dataset23: "srj23",
+  srj23: "srj23",
+  "dataset-srj23": "srj23",
+  "45-degree-trace-srj23": "srj23",
+  "@tsci/0hmx.45-degree-trace-srj23": "srj23",
   zdwiel: "zdwiel",
 }
 
@@ -186,6 +193,8 @@ const datasetLoaders: Record<DatasetName, () => Promise<DatasetModule>> = {
       getSpecifier: (sampleId) =>
         `@tsci/tscircuit.dataset-srj20-partial-bga-breakouts/circuits/sample${sampleId}/sample${sampleId}.circuit.simple-route.json`,
     }),
+  srj23: async () =>
+    (await import("@tsci/0hmX.45-degree-trace-srj23")) as DatasetModule,
 }
 
 const datasetScenarioKeyPatterns: Record<DatasetName, RegExp> = {
@@ -201,6 +210,7 @@ const datasetScenarioKeyPatterns: Record<DatasetName, RegExp> = {
   srj18: /^sample\d{3}$/,
   srj19: /^sample\d{3}Circuit$/,
   srj20: /^sample\d{3}Circuit$/,
+  srj23: /^circuit\d{3}$/,
 }
 
 export const toSimpleRouteJson = (value: unknown): SimpleRouteJson | null => {

--- a/tests/benchmark-datasets.test.ts
+++ b/tests/benchmark-datasets.test.ts
@@ -28,6 +28,9 @@ test("benchmark dataset aliases resolve to canonical dataset names", () => {
   expect(parseDatasetName("20")).toBe("srj20")
   expect(parseDatasetName("dataset20")).toBe("srj20")
   expect(parseDatasetName("dataset-srj20-partial-bga-breakouts")).toBe("srj20")
+  expect(parseDatasetName("23")).toBe("srj23")
+  expect(parseDatasetName("dataset23")).toBe("srj23")
+  expect(parseDatasetName("45-degree-trace-srj23")).toBe("srj23")
 })
 
 test("main branch benchmark dataset config resolves to canonical dataset names", () => {
@@ -40,7 +43,7 @@ test("main branch benchmark dataset config resolves to canonical dataset names",
   }
 })
 
-test("srj11, srj12, srj13, srj15, srj16, srj19, and srj20 benchmark datasets load in sample order", async () => {
+test("srj11, srj12, srj13, srj15, srj16, srj19, srj20, and srj23 benchmark datasets load in sample order", async () => {
   const srj11Scenarios = await loadScenarios("srj11")
   const srj12Scenarios = await loadScenarios("srj12")
   const srj13Scenarios = await loadScenarios("srj13")
@@ -48,6 +51,7 @@ test("srj11, srj12, srj13, srj15, srj16, srj19, and srj20 benchmark datasets loa
   const srj16Scenarios = await loadScenarios("srj16")
   const srj19Scenarios = await loadScenarios("srj19")
   const srj20Scenarios = await loadScenarios("srj20")
+  const srj23Scenarios = await loadScenarios("srj23")
 
   expect(srj11Scenarios).toHaveLength(26)
   expect(srj11Scenarios[0][0]).toBe("sample001Circuit")
@@ -84,6 +88,11 @@ test("srj11, srj12, srj13, srj15, srj16, srj19, and srj20 benchmark datasets loa
   expect(srj20Scenarios[199][0]).toBe("sample200Circuit")
   expect(srj20Scenarios[0][1].connections.length).toBeGreaterThan(0)
 
+  expect(srj23Scenarios).toHaveLength(107)
+  expect(srj23Scenarios[0][0]).toBe("circuit001")
+  expect(srj23Scenarios[106][0]).toBe("circuit107")
+  expect(srj23Scenarios[0][1].connections.length).toBeGreaterThan(0)
+
   const sample11 = await loadScenarioBySampleNumber("srj11", 11)
   expect(sample11.scenarioName).toBe("sample011Circuit")
   expect(sample11.totalSamples).toBe(26)
@@ -103,4 +112,8 @@ test("srj11, srj12, srj13, srj15, srj16, srj19, and srj20 benchmark datasets loa
   const sample20 = await loadScenarioBySampleNumber("srj20", 20)
   expect(sample20.scenarioName).toBe("sample020Circuit")
   expect(sample20.totalSamples).toBe(200)
+
+  const sample23 = await loadScenarioBySampleNumber("srj23", 23)
+  expect(sample23.scenarioName).toBe("circuit023")
+  expect(sample23.totalSamples).toBe(107)
 })

--- a/types/dataset-module-shims.d.ts
+++ b/types/dataset-module-shims.d.ts
@@ -3,6 +3,11 @@ declare module "@tscircuit/autorouting-dataset-01" {
   export = dataset
 }
 
+declare module "@tsci/0hmX.45-degree-trace-srj23" {
+  const dataset: Record<string, any>
+  export = dataset
+}
+
 declare module "@tscircuit/dataset-srj05" {
   const dataset: any
   export = dataset


### PR DESCRIPTION
## Summary
- add the SRJ23 dataset pinned to b4fb684
- add an interactive benchmark fixture for its circuit exports
- enable SRJ23 in local and workflow benchmark dataset selection

## Validation
- `bun test tests/benchmark-datasets.test.ts --timeout 9999999`
- `./benchmark.sh --dataset srj23 --scenario-limit 1 --concurrency 1`