### PR TITLE
Prefix internal SRJ metadata fields

### DIFF
--- a/fixtures/bug-reports/bugreport19/bugreport19.json
+++ b/fixtures/bug-reports/bugreport19/bugreport19.json
@@ -32,7 +32,7 @@
         "pcb_smtpad_15",
         "pcb_port_15"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -62,7 +62,7 @@
         "pcb_smtpad_12",
         "pcb_port_12"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -84,7 +84,7 @@
         "pcb_smtpad_16",
         "pcb_port_16"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -112,7 +112,7 @@
         "pcb_smtpad_8",
         "pcb_port_8"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -134,7 +134,7 @@
         "pcb_smtpad_14",
         "pcb_port_14"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -164,7 +164,7 @@
         "pcb_smtpad_12",
         "pcb_port_12"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -190,7 +190,7 @@
         "pcb_smtpad_10",
         "pcb_port_10"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -218,7 +218,7 @@
         "pcb_smtpad_8",
         "pcb_port_8"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -246,7 +246,7 @@
         "pcb_smtpad_8",
         "pcb_port_8"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -272,7 +272,7 @@
         "pcb_smtpad_10",
         "pcb_port_10"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -298,7 +298,7 @@
         "pcb_smtpad_10",
         "pcb_port_10"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -328,7 +328,7 @@
         "pcb_smtpad_12",
         "pcb_port_12"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -358,7 +358,7 @@
         "pcb_smtpad_12",
         "pcb_port_12"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -386,7 +386,7 @@
         "pcb_smtpad_15",
         "pcb_port_15"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -408,7 +408,7 @@
         "pcb_smtpad_14",
         "pcb_port_14"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -436,7 +436,7 @@
         "pcb_smtpad_15",
         "pcb_port_15"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -458,7 +458,7 @@
         "pcb_smtpad_16",
         "pcb_port_16"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -476,7 +476,7 @@
         "pcb_smtpad_17",
         "pcb_port_17"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     }
   ],
   "connections": [

--- a/fixtures/bug-reports/bugreport20-obstacle-clipping.json
+++ b/fixtures/bug-reports/bugreport20-obstacle-clipping.json
@@ -22,7 +22,7 @@
         "pcb_smtpad_0",
         "pcb_port_0"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -40,7 +40,7 @@
         "pcb_smtpad_1",
         "pcb_port_1"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -61,7 +61,7 @@
         "pcb_smtpad_2",
         "pcb_port_3"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -79,7 +79,7 @@
         "pcb_smtpad_3",
         "pcb_port_4"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     }
   ],
   "connections": [

--- a/fixtures/bug-reports/bugreport21-board-outline.json
+++ b/fixtures/bug-reports/bugreport21-board-outline.json
@@ -22,7 +22,7 @@
         "pcb_smtpad_0",
         "pcb_port_0"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -44,7 +44,7 @@
         "pcb_smtpad_3",
         "pcb_port_3"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -62,7 +62,7 @@
         "pcb_smtpad_2",
         "pcb_port_2"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -84,7 +84,7 @@
         "pcb_smtpad_3",
         "pcb_port_3"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     }
   ],
   "connections": [

--- a/fixtures/bug-reports/bugreport22-2a75ce/bugreport22-2a75ce-single-layer.fixture.tsx
+++ b/fixtures/bug-reports/bugreport22-2a75ce/bugreport22-2a75ce-single-layer.fixture.tsx
@@ -9,7 +9,7 @@ export default () => {
         ...bugReportJson,
         obstacles: bugReportJson.obstacles.map((o) => ({
           ...o,
-          zLayers: [0],
+          __zLayers: [0],
           layers: ["top"],
         })),
         layerCount: 1,

--- a/fixtures/bug-reports/bugreport22-2a75ce/bugreport22-2a75ce.json
+++ b/fixtures/bug-reports/bugreport22-2a75ce/bugreport22-2a75ce.json
@@ -26,7 +26,7 @@
         "pcb_smtpad_0",
         "pcb_port_24"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -48,7 +48,7 @@
         "pcb_smtpad_1",
         "pcb_port_25"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -70,7 +70,7 @@
         "pcb_smtpad_2",
         "pcb_port_26"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -92,7 +92,7 @@
         "pcb_smtpad_3",
         "pcb_port_27"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -114,7 +114,7 @@
         "pcb_smtpad_4",
         "pcb_port_28"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -136,7 +136,7 @@
         "pcb_smtpad_5",
         "pcb_port_29"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -158,7 +158,7 @@
         "pcb_smtpad_6",
         "pcb_port_30"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -180,7 +180,7 @@
         "pcb_smtpad_7",
         "pcb_port_31"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -202,7 +202,7 @@
         "pcb_smtpad_8",
         "pcb_port_32"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -224,7 +224,7 @@
         "pcb_smtpad_9",
         "pcb_port_33"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -246,7 +246,7 @@
         "pcb_smtpad_10",
         "pcb_port_34"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -268,7 +268,7 @@
         "pcb_smtpad_11",
         "pcb_port_35"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -290,7 +290,7 @@
         "pcb_smtpad_12",
         "pcb_port_36"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -312,7 +312,7 @@
         "pcb_smtpad_13",
         "pcb_port_37"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -334,7 +334,7 @@
         "pcb_smtpad_14",
         "pcb_port_38"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -356,7 +356,7 @@
         "pcb_smtpad_15",
         "pcb_port_39"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -378,7 +378,7 @@
         "pcb_smtpad_16",
         "pcb_port_40"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -400,7 +400,7 @@
         "pcb_smtpad_17",
         "pcb_port_41"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -422,7 +422,7 @@
         "pcb_smtpad_18",
         "pcb_port_42"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -444,7 +444,7 @@
         "pcb_smtpad_19",
         "pcb_port_43"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -466,7 +466,7 @@
         "pcb_smtpad_20",
         "pcb_port_44"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -488,7 +488,7 @@
         "pcb_smtpad_21",
         "pcb_port_45"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -510,7 +510,7 @@
         "pcb_smtpad_22",
         "pcb_port_46"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -532,7 +532,7 @@
         "pcb_smtpad_23",
         "pcb_port_47"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -554,7 +554,7 @@
         "pcb_smtpad_12",
         "pcb_port_36"
       ],
-      "zLayers": [0, 1, 2, 3]
+      "__zLayers": [0, 1, 2, 3]
     },
     {
       "type": "oval",
@@ -576,7 +576,7 @@
         "pcb_smtpad_14",
         "pcb_port_38"
       ],
-      "zLayers": [0, 1, 2, 3]
+      "__zLayers": [0, 1, 2, 3]
     },
     {
       "type": "oval",
@@ -598,7 +598,7 @@
         "pcb_smtpad_16",
         "pcb_port_40"
       ],
-      "zLayers": [0, 1, 2, 3]
+      "__zLayers": [0, 1, 2, 3]
     },
     {
       "type": "oval",
@@ -620,7 +620,7 @@
         "pcb_smtpad_18",
         "pcb_port_42"
       ],
-      "zLayers": [0, 1, 2, 3]
+      "__zLayers": [0, 1, 2, 3]
     },
     {
       "type": "oval",
@@ -642,7 +642,7 @@
         "pcb_smtpad_20",
         "pcb_port_44"
       ],
-      "zLayers": [0, 1, 2, 3]
+      "__zLayers": [0, 1, 2, 3]
     },
     {
       "type": "oval",
@@ -664,7 +664,7 @@
         "pcb_smtpad_22",
         "pcb_port_46"
       ],
-      "zLayers": [0, 1, 2, 3]
+      "__zLayers": [0, 1, 2, 3]
     },
     {
       "type": "oval",
@@ -686,7 +686,7 @@
         "pcb_smtpad_23",
         "pcb_port_47"
       ],
-      "zLayers": [0, 1, 2, 3]
+      "__zLayers": [0, 1, 2, 3]
     },
     {
       "type": "oval",
@@ -708,7 +708,7 @@
         "pcb_smtpad_21",
         "pcb_port_45"
       ],
-      "zLayers": [0, 1, 2, 3]
+      "__zLayers": [0, 1, 2, 3]
     },
     {
       "type": "oval",
@@ -730,7 +730,7 @@
         "pcb_smtpad_19",
         "pcb_port_43"
       ],
-      "zLayers": [0, 1, 2, 3]
+      "__zLayers": [0, 1, 2, 3]
     },
     {
       "type": "oval",
@@ -752,7 +752,7 @@
         "pcb_smtpad_17",
         "pcb_port_41"
       ],
-      "zLayers": [0, 1, 2, 3]
+      "__zLayers": [0, 1, 2, 3]
     },
     {
       "type": "oval",
@@ -774,7 +774,7 @@
         "pcb_smtpad_15",
         "pcb_port_39"
       ],
-      "zLayers": [0, 1, 2, 3]
+      "__zLayers": [0, 1, 2, 3]
     },
     {
       "type": "oval",
@@ -796,7 +796,7 @@
         "pcb_smtpad_13",
         "pcb_port_37"
       ],
-      "zLayers": [0, 1, 2, 3]
+      "__zLayers": [0, 1, 2, 3]
     },
     {
       "type": "rect",
@@ -818,7 +818,7 @@
         "pcb_smtpad_1",
         "pcb_port_25"
       ],
-      "zLayers": [0, 1, 2, 3]
+      "__zLayers": [0, 1, 2, 3]
     },
     {
       "type": "oval",
@@ -840,7 +840,7 @@
         "pcb_smtpad_3",
         "pcb_port_27"
       ],
-      "zLayers": [0, 1, 2, 3]
+      "__zLayers": [0, 1, 2, 3]
     },
     {
       "type": "oval",
@@ -862,7 +862,7 @@
         "pcb_smtpad_5",
         "pcb_port_29"
       ],
-      "zLayers": [0, 1, 2, 3]
+      "__zLayers": [0, 1, 2, 3]
     },
     {
       "type": "oval",
@@ -884,7 +884,7 @@
         "pcb_smtpad_7",
         "pcb_port_31"
       ],
-      "zLayers": [0, 1, 2, 3]
+      "__zLayers": [0, 1, 2, 3]
     },
     {
       "type": "oval",
@@ -906,7 +906,7 @@
         "pcb_smtpad_9",
         "pcb_port_33"
       ],
-      "zLayers": [0, 1, 2, 3]
+      "__zLayers": [0, 1, 2, 3]
     },
     {
       "type": "oval",
@@ -928,7 +928,7 @@
         "pcb_smtpad_11",
         "pcb_port_35"
       ],
-      "zLayers": [0, 1, 2, 3]
+      "__zLayers": [0, 1, 2, 3]
     },
     {
       "type": "oval",
@@ -950,7 +950,7 @@
         "pcb_smtpad_10",
         "pcb_port_34"
       ],
-      "zLayers": [0, 1, 2, 3]
+      "__zLayers": [0, 1, 2, 3]
     },
     {
       "type": "oval",
@@ -972,7 +972,7 @@
         "pcb_smtpad_8",
         "pcb_port_32"
       ],
-      "zLayers": [0, 1, 2, 3]
+      "__zLayers": [0, 1, 2, 3]
     },
     {
       "type": "oval",
@@ -994,7 +994,7 @@
         "pcb_smtpad_6",
         "pcb_port_30"
       ],
-      "zLayers": [0, 1, 2, 3]
+      "__zLayers": [0, 1, 2, 3]
     },
     {
       "type": "oval",
@@ -1016,7 +1016,7 @@
         "pcb_smtpad_4",
         "pcb_port_28"
       ],
-      "zLayers": [0, 1, 2, 3]
+      "__zLayers": [0, 1, 2, 3]
     },
     {
       "type": "oval",
@@ -1038,7 +1038,7 @@
         "pcb_smtpad_2",
         "pcb_port_26"
       ],
-      "zLayers": [0, 1, 2, 3]
+      "__zLayers": [0, 1, 2, 3]
     },
     {
       "type": "oval",
@@ -1060,7 +1060,7 @@
         "pcb_smtpad_0",
         "pcb_port_24"
       ],
-      "zLayers": [0, 1, 2, 3]
+      "__zLayers": [0, 1, 2, 3]
     }
   ],
   "connections": [

--- a/fixtures/features/keepoutsolver/keepoutsolver-jumpers-input.json
+++ b/fixtures/features/keepoutsolver/keepoutsolver-jumpers-input.json
@@ -1576,7 +1576,7 @@
           "pcb_plated_hole_8",
           "pcb_port_8"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -1598,7 +1598,7 @@
           "pcb_plated_hole_9",
           "pcb_port_9"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -1620,7 +1620,7 @@
           "pcb_plated_hole_10",
           "pcb_port_10"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -1642,7 +1642,7 @@
           "pcb_plated_hole_11",
           "pcb_port_11"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -1664,7 +1664,7 @@
           "pcb_plated_hole_12",
           "pcb_port_12"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -1686,7 +1686,7 @@
           "pcb_plated_hole_13",
           "pcb_port_13"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -1708,7 +1708,7 @@
           "pcb_plated_hole_14",
           "pcb_port_14"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -1730,7 +1730,7 @@
           "pcb_plated_hole_15",
           "pcb_port_15"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -1752,7 +1752,7 @@
           "pcb_plated_hole_8",
           "pcb_port_8"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -1774,7 +1774,7 @@
           "pcb_plated_hole_9",
           "pcb_port_9"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -1796,7 +1796,7 @@
           "pcb_plated_hole_10",
           "pcb_port_10"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -1818,7 +1818,7 @@
           "pcb_plated_hole_11",
           "pcb_port_11"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -1840,7 +1840,7 @@
           "pcb_plated_hole_12",
           "pcb_port_12"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -1862,7 +1862,7 @@
           "pcb_plated_hole_13",
           "pcb_port_13"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -1884,7 +1884,7 @@
           "pcb_plated_hole_14",
           "pcb_port_14"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -1906,7 +1906,7 @@
           "pcb_plated_hole_15",
           "pcb_port_15"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       }
     ],
     "connMap": {
@@ -2072,7 +2072,7 @@
             "pcb_plated_hole_8",
             "pcb_port_8"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -2094,7 +2094,7 @@
             "pcb_plated_hole_9",
             "pcb_port_9"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -2116,7 +2116,7 @@
             "pcb_plated_hole_10",
             "pcb_port_10"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -2138,7 +2138,7 @@
             "pcb_plated_hole_11",
             "pcb_port_11"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -2160,7 +2160,7 @@
             "pcb_plated_hole_12",
             "pcb_port_12"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -2182,7 +2182,7 @@
             "pcb_plated_hole_13",
             "pcb_port_13"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -2204,7 +2204,7 @@
             "pcb_plated_hole_14",
             "pcb_port_14"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -2226,7 +2226,7 @@
             "pcb_plated_hole_15",
             "pcb_port_15"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -2248,7 +2248,7 @@
             "pcb_plated_hole_8",
             "pcb_port_8"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -2270,7 +2270,7 @@
             "pcb_plated_hole_9",
             "pcb_port_9"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -2292,7 +2292,7 @@
             "pcb_plated_hole_10",
             "pcb_port_10"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -2314,7 +2314,7 @@
             "pcb_plated_hole_11",
             "pcb_port_11"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -2336,7 +2336,7 @@
             "pcb_plated_hole_12",
             "pcb_port_12"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -2358,7 +2358,7 @@
             "pcb_plated_hole_13",
             "pcb_port_13"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -2380,7 +2380,7 @@
             "pcb_plated_hole_14",
             "pcb_port_14"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -2402,7 +2402,7 @@
             "pcb_plated_hole_15",
             "pcb_port_15"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         }
       ],
       "layerCount": 1,

--- a/fixtures/features/keepoutsolver/keepoutsolver01-input.json
+++ b/fixtures/features/keepoutsolver/keepoutsolver01-input.json
@@ -1581,7 +1581,7 @@
           "pcb_smtpad_0",
           "pcb_port_0"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1605,7 +1605,7 @@
           "pcb_plated_hole_0",
           "pcb_port_43"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1649,7 +1649,7 @@
           "pcb_plated_hole_1",
           "pcb_port_44"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1667,7 +1667,7 @@
           "pcb_smtpad_3",
           "pcb_port_3"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1685,7 +1685,7 @@
           "pcb_smtpad_4",
           "pcb_port_4"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1707,7 +1707,7 @@
           "pcb_smtpad_27",
           "pcb_port_27"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1729,7 +1729,7 @@
           "pcb_smtpad_23",
           "pcb_port_23"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1747,7 +1747,7 @@
           "pcb_smtpad_7",
           "pcb_port_7"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1765,7 +1765,7 @@
           "pcb_smtpad_8",
           "pcb_port_8"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1789,7 +1789,7 @@
           "pcb_plated_hole_3",
           "pcb_port_46"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1813,7 +1813,7 @@
           "pcb_plated_hole_2",
           "pcb_port_45"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1831,7 +1831,7 @@
           "pcb_smtpad_11",
           "pcb_port_11"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1853,7 +1853,7 @@
           "pcb_smtpad_36",
           "pcb_port_36"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1875,7 +1875,7 @@
           "pcb_smtpad_40",
           "pcb_port_40"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1893,7 +1893,7 @@
           "pcb_smtpad_14",
           "pcb_port_14"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1911,7 +1911,7 @@
           "pcb_smtpad_15",
           "pcb_port_15"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1933,7 +1933,7 @@
           "pcb_smtpad_32",
           "pcb_port_32"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1951,7 +1951,7 @@
           "pcb_smtpad_17",
           "pcb_port_17"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1969,7 +1969,7 @@
           "pcb_smtpad_18",
           "pcb_port_18"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1987,7 +1987,7 @@
           "pcb_smtpad_19",
           "pcb_port_19"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2005,7 +2005,7 @@
           "pcb_smtpad_20",
           "pcb_port_20"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2023,7 +2023,7 @@
           "pcb_smtpad_21",
           "pcb_port_21"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2041,7 +2041,7 @@
           "pcb_smtpad_22",
           "pcb_port_22"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2063,7 +2063,7 @@
           "pcb_smtpad_23",
           "pcb_port_23"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2081,7 +2081,7 @@
           "pcb_smtpad_24",
           "pcb_port_24"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2125,7 +2125,7 @@
           "pcb_plated_hole_1",
           "pcb_port_44"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2143,7 +2143,7 @@
           "pcb_smtpad_26",
           "pcb_port_26"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2165,7 +2165,7 @@
           "pcb_smtpad_27",
           "pcb_port_27"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2183,7 +2183,7 @@
           "pcb_smtpad_28",
           "pcb_port_28"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2227,7 +2227,7 @@
           "pcb_plated_hole_1",
           "pcb_port_44"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2245,7 +2245,7 @@
           "pcb_smtpad_30",
           "pcb_port_30"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2263,7 +2263,7 @@
           "pcb_smtpad_31",
           "pcb_port_31"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2285,7 +2285,7 @@
           "pcb_smtpad_32",
           "pcb_port_32"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2303,7 +2303,7 @@
           "pcb_smtpad_33",
           "pcb_port_33"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2347,7 +2347,7 @@
           "pcb_plated_hole_1",
           "pcb_port_44"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2365,7 +2365,7 @@
           "pcb_smtpad_35",
           "pcb_port_35"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2387,7 +2387,7 @@
           "pcb_smtpad_36",
           "pcb_port_36"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2405,7 +2405,7 @@
           "pcb_smtpad_37",
           "pcb_port_37"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2449,7 +2449,7 @@
           "pcb_plated_hole_1",
           "pcb_port_44"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2467,7 +2467,7 @@
           "pcb_smtpad_39",
           "pcb_port_39"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2489,7 +2489,7 @@
           "pcb_smtpad_40",
           "pcb_port_40"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2507,7 +2507,7 @@
           "pcb_smtpad_41",
           "pcb_port_41"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2551,7 +2551,7 @@
           "pcb_plated_hole_1",
           "pcb_port_44"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -2575,7 +2575,7 @@
           "pcb_plated_hole_0",
           "pcb_port_43"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -2619,7 +2619,7 @@
           "pcb_plated_hole_1",
           "pcb_port_44"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -2643,7 +2643,7 @@
           "pcb_plated_hole_2",
           "pcb_port_45"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -2667,7 +2667,7 @@
           "pcb_plated_hole_3",
           "pcb_port_46"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2687,7 +2687,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_0"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs0"
       },
       {
@@ -2708,7 +2708,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_1"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs1"
       },
       {
@@ -2729,7 +2729,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_2"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs2"
       },
       {
@@ -2750,7 +2750,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_3"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs3"
       },
       {
@@ -2771,7 +2771,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_0"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs4"
       },
       {
@@ -2792,7 +2792,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_4"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs5"
       },
       {
@@ -2813,7 +2813,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_5"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs6"
       },
       {
@@ -2834,7 +2834,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_1"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs7"
       },
       {
@@ -2855,7 +2855,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_4"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs8"
       },
       {
@@ -2876,7 +2876,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_1"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs9"
       },
       {
@@ -2897,7 +2897,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_6"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs10"
       },
       {
@@ -2918,7 +2918,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_7"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs11"
       },
       {
@@ -2939,7 +2939,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_8"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs12"
       },
       {
@@ -2960,7 +2960,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_9"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs13"
       },
       {
@@ -2981,7 +2981,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_2"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs14"
       },
       {
@@ -3002,7 +3002,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_9"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs15"
       },
       {
@@ -3023,7 +3023,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_6"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs16"
       },
       {
@@ -3044,7 +3044,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_10"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs17"
       },
       {
@@ -3065,7 +3065,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_7"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs18"
       },
       {
@@ -3086,7 +3086,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_11"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs19"
       },
       {
@@ -3107,7 +3107,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_12"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs20"
       },
       {
@@ -3128,7 +3128,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_3"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs21"
       },
       {
@@ -3149,7 +3149,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_2"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs22"
       },
       {
@@ -3170,7 +3170,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_10"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs23"
       },
       {
@@ -3191,7 +3191,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_8"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs24"
       },
       {
@@ -3212,7 +3212,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_3"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs25"
       },
       {
@@ -3233,7 +3233,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_13"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs26"
       },
       {
@@ -3254,7 +3254,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_5"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs27"
       },
       {
@@ -3275,7 +3275,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_14"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs28"
       },
       {
@@ -3296,7 +3296,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_0"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs29"
       },
       {
@@ -3317,7 +3317,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_6"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs30"
       },
       {
@@ -3338,7 +3338,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_4"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs31"
       },
       {
@@ -3359,7 +3359,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_0"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs32"
       },
       {
@@ -3380,7 +3380,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_12"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs33"
       },
       {
@@ -3401,7 +3401,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_6"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs34"
       },
       {
@@ -3422,7 +3422,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_5"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs35"
       },
       {
@@ -3443,7 +3443,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_9"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs36"
       },
       {
@@ -3464,7 +3464,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_13"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs37"
       },
       {
@@ -3485,7 +3485,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_11"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs38"
       },
       {
@@ -3506,7 +3506,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_2"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs39"
       },
       {
@@ -3527,7 +3527,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_14"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs40"
       },
       {
@@ -3548,7 +3548,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_1"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs41"
       },
       {
@@ -3569,7 +3569,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_10"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs42"
       },
       {
@@ -3590,7 +3590,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_7"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs43"
       },
       {
@@ -3611,7 +3611,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_12"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs44"
       },
       {
@@ -3632,7 +3632,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_14"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs45"
       },
       {
@@ -3653,7 +3653,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_13"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs46"
       },
       {
@@ -3674,7 +3674,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_8"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs47"
       },
       {
@@ -3695,7 +3695,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_5"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs48"
       },
       {
@@ -3716,7 +3716,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_0"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs49"
       },
       {
@@ -3737,7 +3737,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_6"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs50"
       },
       {
@@ -3758,7 +3758,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_7"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs51"
       },
       {
@@ -3779,7 +3779,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_2"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs52"
       },
       {
@@ -3800,7 +3800,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_12"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs53"
       },
       {
@@ -3821,7 +3821,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_10"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs54"
       },
       {
@@ -3842,7 +3842,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_9"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs55"
       },
       {
@@ -3863,7 +3863,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_11"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs56"
       },
       {
@@ -3884,7 +3884,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_3"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs57"
       },
       {
@@ -3905,7 +3905,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_4"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs58"
       },
       {
@@ -3926,7 +3926,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_1"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs59"
       },
       {
@@ -3947,7 +3947,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_15"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs60"
       },
       {
@@ -3968,7 +3968,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_16"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs61"
       },
       {
@@ -3989,7 +3989,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_17"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs62"
       },
       {
@@ -4010,7 +4010,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_18"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs63"
       },
       {
@@ -4031,7 +4031,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_15"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs64"
       },
       {
@@ -4052,7 +4052,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_19"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs65"
       },
       {
@@ -4073,7 +4073,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_20"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs66"
       },
       {
@@ -4094,7 +4094,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_16"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs67"
       },
       {
@@ -4115,7 +4115,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_19"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs68"
       },
       {
@@ -4136,7 +4136,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_16"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs69"
       },
       {
@@ -4157,7 +4157,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_21"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs70"
       },
       {
@@ -4178,7 +4178,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_22"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs71"
       },
       {
@@ -4199,7 +4199,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_23"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs72"
       },
       {
@@ -4220,7 +4220,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_24"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs73"
       },
       {
@@ -4241,7 +4241,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_17"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs74"
       },
       {
@@ -4262,7 +4262,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_24"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs75"
       },
       {
@@ -4283,7 +4283,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_21"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs76"
       },
       {
@@ -4304,7 +4304,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_25"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs77"
       },
       {
@@ -4325,7 +4325,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_22"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs78"
       },
       {
@@ -4346,7 +4346,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_26"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs79"
       },
       {
@@ -4367,7 +4367,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_27"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs80"
       },
       {
@@ -4388,7 +4388,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_18"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs81"
       },
       {
@@ -4409,7 +4409,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_17"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs82"
       },
       {
@@ -4430,7 +4430,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_25"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs83"
       },
       {
@@ -4451,7 +4451,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_23"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs84"
       },
       {
@@ -4472,7 +4472,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_18"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs85"
       },
       {
@@ -4493,7 +4493,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_28"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs86"
       },
       {
@@ -4514,7 +4514,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_20"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs87"
       },
       {
@@ -4535,7 +4535,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_29"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs88"
       },
       {
@@ -4556,7 +4556,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_15"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs89"
       },
       {
@@ -4577,7 +4577,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_21"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs90"
       },
       {
@@ -4598,7 +4598,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_19"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs91"
       },
       {
@@ -4619,7 +4619,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_15"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs92"
       },
       {
@@ -4640,7 +4640,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_27"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs93"
       },
       {
@@ -4661,7 +4661,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_21"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs94"
       },
       {
@@ -4682,7 +4682,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_20"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs95"
       },
       {
@@ -4703,7 +4703,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_24"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs96"
       },
       {
@@ -4724,7 +4724,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_28"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs97"
       },
       {
@@ -4745,7 +4745,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_26"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs98"
       },
       {
@@ -4766,7 +4766,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_17"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs99"
       },
       {
@@ -4787,7 +4787,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_29"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs100"
       },
       {
@@ -4808,7 +4808,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_16"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs101"
       },
       {
@@ -4829,7 +4829,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_25"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs102"
       },
       {
@@ -4850,7 +4850,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_22"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs103"
       },
       {
@@ -4871,7 +4871,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_27"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs104"
       },
       {
@@ -4892,7 +4892,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_29"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs105"
       },
       {
@@ -4913,7 +4913,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_28"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs106"
       },
       {
@@ -4934,7 +4934,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_23"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs107"
       },
       {
@@ -4955,7 +4955,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_20"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs108"
       },
       {
@@ -4976,7 +4976,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_15"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs109"
       },
       {
@@ -4997,7 +4997,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_21"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs110"
       },
       {
@@ -5018,7 +5018,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_22"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs111"
       },
       {
@@ -5039,7 +5039,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_17"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs112"
       },
       {
@@ -5060,7 +5060,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_27"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs113"
       },
       {
@@ -5081,7 +5081,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_25"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs114"
       },
       {
@@ -5102,7 +5102,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_24"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs115"
       },
       {
@@ -5123,7 +5123,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_26"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs116"
       },
       {
@@ -5144,7 +5144,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_18"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs117"
       },
       {
@@ -5165,7 +5165,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_19"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs118"
       },
       {
@@ -5186,7 +5186,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_16"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs119"
       },
       {
@@ -5199,7 +5199,7 @@
         "height": 22,
         "layers": ["top", "inner1", "inner2", "bottom"],
         "connectedTo": [],
-        "zLayers": [0]
+        "__zLayers": [0]
       }
     ],
     "connMap": {

--- a/fixtures/features/keepoutsolver/keepoutsolver02-input.json
+++ b/fixtures/features/keepoutsolver/keepoutsolver02-input.json
@@ -1555,7 +1555,7 @@
           "pcb_smtpad_0",
           "pcb_port_0"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1579,7 +1579,7 @@
           "pcb_plated_hole_0",
           "pcb_port_43"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1623,7 +1623,7 @@
           "pcb_plated_hole_1",
           "pcb_port_44"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1641,7 +1641,7 @@
           "pcb_smtpad_3",
           "pcb_port_3"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1659,7 +1659,7 @@
           "pcb_smtpad_4",
           "pcb_port_4"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1681,7 +1681,7 @@
           "pcb_smtpad_27",
           "pcb_port_27"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1703,7 +1703,7 @@
           "pcb_smtpad_23",
           "pcb_port_23"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1721,7 +1721,7 @@
           "pcb_smtpad_7",
           "pcb_port_7"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1739,7 +1739,7 @@
           "pcb_smtpad_8",
           "pcb_port_8"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1763,7 +1763,7 @@
           "pcb_plated_hole_3",
           "pcb_port_46"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1787,7 +1787,7 @@
           "pcb_plated_hole_2",
           "pcb_port_45"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1805,7 +1805,7 @@
           "pcb_smtpad_11",
           "pcb_port_11"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1827,7 +1827,7 @@
           "pcb_smtpad_36",
           "pcb_port_36"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1849,7 +1849,7 @@
           "pcb_smtpad_40",
           "pcb_port_40"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1867,7 +1867,7 @@
           "pcb_smtpad_14",
           "pcb_port_14"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1885,7 +1885,7 @@
           "pcb_smtpad_15",
           "pcb_port_15"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1907,7 +1907,7 @@
           "pcb_smtpad_32",
           "pcb_port_32"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1925,7 +1925,7 @@
           "pcb_smtpad_17",
           "pcb_port_17"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1943,7 +1943,7 @@
           "pcb_smtpad_18",
           "pcb_port_18"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1961,7 +1961,7 @@
           "pcb_smtpad_19",
           "pcb_port_19"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1979,7 +1979,7 @@
           "pcb_smtpad_20",
           "pcb_port_20"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1997,7 +1997,7 @@
           "pcb_smtpad_21",
           "pcb_port_21"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2015,7 +2015,7 @@
           "pcb_smtpad_22",
           "pcb_port_22"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2037,7 +2037,7 @@
           "pcb_smtpad_23",
           "pcb_port_23"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2055,7 +2055,7 @@
           "pcb_smtpad_24",
           "pcb_port_24"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2099,7 +2099,7 @@
           "pcb_plated_hole_1",
           "pcb_port_44"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2117,7 +2117,7 @@
           "pcb_smtpad_26",
           "pcb_port_26"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2139,7 +2139,7 @@
           "pcb_smtpad_27",
           "pcb_port_27"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2157,7 +2157,7 @@
           "pcb_smtpad_28",
           "pcb_port_28"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2201,7 +2201,7 @@
           "pcb_plated_hole_1",
           "pcb_port_44"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2219,7 +2219,7 @@
           "pcb_smtpad_30",
           "pcb_port_30"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2237,7 +2237,7 @@
           "pcb_smtpad_31",
           "pcb_port_31"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2259,7 +2259,7 @@
           "pcb_smtpad_32",
           "pcb_port_32"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2277,7 +2277,7 @@
           "pcb_smtpad_33",
           "pcb_port_33"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2321,7 +2321,7 @@
           "pcb_plated_hole_1",
           "pcb_port_44"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2339,7 +2339,7 @@
           "pcb_smtpad_35",
           "pcb_port_35"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2361,7 +2361,7 @@
           "pcb_smtpad_36",
           "pcb_port_36"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2379,7 +2379,7 @@
           "pcb_smtpad_37",
           "pcb_port_37"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2423,7 +2423,7 @@
           "pcb_plated_hole_1",
           "pcb_port_44"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2441,7 +2441,7 @@
           "pcb_smtpad_39",
           "pcb_port_39"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2463,7 +2463,7 @@
           "pcb_smtpad_40",
           "pcb_port_40"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2481,7 +2481,7 @@
           "pcb_smtpad_41",
           "pcb_port_41"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2525,7 +2525,7 @@
           "pcb_plated_hole_1",
           "pcb_port_44"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -2549,7 +2549,7 @@
           "pcb_plated_hole_0",
           "pcb_port_43"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -2593,7 +2593,7 @@
           "pcb_plated_hole_1",
           "pcb_port_44"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -2617,7 +2617,7 @@
           "pcb_plated_hole_2",
           "pcb_port_45"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -2641,7 +2641,7 @@
           "pcb_plated_hole_3",
           "pcb_port_46"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2661,7 +2661,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_0"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs0"
       },
       {
@@ -2682,7 +2682,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_1"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs1"
       },
       {
@@ -2703,7 +2703,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_2"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs2"
       },
       {
@@ -2724,7 +2724,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_3"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs3"
       },
       {
@@ -2745,7 +2745,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_0"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs4"
       },
       {
@@ -2766,7 +2766,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_4"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs5"
       },
       {
@@ -2787,7 +2787,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_5"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs6"
       },
       {
@@ -2808,7 +2808,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_1"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs7"
       },
       {
@@ -2829,7 +2829,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_4"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs8"
       },
       {
@@ -2850,7 +2850,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_1"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs9"
       },
       {
@@ -2871,7 +2871,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_6"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs10"
       },
       {
@@ -2892,7 +2892,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_7"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs11"
       },
       {
@@ -2913,7 +2913,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_8"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs12"
       },
       {
@@ -2934,7 +2934,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_9"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs13"
       },
       {
@@ -2955,7 +2955,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_2"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs14"
       },
       {
@@ -2976,7 +2976,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_9"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs15"
       },
       {
@@ -2997,7 +2997,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_6"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs16"
       },
       {
@@ -3018,7 +3018,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_10"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs17"
       },
       {
@@ -3039,7 +3039,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_7"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs18"
       },
       {
@@ -3060,7 +3060,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_11"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs19"
       },
       {
@@ -3081,7 +3081,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_12"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs20"
       },
       {
@@ -3102,7 +3102,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_3"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs21"
       },
       {
@@ -3123,7 +3123,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_2"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs22"
       },
       {
@@ -3144,7 +3144,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_10"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs23"
       },
       {
@@ -3165,7 +3165,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_8"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs24"
       },
       {
@@ -3186,7 +3186,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_3"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs25"
       },
       {
@@ -3207,7 +3207,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_13"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs26"
       },
       {
@@ -3228,7 +3228,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_5"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs27"
       },
       {
@@ -3249,7 +3249,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_14"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs28"
       },
       {
@@ -3270,7 +3270,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_0"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs29"
       },
       {
@@ -3291,7 +3291,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_6"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs30"
       },
       {
@@ -3312,7 +3312,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_4"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs31"
       },
       {
@@ -3333,7 +3333,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_0"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs32"
       },
       {
@@ -3354,7 +3354,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_12"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs33"
       },
       {
@@ -3375,7 +3375,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_6"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs34"
       },
       {
@@ -3396,7 +3396,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_5"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs35"
       },
       {
@@ -3417,7 +3417,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_9"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs36"
       },
       {
@@ -3438,7 +3438,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_13"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs37"
       },
       {
@@ -3459,7 +3459,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_11"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs38"
       },
       {
@@ -3480,7 +3480,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_2"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs39"
       },
       {
@@ -3501,7 +3501,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_14"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs40"
       },
       {
@@ -3522,7 +3522,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_1"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs41"
       },
       {
@@ -3543,7 +3543,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_10"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs42"
       },
       {
@@ -3564,7 +3564,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_7"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs43"
       },
       {
@@ -3585,7 +3585,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_12"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs44"
       },
       {
@@ -3606,7 +3606,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_14"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs45"
       },
       {
@@ -3627,7 +3627,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_13"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs46"
       },
       {
@@ -3648,7 +3648,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_8"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs47"
       },
       {
@@ -3669,7 +3669,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_5"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs48"
       },
       {
@@ -3690,7 +3690,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_0"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs49"
       },
       {
@@ -3711,7 +3711,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_6"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs50"
       },
       {
@@ -3732,7 +3732,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_7"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs51"
       },
       {
@@ -3753,7 +3753,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_2"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs52"
       },
       {
@@ -3774,7 +3774,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_12"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs53"
       },
       {
@@ -3795,7 +3795,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_10"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs54"
       },
       {
@@ -3816,7 +3816,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_9"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs55"
       },
       {
@@ -3837,7 +3837,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_11"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs56"
       },
       {
@@ -3858,7 +3858,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_3"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs57"
       },
       {
@@ -3879,7 +3879,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_4"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs58"
       },
       {
@@ -3900,7 +3900,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_1"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs59"
       },
       {
@@ -3921,7 +3921,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_15"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs60"
       },
       {
@@ -3942,7 +3942,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_16"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs61"
       },
       {
@@ -3963,7 +3963,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_17"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs62"
       },
       {
@@ -3984,7 +3984,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_18"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs63"
       },
       {
@@ -4005,7 +4005,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_15"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs64"
       },
       {
@@ -4026,7 +4026,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_19"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs65"
       },
       {
@@ -4047,7 +4047,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_20"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs66"
       },
       {
@@ -4068,7 +4068,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_16"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs67"
       },
       {
@@ -4089,7 +4089,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_19"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs68"
       },
       {
@@ -4110,7 +4110,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_16"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs69"
       },
       {
@@ -4131,7 +4131,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_21"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs70"
       },
       {
@@ -4152,7 +4152,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_22"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs71"
       },
       {
@@ -4173,7 +4173,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_23"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs72"
       },
       {
@@ -4194,7 +4194,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_24"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs73"
       },
       {
@@ -4215,7 +4215,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_17"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs74"
       },
       {
@@ -4236,7 +4236,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_24"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs75"
       },
       {
@@ -4257,7 +4257,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_21"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs76"
       },
       {
@@ -4278,7 +4278,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_25"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs77"
       },
       {
@@ -4299,7 +4299,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_22"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs78"
       },
       {
@@ -4320,7 +4320,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_26"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs79"
       },
       {
@@ -4341,7 +4341,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_27"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs80"
       },
       {
@@ -4362,7 +4362,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_18"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs81"
       },
       {
@@ -4383,7 +4383,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_17"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs82"
       },
       {
@@ -4404,7 +4404,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_25"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs83"
       },
       {
@@ -4425,7 +4425,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_23"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs84"
       },
       {
@@ -4446,7 +4446,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_18"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs85"
       },
       {
@@ -4467,7 +4467,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_28"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs86"
       },
       {
@@ -4488,7 +4488,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_20"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs87"
       },
       {
@@ -4509,7 +4509,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_29"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs88"
       },
       {
@@ -4530,7 +4530,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_15"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs89"
       },
       {
@@ -4551,7 +4551,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_21"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs90"
       },
       {
@@ -4572,7 +4572,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_19"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs91"
       },
       {
@@ -4593,7 +4593,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_15"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs92"
       },
       {
@@ -4614,7 +4614,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_27"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs93"
       },
       {
@@ -4635,7 +4635,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_21"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs94"
       },
       {
@@ -4656,7 +4656,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_20"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs95"
       },
       {
@@ -4677,7 +4677,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_24"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs96"
       },
       {
@@ -4698,7 +4698,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_28"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs97"
       },
       {
@@ -4719,7 +4719,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_26"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs98"
       },
       {
@@ -4740,7 +4740,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_17"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs99"
       },
       {
@@ -4761,7 +4761,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_29"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs100"
       },
       {
@@ -4782,7 +4782,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_16"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs101"
       },
       {
@@ -4803,7 +4803,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_25"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs102"
       },
       {
@@ -4824,7 +4824,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_22"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs103"
       },
       {
@@ -4845,7 +4845,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_27"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs104"
       },
       {
@@ -4866,7 +4866,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_29"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs105"
       },
       {
@@ -4887,7 +4887,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_28"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs106"
       },
       {
@@ -4908,7 +4908,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_23"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs107"
       },
       {
@@ -4929,7 +4929,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_20"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs108"
       },
       {
@@ -4950,7 +4950,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_15"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs109"
       },
       {
@@ -4971,7 +4971,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_21"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs110"
       },
       {
@@ -4992,7 +4992,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_22"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs111"
       },
       {
@@ -5013,7 +5013,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_17"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs112"
       },
       {
@@ -5034,7 +5034,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_27"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs113"
       },
       {
@@ -5055,7 +5055,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_25"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs114"
       },
       {
@@ -5076,7 +5076,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_24"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs115"
       },
       {
@@ -5097,7 +5097,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_26"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs116"
       },
       {
@@ -5118,7 +5118,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_18"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs117"
       },
       {
@@ -5139,7 +5139,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_19"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs118"
       },
       {
@@ -5160,7 +5160,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_16"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs119"
       },
       {
@@ -5173,7 +5173,7 @@
         "height": 24,
         "layers": ["top", "inner1", "inner2", "bottom"],
         "connectedTo": [],
-        "zLayers": [0]
+        "__zLayers": [0]
       }
     ],
     "connMap": {

--- a/fixtures/features/keepoutsolver/keepoutsolver03-input.json
+++ b/fixtures/features/keepoutsolver/keepoutsolver03-input.json
@@ -702,7 +702,7 @@
           "pcb_smtpad_0",
           "pcb_port_0"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -726,7 +726,7 @@
           "pcb_plated_hole_0",
           "pcb_port_43"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -770,7 +770,7 @@
           "pcb_plated_hole_1",
           "pcb_port_44"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -788,7 +788,7 @@
           "pcb_smtpad_3",
           "pcb_port_3"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -806,7 +806,7 @@
           "pcb_smtpad_4",
           "pcb_port_4"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -828,7 +828,7 @@
           "pcb_smtpad_27",
           "pcb_port_27"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -850,7 +850,7 @@
           "pcb_smtpad_23",
           "pcb_port_23"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -868,7 +868,7 @@
           "pcb_smtpad_7",
           "pcb_port_7"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -886,7 +886,7 @@
           "pcb_smtpad_8",
           "pcb_port_8"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -910,7 +910,7 @@
           "pcb_plated_hole_3",
           "pcb_port_46"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -934,7 +934,7 @@
           "pcb_plated_hole_2",
           "pcb_port_45"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -952,7 +952,7 @@
           "pcb_smtpad_11",
           "pcb_port_11"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -974,7 +974,7 @@
           "pcb_smtpad_36",
           "pcb_port_36"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -996,7 +996,7 @@
           "pcb_smtpad_40",
           "pcb_port_40"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1014,7 +1014,7 @@
           "pcb_smtpad_14",
           "pcb_port_14"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1032,7 +1032,7 @@
           "pcb_smtpad_15",
           "pcb_port_15"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1054,7 +1054,7 @@
           "pcb_smtpad_32",
           "pcb_port_32"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1072,7 +1072,7 @@
           "pcb_smtpad_17",
           "pcb_port_17"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1090,7 +1090,7 @@
           "pcb_smtpad_18",
           "pcb_port_18"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1108,7 +1108,7 @@
           "pcb_smtpad_19",
           "pcb_port_19"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1126,7 +1126,7 @@
           "pcb_smtpad_20",
           "pcb_port_20"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1144,7 +1144,7 @@
           "pcb_smtpad_21",
           "pcb_port_21"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1162,7 +1162,7 @@
           "pcb_smtpad_22",
           "pcb_port_22"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1184,7 +1184,7 @@
           "pcb_smtpad_23",
           "pcb_port_23"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1202,7 +1202,7 @@
           "pcb_smtpad_24",
           "pcb_port_24"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1246,7 +1246,7 @@
           "pcb_plated_hole_1",
           "pcb_port_44"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1264,7 +1264,7 @@
           "pcb_smtpad_26",
           "pcb_port_26"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1286,7 +1286,7 @@
           "pcb_smtpad_27",
           "pcb_port_27"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1304,7 +1304,7 @@
           "pcb_smtpad_28",
           "pcb_port_28"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1348,7 +1348,7 @@
           "pcb_plated_hole_1",
           "pcb_port_44"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1366,7 +1366,7 @@
           "pcb_smtpad_30",
           "pcb_port_30"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1384,7 +1384,7 @@
           "pcb_smtpad_31",
           "pcb_port_31"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1406,7 +1406,7 @@
           "pcb_smtpad_32",
           "pcb_port_32"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1424,7 +1424,7 @@
           "pcb_smtpad_33",
           "pcb_port_33"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1468,7 +1468,7 @@
           "pcb_plated_hole_1",
           "pcb_port_44"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1486,7 +1486,7 @@
           "pcb_smtpad_35",
           "pcb_port_35"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1508,7 +1508,7 @@
           "pcb_smtpad_36",
           "pcb_port_36"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1526,7 +1526,7 @@
           "pcb_smtpad_37",
           "pcb_port_37"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1570,7 +1570,7 @@
           "pcb_plated_hole_1",
           "pcb_port_44"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1588,7 +1588,7 @@
           "pcb_smtpad_39",
           "pcb_port_39"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1610,7 +1610,7 @@
           "pcb_smtpad_40",
           "pcb_port_40"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1628,7 +1628,7 @@
           "pcb_smtpad_41",
           "pcb_port_41"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1672,7 +1672,7 @@
           "pcb_plated_hole_1",
           "pcb_port_44"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -1696,7 +1696,7 @@
           "pcb_plated_hole_0",
           "pcb_port_43"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -1740,7 +1740,7 @@
           "pcb_plated_hole_1",
           "pcb_port_44"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -1764,7 +1764,7 @@
           "pcb_plated_hole_2",
           "pcb_port_45"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -1788,7 +1788,7 @@
           "pcb_plated_hole_3",
           "pcb_port_46"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1808,7 +1808,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_0"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs0"
       },
       {
@@ -1829,7 +1829,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_1"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs1"
       },
       {
@@ -1850,7 +1850,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_2"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs2"
       },
       {
@@ -1871,7 +1871,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_3"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs3"
       },
       {
@@ -1892,7 +1892,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_0"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs4"
       },
       {
@@ -1913,7 +1913,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_4"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs5"
       },
       {
@@ -1934,7 +1934,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_5"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs6"
       },
       {
@@ -1955,7 +1955,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_1"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs7"
       },
       {
@@ -1976,7 +1976,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_4"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs8"
       },
       {
@@ -1997,7 +1997,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_1"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs9"
       },
       {
@@ -2018,7 +2018,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_6"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs10"
       },
       {
@@ -2039,7 +2039,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_7"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs11"
       },
       {
@@ -2060,7 +2060,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_8"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs12"
       },
       {
@@ -2081,7 +2081,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_9"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs13"
       },
       {
@@ -2102,7 +2102,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_2"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs14"
       },
       {
@@ -2123,7 +2123,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_9"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs15"
       },
       {
@@ -2144,7 +2144,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_6"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs16"
       },
       {
@@ -2165,7 +2165,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_10"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs17"
       },
       {
@@ -2186,7 +2186,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_7"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs18"
       },
       {
@@ -2207,7 +2207,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_11"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs19"
       },
       {
@@ -2228,7 +2228,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_12"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs20"
       },
       {
@@ -2249,7 +2249,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_3"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs21"
       },
       {
@@ -2270,7 +2270,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_2"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs22"
       },
       {
@@ -2291,7 +2291,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_10"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs23"
       },
       {
@@ -2312,7 +2312,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_8"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs24"
       },
       {
@@ -2333,7 +2333,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_3"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs25"
       },
       {
@@ -2354,7 +2354,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_13"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs26"
       },
       {
@@ -2375,7 +2375,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_5"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs27"
       },
       {
@@ -2396,7 +2396,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_14"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs28"
       },
       {
@@ -2417,7 +2417,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_0"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs29"
       },
       {
@@ -2438,7 +2438,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_6"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs30"
       },
       {
@@ -2459,7 +2459,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_4"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs31"
       },
       {
@@ -2480,7 +2480,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_0"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs32"
       },
       {
@@ -2501,7 +2501,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_12"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs33"
       },
       {
@@ -2522,7 +2522,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_6"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs34"
       },
       {
@@ -2543,7 +2543,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_5"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs35"
       },
       {
@@ -2564,7 +2564,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_9"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs36"
       },
       {
@@ -2585,7 +2585,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_13"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs37"
       },
       {
@@ -2606,7 +2606,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_11"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs38"
       },
       {
@@ -2627,7 +2627,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_2"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs39"
       },
       {
@@ -2648,7 +2648,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_14"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs40"
       },
       {
@@ -2669,7 +2669,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_1"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs41"
       },
       {
@@ -2690,7 +2690,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_10"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs42"
       },
       {
@@ -2711,7 +2711,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_7"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs43"
       },
       {
@@ -2732,7 +2732,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_12"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs44"
       },
       {
@@ -2753,7 +2753,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_14"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs45"
       },
       {
@@ -2774,7 +2774,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_13"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs46"
       },
       {
@@ -2795,7 +2795,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_8"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs47"
       },
       {
@@ -2816,7 +2816,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_5"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs48"
       },
       {
@@ -2837,7 +2837,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_0"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs49"
       },
       {
@@ -2858,7 +2858,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_6"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs50"
       },
       {
@@ -2879,7 +2879,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_7"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs51"
       },
       {
@@ -2900,7 +2900,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_2"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs52"
       },
       {
@@ -2921,7 +2921,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_12"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs53"
       },
       {
@@ -2942,7 +2942,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_10"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs54"
       },
       {
@@ -2963,7 +2963,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_9"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs55"
       },
       {
@@ -2984,7 +2984,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_11"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs56"
       },
       {
@@ -3005,7 +3005,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_3"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs57"
       },
       {
@@ -3026,7 +3026,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_4"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs58"
       },
       {
@@ -3047,7 +3047,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_1"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs59"
       },
       {
@@ -3068,7 +3068,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_15"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs60"
       },
       {
@@ -3089,7 +3089,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_16"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs61"
       },
       {
@@ -3110,7 +3110,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_17"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs62"
       },
       {
@@ -3131,7 +3131,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_18"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs63"
       },
       {
@@ -3152,7 +3152,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_15"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs64"
       },
       {
@@ -3173,7 +3173,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_19"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs65"
       },
       {
@@ -3194,7 +3194,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_20"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs66"
       },
       {
@@ -3215,7 +3215,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_16"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs67"
       },
       {
@@ -3236,7 +3236,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_19"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs68"
       },
       {
@@ -3257,7 +3257,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_16"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs69"
       },
       {
@@ -3278,7 +3278,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_21"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs70"
       },
       {
@@ -3299,7 +3299,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_22"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs71"
       },
       {
@@ -3320,7 +3320,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_23"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs72"
       },
       {
@@ -3341,7 +3341,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_24"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs73"
       },
       {
@@ -3362,7 +3362,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_17"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs74"
       },
       {
@@ -3383,7 +3383,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_24"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs75"
       },
       {
@@ -3404,7 +3404,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_21"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs76"
       },
       {
@@ -3425,7 +3425,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_25"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs77"
       },
       {
@@ -3446,7 +3446,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_22"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs78"
       },
       {
@@ -3467,7 +3467,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_26"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs79"
       },
       {
@@ -3488,7 +3488,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_27"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs80"
       },
       {
@@ -3509,7 +3509,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_18"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs81"
       },
       {
@@ -3530,7 +3530,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_17"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs82"
       },
       {
@@ -3551,7 +3551,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_25"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs83"
       },
       {
@@ -3572,7 +3572,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_23"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs84"
       },
       {
@@ -3593,7 +3593,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_18"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs85"
       },
       {
@@ -3614,7 +3614,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_28"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs86"
       },
       {
@@ -3635,7 +3635,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_20"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs87"
       },
       {
@@ -3656,7 +3656,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_29"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs88"
       },
       {
@@ -3677,7 +3677,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_15"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs89"
       },
       {
@@ -3698,7 +3698,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_21"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs90"
       },
       {
@@ -3719,7 +3719,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_19"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs91"
       },
       {
@@ -3740,7 +3740,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_15"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs92"
       },
       {
@@ -3761,7 +3761,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_27"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs93"
       },
       {
@@ -3782,7 +3782,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_21"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs94"
       },
       {
@@ -3803,7 +3803,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_20"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs95"
       },
       {
@@ -3824,7 +3824,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_24"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs96"
       },
       {
@@ -3845,7 +3845,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_28"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs97"
       },
       {
@@ -3866,7 +3866,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_26"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs98"
       },
       {
@@ -3887,7 +3887,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_17"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs99"
       },
       {
@@ -3908,7 +3908,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_29"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs100"
       },
       {
@@ -3929,7 +3929,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_16"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs101"
       },
       {
@@ -3950,7 +3950,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_25"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs102"
       },
       {
@@ -3971,7 +3971,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_22"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs103"
       },
       {
@@ -3992,7 +3992,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_27"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs104"
       },
       {
@@ -4013,7 +4013,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_29"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs105"
       },
       {
@@ -4034,7 +4034,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_28"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs106"
       },
       {
@@ -4055,7 +4055,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_23"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs107"
       },
       {
@@ -4076,7 +4076,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_20"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs108"
       },
       {
@@ -4097,7 +4097,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_15"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs109"
       },
       {
@@ -4118,7 +4118,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_21"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs110"
       },
       {
@@ -4139,7 +4139,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_22"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs111"
       },
       {
@@ -4160,7 +4160,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_17"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs112"
       },
       {
@@ -4181,7 +4181,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_27"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs113"
       },
       {
@@ -4202,7 +4202,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_25"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs114"
       },
       {
@@ -4223,7 +4223,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_24"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs115"
       },
       {
@@ -4244,7 +4244,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_26"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs116"
       },
       {
@@ -4265,7 +4265,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_18"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs117"
       },
       {
@@ -4286,7 +4286,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_19"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs118"
       },
       {
@@ -4307,7 +4307,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_16"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs119"
       },
       {
@@ -4320,7 +4320,7 @@
         "height": 24,
         "layers": ["top", "inner1", "inner2", "bottom"],
         "connectedTo": [],
-        "zLayers": [0]
+        "__zLayers": [0]
       }
     ],
     "connMap": {
@@ -7422,7 +7422,7 @@
             "pcb_smtpad_0",
             "pcb_port_0"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -7446,7 +7446,7 @@
             "pcb_plated_hole_0",
             "pcb_port_43"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -7490,7 +7490,7 @@
             "pcb_plated_hole_1",
             "pcb_port_44"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -7508,7 +7508,7 @@
             "pcb_smtpad_3",
             "pcb_port_3"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -7526,7 +7526,7 @@
             "pcb_smtpad_4",
             "pcb_port_4"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -7548,7 +7548,7 @@
             "pcb_smtpad_27",
             "pcb_port_27"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -7570,7 +7570,7 @@
             "pcb_smtpad_23",
             "pcb_port_23"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -7588,7 +7588,7 @@
             "pcb_smtpad_7",
             "pcb_port_7"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -7606,7 +7606,7 @@
             "pcb_smtpad_8",
             "pcb_port_8"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -7630,7 +7630,7 @@
             "pcb_plated_hole_3",
             "pcb_port_46"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -7654,7 +7654,7 @@
             "pcb_plated_hole_2",
             "pcb_port_45"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -7672,7 +7672,7 @@
             "pcb_smtpad_11",
             "pcb_port_11"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -7694,7 +7694,7 @@
             "pcb_smtpad_36",
             "pcb_port_36"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -7716,7 +7716,7 @@
             "pcb_smtpad_40",
             "pcb_port_40"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -7734,7 +7734,7 @@
             "pcb_smtpad_14",
             "pcb_port_14"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -7752,7 +7752,7 @@
             "pcb_smtpad_15",
             "pcb_port_15"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -7774,7 +7774,7 @@
             "pcb_smtpad_32",
             "pcb_port_32"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -7792,7 +7792,7 @@
             "pcb_smtpad_17",
             "pcb_port_17"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -7810,7 +7810,7 @@
             "pcb_smtpad_18",
             "pcb_port_18"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -7828,7 +7828,7 @@
             "pcb_smtpad_19",
             "pcb_port_19"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -7846,7 +7846,7 @@
             "pcb_smtpad_20",
             "pcb_port_20"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -7864,7 +7864,7 @@
             "pcb_smtpad_21",
             "pcb_port_21"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -7882,7 +7882,7 @@
             "pcb_smtpad_22",
             "pcb_port_22"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -7904,7 +7904,7 @@
             "pcb_smtpad_23",
             "pcb_port_23"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -7922,7 +7922,7 @@
             "pcb_smtpad_24",
             "pcb_port_24"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -7966,7 +7966,7 @@
             "pcb_plated_hole_1",
             "pcb_port_44"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -7984,7 +7984,7 @@
             "pcb_smtpad_26",
             "pcb_port_26"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -8006,7 +8006,7 @@
             "pcb_smtpad_27",
             "pcb_port_27"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -8024,7 +8024,7 @@
             "pcb_smtpad_28",
             "pcb_port_28"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -8068,7 +8068,7 @@
             "pcb_plated_hole_1",
             "pcb_port_44"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -8086,7 +8086,7 @@
             "pcb_smtpad_30",
             "pcb_port_30"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -8104,7 +8104,7 @@
             "pcb_smtpad_31",
             "pcb_port_31"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -8126,7 +8126,7 @@
             "pcb_smtpad_32",
             "pcb_port_32"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -8144,7 +8144,7 @@
             "pcb_smtpad_33",
             "pcb_port_33"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -8188,7 +8188,7 @@
             "pcb_plated_hole_1",
             "pcb_port_44"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -8206,7 +8206,7 @@
             "pcb_smtpad_35",
             "pcb_port_35"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -8228,7 +8228,7 @@
             "pcb_smtpad_36",
             "pcb_port_36"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -8246,7 +8246,7 @@
             "pcb_smtpad_37",
             "pcb_port_37"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -8290,7 +8290,7 @@
             "pcb_plated_hole_1",
             "pcb_port_44"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -8308,7 +8308,7 @@
             "pcb_smtpad_39",
             "pcb_port_39"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -8330,7 +8330,7 @@
             "pcb_smtpad_40",
             "pcb_port_40"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -8348,7 +8348,7 @@
             "pcb_smtpad_41",
             "pcb_port_41"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -8392,7 +8392,7 @@
             "pcb_plated_hole_1",
             "pcb_port_44"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -8416,7 +8416,7 @@
             "pcb_plated_hole_0",
             "pcb_port_43"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -8460,7 +8460,7 @@
             "pcb_plated_hole_1",
             "pcb_port_44"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -8484,7 +8484,7 @@
             "pcb_plated_hole_2",
             "pcb_port_45"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -8508,7 +8508,7 @@
             "pcb_plated_hole_3",
             "pcb_port_46"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -8528,7 +8528,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_0"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs0"
         },
         {
@@ -8549,7 +8549,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_1"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs1"
         },
         {
@@ -8570,7 +8570,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_2"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs2"
         },
         {
@@ -8591,7 +8591,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_3"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs3"
         },
         {
@@ -8612,7 +8612,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_0"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs4"
         },
         {
@@ -8633,7 +8633,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_4"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs5"
         },
         {
@@ -8654,7 +8654,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_5"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs6"
         },
         {
@@ -8675,7 +8675,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_1"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs7"
         },
         {
@@ -8696,7 +8696,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_4"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs8"
         },
         {
@@ -8717,7 +8717,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_1"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs9"
         },
         {
@@ -8738,7 +8738,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_6"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs10"
         },
         {
@@ -8759,7 +8759,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_7"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs11"
         },
         {
@@ -8780,7 +8780,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_8"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs12"
         },
         {
@@ -8801,7 +8801,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_9"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs13"
         },
         {
@@ -8822,7 +8822,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_2"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs14"
         },
         {
@@ -8843,7 +8843,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_9"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs15"
         },
         {
@@ -8864,7 +8864,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_6"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs16"
         },
         {
@@ -8885,7 +8885,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_10"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs17"
         },
         {
@@ -8906,7 +8906,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_7"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs18"
         },
         {
@@ -8927,7 +8927,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_11"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs19"
         },
         {
@@ -8948,7 +8948,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_12"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs20"
         },
         {
@@ -8969,7 +8969,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_3"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs21"
         },
         {
@@ -8990,7 +8990,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_2"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs22"
         },
         {
@@ -9011,7 +9011,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_10"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs23"
         },
         {
@@ -9032,7 +9032,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_8"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs24"
         },
         {
@@ -9053,7 +9053,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_3"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs25"
         },
         {
@@ -9074,7 +9074,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_13"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs26"
         },
         {
@@ -9095,7 +9095,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_5"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs27"
         },
         {
@@ -9116,7 +9116,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_14"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs28"
         },
         {
@@ -9137,7 +9137,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_0"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs29"
         },
         {
@@ -9158,7 +9158,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_6"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs30"
         },
         {
@@ -9179,7 +9179,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_4"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs31"
         },
         {
@@ -9200,7 +9200,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_0"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs32"
         },
         {
@@ -9221,7 +9221,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_12"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs33"
         },
         {
@@ -9242,7 +9242,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_6"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs34"
         },
         {
@@ -9263,7 +9263,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_5"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs35"
         },
         {
@@ -9284,7 +9284,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_9"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs36"
         },
         {
@@ -9305,7 +9305,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_13"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs37"
         },
         {
@@ -9326,7 +9326,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_11"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs38"
         },
         {
@@ -9347,7 +9347,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_2"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs39"
         },
         {
@@ -9368,7 +9368,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_14"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs40"
         },
         {
@@ -9389,7 +9389,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_1"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs41"
         },
         {
@@ -9410,7 +9410,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_10"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs42"
         },
         {
@@ -9431,7 +9431,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_7"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs43"
         },
         {
@@ -9452,7 +9452,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_12"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs44"
         },
         {
@@ -9473,7 +9473,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_14"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs45"
         },
         {
@@ -9494,7 +9494,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_13"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs46"
         },
         {
@@ -9515,7 +9515,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_8"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs47"
         },
         {
@@ -9536,7 +9536,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_5"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs48"
         },
         {
@@ -9557,7 +9557,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_0"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs49"
         },
         {
@@ -9578,7 +9578,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_6"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs50"
         },
         {
@@ -9599,7 +9599,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_7"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs51"
         },
         {
@@ -9620,7 +9620,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_2"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs52"
         },
         {
@@ -9641,7 +9641,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_12"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs53"
         },
         {
@@ -9662,7 +9662,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_10"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs54"
         },
         {
@@ -9683,7 +9683,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_9"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs55"
         },
         {
@@ -9704,7 +9704,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_11"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs56"
         },
         {
@@ -9725,7 +9725,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_3"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs57"
         },
         {
@@ -9746,7 +9746,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_4"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs58"
         },
         {
@@ -9767,7 +9767,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_1"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs59"
         },
         {
@@ -9788,7 +9788,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_15"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs60"
         },
         {
@@ -9809,7 +9809,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_16"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs61"
         },
         {
@@ -9830,7 +9830,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_17"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs62"
         },
         {
@@ -9851,7 +9851,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_18"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs63"
         },
         {
@@ -9872,7 +9872,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_15"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs64"
         },
         {
@@ -9893,7 +9893,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_19"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs65"
         },
         {
@@ -9914,7 +9914,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_20"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs66"
         },
         {
@@ -9935,7 +9935,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_16"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs67"
         },
         {
@@ -9956,7 +9956,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_19"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs68"
         },
         {
@@ -9977,7 +9977,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_16"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs69"
         },
         {
@@ -9998,7 +9998,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_21"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs70"
         },
         {
@@ -10019,7 +10019,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_22"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs71"
         },
         {
@@ -10040,7 +10040,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_23"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs72"
         },
         {
@@ -10061,7 +10061,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_24"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs73"
         },
         {
@@ -10082,7 +10082,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_17"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs74"
         },
         {
@@ -10103,7 +10103,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_24"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs75"
         },
         {
@@ -10124,7 +10124,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_21"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs76"
         },
         {
@@ -10145,7 +10145,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_25"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs77"
         },
         {
@@ -10166,7 +10166,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_22"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs78"
         },
         {
@@ -10187,7 +10187,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_26"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs79"
         },
         {
@@ -10208,7 +10208,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_27"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs80"
         },
         {
@@ -10229,7 +10229,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_18"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs81"
         },
         {
@@ -10250,7 +10250,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_17"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs82"
         },
         {
@@ -10271,7 +10271,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_25"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs83"
         },
         {
@@ -10292,7 +10292,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_23"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs84"
         },
         {
@@ -10313,7 +10313,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_18"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs85"
         },
         {
@@ -10334,7 +10334,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_28"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs86"
         },
         {
@@ -10355,7 +10355,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_20"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs87"
         },
         {
@@ -10376,7 +10376,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_29"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs88"
         },
         {
@@ -10397,7 +10397,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_15"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs89"
         },
         {
@@ -10418,7 +10418,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_21"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs90"
         },
         {
@@ -10439,7 +10439,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_19"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs91"
         },
         {
@@ -10460,7 +10460,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_15"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs92"
         },
         {
@@ -10481,7 +10481,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_27"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs93"
         },
         {
@@ -10502,7 +10502,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_21"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs94"
         },
         {
@@ -10523,7 +10523,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_20"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs95"
         },
         {
@@ -10544,7 +10544,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_24"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs96"
         },
         {
@@ -10565,7 +10565,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_28"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs97"
         },
         {
@@ -10586,7 +10586,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_26"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs98"
         },
         {
@@ -10607,7 +10607,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_17"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs99"
         },
         {
@@ -10628,7 +10628,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_29"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs100"
         },
         {
@@ -10649,7 +10649,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_16"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs101"
         },
         {
@@ -10670,7 +10670,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_25"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs102"
         },
         {
@@ -10691,7 +10691,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_22"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs103"
         },
         {
@@ -10712,7 +10712,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_27"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs104"
         },
         {
@@ -10733,7 +10733,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_29"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs105"
         },
         {
@@ -10754,7 +10754,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_28"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs106"
         },
         {
@@ -10775,7 +10775,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_23"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs107"
         },
         {
@@ -10796,7 +10796,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_20"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs108"
         },
         {
@@ -10817,7 +10817,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_15"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs109"
         },
         {
@@ -10838,7 +10838,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_21"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs110"
         },
         {
@@ -10859,7 +10859,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_22"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs111"
         },
         {
@@ -10880,7 +10880,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_17"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs112"
         },
         {
@@ -10901,7 +10901,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_27"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs113"
         },
         {
@@ -10922,7 +10922,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_25"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs114"
         },
         {
@@ -10943,7 +10943,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_24"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs115"
         },
         {
@@ -10964,7 +10964,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_26"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs116"
         },
         {
@@ -10985,7 +10985,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_18"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs117"
         },
         {
@@ -11006,7 +11006,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_19"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs118"
         },
         {
@@ -11027,7 +11027,7 @@
           ],
           "netIsAssignable": true,
           "offBoardConnectsTo": ["source_component_internal_connection_16"],
-          "zLayers": [0],
+          "__zLayers": [0],
           "obstacleId": "__obs119"
         },
         {
@@ -11040,7 +11040,7 @@
           "height": 24,
           "layers": ["top", "inner1", "inner2", "bottom"],
           "connectedTo": [],
-          "zLayers": [0]
+          "__zLayers": [0]
         }
       ],
       "layerCount": 1,

--- a/fixtures/features/polygon-outline/polygon-outline02.fixture.tsx
+++ b/fixtures/features/polygon-outline/polygon-outline02.fixture.tsx
@@ -25,7 +25,7 @@ const simpleRouteJson: SimpleRouteJson = {
         "pcb_smtpad_0",
         "pcb_port_0",
       ],
-      zLayers: [0],
+      __zLayers: [0],
     },
     {
       type: "rect",
@@ -47,7 +47,7 @@ const simpleRouteJson: SimpleRouteJson = {
         "pcb_smtpad_3",
         "pcb_port_3",
       ],
-      zLayers: [0],
+      __zLayers: [0],
     },
     {
       type: "rect",
@@ -65,7 +65,7 @@ const simpleRouteJson: SimpleRouteJson = {
         "pcb_smtpad_2",
         "pcb_port_2",
       ],
-      zLayers: [0],
+      __zLayers: [0],
     },
     {
       type: "rect",
@@ -87,7 +87,7 @@ const simpleRouteJson: SimpleRouteJson = {
         "pcb_smtpad_3",
         "pcb_port_3",
       ],
-      zLayers: [0],
+      __zLayers: [0],
     },
   ],
   connections: [

--- a/fixtures/features/portpointpathing/portpointpathing01-input.json
+++ b/fixtures/features/portpointpathing/portpointpathing01-input.json
@@ -15,7 +15,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_0"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -29,7 +29,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_0"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -43,7 +43,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_1"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -57,7 +57,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_1"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -71,7 +71,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_2"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -85,7 +85,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_2"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -99,7 +99,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_3"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -113,7 +113,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_3"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -127,7 +127,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_4"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -141,7 +141,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_4"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -155,7 +155,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_5"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -169,7 +169,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_5"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -183,7 +183,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_6"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -197,7 +197,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_6"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -211,7 +211,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_7"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -225,7 +225,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_7"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -239,7 +239,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_8"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -253,7 +253,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_8"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -267,7 +267,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_9"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -281,7 +281,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_9"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -295,7 +295,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_10"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -309,7 +309,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_10"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -323,7 +323,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_11"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -337,7 +337,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_11"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -351,7 +351,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_12"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -365,7 +365,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_12"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -379,7 +379,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_13"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -393,7 +393,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_13"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -407,7 +407,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_14"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -421,7 +421,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_14"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -435,7 +435,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_15"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -449,7 +449,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_15"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -463,7 +463,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_16"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -477,7 +477,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_16"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -491,7 +491,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_17"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -505,7 +505,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_17"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -519,7 +519,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_18"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -533,7 +533,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_18"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -547,7 +547,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_19"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -561,7 +561,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_19"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -575,7 +575,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_20"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -589,7 +589,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_20"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -603,7 +603,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_21"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -617,7 +617,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_21"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -631,7 +631,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_22"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -645,7 +645,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_22"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -659,7 +659,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_23"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -673,7 +673,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_23"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -687,7 +687,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_24"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -701,7 +701,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_24"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -715,7 +715,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_25"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -729,7 +729,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_25"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -743,7 +743,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_26"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -757,7 +757,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_26"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -771,7 +771,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_27"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -785,7 +785,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_27"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -799,7 +799,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_28"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -813,7 +813,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_28"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -827,7 +827,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_29"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -841,7 +841,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_29"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -855,7 +855,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_30"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -869,7 +869,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_30"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -883,7 +883,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_31"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -897,7 +897,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_31"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -911,7 +911,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_32"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -925,7 +925,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_32"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -939,7 +939,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_33"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -953,7 +953,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_33"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -967,7 +967,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_34"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -981,7 +981,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_34"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -995,7 +995,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_35"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1009,7 +1009,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_35"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1023,7 +1023,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_36"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1037,7 +1037,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_36"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1051,7 +1051,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_37"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1065,7 +1065,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_37"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1079,7 +1079,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_38"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1093,7 +1093,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_38"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1107,7 +1107,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_39"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1121,7 +1121,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_39"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1135,7 +1135,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_40"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1149,7 +1149,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_40"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1163,7 +1163,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_41"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1177,7 +1177,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_41"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1191,7 +1191,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_42"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1205,7 +1205,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_42"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1219,7 +1219,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_43"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1233,7 +1233,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_43"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1247,7 +1247,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_44"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1261,7 +1261,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_44"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1275,7 +1275,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_45"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1289,7 +1289,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_45"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1303,7 +1303,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_46"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1317,7 +1317,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_46"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1331,7 +1331,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_47"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1345,7 +1345,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_47"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1359,7 +1359,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_48"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1373,7 +1373,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_48"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1387,7 +1387,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_49"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1401,7 +1401,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_49"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1415,7 +1415,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_50"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1429,7 +1429,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_50"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1443,7 +1443,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_51"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1457,7 +1457,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_51"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1471,7 +1471,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_52"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1485,7 +1485,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_52"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1499,7 +1499,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_53"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1513,7 +1513,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_53"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1527,7 +1527,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_54"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1541,7 +1541,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_54"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1555,7 +1555,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_55"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1569,7 +1569,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_55"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1583,7 +1583,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_56"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1597,7 +1597,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_56"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1611,7 +1611,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_57"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1625,7 +1625,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_57"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1639,7 +1639,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_58"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1653,7 +1653,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_58"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1667,7 +1667,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_59"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1681,7 +1681,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_59"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1695,7 +1695,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_60"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1709,7 +1709,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_60"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1723,7 +1723,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_61"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1737,7 +1737,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_61"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1751,7 +1751,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_62"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1765,7 +1765,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_62"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1779,7 +1779,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_63"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1793,7 +1793,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_63"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1807,7 +1807,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_64"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1821,7 +1821,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_64"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1835,7 +1835,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_65"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1849,7 +1849,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_65"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1863,7 +1863,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_66"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1877,7 +1877,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_66"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1891,7 +1891,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_67"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1905,7 +1905,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_67"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1919,7 +1919,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_68"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1933,7 +1933,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_68"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1947,7 +1947,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_69"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1961,7 +1961,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_69"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1975,7 +1975,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_70"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1989,7 +1989,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_70"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2003,7 +2003,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_71"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2017,7 +2017,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_71"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2031,7 +2031,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_72"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2045,7 +2045,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_72"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2059,7 +2059,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_73"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2073,7 +2073,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_73"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2087,7 +2087,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_74"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2101,7 +2101,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_74"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2115,7 +2115,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_75"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2129,7 +2129,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_75"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2143,7 +2143,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_76"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2157,7 +2157,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_76"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2171,7 +2171,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_77"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2185,7 +2185,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_77"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2199,7 +2199,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_78"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2213,7 +2213,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_78"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2227,7 +2227,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_79"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2241,7 +2241,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_79"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2255,7 +2255,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_80"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2269,7 +2269,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_80"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2283,7 +2283,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_81"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2297,7 +2297,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_81"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2311,7 +2311,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_82"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2325,7 +2325,7 @@
         "height": 0.95,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_82"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2339,7 +2339,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_83"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2353,7 +2353,7 @@
         "height": 0.8,
         "connectedTo": [],
         "offBoardConnectsTo": ["jumper_conn_83"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2366,7 +2366,7 @@
         "width": 0.3,
         "height": 0.3,
         "connectedTo": ["source_net_6"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2379,7 +2379,7 @@
         "width": 0.3,
         "height": 0.3,
         "connectedTo": ["source_net_6"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2392,7 +2392,7 @@
         "width": 0.3,
         "height": 0.3,
         "connectedTo": ["source_net_2_mst2"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2405,7 +2405,7 @@
         "width": 0.3,
         "height": 0.3,
         "connectedTo": ["source_net_2_mst2"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2418,7 +2418,7 @@
         "width": 0.3,
         "height": 0.3,
         "connectedTo": ["source_net_15"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2431,7 +2431,7 @@
         "width": 0.3,
         "height": 0.3,
         "connectedTo": ["source_net_15"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2444,7 +2444,7 @@
         "width": 0.3,
         "height": 0.3,
         "connectedTo": ["source_net_4"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2457,7 +2457,7 @@
         "width": 0.3,
         "height": 0.3,
         "connectedTo": ["source_net_4"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2470,7 +2470,7 @@
         "width": 0.3,
         "height": 0.3,
         "connectedTo": ["source_net_3_mst1"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2483,7 +2483,7 @@
         "width": 0.3,
         "height": 0.3,
         "connectedTo": ["source_net_3_mst1"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2496,7 +2496,7 @@
         "width": 0.3,
         "height": 0.3,
         "connectedTo": ["source_net_3_mst2"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2509,7 +2509,7 @@
         "width": 0.3,
         "height": 0.3,
         "connectedTo": ["source_net_3_mst2"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2522,7 +2522,7 @@
         "width": 0.3,
         "height": 0.3,
         "connectedTo": ["source_net_2_mst1"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2535,7 +2535,7 @@
         "width": 0.3,
         "height": 0.3,
         "connectedTo": ["source_net_2_mst1"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2548,7 +2548,7 @@
         "width": 0.3,
         "height": 0.3,
         "connectedTo": ["source_net_0_mst7"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2561,7 +2561,7 @@
         "width": 0.3,
         "height": 0.3,
         "connectedTo": ["source_net_0_mst7"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2574,7 +2574,7 @@
         "width": 0.3,
         "height": 0.3,
         "connectedTo": ["source_net_7"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2587,7 +2587,7 @@
         "width": 0.3,
         "height": 0.3,
         "connectedTo": ["source_net_7"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2600,7 +2600,7 @@
         "width": 0.3,
         "height": 0.3,
         "connectedTo": ["source_net_1_mst2"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2613,7 +2613,7 @@
         "width": 0.3,
         "height": 0.3,
         "connectedTo": ["source_net_1_mst2"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2626,7 +2626,7 @@
         "width": 0.3,
         "height": 0.3,
         "connectedTo": ["source_net_5"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2639,7 +2639,7 @@
         "width": 0.3,
         "height": 0.3,
         "connectedTo": ["source_net_5"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2652,7 +2652,7 @@
         "width": 0.3,
         "height": 0.3,
         "connectedTo": ["source_net_9"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2665,7 +2665,7 @@
         "width": 0.3,
         "height": 0.3,
         "connectedTo": ["source_net_9"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2678,7 +2678,7 @@
         "width": 0.3,
         "height": 0.3,
         "connectedTo": ["source_net_11"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2691,7 +2691,7 @@
         "width": 0.3,
         "height": 0.3,
         "connectedTo": ["source_net_11"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2704,7 +2704,7 @@
         "width": 0.3,
         "height": 0.3,
         "connectedTo": ["source_net_0_mst8"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2717,7 +2717,7 @@
         "width": 0.3,
         "height": 0.3,
         "connectedTo": ["source_net_0_mst8"],
-        "zLayers": [0]
+        "__zLayers": [0]
       }
     ],
     "connections": [

--- a/fixtures/features/portpointpathing/portpointpathing02-input.json
+++ b/fixtures/features/portpointpathing/portpointpathing02-input.json
@@ -28,7 +28,7 @@
             "pcb_plated_hole_8",
             "pcb_port_8"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -50,7 +50,7 @@
             "pcb_plated_hole_9",
             "pcb_port_9"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -72,7 +72,7 @@
             "pcb_plated_hole_10",
             "pcb_port_10"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -94,7 +94,7 @@
             "pcb_plated_hole_11",
             "pcb_port_11"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -116,7 +116,7 @@
             "pcb_plated_hole_12",
             "pcb_port_12"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -138,7 +138,7 @@
             "pcb_plated_hole_13",
             "pcb_port_13"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -160,7 +160,7 @@
             "pcb_plated_hole_14",
             "pcb_port_14"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -182,7 +182,7 @@
             "pcb_plated_hole_15",
             "pcb_port_15"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -204,7 +204,7 @@
             "pcb_plated_hole_8",
             "pcb_port_8"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -226,7 +226,7 @@
             "pcb_plated_hole_9",
             "pcb_port_9"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -248,7 +248,7 @@
             "pcb_plated_hole_10",
             "pcb_port_10"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -270,7 +270,7 @@
             "pcb_plated_hole_11",
             "pcb_port_11"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -292,7 +292,7 @@
             "pcb_plated_hole_12",
             "pcb_port_12"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -314,7 +314,7 @@
             "pcb_plated_hole_13",
             "pcb_port_13"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -336,7 +336,7 @@
             "pcb_plated_hole_14",
             "pcb_port_14"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -358,7 +358,7 @@
             "pcb_plated_hole_15",
             "pcb_port_15"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         }
       ],
       "layerCount": 1,

--- a/fixtures/features/pour-via-escape/pour-via-escape01.json
+++ b/fixtures/features/pour-via-escape/pour-via-escape01.json
@@ -358,7 +358,7 @@
       },
       {
         "name": "source_net_0",
-        "netConnectionName": "net.VCC",
+        "__netConnectionName": "net.VCC",
         "pointsToConnect": [
           {
             "x": -2.15,
@@ -392,7 +392,7 @@
       },
       {
         "name": "source_net_1",
-        "netConnectionName": "net.GND",
+        "__netConnectionName": "net.GND",
         "pointsToConnect": [
           {
             "x": -2.15,

--- a/fixtures/features/tracewidthsolver/tracewidthsolver01-input.json
+++ b/fixtures/features/tracewidthsolver/tracewidthsolver01-input.json
@@ -6392,7 +6392,7 @@
           "pcb_smtpad_0",
           "pcb_port_0"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -6416,7 +6416,7 @@
           "pcb_plated_hole_0",
           "pcb_port_43"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -6460,7 +6460,7 @@
           "pcb_plated_hole_1",
           "pcb_port_44"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -6478,7 +6478,7 @@
           "pcb_smtpad_3",
           "pcb_port_3"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -6496,7 +6496,7 @@
           "pcb_smtpad_4",
           "pcb_port_4"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -6518,7 +6518,7 @@
           "pcb_smtpad_27",
           "pcb_port_27"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -6540,7 +6540,7 @@
           "pcb_smtpad_23",
           "pcb_port_23"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -6558,7 +6558,7 @@
           "pcb_smtpad_7",
           "pcb_port_7"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -6576,7 +6576,7 @@
           "pcb_smtpad_8",
           "pcb_port_8"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -6600,7 +6600,7 @@
           "pcb_plated_hole_3",
           "pcb_port_46"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -6624,7 +6624,7 @@
           "pcb_plated_hole_2",
           "pcb_port_45"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -6642,7 +6642,7 @@
           "pcb_smtpad_11",
           "pcb_port_11"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -6664,7 +6664,7 @@
           "pcb_smtpad_36",
           "pcb_port_36"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -6686,7 +6686,7 @@
           "pcb_smtpad_40",
           "pcb_port_40"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -6704,7 +6704,7 @@
           "pcb_smtpad_14",
           "pcb_port_14"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -6722,7 +6722,7 @@
           "pcb_smtpad_15",
           "pcb_port_15"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -6744,7 +6744,7 @@
           "pcb_smtpad_32",
           "pcb_port_32"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -6762,7 +6762,7 @@
           "pcb_smtpad_17",
           "pcb_port_17"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -6780,7 +6780,7 @@
           "pcb_smtpad_18",
           "pcb_port_18"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -6798,7 +6798,7 @@
           "pcb_smtpad_19",
           "pcb_port_19"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -6816,7 +6816,7 @@
           "pcb_smtpad_20",
           "pcb_port_20"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -6834,7 +6834,7 @@
           "pcb_smtpad_21",
           "pcb_port_21"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -6852,7 +6852,7 @@
           "pcb_smtpad_22",
           "pcb_port_22"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -6874,7 +6874,7 @@
           "pcb_smtpad_23",
           "pcb_port_23"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -6892,7 +6892,7 @@
           "pcb_smtpad_24",
           "pcb_port_24"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -6936,7 +6936,7 @@
           "pcb_plated_hole_1",
           "pcb_port_44"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -6954,7 +6954,7 @@
           "pcb_smtpad_26",
           "pcb_port_26"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -6976,7 +6976,7 @@
           "pcb_smtpad_27",
           "pcb_port_27"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -6994,7 +6994,7 @@
           "pcb_smtpad_28",
           "pcb_port_28"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -7038,7 +7038,7 @@
           "pcb_plated_hole_1",
           "pcb_port_44"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -7056,7 +7056,7 @@
           "pcb_smtpad_30",
           "pcb_port_30"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -7074,7 +7074,7 @@
           "pcb_smtpad_31",
           "pcb_port_31"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -7096,7 +7096,7 @@
           "pcb_smtpad_32",
           "pcb_port_32"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -7114,7 +7114,7 @@
           "pcb_smtpad_33",
           "pcb_port_33"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -7158,7 +7158,7 @@
           "pcb_plated_hole_1",
           "pcb_port_44"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -7176,7 +7176,7 @@
           "pcb_smtpad_35",
           "pcb_port_35"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -7198,7 +7198,7 @@
           "pcb_smtpad_36",
           "pcb_port_36"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -7216,7 +7216,7 @@
           "pcb_smtpad_37",
           "pcb_port_37"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -7260,7 +7260,7 @@
           "pcb_plated_hole_1",
           "pcb_port_44"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -7278,7 +7278,7 @@
           "pcb_smtpad_39",
           "pcb_port_39"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -7300,7 +7300,7 @@
           "pcb_smtpad_40",
           "pcb_port_40"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -7318,7 +7318,7 @@
           "pcb_smtpad_41",
           "pcb_port_41"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -7362,7 +7362,7 @@
           "pcb_plated_hole_1",
           "pcb_port_44"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -7386,7 +7386,7 @@
           "pcb_plated_hole_0",
           "pcb_port_43"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -7430,7 +7430,7 @@
           "pcb_plated_hole_1",
           "pcb_port_44"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -7454,7 +7454,7 @@
           "pcb_plated_hole_2",
           "pcb_port_45"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -7478,7 +7478,7 @@
           "pcb_plated_hole_3",
           "pcb_port_46"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -7498,7 +7498,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_0"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs0"
       },
       {
@@ -7519,7 +7519,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_1"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs1"
       },
       {
@@ -7540,7 +7540,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_2"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs2"
       },
       {
@@ -7561,7 +7561,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_3"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs3"
       },
       {
@@ -7582,7 +7582,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_0"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs4"
       },
       {
@@ -7603,7 +7603,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_4"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs5"
       },
       {
@@ -7624,7 +7624,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_5"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs6"
       },
       {
@@ -7645,7 +7645,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_1"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs7"
       },
       {
@@ -7666,7 +7666,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_4"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs8"
       },
       {
@@ -7687,7 +7687,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_1"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs9"
       },
       {
@@ -7708,7 +7708,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_6"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs10"
       },
       {
@@ -7729,7 +7729,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_7"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs11"
       },
       {
@@ -7750,7 +7750,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_8"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs12"
       },
       {
@@ -7771,7 +7771,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_9"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs13"
       },
       {
@@ -7792,7 +7792,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_2"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs14"
       },
       {
@@ -7813,7 +7813,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_9"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs15"
       },
       {
@@ -7834,7 +7834,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_6"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs16"
       },
       {
@@ -7855,7 +7855,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_10"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs17"
       },
       {
@@ -7876,7 +7876,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_7"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs18"
       },
       {
@@ -7897,7 +7897,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_11"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs19"
       },
       {
@@ -7918,7 +7918,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_12"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs20"
       },
       {
@@ -7939,7 +7939,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_3"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs21"
       },
       {
@@ -7960,7 +7960,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_2"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs22"
       },
       {
@@ -7981,7 +7981,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_10"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs23"
       },
       {
@@ -8002,7 +8002,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_8"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs24"
       },
       {
@@ -8023,7 +8023,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_3"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs25"
       },
       {
@@ -8044,7 +8044,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_13"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs26"
       },
       {
@@ -8065,7 +8065,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_5"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs27"
       },
       {
@@ -8086,7 +8086,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_14"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs28"
       },
       {
@@ -8107,7 +8107,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_0"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs29"
       },
       {
@@ -8128,7 +8128,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_6"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs30"
       },
       {
@@ -8149,7 +8149,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_4"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs31"
       },
       {
@@ -8170,7 +8170,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_0"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs32"
       },
       {
@@ -8191,7 +8191,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_12"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs33"
       },
       {
@@ -8212,7 +8212,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_6"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs34"
       },
       {
@@ -8233,7 +8233,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_5"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs35"
       },
       {
@@ -8254,7 +8254,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_9"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs36"
       },
       {
@@ -8275,7 +8275,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_13"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs37"
       },
       {
@@ -8296,7 +8296,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_11"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs38"
       },
       {
@@ -8317,7 +8317,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_2"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs39"
       },
       {
@@ -8338,7 +8338,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_14"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs40"
       },
       {
@@ -8359,7 +8359,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_1"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs41"
       },
       {
@@ -8380,7 +8380,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_10"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs42"
       },
       {
@@ -8401,7 +8401,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_7"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs43"
       },
       {
@@ -8422,7 +8422,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_12"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs44"
       },
       {
@@ -8443,7 +8443,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_14"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs45"
       },
       {
@@ -8464,7 +8464,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_13"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs46"
       },
       {
@@ -8485,7 +8485,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_8"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs47"
       },
       {
@@ -8506,7 +8506,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_5"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs48"
       },
       {
@@ -8527,7 +8527,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_0"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs49"
       },
       {
@@ -8548,7 +8548,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_6"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs50"
       },
       {
@@ -8569,7 +8569,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_7"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs51"
       },
       {
@@ -8590,7 +8590,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_2"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs52"
       },
       {
@@ -8611,7 +8611,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_12"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs53"
       },
       {
@@ -8632,7 +8632,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_10"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs54"
       },
       {
@@ -8653,7 +8653,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_9"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs55"
       },
       {
@@ -8674,7 +8674,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_11"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs56"
       },
       {
@@ -8695,7 +8695,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_3"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs57"
       },
       {
@@ -8716,7 +8716,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_4"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs58"
       },
       {
@@ -8737,7 +8737,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_1"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs59"
       },
       {
@@ -8758,7 +8758,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_15"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs60"
       },
       {
@@ -8779,7 +8779,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_16"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs61"
       },
       {
@@ -8800,7 +8800,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_17"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs62"
       },
       {
@@ -8821,7 +8821,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_18"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs63"
       },
       {
@@ -8842,7 +8842,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_15"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs64"
       },
       {
@@ -8863,7 +8863,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_19"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs65"
       },
       {
@@ -8884,7 +8884,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_20"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs66"
       },
       {
@@ -8905,7 +8905,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_16"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs67"
       },
       {
@@ -8926,7 +8926,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_19"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs68"
       },
       {
@@ -8947,7 +8947,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_16"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs69"
       },
       {
@@ -8968,7 +8968,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_21"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs70"
       },
       {
@@ -8989,7 +8989,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_22"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs71"
       },
       {
@@ -9010,7 +9010,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_23"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs72"
       },
       {
@@ -9031,7 +9031,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_24"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs73"
       },
       {
@@ -9052,7 +9052,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_17"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs74"
       },
       {
@@ -9073,7 +9073,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_24"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs75"
       },
       {
@@ -9094,7 +9094,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_21"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs76"
       },
       {
@@ -9115,7 +9115,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_25"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs77"
       },
       {
@@ -9136,7 +9136,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_22"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs78"
       },
       {
@@ -9157,7 +9157,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_26"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs79"
       },
       {
@@ -9178,7 +9178,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_27"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs80"
       },
       {
@@ -9199,7 +9199,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_18"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs81"
       },
       {
@@ -9220,7 +9220,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_17"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs82"
       },
       {
@@ -9241,7 +9241,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_25"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs83"
       },
       {
@@ -9262,7 +9262,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_23"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs84"
       },
       {
@@ -9283,7 +9283,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_18"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs85"
       },
       {
@@ -9304,7 +9304,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_28"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs86"
       },
       {
@@ -9325,7 +9325,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_20"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs87"
       },
       {
@@ -9346,7 +9346,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_29"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs88"
       },
       {
@@ -9367,7 +9367,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_15"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs89"
       },
       {
@@ -9388,7 +9388,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_21"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs90"
       },
       {
@@ -9409,7 +9409,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_19"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs91"
       },
       {
@@ -9430,7 +9430,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_15"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs92"
       },
       {
@@ -9451,7 +9451,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_27"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs93"
       },
       {
@@ -9472,7 +9472,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_21"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs94"
       },
       {
@@ -9493,7 +9493,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_20"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs95"
       },
       {
@@ -9514,7 +9514,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_24"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs96"
       },
       {
@@ -9535,7 +9535,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_28"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs97"
       },
       {
@@ -9556,7 +9556,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_26"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs98"
       },
       {
@@ -9577,7 +9577,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_17"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs99"
       },
       {
@@ -9598,7 +9598,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_29"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs100"
       },
       {
@@ -9619,7 +9619,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_16"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs101"
       },
       {
@@ -9640,7 +9640,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_25"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs102"
       },
       {
@@ -9661,7 +9661,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_22"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs103"
       },
       {
@@ -9682,7 +9682,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_27"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs104"
       },
       {
@@ -9703,7 +9703,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_29"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs105"
       },
       {
@@ -9724,7 +9724,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_28"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs106"
       },
       {
@@ -9745,7 +9745,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_23"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs107"
       },
       {
@@ -9766,7 +9766,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_20"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs108"
       },
       {
@@ -9787,7 +9787,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_15"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs109"
       },
       {
@@ -9808,7 +9808,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_21"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs110"
       },
       {
@@ -9829,7 +9829,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_22"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs111"
       },
       {
@@ -9850,7 +9850,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_17"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs112"
       },
       {
@@ -9871,7 +9871,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_27"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs113"
       },
       {
@@ -9892,7 +9892,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_25"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs114"
       },
       {
@@ -9913,7 +9913,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_24"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs115"
       },
       {
@@ -9934,7 +9934,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_26"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs116"
       },
       {
@@ -9955,7 +9955,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_18"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs117"
       },
       {
@@ -9976,7 +9976,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_19"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs118"
       },
       {
@@ -9997,7 +9997,7 @@
         ],
         "netIsAssignable": true,
         "offBoardConnectsTo": ["source_component_internal_connection_16"],
-        "zLayers": [0],
+        "__zLayers": [0],
         "obstacleId": "__obs119"
       },
       {
@@ -10010,7 +10010,7 @@
         "height": 24,
         "layers": ["top", "inner1", "inner2", "bottom"],
         "connectedTo": [],
-        "zLayers": [0]
+        "__zLayers": [0]
       }
     ],
     "connMap": {

--- a/fixtures/features/tracewidthsolver/tracewidthsolver02-input.json
+++ b/fixtures/features/tracewidthsolver/tracewidthsolver02-input.json
@@ -8901,7 +8901,7 @@
           "pcb_plated_hole_8",
           "pcb_port_8"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -8923,7 +8923,7 @@
           "pcb_plated_hole_9",
           "pcb_port_9"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -8945,7 +8945,7 @@
           "pcb_plated_hole_10",
           "pcb_port_10"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -8967,7 +8967,7 @@
           "pcb_plated_hole_11",
           "pcb_port_11"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -8989,7 +8989,7 @@
           "pcb_plated_hole_12",
           "pcb_port_12"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -9011,7 +9011,7 @@
           "pcb_plated_hole_13",
           "pcb_port_13"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -9033,7 +9033,7 @@
           "pcb_plated_hole_14",
           "pcb_port_14"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -9055,7 +9055,7 @@
           "pcb_plated_hole_15",
           "pcb_port_15"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -9077,7 +9077,7 @@
           "pcb_plated_hole_8",
           "pcb_port_8"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -9099,7 +9099,7 @@
           "pcb_plated_hole_9",
           "pcb_port_9"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -9121,7 +9121,7 @@
           "pcb_plated_hole_10",
           "pcb_port_10"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -9143,7 +9143,7 @@
           "pcb_plated_hole_11",
           "pcb_port_11"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -9165,7 +9165,7 @@
           "pcb_plated_hole_12",
           "pcb_port_12"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -9187,7 +9187,7 @@
           "pcb_plated_hole_13",
           "pcb_port_13"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -9209,7 +9209,7 @@
           "pcb_plated_hole_14",
           "pcb_port_14"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -9231,7 +9231,7 @@
           "pcb_plated_hole_15",
           "pcb_port_15"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",

--- a/fixtures/legacy/assets/capacityplanning5.json
+++ b/fixtures/legacy/assets/capacityplanning5.json
@@ -46,7 +46,7 @@
             "pcb_smtpad_283",
             "pcb_port_244"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -68,7 +68,7 @@
             "pcb_smtpad_3",
             "pcb_port_3"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -144,7 +144,7 @@
             "pcb_smtpad_245",
             "pcb_port_263"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -166,7 +166,7 @@
             "pcb_smtpad_3",
             "pcb_port_3"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -206,7 +206,7 @@
             "pcb_smtpad_281",
             "pcb_port_245"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -228,7 +228,7 @@
             "pcb_smtpad_7",
             "pcb_port_7"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -304,7 +304,7 @@
             "pcb_smtpad_245",
             "pcb_port_263"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -326,7 +326,7 @@
             "pcb_smtpad_7",
             "pcb_port_7"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -366,7 +366,7 @@
             "pcb_smtpad_277",
             "pcb_port_247"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -388,7 +388,7 @@
             "pcb_smtpad_11",
             "pcb_port_11"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -464,7 +464,7 @@
             "pcb_smtpad_245",
             "pcb_port_263"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -486,7 +486,7 @@
             "pcb_smtpad_11",
             "pcb_port_11"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -526,7 +526,7 @@
             "pcb_smtpad_275",
             "pcb_port_248"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -548,7 +548,7 @@
             "pcb_smtpad_15",
             "pcb_port_15"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -624,7 +624,7 @@
             "pcb_smtpad_245",
             "pcb_port_263"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -646,7 +646,7 @@
             "pcb_smtpad_15",
             "pcb_port_15"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -686,7 +686,7 @@
             "pcb_smtpad_273",
             "pcb_port_249"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -708,7 +708,7 @@
             "pcb_smtpad_19",
             "pcb_port_19"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -784,7 +784,7 @@
             "pcb_smtpad_245",
             "pcb_port_263"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -806,7 +806,7 @@
             "pcb_smtpad_19",
             "pcb_port_19"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -846,7 +846,7 @@
             "pcb_smtpad_271",
             "pcb_port_250"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -868,7 +868,7 @@
             "pcb_smtpad_23",
             "pcb_port_23"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -944,7 +944,7 @@
             "pcb_smtpad_245",
             "pcb_port_263"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -966,7 +966,7 @@
             "pcb_smtpad_23",
             "pcb_port_23"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -1006,7 +1006,7 @@
             "pcb_smtpad_267",
             "pcb_port_252"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -1028,7 +1028,7 @@
             "pcb_smtpad_27",
             "pcb_port_27"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -1104,7 +1104,7 @@
             "pcb_smtpad_245",
             "pcb_port_263"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -1126,7 +1126,7 @@
             "pcb_smtpad_27",
             "pcb_port_27"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -1166,7 +1166,7 @@
             "pcb_smtpad_265",
             "pcb_port_253"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -1188,7 +1188,7 @@
             "pcb_smtpad_31",
             "pcb_port_31"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -1264,7 +1264,7 @@
             "pcb_smtpad_245",
             "pcb_port_263"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -1286,7 +1286,7 @@
             "pcb_smtpad_31",
             "pcb_port_31"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -1322,7 +1322,7 @@
             "pcb_smtpad_263",
             "pcb_port_254"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -1344,7 +1344,7 @@
             "pcb_smtpad_35",
             "pcb_port_35"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -1420,7 +1420,7 @@
             "pcb_smtpad_245",
             "pcb_port_263"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -1442,7 +1442,7 @@
             "pcb_smtpad_35",
             "pcb_port_35"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -1478,7 +1478,7 @@
             "pcb_smtpad_261",
             "pcb_port_255"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -1500,7 +1500,7 @@
             "pcb_smtpad_39",
             "pcb_port_39"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -1576,7 +1576,7 @@
             "pcb_smtpad_245",
             "pcb_port_263"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -1598,7 +1598,7 @@
             "pcb_smtpad_39",
             "pcb_port_39"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -1634,7 +1634,7 @@
             "pcb_smtpad_257",
             "pcb_port_257"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -1656,7 +1656,7 @@
             "pcb_smtpad_43",
             "pcb_port_43"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -1732,7 +1732,7 @@
             "pcb_smtpad_245",
             "pcb_port_263"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -1754,7 +1754,7 @@
             "pcb_smtpad_43",
             "pcb_port_43"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -1790,7 +1790,7 @@
             "pcb_smtpad_255",
             "pcb_port_258"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -1812,7 +1812,7 @@
             "pcb_smtpad_47",
             "pcb_port_47"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -1888,7 +1888,7 @@
             "pcb_smtpad_245",
             "pcb_port_263"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -1910,7 +1910,7 @@
             "pcb_smtpad_47",
             "pcb_port_47"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -1942,7 +1942,7 @@
             "pcb_smtpad_253",
             "pcb_port_259"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -1964,7 +1964,7 @@
             "pcb_smtpad_51",
             "pcb_port_51"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -2040,7 +2040,7 @@
             "pcb_smtpad_245",
             "pcb_port_263"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -2062,7 +2062,7 @@
             "pcb_smtpad_51",
             "pcb_port_51"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -2090,7 +2090,7 @@
             "pcb_smtpad_251",
             "pcb_port_260"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -2112,7 +2112,7 @@
             "pcb_smtpad_55",
             "pcb_port_55"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -2188,7 +2188,7 @@
             "pcb_smtpad_245",
             "pcb_port_263"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -2210,7 +2210,7 @@
             "pcb_smtpad_55",
             "pcb_port_55"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -2250,7 +2250,7 @@
             "pcb_smtpad_283",
             "pcb_port_244"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -2272,7 +2272,7 @@
             "pcb_smtpad_59",
             "pcb_port_59"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -2348,7 +2348,7 @@
             "pcb_smtpad_244",
             "pcb_port_264"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -2370,7 +2370,7 @@
             "pcb_smtpad_59",
             "pcb_port_59"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -2410,7 +2410,7 @@
             "pcb_smtpad_281",
             "pcb_port_245"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -2432,7 +2432,7 @@
             "pcb_smtpad_63",
             "pcb_port_63"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -2508,7 +2508,7 @@
             "pcb_smtpad_244",
             "pcb_port_264"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -2530,7 +2530,7 @@
             "pcb_smtpad_63",
             "pcb_port_63"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -2570,7 +2570,7 @@
             "pcb_smtpad_277",
             "pcb_port_247"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -2592,7 +2592,7 @@
             "pcb_smtpad_67",
             "pcb_port_67"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -2668,7 +2668,7 @@
             "pcb_smtpad_244",
             "pcb_port_264"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -2690,7 +2690,7 @@
             "pcb_smtpad_67",
             "pcb_port_67"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -2730,7 +2730,7 @@
             "pcb_smtpad_275",
             "pcb_port_248"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -2752,7 +2752,7 @@
             "pcb_smtpad_71",
             "pcb_port_71"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -2828,7 +2828,7 @@
             "pcb_smtpad_244",
             "pcb_port_264"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -2850,7 +2850,7 @@
             "pcb_smtpad_71",
             "pcb_port_71"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -2890,7 +2890,7 @@
             "pcb_smtpad_273",
             "pcb_port_249"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -2912,7 +2912,7 @@
             "pcb_smtpad_75",
             "pcb_port_75"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -2988,7 +2988,7 @@
             "pcb_smtpad_244",
             "pcb_port_264"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -3010,7 +3010,7 @@
             "pcb_smtpad_75",
             "pcb_port_75"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -3050,7 +3050,7 @@
             "pcb_smtpad_271",
             "pcb_port_250"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -3072,7 +3072,7 @@
             "pcb_smtpad_79",
             "pcb_port_79"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -3148,7 +3148,7 @@
             "pcb_smtpad_244",
             "pcb_port_264"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -3170,7 +3170,7 @@
             "pcb_smtpad_79",
             "pcb_port_79"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -3210,7 +3210,7 @@
             "pcb_smtpad_267",
             "pcb_port_252"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -3232,7 +3232,7 @@
             "pcb_smtpad_83",
             "pcb_port_83"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -3308,7 +3308,7 @@
             "pcb_smtpad_244",
             "pcb_port_264"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -3330,7 +3330,7 @@
             "pcb_smtpad_83",
             "pcb_port_83"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -3370,7 +3370,7 @@
             "pcb_smtpad_265",
             "pcb_port_253"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -3392,7 +3392,7 @@
             "pcb_smtpad_87",
             "pcb_port_87"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -3468,7 +3468,7 @@
             "pcb_smtpad_244",
             "pcb_port_264"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -3490,7 +3490,7 @@
             "pcb_smtpad_87",
             "pcb_port_87"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -3526,7 +3526,7 @@
             "pcb_smtpad_263",
             "pcb_port_254"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -3548,7 +3548,7 @@
             "pcb_smtpad_91",
             "pcb_port_91"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -3624,7 +3624,7 @@
             "pcb_smtpad_244",
             "pcb_port_264"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -3646,7 +3646,7 @@
             "pcb_smtpad_91",
             "pcb_port_91"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -3682,7 +3682,7 @@
             "pcb_smtpad_261",
             "pcb_port_255"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -3704,7 +3704,7 @@
             "pcb_smtpad_95",
             "pcb_port_95"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -3780,7 +3780,7 @@
             "pcb_smtpad_244",
             "pcb_port_264"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -3802,7 +3802,7 @@
             "pcb_smtpad_95",
             "pcb_port_95"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -3838,7 +3838,7 @@
             "pcb_smtpad_257",
             "pcb_port_257"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -3860,7 +3860,7 @@
             "pcb_smtpad_99",
             "pcb_port_99"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -3936,7 +3936,7 @@
             "pcb_smtpad_244",
             "pcb_port_264"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -3958,7 +3958,7 @@
             "pcb_smtpad_99",
             "pcb_port_99"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -3994,7 +3994,7 @@
             "pcb_smtpad_255",
             "pcb_port_258"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -4016,7 +4016,7 @@
             "pcb_smtpad_103",
             "pcb_port_103"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -4092,7 +4092,7 @@
             "pcb_smtpad_244",
             "pcb_port_264"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -4114,7 +4114,7 @@
             "pcb_smtpad_103",
             "pcb_port_103"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -4146,7 +4146,7 @@
             "pcb_smtpad_253",
             "pcb_port_259"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -4168,7 +4168,7 @@
             "pcb_smtpad_107",
             "pcb_port_107"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -4244,7 +4244,7 @@
             "pcb_smtpad_244",
             "pcb_port_264"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -4266,7 +4266,7 @@
             "pcb_smtpad_107",
             "pcb_port_107"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -4294,7 +4294,7 @@
             "pcb_smtpad_251",
             "pcb_port_260"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -4316,7 +4316,7 @@
             "pcb_smtpad_111",
             "pcb_port_111"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -4392,7 +4392,7 @@
             "pcb_smtpad_244",
             "pcb_port_264"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -4414,7 +4414,7 @@
             "pcb_smtpad_111",
             "pcb_port_111"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -4454,7 +4454,7 @@
             "pcb_smtpad_283",
             "pcb_port_244"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -4476,7 +4476,7 @@
             "pcb_smtpad_115",
             "pcb_port_115"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -4548,7 +4548,7 @@
             "pcb_smtpad_246",
             "pcb_port_265"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -4570,7 +4570,7 @@
             "pcb_smtpad_115",
             "pcb_port_115"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -4610,7 +4610,7 @@
             "pcb_smtpad_281",
             "pcb_port_245"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -4632,7 +4632,7 @@
             "pcb_smtpad_119",
             "pcb_port_119"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -4704,7 +4704,7 @@
             "pcb_smtpad_246",
             "pcb_port_265"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -4726,7 +4726,7 @@
             "pcb_smtpad_119",
             "pcb_port_119"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -4766,7 +4766,7 @@
             "pcb_smtpad_277",
             "pcb_port_247"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -4788,7 +4788,7 @@
             "pcb_smtpad_123",
             "pcb_port_123"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -4860,7 +4860,7 @@
             "pcb_smtpad_246",
             "pcb_port_265"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -4882,7 +4882,7 @@
             "pcb_smtpad_123",
             "pcb_port_123"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -4922,7 +4922,7 @@
             "pcb_smtpad_275",
             "pcb_port_248"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -4944,7 +4944,7 @@
             "pcb_smtpad_127",
             "pcb_port_127"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -5016,7 +5016,7 @@
             "pcb_smtpad_246",
             "pcb_port_265"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -5038,7 +5038,7 @@
             "pcb_smtpad_127",
             "pcb_port_127"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -5078,7 +5078,7 @@
             "pcb_smtpad_273",
             "pcb_port_249"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -5100,7 +5100,7 @@
             "pcb_smtpad_131",
             "pcb_port_131"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -5172,7 +5172,7 @@
             "pcb_smtpad_246",
             "pcb_port_265"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -5194,7 +5194,7 @@
             "pcb_smtpad_131",
             "pcb_port_131"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -5234,7 +5234,7 @@
             "pcb_smtpad_271",
             "pcb_port_250"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -5256,7 +5256,7 @@
             "pcb_smtpad_135",
             "pcb_port_135"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -5328,7 +5328,7 @@
             "pcb_smtpad_246",
             "pcb_port_265"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -5350,7 +5350,7 @@
             "pcb_smtpad_135",
             "pcb_port_135"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -5390,7 +5390,7 @@
             "pcb_smtpad_267",
             "pcb_port_252"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -5412,7 +5412,7 @@
             "pcb_smtpad_139",
             "pcb_port_139"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -5484,7 +5484,7 @@
             "pcb_smtpad_246",
             "pcb_port_265"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -5506,7 +5506,7 @@
             "pcb_smtpad_139",
             "pcb_port_139"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -5546,7 +5546,7 @@
             "pcb_smtpad_265",
             "pcb_port_253"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -5568,7 +5568,7 @@
             "pcb_smtpad_143",
             "pcb_port_143"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -5640,7 +5640,7 @@
             "pcb_smtpad_246",
             "pcb_port_265"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -5662,7 +5662,7 @@
             "pcb_smtpad_143",
             "pcb_port_143"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -5698,7 +5698,7 @@
             "pcb_smtpad_263",
             "pcb_port_254"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -5720,7 +5720,7 @@
             "pcb_smtpad_147",
             "pcb_port_147"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -5792,7 +5792,7 @@
             "pcb_smtpad_246",
             "pcb_port_265"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -5814,7 +5814,7 @@
             "pcb_smtpad_147",
             "pcb_port_147"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -5850,7 +5850,7 @@
             "pcb_smtpad_261",
             "pcb_port_255"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -5872,7 +5872,7 @@
             "pcb_smtpad_151",
             "pcb_port_151"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -5944,7 +5944,7 @@
             "pcb_smtpad_246",
             "pcb_port_265"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -5966,7 +5966,7 @@
             "pcb_smtpad_151",
             "pcb_port_151"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -6002,7 +6002,7 @@
             "pcb_smtpad_257",
             "pcb_port_257"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -6024,7 +6024,7 @@
             "pcb_smtpad_155",
             "pcb_port_155"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -6096,7 +6096,7 @@
             "pcb_smtpad_246",
             "pcb_port_265"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -6118,7 +6118,7 @@
             "pcb_smtpad_155",
             "pcb_port_155"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -6154,7 +6154,7 @@
             "pcb_smtpad_255",
             "pcb_port_258"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -6176,7 +6176,7 @@
             "pcb_smtpad_159",
             "pcb_port_159"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -6248,7 +6248,7 @@
             "pcb_smtpad_246",
             "pcb_port_265"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -6270,7 +6270,7 @@
             "pcb_smtpad_159",
             "pcb_port_159"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -6302,7 +6302,7 @@
             "pcb_smtpad_253",
             "pcb_port_259"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -6324,7 +6324,7 @@
             "pcb_smtpad_163",
             "pcb_port_163"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -6396,7 +6396,7 @@
             "pcb_smtpad_246",
             "pcb_port_265"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -6418,7 +6418,7 @@
             "pcb_smtpad_163",
             "pcb_port_163"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -6458,7 +6458,7 @@
             "pcb_smtpad_283",
             "pcb_port_244"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -6480,7 +6480,7 @@
             "pcb_smtpad_167",
             "pcb_port_167"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -6548,7 +6548,7 @@
             "pcb_smtpad_250",
             "pcb_port_267"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -6570,7 +6570,7 @@
             "pcb_smtpad_167",
             "pcb_port_167"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -6610,7 +6610,7 @@
             "pcb_smtpad_281",
             "pcb_port_245"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -6632,7 +6632,7 @@
             "pcb_smtpad_171",
             "pcb_port_171"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -6700,7 +6700,7 @@
             "pcb_smtpad_250",
             "pcb_port_267"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -6722,7 +6722,7 @@
             "pcb_smtpad_171",
             "pcb_port_171"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -6762,7 +6762,7 @@
             "pcb_smtpad_277",
             "pcb_port_247"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -6784,7 +6784,7 @@
             "pcb_smtpad_175",
             "pcb_port_175"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -6852,7 +6852,7 @@
             "pcb_smtpad_250",
             "pcb_port_267"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -6874,7 +6874,7 @@
             "pcb_smtpad_175",
             "pcb_port_175"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -6914,7 +6914,7 @@
             "pcb_smtpad_275",
             "pcb_port_248"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -6936,7 +6936,7 @@
             "pcb_smtpad_179",
             "pcb_port_179"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -7004,7 +7004,7 @@
             "pcb_smtpad_250",
             "pcb_port_267"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -7026,7 +7026,7 @@
             "pcb_smtpad_179",
             "pcb_port_179"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -7066,7 +7066,7 @@
             "pcb_smtpad_273",
             "pcb_port_249"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -7088,7 +7088,7 @@
             "pcb_smtpad_183",
             "pcb_port_183"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -7156,7 +7156,7 @@
             "pcb_smtpad_250",
             "pcb_port_267"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -7178,7 +7178,7 @@
             "pcb_smtpad_183",
             "pcb_port_183"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -7218,7 +7218,7 @@
             "pcb_smtpad_271",
             "pcb_port_250"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -7240,7 +7240,7 @@
             "pcb_smtpad_187",
             "pcb_port_187"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -7308,7 +7308,7 @@
             "pcb_smtpad_250",
             "pcb_port_267"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -7330,7 +7330,7 @@
             "pcb_smtpad_187",
             "pcb_port_187"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -7370,7 +7370,7 @@
             "pcb_smtpad_267",
             "pcb_port_252"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -7392,7 +7392,7 @@
             "pcb_smtpad_191",
             "pcb_port_191"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -7460,7 +7460,7 @@
             "pcb_smtpad_250",
             "pcb_port_267"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -7482,7 +7482,7 @@
             "pcb_smtpad_191",
             "pcb_port_191"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -7522,7 +7522,7 @@
             "pcb_smtpad_265",
             "pcb_port_253"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -7544,7 +7544,7 @@
             "pcb_smtpad_195",
             "pcb_port_195"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -7612,7 +7612,7 @@
             "pcb_smtpad_250",
             "pcb_port_267"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -7634,7 +7634,7 @@
             "pcb_smtpad_195",
             "pcb_port_195"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -7670,7 +7670,7 @@
             "pcb_smtpad_263",
             "pcb_port_254"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -7692,7 +7692,7 @@
             "pcb_smtpad_199",
             "pcb_port_199"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -7760,7 +7760,7 @@
             "pcb_smtpad_250",
             "pcb_port_267"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -7782,7 +7782,7 @@
             "pcb_smtpad_199",
             "pcb_port_199"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -7818,7 +7818,7 @@
             "pcb_smtpad_261",
             "pcb_port_255"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -7840,7 +7840,7 @@
             "pcb_smtpad_203",
             "pcb_port_203"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -7908,7 +7908,7 @@
             "pcb_smtpad_250",
             "pcb_port_267"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -7930,7 +7930,7 @@
             "pcb_smtpad_203",
             "pcb_port_203"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -7966,7 +7966,7 @@
             "pcb_smtpad_257",
             "pcb_port_257"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -7988,7 +7988,7 @@
             "pcb_smtpad_207",
             "pcb_port_207"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -8056,7 +8056,7 @@
             "pcb_smtpad_250",
             "pcb_port_267"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -8078,7 +8078,7 @@
             "pcb_smtpad_207",
             "pcb_port_207"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -8114,7 +8114,7 @@
             "pcb_smtpad_255",
             "pcb_port_258"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -8136,7 +8136,7 @@
             "pcb_smtpad_211",
             "pcb_port_211"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -8204,7 +8204,7 @@
             "pcb_smtpad_250",
             "pcb_port_267"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -8226,7 +8226,7 @@
             "pcb_smtpad_211",
             "pcb_port_211"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -8266,7 +8266,7 @@
             "pcb_smtpad_283",
             "pcb_port_244"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -8288,7 +8288,7 @@
             "pcb_smtpad_215",
             "pcb_port_215"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -8340,7 +8340,7 @@
             "pcb_smtpad_252",
             "pcb_port_268"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -8362,7 +8362,7 @@
             "pcb_smtpad_215",
             "pcb_port_215"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -8402,7 +8402,7 @@
             "pcb_smtpad_281",
             "pcb_port_245"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -8424,7 +8424,7 @@
             "pcb_smtpad_219",
             "pcb_port_219"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -8476,7 +8476,7 @@
             "pcb_smtpad_252",
             "pcb_port_268"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -8498,7 +8498,7 @@
             "pcb_smtpad_219",
             "pcb_port_219"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -8538,7 +8538,7 @@
             "pcb_smtpad_277",
             "pcb_port_247"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -8560,7 +8560,7 @@
             "pcb_smtpad_223",
             "pcb_port_223"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -8612,7 +8612,7 @@
             "pcb_smtpad_252",
             "pcb_port_268"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -8634,7 +8634,7 @@
             "pcb_smtpad_223",
             "pcb_port_223"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -8674,7 +8674,7 @@
             "pcb_smtpad_275",
             "pcb_port_248"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -8696,7 +8696,7 @@
             "pcb_smtpad_227",
             "pcb_port_227"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -8748,7 +8748,7 @@
             "pcb_smtpad_252",
             "pcb_port_268"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -8770,7 +8770,7 @@
             "pcb_smtpad_227",
             "pcb_port_227"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -8810,7 +8810,7 @@
             "pcb_smtpad_273",
             "pcb_port_249"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -8832,7 +8832,7 @@
             "pcb_smtpad_231",
             "pcb_port_231"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -8884,7 +8884,7 @@
             "pcb_smtpad_252",
             "pcb_port_268"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -8906,7 +8906,7 @@
             "pcb_smtpad_231",
             "pcb_port_231"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -8946,7 +8946,7 @@
             "pcb_smtpad_271",
             "pcb_port_250"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -8968,7 +8968,7 @@
             "pcb_smtpad_235",
             "pcb_port_235"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -9020,7 +9020,7 @@
             "pcb_smtpad_252",
             "pcb_port_268"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -9042,7 +9042,7 @@
             "pcb_smtpad_235",
             "pcb_port_235"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -9082,7 +9082,7 @@
             "pcb_smtpad_267",
             "pcb_port_252"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -9104,7 +9104,7 @@
             "pcb_smtpad_239",
             "pcb_port_239"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -9156,7 +9156,7 @@
             "pcb_smtpad_252",
             "pcb_port_268"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -9178,7 +9178,7 @@
             "pcb_smtpad_239",
             "pcb_port_239"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -9218,7 +9218,7 @@
             "pcb_smtpad_265",
             "pcb_port_253"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -9240,7 +9240,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -9292,7 +9292,7 @@
             "pcb_smtpad_252",
             "pcb_port_268"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -9314,7 +9314,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -9390,7 +9390,7 @@
             "pcb_smtpad_244",
             "pcb_port_264"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -9466,7 +9466,7 @@
             "pcb_smtpad_245",
             "pcb_port_263"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -9538,7 +9538,7 @@
             "pcb_smtpad_246",
             "pcb_port_265"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -9558,7 +9558,7 @@
             "pcb_smtpad_247",
             "pcb_port_262"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -9576,7 +9576,7 @@
             "pcb_smtpad_248",
             "pcb_port_266"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -9594,7 +9594,7 @@
             "pcb_smtpad_249",
             "pcb_port_261"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -9662,7 +9662,7 @@
             "pcb_smtpad_250",
             "pcb_port_267"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -9690,7 +9690,7 @@
             "pcb_smtpad_251",
             "pcb_port_260"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -9742,7 +9742,7 @@
             "pcb_smtpad_252",
             "pcb_port_268"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -9774,7 +9774,7 @@
             "pcb_smtpad_253",
             "pcb_port_259"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -9792,7 +9792,7 @@
             "pcb_smtpad_254",
             "pcb_port_269"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -9828,7 +9828,7 @@
             "pcb_smtpad_255",
             "pcb_port_258"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -9846,7 +9846,7 @@
             "pcb_smtpad_256",
             "pcb_port_270"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -9882,7 +9882,7 @@
             "pcb_smtpad_257",
             "pcb_port_257"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -9900,7 +9900,7 @@
             "pcb_smtpad_258",
             "pcb_port_271"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -9918,7 +9918,7 @@
             "pcb_smtpad_259",
             "pcb_port_256"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -9936,7 +9936,7 @@
             "pcb_smtpad_260",
             "pcb_port_272"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -9972,7 +9972,7 @@
             "pcb_smtpad_261",
             "pcb_port_255"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -9990,7 +9990,7 @@
             "pcb_smtpad_262",
             "pcb_port_273"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -10026,7 +10026,7 @@
             "pcb_smtpad_263",
             "pcb_port_254"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -10044,7 +10044,7 @@
             "pcb_smtpad_264",
             "pcb_port_274"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -10084,7 +10084,7 @@
             "pcb_smtpad_265",
             "pcb_port_253"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -10102,7 +10102,7 @@
             "pcb_smtpad_266",
             "pcb_port_275"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -10142,7 +10142,7 @@
             "pcb_smtpad_267",
             "pcb_port_252"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -10160,7 +10160,7 @@
             "pcb_smtpad_268",
             "pcb_port_276"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -10178,7 +10178,7 @@
             "pcb_smtpad_269",
             "pcb_port_251"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -10196,7 +10196,7 @@
             "pcb_smtpad_270",
             "pcb_port_277"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -10236,7 +10236,7 @@
             "pcb_smtpad_271",
             "pcb_port_250"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -10254,7 +10254,7 @@
             "pcb_smtpad_272",
             "pcb_port_278"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -10294,7 +10294,7 @@
             "pcb_smtpad_273",
             "pcb_port_249"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -10312,7 +10312,7 @@
             "pcb_smtpad_274",
             "pcb_port_279"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -10352,7 +10352,7 @@
             "pcb_smtpad_275",
             "pcb_port_248"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -10370,7 +10370,7 @@
             "pcb_smtpad_276",
             "pcb_port_280"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -10410,7 +10410,7 @@
             "pcb_smtpad_277",
             "pcb_port_247"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -10428,7 +10428,7 @@
             "pcb_smtpad_278",
             "pcb_port_281"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -10446,7 +10446,7 @@
             "pcb_smtpad_279",
             "pcb_port_246"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -10464,7 +10464,7 @@
             "pcb_smtpad_280",
             "pcb_port_282"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -10504,7 +10504,7 @@
             "pcb_smtpad_281",
             "pcb_port_245"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -10522,7 +10522,7 @@
             "pcb_smtpad_282",
             "pcb_port_283"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -10562,7 +10562,7 @@
             "pcb_smtpad_283",
             "pcb_port_244"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -10580,7 +10580,7 @@
             "pcb_smtpad_284",
             "pcb_port_284"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -10598,7 +10598,7 @@
             "pcb_smtpad_285",
             "pcb_port_285"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -10616,7 +10616,7 @@
             "pcb_smtpad_286",
             "pcb_port_286"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -10634,7 +10634,7 @@
             "pcb_smtpad_287",
             "pcb_port_287"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -10652,7 +10652,7 @@
             "pcb_smtpad_288",
             "pcb_port_288"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -10670,7 +10670,7 @@
             "pcb_smtpad_289",
             "pcb_port_289"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -10688,7 +10688,7 @@
             "pcb_smtpad_290",
             "pcb_port_290"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -10706,7 +10706,7 @@
             "pcb_smtpad_291",
             "pcb_port_291"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -10724,7 +10724,7 @@
             "pcb_smtpad_292",
             "pcb_port_292"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -10736,7 +10736,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -10748,7 +10748,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -10760,7 +10760,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -10772,7 +10772,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -10784,7 +10784,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -10796,7 +10796,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -10808,7 +10808,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -10820,7 +10820,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -10832,7 +10832,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -10844,7 +10844,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -10856,7 +10856,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -10868,7 +10868,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -10880,7 +10880,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -10892,7 +10892,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -10904,7 +10904,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -10916,7 +10916,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -10928,7 +10928,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -10940,7 +10940,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -10952,7 +10952,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -10964,7 +10964,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -10976,7 +10976,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -10988,7 +10988,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11000,7 +11000,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11012,7 +11012,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11024,7 +11024,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11036,7 +11036,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11048,7 +11048,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11060,7 +11060,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11072,7 +11072,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11084,7 +11084,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11096,7 +11096,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11108,7 +11108,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11120,7 +11120,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11132,7 +11132,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11144,7 +11144,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11156,7 +11156,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11168,7 +11168,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11180,7 +11180,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11192,7 +11192,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11204,7 +11204,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11216,7 +11216,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11228,7 +11228,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11240,7 +11240,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11252,7 +11252,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11264,7 +11264,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11276,7 +11276,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11288,7 +11288,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11300,7 +11300,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11312,7 +11312,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11324,7 +11324,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11336,7 +11336,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11348,7 +11348,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11360,7 +11360,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11372,7 +11372,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11384,7 +11384,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11396,7 +11396,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11408,7 +11408,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11420,7 +11420,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11432,7 +11432,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11444,7 +11444,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11456,7 +11456,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11468,7 +11468,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11480,7 +11480,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11492,7 +11492,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11504,7 +11504,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11516,7 +11516,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11528,7 +11528,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11540,7 +11540,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11552,7 +11552,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11564,7 +11564,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11576,7 +11576,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11588,7 +11588,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11600,7 +11600,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11612,7 +11612,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11624,7 +11624,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11636,7 +11636,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11648,7 +11648,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11660,7 +11660,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11672,7 +11672,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11684,7 +11684,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11696,7 +11696,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11708,7 +11708,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11720,7 +11720,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11732,7 +11732,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11744,7 +11744,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11756,7 +11756,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11768,7 +11768,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11780,7 +11780,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11792,7 +11792,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11804,7 +11804,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11816,7 +11816,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11828,7 +11828,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11840,7 +11840,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11852,7 +11852,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11864,7 +11864,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11876,7 +11876,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11888,7 +11888,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11900,7 +11900,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11912,7 +11912,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11924,7 +11924,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11936,7 +11936,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11948,7 +11948,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11960,7 +11960,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11972,7 +11972,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11984,7 +11984,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -11996,7 +11996,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12008,7 +12008,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12020,7 +12020,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12032,7 +12032,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12044,7 +12044,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12056,7 +12056,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12068,7 +12068,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12080,7 +12080,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12092,7 +12092,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12104,7 +12104,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12116,7 +12116,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12128,7 +12128,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12140,7 +12140,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12152,7 +12152,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12164,7 +12164,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12176,7 +12176,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12188,7 +12188,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12200,7 +12200,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12212,7 +12212,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12224,7 +12224,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12236,7 +12236,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12248,7 +12248,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12260,7 +12260,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12272,7 +12272,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12284,7 +12284,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12296,7 +12296,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12308,7 +12308,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12320,7 +12320,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12332,7 +12332,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12344,7 +12344,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12356,7 +12356,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12368,7 +12368,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12380,7 +12380,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12392,7 +12392,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12404,7 +12404,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12416,7 +12416,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12428,7 +12428,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12440,7 +12440,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12452,7 +12452,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12464,7 +12464,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12476,7 +12476,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12488,7 +12488,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12500,7 +12500,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12512,7 +12512,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12524,7 +12524,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12536,7 +12536,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12548,7 +12548,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12560,7 +12560,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12572,7 +12572,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12584,7 +12584,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12596,7 +12596,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12608,7 +12608,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12620,7 +12620,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12632,7 +12632,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12644,7 +12644,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12656,7 +12656,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12668,7 +12668,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12680,7 +12680,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12692,7 +12692,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12704,7 +12704,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12716,7 +12716,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12728,7 +12728,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12740,7 +12740,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12752,7 +12752,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12764,7 +12764,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12776,7 +12776,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12788,7 +12788,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12800,7 +12800,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12812,7 +12812,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12824,7 +12824,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12836,7 +12836,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12848,7 +12848,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12860,7 +12860,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12872,7 +12872,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12884,7 +12884,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12896,7 +12896,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12908,7 +12908,7 @@
           "width": 2.9999939999999996,
           "height": 2.9999939999999996,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         },
         {
           "type": "rect",
@@ -12920,7 +12920,7 @@
           "width": 4.1999916,
           "height": 4.1999916,
           "connectedTo": [],
-          "zLayers": [0, 1, 2, 1]
+          "__zLayers": [0, 1, 2, 1]
         }
       ],
       "connections": [

--- a/fixtures/legacy/assets/multisectioncapacitypathing1_pathingInput.json
+++ b/fixtures/legacy/assets/multisectioncapacitypathing1_pathingInput.json
@@ -24,7 +24,7 @@
             "pcb_smtpad_0",
             "pcb_port_0"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -62,7 +62,7 @@
             "pcb_smtpad_12",
             "pcb_port_12"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -80,7 +80,7 @@
             "pcb_smtpad_2",
             "pcb_port_2"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -118,7 +118,7 @@
             "pcb_smtpad_12",
             "pcb_port_12"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -136,7 +136,7 @@
             "pcb_smtpad_4",
             "pcb_port_4"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -174,7 +174,7 @@
             "pcb_smtpad_12",
             "pcb_port_12"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -192,7 +192,7 @@
             "pcb_smtpad_6",
             "pcb_port_6"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -230,7 +230,7 @@
             "pcb_smtpad_12",
             "pcb_port_12"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -248,7 +248,7 @@
             "pcb_smtpad_8",
             "pcb_port_8"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -286,7 +286,7 @@
             "pcb_smtpad_12",
             "pcb_port_12"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -308,7 +308,7 @@
             "pcb_smtpad_13",
             "pcb_port_13"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -326,7 +326,7 @@
             "pcb_smtpad_11",
             "pcb_port_11"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -364,7 +364,7 @@
             "pcb_smtpad_12",
             "pcb_port_12"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -386,7 +386,7 @@
             "pcb_smtpad_13",
             "pcb_port_13"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         }
       ],
       "connections": [

--- a/fixtures/legacy/assets/multisectioncapacitypathing2.json
+++ b/fixtures/legacy/assets/multisectioncapacitypathing2.json
@@ -26,7 +26,7 @@
             "pcb_smtpad_0",
             "pcb_port_40"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -48,7 +48,7 @@
             "pcb_smtpad_1",
             "pcb_port_41"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -70,7 +70,7 @@
             "pcb_smtpad_2",
             "pcb_port_42"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -92,7 +92,7 @@
             "pcb_smtpad_3",
             "pcb_port_43"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -114,7 +114,7 @@
             "pcb_smtpad_4",
             "pcb_port_44"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -136,7 +136,7 @@
             "pcb_smtpad_5",
             "pcb_port_45"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -158,7 +158,7 @@
             "pcb_smtpad_6",
             "pcb_port_0"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -382,7 +382,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -404,7 +404,7 @@
             "pcb_smtpad_8",
             "pcb_port_1"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -426,7 +426,7 @@
             "pcb_smtpad_9",
             "pcb_port_38"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -674,7 +674,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -922,7 +922,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -944,7 +944,7 @@
             "pcb_smtpad_12",
             "pcb_port_3"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -966,7 +966,7 @@
             "pcb_smtpad_13",
             "pcb_port_36"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -988,7 +988,7 @@
             "pcb_smtpad_14",
             "pcb_port_4"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -1010,7 +1010,7 @@
             "pcb_smtpad_15",
             "pcb_port_35"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -1032,7 +1032,7 @@
             "pcb_smtpad_16",
             "pcb_port_5"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -1054,7 +1054,7 @@
             "pcb_smtpad_17",
             "pcb_port_34"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -1076,7 +1076,7 @@
             "pcb_smtpad_18",
             "pcb_port_6"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -1098,7 +1098,7 @@
             "pcb_smtpad_19",
             "pcb_port_33"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -1346,7 +1346,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -1368,7 +1368,7 @@
             "pcb_smtpad_21",
             "pcb_port_32"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -1390,7 +1390,7 @@
             "pcb_smtpad_22",
             "pcb_port_8"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -1412,7 +1412,7 @@
             "pcb_smtpad_23",
             "pcb_port_31"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -1434,7 +1434,7 @@
             "pcb_smtpad_24",
             "pcb_port_9"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -1456,7 +1456,7 @@
             "pcb_smtpad_25",
             "pcb_port_30"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -1478,7 +1478,7 @@
             "pcb_smtpad_26",
             "pcb_port_10"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -1500,7 +1500,7 @@
             "pcb_smtpad_27",
             "pcb_port_29"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -1522,7 +1522,7 @@
             "pcb_smtpad_28",
             "pcb_port_11"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -1544,7 +1544,7 @@
             "pcb_smtpad_29",
             "pcb_port_28"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -1792,7 +1792,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -2040,7 +2040,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -2062,7 +2062,7 @@
             "pcb_smtpad_32",
             "pcb_port_13"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -2084,7 +2084,7 @@
             "pcb_smtpad_33",
             "pcb_port_26"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -2110,7 +2110,7 @@
             "pcb_smtpad_48",
             "pcb_port_48"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -2132,7 +2132,7 @@
             "pcb_smtpad_35",
             "pcb_port_25"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -2154,7 +2154,7 @@
             "pcb_smtpad_36",
             "pcb_port_15"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -2176,7 +2176,7 @@
             "pcb_smtpad_37",
             "pcb_port_24"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -2198,7 +2198,7 @@
             "pcb_smtpad_38",
             "pcb_port_16"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -2220,7 +2220,7 @@
             "pcb_smtpad_39",
             "pcb_port_23"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -2468,7 +2468,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -2716,7 +2716,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -2738,7 +2738,7 @@
             "pcb_smtpad_42",
             "pcb_port_18"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -2760,7 +2760,7 @@
             "pcb_smtpad_43",
             "pcb_port_21"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -2782,7 +2782,7 @@
             "pcb_smtpad_44",
             "pcb_port_19"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -2804,7 +2804,7 @@
             "pcb_smtpad_45",
             "pcb_port_20"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -2830,7 +2830,7 @@
             "pcb_smtpad_52",
             "pcb_port_52"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -3078,7 +3078,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -3104,7 +3104,7 @@
             "pcb_smtpad_48",
             "pcb_port_48"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -3328,7 +3328,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -3354,7 +3354,7 @@
             "pcb_smtpad_56",
             "pcb_port_56"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -3602,7 +3602,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -3628,7 +3628,7 @@
             "pcb_smtpad_52",
             "pcb_port_52"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -3852,7 +3852,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -3878,7 +3878,7 @@
             "pcb_smtpad_60",
             "pcb_port_60"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -4126,7 +4126,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -4152,7 +4152,7 @@
             "pcb_smtpad_56",
             "pcb_port_56"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -4376,7 +4376,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -4402,7 +4402,7 @@
             "pcb_smtpad_64",
             "pcb_port_64"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -4650,7 +4650,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -4676,7 +4676,7 @@
             "pcb_smtpad_60",
             "pcb_port_60"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -4900,7 +4900,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -4926,7 +4926,7 @@
             "pcb_smtpad_68",
             "pcb_port_68"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -5174,7 +5174,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -5200,7 +5200,7 @@
             "pcb_smtpad_64",
             "pcb_port_64"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -5424,7 +5424,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -5450,7 +5450,7 @@
             "pcb_smtpad_72",
             "pcb_port_72"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -5698,7 +5698,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -5724,7 +5724,7 @@
             "pcb_smtpad_68",
             "pcb_port_68"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -5948,7 +5948,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -5974,7 +5974,7 @@
             "pcb_smtpad_76",
             "pcb_port_76"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -6222,7 +6222,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -6248,7 +6248,7 @@
             "pcb_smtpad_72",
             "pcb_port_72"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -6472,7 +6472,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -6498,7 +6498,7 @@
             "pcb_smtpad_80",
             "pcb_port_80"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -6746,7 +6746,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -6772,7 +6772,7 @@
             "pcb_smtpad_76",
             "pcb_port_76"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -6996,7 +6996,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -7022,7 +7022,7 @@
             "pcb_smtpad_84",
             "pcb_port_84"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -7270,7 +7270,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -7296,7 +7296,7 @@
             "pcb_smtpad_80",
             "pcb_port_80"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -7520,7 +7520,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -7546,7 +7546,7 @@
             "pcb_smtpad_88",
             "pcb_port_88"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -7794,7 +7794,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -7820,7 +7820,7 @@
             "pcb_smtpad_84",
             "pcb_port_84"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -8044,7 +8044,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -8070,7 +8070,7 @@
             "pcb_smtpad_92",
             "pcb_port_92"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -8318,7 +8318,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -8344,7 +8344,7 @@
             "pcb_smtpad_88",
             "pcb_port_88"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -8568,7 +8568,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -8594,7 +8594,7 @@
             "pcb_smtpad_96",
             "pcb_port_96"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -8842,7 +8842,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -8868,7 +8868,7 @@
             "pcb_smtpad_92",
             "pcb_port_92"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -9092,7 +9092,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -9118,7 +9118,7 @@
             "pcb_smtpad_100",
             "pcb_port_100"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -9366,7 +9366,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -9392,7 +9392,7 @@
             "pcb_smtpad_96",
             "pcb_port_96"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -9616,7 +9616,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -9642,7 +9642,7 @@
             "pcb_smtpad_104",
             "pcb_port_104"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -9890,7 +9890,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -9916,7 +9916,7 @@
             "pcb_smtpad_100",
             "pcb_port_100"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -10140,7 +10140,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -10166,7 +10166,7 @@
             "pcb_smtpad_108",
             "pcb_port_108"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -10414,7 +10414,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -10440,7 +10440,7 @@
             "pcb_smtpad_104",
             "pcb_port_104"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -10664,7 +10664,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -10690,7 +10690,7 @@
             "pcb_smtpad_112",
             "pcb_port_112"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -10938,7 +10938,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -10964,7 +10964,7 @@
             "pcb_smtpad_108",
             "pcb_port_108"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -11188,7 +11188,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -11214,7 +11214,7 @@
             "pcb_smtpad_116",
             "pcb_port_116"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -11462,7 +11462,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -11488,7 +11488,7 @@
             "pcb_smtpad_112",
             "pcb_port_112"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -11712,7 +11712,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -11738,7 +11738,7 @@
             "pcb_smtpad_120",
             "pcb_port_120"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -11986,7 +11986,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -12012,7 +12012,7 @@
             "pcb_smtpad_116",
             "pcb_port_116"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -12236,7 +12236,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -12262,7 +12262,7 @@
             "pcb_smtpad_124",
             "pcb_port_124"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -12510,7 +12510,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -12536,7 +12536,7 @@
             "pcb_smtpad_120",
             "pcb_port_120"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -12760,7 +12760,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -12786,7 +12786,7 @@
             "pcb_smtpad_128",
             "pcb_port_128"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -13034,7 +13034,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -13060,7 +13060,7 @@
             "pcb_smtpad_124",
             "pcb_port_124"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -13284,7 +13284,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -13310,7 +13310,7 @@
             "pcb_smtpad_132",
             "pcb_port_132"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -13558,7 +13558,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -13584,7 +13584,7 @@
             "pcb_smtpad_128",
             "pcb_port_128"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -13808,7 +13808,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -13834,7 +13834,7 @@
             "pcb_smtpad_136",
             "pcb_port_136"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -14082,7 +14082,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -14108,7 +14108,7 @@
             "pcb_smtpad_132",
             "pcb_port_132"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -14332,7 +14332,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -14358,7 +14358,7 @@
             "pcb_smtpad_140",
             "pcb_port_140"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -14606,7 +14606,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -14632,7 +14632,7 @@
             "pcb_smtpad_136",
             "pcb_port_136"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -14856,7 +14856,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -14882,7 +14882,7 @@
             "pcb_smtpad_144",
             "pcb_port_144"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -15130,7 +15130,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -15156,7 +15156,7 @@
             "pcb_smtpad_140",
             "pcb_port_140"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -15380,7 +15380,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -15406,7 +15406,7 @@
             "pcb_smtpad_148",
             "pcb_port_148"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -15654,7 +15654,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -15680,7 +15680,7 @@
             "pcb_smtpad_144",
             "pcb_port_144"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -15904,7 +15904,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -15930,7 +15930,7 @@
             "pcb_smtpad_152",
             "pcb_port_152"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -16178,7 +16178,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -16204,7 +16204,7 @@
             "pcb_smtpad_148",
             "pcb_port_148"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -16428,7 +16428,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -16454,7 +16454,7 @@
             "pcb_smtpad_156",
             "pcb_port_156"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -16702,7 +16702,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -16728,7 +16728,7 @@
             "pcb_smtpad_152",
             "pcb_port_152"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -16952,7 +16952,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -16978,7 +16978,7 @@
             "pcb_smtpad_160",
             "pcb_port_160"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -17226,7 +17226,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -17252,7 +17252,7 @@
             "pcb_smtpad_156",
             "pcb_port_156"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -17476,7 +17476,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -17502,7 +17502,7 @@
             "pcb_smtpad_164",
             "pcb_port_164"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -17750,7 +17750,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -17776,7 +17776,7 @@
             "pcb_smtpad_160",
             "pcb_port_160"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -18000,7 +18000,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -18026,7 +18026,7 @@
             "pcb_smtpad_168",
             "pcb_port_168"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -18274,7 +18274,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -18300,7 +18300,7 @@
             "pcb_smtpad_164",
             "pcb_port_164"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -18524,7 +18524,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -18550,7 +18550,7 @@
             "pcb_smtpad_172",
             "pcb_port_172"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -18798,7 +18798,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -18824,7 +18824,7 @@
             "pcb_smtpad_168",
             "pcb_port_168"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -19048,7 +19048,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -19074,7 +19074,7 @@
             "pcb_smtpad_176",
             "pcb_port_176"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -19322,7 +19322,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -19348,7 +19348,7 @@
             "pcb_smtpad_172",
             "pcb_port_172"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -19572,7 +19572,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -19598,7 +19598,7 @@
             "pcb_smtpad_180",
             "pcb_port_180"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -19846,7 +19846,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -19872,7 +19872,7 @@
             "pcb_smtpad_176",
             "pcb_port_176"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -20096,7 +20096,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -20122,7 +20122,7 @@
             "pcb_smtpad_184",
             "pcb_port_184"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -20370,7 +20370,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -20396,7 +20396,7 @@
             "pcb_smtpad_180",
             "pcb_port_180"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -20620,7 +20620,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -20646,7 +20646,7 @@
             "pcb_smtpad_188",
             "pcb_port_188"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -20894,7 +20894,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -20920,7 +20920,7 @@
             "pcb_smtpad_184",
             "pcb_port_184"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -21144,7 +21144,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -21170,7 +21170,7 @@
             "pcb_smtpad_192",
             "pcb_port_192"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -21418,7 +21418,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -21444,7 +21444,7 @@
             "pcb_smtpad_188",
             "pcb_port_188"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -21668,7 +21668,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -21694,7 +21694,7 @@
             "pcb_smtpad_196",
             "pcb_port_196"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -21942,7 +21942,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -21968,7 +21968,7 @@
             "pcb_smtpad_192",
             "pcb_port_192"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -22192,7 +22192,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -22218,7 +22218,7 @@
             "pcb_smtpad_200",
             "pcb_port_200"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -22466,7 +22466,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -22492,7 +22492,7 @@
             "pcb_smtpad_196",
             "pcb_port_196"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -22716,7 +22716,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -22742,7 +22742,7 @@
             "pcb_smtpad_204",
             "pcb_port_204"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -22990,7 +22990,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -23016,7 +23016,7 @@
             "pcb_smtpad_200",
             "pcb_port_200"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -23240,7 +23240,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -23266,7 +23266,7 @@
             "pcb_smtpad_208",
             "pcb_port_208"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -23514,7 +23514,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -23540,7 +23540,7 @@
             "pcb_smtpad_204",
             "pcb_port_204"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -23764,7 +23764,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -23790,7 +23790,7 @@
             "pcb_smtpad_212",
             "pcb_port_212"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -24038,7 +24038,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -24064,7 +24064,7 @@
             "pcb_smtpad_208",
             "pcb_port_208"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -24288,7 +24288,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -24314,7 +24314,7 @@
             "pcb_smtpad_216",
             "pcb_port_216"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -24562,7 +24562,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -24588,7 +24588,7 @@
             "pcb_smtpad_212",
             "pcb_port_212"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -24812,7 +24812,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -24838,7 +24838,7 @@
             "pcb_smtpad_220",
             "pcb_port_220"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -25086,7 +25086,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -25112,7 +25112,7 @@
             "pcb_smtpad_216",
             "pcb_port_216"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -25336,7 +25336,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -25362,7 +25362,7 @@
             "pcb_smtpad_224",
             "pcb_port_224"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -25610,7 +25610,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -25636,7 +25636,7 @@
             "pcb_smtpad_220",
             "pcb_port_220"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -25860,7 +25860,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -25886,7 +25886,7 @@
             "pcb_smtpad_228",
             "pcb_port_228"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -26134,7 +26134,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -26160,7 +26160,7 @@
             "pcb_smtpad_224",
             "pcb_port_224"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -26384,7 +26384,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -26410,7 +26410,7 @@
             "pcb_smtpad_232",
             "pcb_port_232"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -26658,7 +26658,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -26684,7 +26684,7 @@
             "pcb_smtpad_228",
             "pcb_port_228"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -26908,7 +26908,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -26934,7 +26934,7 @@
             "pcb_smtpad_236",
             "pcb_port_236"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -27182,7 +27182,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -27208,7 +27208,7 @@
             "pcb_smtpad_232",
             "pcb_port_232"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -27432,7 +27432,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -27458,7 +27458,7 @@
             "pcb_smtpad_240",
             "pcb_port_240"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -27706,7 +27706,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -27732,7 +27732,7 @@
             "pcb_smtpad_236",
             "pcb_port_236"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -27956,7 +27956,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -27978,7 +27978,7 @@
             "pcb_smtpad_238",
             "pcb_port_238"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -28226,7 +28226,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -28252,7 +28252,7 @@
             "pcb_smtpad_240",
             "pcb_port_240"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -28476,7 +28476,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -28700,7 +28700,7 @@
             "pcb_smtpad_242",
             "pcb_port_242"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -28948,7 +28948,7 @@
             "pcb_smtpad_243",
             "pcb_port_243"
           ],
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -28967,7 +28967,7 @@
           "width": 4.8,
           "height": 4.8,
           "connectedTo": [],
-          "zLayers": [
+          "__zLayers": [
             0,
             1,
             2,
@@ -28989,7 +28989,7 @@
           "width": 4.8,
           "height": 4.8,
           "connectedTo": [],
-          "zLayers": [
+          "__zLayers": [
             0,
             1,
             2,
@@ -29011,7 +29011,7 @@
           "width": 4.8,
           "height": 4.8,
           "connectedTo": [],
-          "zLayers": [
+          "__zLayers": [
             0,
             1,
             2,
@@ -29033,7 +29033,7 @@
           "width": 4.8,
           "height": 4.8,
           "connectedTo": [],
-          "zLayers": [
+          "__zLayers": [
             0,
             1,
             2,

--- a/fixtures/legacy/assets/simplifiedpathsolver1.json
+++ b/fixtures/legacy/assets/simplifiedpathsolver1.json
@@ -1809,7 +1809,7 @@
         "pcb_smtpad_13",
         "pcb_port_19"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -1831,7 +1831,7 @@
         "pcb_smtpad_13",
         "pcb_port_19"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -1853,7 +1853,7 @@
         "pcb_smtpad_13",
         "pcb_port_19"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -1875,7 +1875,7 @@
         "pcb_smtpad_13",
         "pcb_port_19"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -1901,7 +1901,7 @@
         "pcb_smtpad_3",
         "pcb_port_9"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -1927,7 +1927,7 @@
         "pcb_smtpad_3",
         "pcb_port_9"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -1953,7 +1953,7 @@
         "pcb_smtpad_3",
         "pcb_port_9"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -1979,7 +1979,7 @@
         "pcb_smtpad_3",
         "pcb_port_9"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -1997,7 +1997,7 @@
         "pcb_smtpad_2",
         "pcb_port_8"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -2023,7 +2023,7 @@
         "pcb_smtpad_3",
         "pcb_port_9"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -2045,7 +2045,7 @@
         "pcb_smtpad_4",
         "pcb_port_10"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -2063,7 +2063,7 @@
         "pcb_smtpad_5",
         "pcb_port_11"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -2081,7 +2081,7 @@
         "pcb_smtpad_6",
         "pcb_port_12"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -2099,7 +2099,7 @@
         "pcb_smtpad_7",
         "pcb_port_13"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -2117,7 +2117,7 @@
         "pcb_smtpad_8",
         "pcb_port_14"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -2135,7 +2135,7 @@
         "pcb_smtpad_9",
         "pcb_port_15"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -2153,7 +2153,7 @@
         "pcb_smtpad_10",
         "pcb_port_16"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -2171,7 +2171,7 @@
         "pcb_smtpad_11",
         "pcb_port_17"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -2189,7 +2189,7 @@
         "pcb_smtpad_12",
         "pcb_port_18"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -2211,7 +2211,7 @@
         "pcb_smtpad_13",
         "pcb_port_19"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -2243,7 +2243,7 @@
         "pcb_smtpad_21",
         "pcb_port_27"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -2261,7 +2261,7 @@
         "pcb_smtpad_15",
         "pcb_port_21"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -2283,7 +2283,7 @@
         "pcb_smtpad_16",
         "pcb_port_22"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -2305,7 +2305,7 @@
         "pcb_smtpad_17",
         "pcb_port_23"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -2323,7 +2323,7 @@
         "pcb_smtpad_18",
         "pcb_port_24"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -2341,7 +2341,7 @@
         "pcb_smtpad_19",
         "pcb_port_25"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -2359,7 +2359,7 @@
         "pcb_smtpad_20",
         "pcb_port_26"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -2391,7 +2391,7 @@
         "pcb_smtpad_21",
         "pcb_port_27"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -2409,7 +2409,7 @@
         "pcb_smtpad_22",
         "pcb_port_28"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -2427,7 +2427,7 @@
         "pcb_smtpad_23",
         "pcb_port_29"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -2445,7 +2445,7 @@
         "pcb_smtpad_24",
         "pcb_port_30"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -2463,7 +2463,7 @@
         "pcb_smtpad_25",
         "pcb_port_31"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "oval",
@@ -2485,7 +2485,7 @@
         "pcb_smtpad_17",
         "pcb_port_23"
       ],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "oval",
@@ -2507,7 +2507,7 @@
         "pcb_smtpad_16",
         "pcb_port_22"
       ],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "oval",
@@ -2533,7 +2533,7 @@
         "pcb_smtpad_3",
         "pcb_port_9"
       ],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "oval",
@@ -2565,7 +2565,7 @@
         "pcb_smtpad_21",
         "pcb_port_27"
       ],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "oval",
@@ -2587,7 +2587,7 @@
         "pcb_smtpad_4",
         "pcb_port_10"
       ],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "oval",
@@ -2619,7 +2619,7 @@
         "pcb_smtpad_21",
         "pcb_port_27"
       ],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     }
   ]
 ]

--- a/fixtures/legacy/assets/simplifiedpathsolver4.json
+++ b/fixtures/legacy/assets/simplifiedpathsolver4.json
@@ -1499,7 +1499,7 @@
           "pcb_smtpad_13",
           "pcb_port_19"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1521,7 +1521,7 @@
           "pcb_smtpad_13",
           "pcb_port_19"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1543,7 +1543,7 @@
           "pcb_smtpad_13",
           "pcb_port_19"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1565,7 +1565,7 @@
           "pcb_smtpad_13",
           "pcb_port_19"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1591,7 +1591,7 @@
           "pcb_smtpad_3",
           "pcb_port_9"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1617,7 +1617,7 @@
           "pcb_smtpad_3",
           "pcb_port_9"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1643,7 +1643,7 @@
           "pcb_smtpad_3",
           "pcb_port_9"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1669,7 +1669,7 @@
           "pcb_smtpad_3",
           "pcb_port_9"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1687,7 +1687,7 @@
           "pcb_smtpad_2",
           "pcb_port_8"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1713,7 +1713,7 @@
           "pcb_smtpad_3",
           "pcb_port_9"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1735,7 +1735,7 @@
           "pcb_smtpad_4",
           "pcb_port_10"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1753,7 +1753,7 @@
           "pcb_smtpad_5",
           "pcb_port_11"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1771,7 +1771,7 @@
           "pcb_smtpad_6",
           "pcb_port_12"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1789,7 +1789,7 @@
           "pcb_smtpad_7",
           "pcb_port_13"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1807,7 +1807,7 @@
           "pcb_smtpad_8",
           "pcb_port_14"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1825,7 +1825,7 @@
           "pcb_smtpad_9",
           "pcb_port_15"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1843,7 +1843,7 @@
           "pcb_smtpad_10",
           "pcb_port_16"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1861,7 +1861,7 @@
           "pcb_smtpad_11",
           "pcb_port_17"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1879,7 +1879,7 @@
           "pcb_smtpad_12",
           "pcb_port_18"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1901,7 +1901,7 @@
           "pcb_smtpad_13",
           "pcb_port_19"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1933,7 +1933,7 @@
           "pcb_smtpad_21",
           "pcb_port_27"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1951,7 +1951,7 @@
           "pcb_smtpad_15",
           "pcb_port_21"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1973,7 +1973,7 @@
           "pcb_smtpad_16",
           "pcb_port_22"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -1995,7 +1995,7 @@
           "pcb_smtpad_17",
           "pcb_port_23"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2013,7 +2013,7 @@
           "pcb_smtpad_18",
           "pcb_port_24"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2031,7 +2031,7 @@
           "pcb_smtpad_19",
           "pcb_port_25"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2049,7 +2049,7 @@
           "pcb_smtpad_20",
           "pcb_port_26"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2081,7 +2081,7 @@
           "pcb_smtpad_21",
           "pcb_port_27"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2099,7 +2099,7 @@
           "pcb_smtpad_22",
           "pcb_port_28"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2117,7 +2117,7 @@
           "pcb_smtpad_23",
           "pcb_port_29"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2135,7 +2135,7 @@
           "pcb_smtpad_24",
           "pcb_port_30"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -2153,7 +2153,7 @@
           "pcb_smtpad_25",
           "pcb_port_31"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "oval",
@@ -2175,7 +2175,7 @@
           "pcb_smtpad_17",
           "pcb_port_23"
         ],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "oval",
@@ -2197,7 +2197,7 @@
           "pcb_smtpad_16",
           "pcb_port_22"
         ],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "oval",
@@ -2223,7 +2223,7 @@
           "pcb_smtpad_3",
           "pcb_port_9"
         ],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "oval",
@@ -2255,7 +2255,7 @@
           "pcb_smtpad_21",
           "pcb_port_27"
         ],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "oval",
@@ -2277,7 +2277,7 @@
           "pcb_smtpad_4",
           "pcb_port_10"
         ],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "oval",
@@ -2309,7 +2309,7 @@
           "pcb_smtpad_21",
           "pcb_port_27"
         ],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       }
     ],
     "connMap": {

--- a/fixtures/legacy/assets/simplifiedpathsolver5.json
+++ b/fixtures/legacy/assets/simplifiedpathsolver5.json
@@ -19203,7 +19203,7 @@
           "source_trace_4",
           "source_trace_7"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19220,7 +19220,7 @@
           "source_trace_13",
           "source_trace_16"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19232,7 +19232,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_2"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19244,7 +19244,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_3"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19256,7 +19256,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_4"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19268,7 +19268,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_5"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19285,7 +19285,7 @@
           "source_trace_17",
           "source_trace_26"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19297,7 +19297,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_7"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19309,7 +19309,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_8"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19321,7 +19321,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_9"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19333,7 +19333,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_10"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19345,7 +19345,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_11"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19357,7 +19357,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_12"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19374,7 +19374,7 @@
           "source_trace_22",
           "source_trace_25"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19386,7 +19386,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_14"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19398,7 +19398,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_15"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19410,7 +19410,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_16"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19422,7 +19422,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_17"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19434,7 +19434,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_18"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19446,7 +19446,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_19"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19458,7 +19458,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_20"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19475,7 +19475,7 @@
           "source_trace_14",
           "source_trace_23"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19487,7 +19487,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_22"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19499,7 +19499,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_23"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19516,7 +19516,7 @@
           "source_trace_11",
           "source_trace_20"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19528,7 +19528,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_25"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19540,7 +19540,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_26"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19552,7 +19552,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_27"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19564,7 +19564,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_28"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19576,7 +19576,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_29"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19588,7 +19588,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_30"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19600,7 +19600,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_31"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19612,7 +19612,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_32"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19624,7 +19624,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_33"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19636,7 +19636,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_34"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19648,7 +19648,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_35"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19660,7 +19660,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_36"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19672,7 +19672,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_37"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19684,7 +19684,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_38"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19696,7 +19696,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_39"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -19708,7 +19708,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_40", "source_trace_2"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -19720,7 +19720,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_41", "source_trace_0"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -19732,7 +19732,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_42", "source_trace_0"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -19744,7 +19744,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_43", "source_trace_1"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -19756,7 +19756,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_44", "source_trace_5"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -19768,7 +19768,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_45", "source_trace_3"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -19780,7 +19780,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_46", "source_trace_3"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -19792,7 +19792,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_47", "source_trace_4"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -19804,7 +19804,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_48", "source_trace_8"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -19816,7 +19816,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_49", "source_trace_6"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -19828,7 +19828,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_50", "source_trace_6"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -19840,7 +19840,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_51", "source_trace_7"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -19852,7 +19852,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_52", "source_trace_11"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -19864,7 +19864,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_53", "source_trace_9"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -19876,7 +19876,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_54", "source_trace_9"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -19888,7 +19888,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_55", "source_trace_10"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -19900,7 +19900,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_56", "source_trace_14"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -19912,7 +19912,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_57", "source_trace_12"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -19924,7 +19924,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_58", "source_trace_12"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -19936,7 +19936,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_59", "source_trace_13"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -19948,7 +19948,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_60", "source_trace_17"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -19960,7 +19960,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_61", "source_trace_15"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -19972,7 +19972,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_62", "source_trace_15"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -19984,7 +19984,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_63", "source_trace_16"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -19996,7 +19996,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_64", "source_trace_20"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -20008,7 +20008,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_65", "source_trace_18"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -20020,7 +20020,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_66", "source_trace_18"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -20032,7 +20032,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_67", "source_trace_19"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -20044,7 +20044,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_68", "source_trace_23"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -20056,7 +20056,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_69", "source_trace_21"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -20068,7 +20068,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_70", "source_trace_21"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -20080,7 +20080,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_71", "source_trace_22"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -20092,7 +20092,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_72", "source_trace_26"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -20104,7 +20104,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_73", "source_trace_24"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -20116,7 +20116,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_74", "source_trace_24"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -20128,7 +20128,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_75", "source_trace_25"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -20140,7 +20140,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -20152,7 +20152,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -20164,7 +20164,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -20176,7 +20176,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -20188,7 +20188,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -20200,7 +20200,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -20212,7 +20212,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -20224,7 +20224,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -20236,7 +20236,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -20248,7 +20248,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -20260,7 +20260,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -20272,7 +20272,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -20284,7 +20284,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -20296,7 +20296,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -20308,7 +20308,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -20320,7 +20320,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -20332,7 +20332,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -20344,7 +20344,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -20356,7 +20356,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -20368,7 +20368,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -20380,7 +20380,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -20392,7 +20392,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -20404,7 +20404,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -20416,7 +20416,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -20428,7 +20428,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -20440,7 +20440,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -20452,7 +20452,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       }
     ],
     "connMap": {

--- a/fixtures/legacy/assets/simplifiedpathsolver6.json
+++ b/fixtures/legacy/assets/simplifiedpathsolver6.json
@@ -21969,7 +21969,7 @@
           "source_trace_4",
           "source_trace_7"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -21986,7 +21986,7 @@
           "source_trace_13",
           "source_trace_16"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -21998,7 +21998,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_2"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22010,7 +22010,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_3"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22022,7 +22022,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_4"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22034,7 +22034,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_5"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22051,7 +22051,7 @@
           "source_trace_17",
           "source_trace_26"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22063,7 +22063,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_7"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22075,7 +22075,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_8"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22087,7 +22087,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_9"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22099,7 +22099,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_10"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22111,7 +22111,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_11"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22123,7 +22123,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_12"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22140,7 +22140,7 @@
           "source_trace_22",
           "source_trace_25"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22152,7 +22152,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_14"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22164,7 +22164,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_15"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22176,7 +22176,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_16"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22188,7 +22188,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_17"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22200,7 +22200,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_18"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22212,7 +22212,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_19"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22224,7 +22224,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_20"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22241,7 +22241,7 @@
           "source_trace_14",
           "source_trace_23"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22253,7 +22253,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_22"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22265,7 +22265,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_23"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22282,7 +22282,7 @@
           "source_trace_11",
           "source_trace_20"
         ],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22294,7 +22294,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_25"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22306,7 +22306,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_26"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22318,7 +22318,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_27"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22330,7 +22330,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_28"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22342,7 +22342,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_29"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22354,7 +22354,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_30"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22366,7 +22366,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_31"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22378,7 +22378,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_32"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22390,7 +22390,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_33"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22402,7 +22402,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_34"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22414,7 +22414,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_35"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22426,7 +22426,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_36"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22438,7 +22438,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_37"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22450,7 +22450,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_38"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22462,7 +22462,7 @@
         "width": 3.8,
         "height": 2.28,
         "connectedTo": ["pcb_smtpad_39"],
-        "zLayers": [0]
+        "__zLayers": [0]
       },
       {
         "type": "rect",
@@ -22474,7 +22474,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_40", "source_trace_2"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22486,7 +22486,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_41", "source_trace_0"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22498,7 +22498,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_42", "source_trace_0"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22510,7 +22510,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_43", "source_trace_1"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22522,7 +22522,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_44", "source_trace_5"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22534,7 +22534,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_45", "source_trace_3"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22546,7 +22546,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_46", "source_trace_3"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22558,7 +22558,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_47", "source_trace_4"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22570,7 +22570,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_48", "source_trace_8"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22582,7 +22582,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_49", "source_trace_6"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22594,7 +22594,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_50", "source_trace_6"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22606,7 +22606,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_51", "source_trace_7"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22618,7 +22618,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_52", "source_trace_11"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22630,7 +22630,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_53", "source_trace_9"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22642,7 +22642,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_54", "source_trace_9"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22654,7 +22654,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_55", "source_trace_10"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22666,7 +22666,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_56", "source_trace_14"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22678,7 +22678,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_57", "source_trace_12"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22690,7 +22690,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_58", "source_trace_12"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22702,7 +22702,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_59", "source_trace_13"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22714,7 +22714,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_60", "source_trace_17"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22726,7 +22726,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_61", "source_trace_15"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22738,7 +22738,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_62", "source_trace_15"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22750,7 +22750,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_63", "source_trace_16"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22762,7 +22762,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_64", "source_trace_20"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22774,7 +22774,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_65", "source_trace_18"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22786,7 +22786,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_66", "source_trace_18"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22798,7 +22798,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_67", "source_trace_19"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22810,7 +22810,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_68", "source_trace_23"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22822,7 +22822,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_69", "source_trace_21"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22834,7 +22834,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_70", "source_trace_21"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22846,7 +22846,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_71", "source_trace_22"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22858,7 +22858,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_72", "source_trace_26"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22870,7 +22870,7 @@
         "width": 2.8999941999999996,
         "height": 2.4999949999999997,
         "connectedTo": ["pcb_smtpad_73", "source_trace_24"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22882,7 +22882,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_74", "source_trace_24"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22894,7 +22894,7 @@
         "width": 0.9999979999999999,
         "height": 0.7500112,
         "connectedTo": ["pcb_smtpad_75", "source_trace_25"],
-        "zLayers": [1]
+        "__zLayers": [1]
       },
       {
         "type": "rect",
@@ -22906,7 +22906,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -22918,7 +22918,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -22930,7 +22930,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -22942,7 +22942,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -22954,7 +22954,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -22966,7 +22966,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -22978,7 +22978,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -22990,7 +22990,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -23002,7 +23002,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -23014,7 +23014,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -23026,7 +23026,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -23038,7 +23038,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -23050,7 +23050,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -23062,7 +23062,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -23074,7 +23074,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -23086,7 +23086,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -23098,7 +23098,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -23110,7 +23110,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -23122,7 +23122,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -23134,7 +23134,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -23146,7 +23146,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -23158,7 +23158,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -23170,7 +23170,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -23182,7 +23182,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -23194,7 +23194,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -23206,7 +23206,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       },
       {
         "type": "rect",
@@ -23218,7 +23218,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [0, 1, 2, 1]
+        "__zLayers": [0, 1, 2, 1]
       }
     ],
     "connMap": {

--- a/fixtures/legacy/assets/simplifiedpathsolver7.json
+++ b/fixtures/legacy/assets/simplifiedpathsolver7.json
@@ -35795,7 +35795,7 @@
         "pcb_smtpad_283",
         "pcb_port_244"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -35817,7 +35817,7 @@
         "pcb_smtpad_3",
         "pcb_port_3"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -35893,7 +35893,7 @@
         "pcb_smtpad_245",
         "pcb_port_263"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -35915,7 +35915,7 @@
         "pcb_smtpad_3",
         "pcb_port_3"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -35955,7 +35955,7 @@
         "pcb_smtpad_281",
         "pcb_port_245"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -35977,7 +35977,7 @@
         "pcb_smtpad_7",
         "pcb_port_7"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -36053,7 +36053,7 @@
         "pcb_smtpad_245",
         "pcb_port_263"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -36075,7 +36075,7 @@
         "pcb_smtpad_7",
         "pcb_port_7"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -36115,7 +36115,7 @@
         "pcb_smtpad_277",
         "pcb_port_247"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -36137,7 +36137,7 @@
         "pcb_smtpad_11",
         "pcb_port_11"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -36213,7 +36213,7 @@
         "pcb_smtpad_245",
         "pcb_port_263"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -36235,7 +36235,7 @@
         "pcb_smtpad_11",
         "pcb_port_11"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -36275,7 +36275,7 @@
         "pcb_smtpad_275",
         "pcb_port_248"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -36297,7 +36297,7 @@
         "pcb_smtpad_15",
         "pcb_port_15"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -36373,7 +36373,7 @@
         "pcb_smtpad_245",
         "pcb_port_263"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -36395,7 +36395,7 @@
         "pcb_smtpad_15",
         "pcb_port_15"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -36435,7 +36435,7 @@
         "pcb_smtpad_273",
         "pcb_port_249"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -36457,7 +36457,7 @@
         "pcb_smtpad_19",
         "pcb_port_19"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -36533,7 +36533,7 @@
         "pcb_smtpad_245",
         "pcb_port_263"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -36555,7 +36555,7 @@
         "pcb_smtpad_19",
         "pcb_port_19"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -36595,7 +36595,7 @@
         "pcb_smtpad_271",
         "pcb_port_250"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -36617,7 +36617,7 @@
         "pcb_smtpad_23",
         "pcb_port_23"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -36693,7 +36693,7 @@
         "pcb_smtpad_245",
         "pcb_port_263"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -36715,7 +36715,7 @@
         "pcb_smtpad_23",
         "pcb_port_23"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -36755,7 +36755,7 @@
         "pcb_smtpad_267",
         "pcb_port_252"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -36777,7 +36777,7 @@
         "pcb_smtpad_27",
         "pcb_port_27"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -36853,7 +36853,7 @@
         "pcb_smtpad_245",
         "pcb_port_263"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -36875,7 +36875,7 @@
         "pcb_smtpad_27",
         "pcb_port_27"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -36915,7 +36915,7 @@
         "pcb_smtpad_265",
         "pcb_port_253"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -36937,7 +36937,7 @@
         "pcb_smtpad_31",
         "pcb_port_31"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -37013,7 +37013,7 @@
         "pcb_smtpad_245",
         "pcb_port_263"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -37035,7 +37035,7 @@
         "pcb_smtpad_31",
         "pcb_port_31"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -37071,7 +37071,7 @@
         "pcb_smtpad_263",
         "pcb_port_254"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -37093,7 +37093,7 @@
         "pcb_smtpad_35",
         "pcb_port_35"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -37169,7 +37169,7 @@
         "pcb_smtpad_245",
         "pcb_port_263"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -37191,7 +37191,7 @@
         "pcb_smtpad_35",
         "pcb_port_35"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -37227,7 +37227,7 @@
         "pcb_smtpad_261",
         "pcb_port_255"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -37249,7 +37249,7 @@
         "pcb_smtpad_39",
         "pcb_port_39"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -37325,7 +37325,7 @@
         "pcb_smtpad_245",
         "pcb_port_263"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -37347,7 +37347,7 @@
         "pcb_smtpad_39",
         "pcb_port_39"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -37383,7 +37383,7 @@
         "pcb_smtpad_257",
         "pcb_port_257"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -37405,7 +37405,7 @@
         "pcb_smtpad_43",
         "pcb_port_43"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -37481,7 +37481,7 @@
         "pcb_smtpad_245",
         "pcb_port_263"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -37503,7 +37503,7 @@
         "pcb_smtpad_43",
         "pcb_port_43"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -37539,7 +37539,7 @@
         "pcb_smtpad_255",
         "pcb_port_258"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -37561,7 +37561,7 @@
         "pcb_smtpad_47",
         "pcb_port_47"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -37637,7 +37637,7 @@
         "pcb_smtpad_245",
         "pcb_port_263"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -37659,7 +37659,7 @@
         "pcb_smtpad_47",
         "pcb_port_47"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -37691,7 +37691,7 @@
         "pcb_smtpad_253",
         "pcb_port_259"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -37713,7 +37713,7 @@
         "pcb_smtpad_51",
         "pcb_port_51"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -37789,7 +37789,7 @@
         "pcb_smtpad_245",
         "pcb_port_263"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -37811,7 +37811,7 @@
         "pcb_smtpad_51",
         "pcb_port_51"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -37839,7 +37839,7 @@
         "pcb_smtpad_251",
         "pcb_port_260"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -37861,7 +37861,7 @@
         "pcb_smtpad_55",
         "pcb_port_55"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -37937,7 +37937,7 @@
         "pcb_smtpad_245",
         "pcb_port_263"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -37959,7 +37959,7 @@
         "pcb_smtpad_55",
         "pcb_port_55"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -37999,7 +37999,7 @@
         "pcb_smtpad_283",
         "pcb_port_244"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -38021,7 +38021,7 @@
         "pcb_smtpad_59",
         "pcb_port_59"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -38097,7 +38097,7 @@
         "pcb_smtpad_244",
         "pcb_port_264"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -38119,7 +38119,7 @@
         "pcb_smtpad_59",
         "pcb_port_59"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -38159,7 +38159,7 @@
         "pcb_smtpad_281",
         "pcb_port_245"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -38181,7 +38181,7 @@
         "pcb_smtpad_63",
         "pcb_port_63"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -38257,7 +38257,7 @@
         "pcb_smtpad_244",
         "pcb_port_264"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -38279,7 +38279,7 @@
         "pcb_smtpad_63",
         "pcb_port_63"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -38319,7 +38319,7 @@
         "pcb_smtpad_277",
         "pcb_port_247"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -38341,7 +38341,7 @@
         "pcb_smtpad_67",
         "pcb_port_67"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -38417,7 +38417,7 @@
         "pcb_smtpad_244",
         "pcb_port_264"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -38439,7 +38439,7 @@
         "pcb_smtpad_67",
         "pcb_port_67"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -38479,7 +38479,7 @@
         "pcb_smtpad_275",
         "pcb_port_248"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -38501,7 +38501,7 @@
         "pcb_smtpad_71",
         "pcb_port_71"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -38577,7 +38577,7 @@
         "pcb_smtpad_244",
         "pcb_port_264"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -38599,7 +38599,7 @@
         "pcb_smtpad_71",
         "pcb_port_71"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -38639,7 +38639,7 @@
         "pcb_smtpad_273",
         "pcb_port_249"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -38661,7 +38661,7 @@
         "pcb_smtpad_75",
         "pcb_port_75"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -38737,7 +38737,7 @@
         "pcb_smtpad_244",
         "pcb_port_264"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -38759,7 +38759,7 @@
         "pcb_smtpad_75",
         "pcb_port_75"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -38799,7 +38799,7 @@
         "pcb_smtpad_271",
         "pcb_port_250"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -38821,7 +38821,7 @@
         "pcb_smtpad_79",
         "pcb_port_79"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -38897,7 +38897,7 @@
         "pcb_smtpad_244",
         "pcb_port_264"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -38919,7 +38919,7 @@
         "pcb_smtpad_79",
         "pcb_port_79"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -38959,7 +38959,7 @@
         "pcb_smtpad_267",
         "pcb_port_252"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -38981,7 +38981,7 @@
         "pcb_smtpad_83",
         "pcb_port_83"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -39057,7 +39057,7 @@
         "pcb_smtpad_244",
         "pcb_port_264"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -39079,7 +39079,7 @@
         "pcb_smtpad_83",
         "pcb_port_83"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -39119,7 +39119,7 @@
         "pcb_smtpad_265",
         "pcb_port_253"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -39141,7 +39141,7 @@
         "pcb_smtpad_87",
         "pcb_port_87"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -39217,7 +39217,7 @@
         "pcb_smtpad_244",
         "pcb_port_264"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -39239,7 +39239,7 @@
         "pcb_smtpad_87",
         "pcb_port_87"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -39275,7 +39275,7 @@
         "pcb_smtpad_263",
         "pcb_port_254"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -39297,7 +39297,7 @@
         "pcb_smtpad_91",
         "pcb_port_91"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -39373,7 +39373,7 @@
         "pcb_smtpad_244",
         "pcb_port_264"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -39395,7 +39395,7 @@
         "pcb_smtpad_91",
         "pcb_port_91"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -39431,7 +39431,7 @@
         "pcb_smtpad_261",
         "pcb_port_255"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -39453,7 +39453,7 @@
         "pcb_smtpad_95",
         "pcb_port_95"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -39529,7 +39529,7 @@
         "pcb_smtpad_244",
         "pcb_port_264"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -39551,7 +39551,7 @@
         "pcb_smtpad_95",
         "pcb_port_95"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -39587,7 +39587,7 @@
         "pcb_smtpad_257",
         "pcb_port_257"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -39609,7 +39609,7 @@
         "pcb_smtpad_99",
         "pcb_port_99"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -39685,7 +39685,7 @@
         "pcb_smtpad_244",
         "pcb_port_264"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -39707,7 +39707,7 @@
         "pcb_smtpad_99",
         "pcb_port_99"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -39743,7 +39743,7 @@
         "pcb_smtpad_255",
         "pcb_port_258"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -39765,7 +39765,7 @@
         "pcb_smtpad_103",
         "pcb_port_103"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -39841,7 +39841,7 @@
         "pcb_smtpad_244",
         "pcb_port_264"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -39863,7 +39863,7 @@
         "pcb_smtpad_103",
         "pcb_port_103"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -39895,7 +39895,7 @@
         "pcb_smtpad_253",
         "pcb_port_259"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -39917,7 +39917,7 @@
         "pcb_smtpad_107",
         "pcb_port_107"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -39993,7 +39993,7 @@
         "pcb_smtpad_244",
         "pcb_port_264"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -40015,7 +40015,7 @@
         "pcb_smtpad_107",
         "pcb_port_107"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -40043,7 +40043,7 @@
         "pcb_smtpad_251",
         "pcb_port_260"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -40065,7 +40065,7 @@
         "pcb_smtpad_111",
         "pcb_port_111"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -40141,7 +40141,7 @@
         "pcb_smtpad_244",
         "pcb_port_264"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -40163,7 +40163,7 @@
         "pcb_smtpad_111",
         "pcb_port_111"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -40203,7 +40203,7 @@
         "pcb_smtpad_283",
         "pcb_port_244"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -40225,7 +40225,7 @@
         "pcb_smtpad_115",
         "pcb_port_115"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -40297,7 +40297,7 @@
         "pcb_smtpad_246",
         "pcb_port_265"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -40319,7 +40319,7 @@
         "pcb_smtpad_115",
         "pcb_port_115"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -40359,7 +40359,7 @@
         "pcb_smtpad_281",
         "pcb_port_245"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -40381,7 +40381,7 @@
         "pcb_smtpad_119",
         "pcb_port_119"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -40453,7 +40453,7 @@
         "pcb_smtpad_246",
         "pcb_port_265"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -40475,7 +40475,7 @@
         "pcb_smtpad_119",
         "pcb_port_119"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -40515,7 +40515,7 @@
         "pcb_smtpad_277",
         "pcb_port_247"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -40537,7 +40537,7 @@
         "pcb_smtpad_123",
         "pcb_port_123"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -40609,7 +40609,7 @@
         "pcb_smtpad_246",
         "pcb_port_265"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -40631,7 +40631,7 @@
         "pcb_smtpad_123",
         "pcb_port_123"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -40671,7 +40671,7 @@
         "pcb_smtpad_275",
         "pcb_port_248"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -40693,7 +40693,7 @@
         "pcb_smtpad_127",
         "pcb_port_127"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -40765,7 +40765,7 @@
         "pcb_smtpad_246",
         "pcb_port_265"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -40787,7 +40787,7 @@
         "pcb_smtpad_127",
         "pcb_port_127"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -40827,7 +40827,7 @@
         "pcb_smtpad_273",
         "pcb_port_249"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -40849,7 +40849,7 @@
         "pcb_smtpad_131",
         "pcb_port_131"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -40921,7 +40921,7 @@
         "pcb_smtpad_246",
         "pcb_port_265"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -40943,7 +40943,7 @@
         "pcb_smtpad_131",
         "pcb_port_131"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -40983,7 +40983,7 @@
         "pcb_smtpad_271",
         "pcb_port_250"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -41005,7 +41005,7 @@
         "pcb_smtpad_135",
         "pcb_port_135"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -41077,7 +41077,7 @@
         "pcb_smtpad_246",
         "pcb_port_265"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -41099,7 +41099,7 @@
         "pcb_smtpad_135",
         "pcb_port_135"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -41139,7 +41139,7 @@
         "pcb_smtpad_267",
         "pcb_port_252"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -41161,7 +41161,7 @@
         "pcb_smtpad_139",
         "pcb_port_139"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -41233,7 +41233,7 @@
         "pcb_smtpad_246",
         "pcb_port_265"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -41255,7 +41255,7 @@
         "pcb_smtpad_139",
         "pcb_port_139"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -41295,7 +41295,7 @@
         "pcb_smtpad_265",
         "pcb_port_253"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -41317,7 +41317,7 @@
         "pcb_smtpad_143",
         "pcb_port_143"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -41389,7 +41389,7 @@
         "pcb_smtpad_246",
         "pcb_port_265"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -41411,7 +41411,7 @@
         "pcb_smtpad_143",
         "pcb_port_143"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -41447,7 +41447,7 @@
         "pcb_smtpad_263",
         "pcb_port_254"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -41469,7 +41469,7 @@
         "pcb_smtpad_147",
         "pcb_port_147"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -41541,7 +41541,7 @@
         "pcb_smtpad_246",
         "pcb_port_265"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -41563,7 +41563,7 @@
         "pcb_smtpad_147",
         "pcb_port_147"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -41599,7 +41599,7 @@
         "pcb_smtpad_261",
         "pcb_port_255"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -41621,7 +41621,7 @@
         "pcb_smtpad_151",
         "pcb_port_151"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -41693,7 +41693,7 @@
         "pcb_smtpad_246",
         "pcb_port_265"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -41715,7 +41715,7 @@
         "pcb_smtpad_151",
         "pcb_port_151"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -41751,7 +41751,7 @@
         "pcb_smtpad_257",
         "pcb_port_257"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -41773,7 +41773,7 @@
         "pcb_smtpad_155",
         "pcb_port_155"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -41845,7 +41845,7 @@
         "pcb_smtpad_246",
         "pcb_port_265"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -41867,7 +41867,7 @@
         "pcb_smtpad_155",
         "pcb_port_155"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -41903,7 +41903,7 @@
         "pcb_smtpad_255",
         "pcb_port_258"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -41925,7 +41925,7 @@
         "pcb_smtpad_159",
         "pcb_port_159"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -41997,7 +41997,7 @@
         "pcb_smtpad_246",
         "pcb_port_265"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -42019,7 +42019,7 @@
         "pcb_smtpad_159",
         "pcb_port_159"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -42051,7 +42051,7 @@
         "pcb_smtpad_253",
         "pcb_port_259"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -42073,7 +42073,7 @@
         "pcb_smtpad_163",
         "pcb_port_163"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -42145,7 +42145,7 @@
         "pcb_smtpad_246",
         "pcb_port_265"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -42167,7 +42167,7 @@
         "pcb_smtpad_163",
         "pcb_port_163"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -42207,7 +42207,7 @@
         "pcb_smtpad_283",
         "pcb_port_244"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -42229,7 +42229,7 @@
         "pcb_smtpad_167",
         "pcb_port_167"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -42297,7 +42297,7 @@
         "pcb_smtpad_250",
         "pcb_port_267"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -42319,7 +42319,7 @@
         "pcb_smtpad_167",
         "pcb_port_167"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -42359,7 +42359,7 @@
         "pcb_smtpad_281",
         "pcb_port_245"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -42381,7 +42381,7 @@
         "pcb_smtpad_171",
         "pcb_port_171"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -42449,7 +42449,7 @@
         "pcb_smtpad_250",
         "pcb_port_267"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -42471,7 +42471,7 @@
         "pcb_smtpad_171",
         "pcb_port_171"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -42511,7 +42511,7 @@
         "pcb_smtpad_277",
         "pcb_port_247"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -42533,7 +42533,7 @@
         "pcb_smtpad_175",
         "pcb_port_175"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -42601,7 +42601,7 @@
         "pcb_smtpad_250",
         "pcb_port_267"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -42623,7 +42623,7 @@
         "pcb_smtpad_175",
         "pcb_port_175"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -42663,7 +42663,7 @@
         "pcb_smtpad_275",
         "pcb_port_248"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -42685,7 +42685,7 @@
         "pcb_smtpad_179",
         "pcb_port_179"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -42753,7 +42753,7 @@
         "pcb_smtpad_250",
         "pcb_port_267"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -42775,7 +42775,7 @@
         "pcb_smtpad_179",
         "pcb_port_179"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -42815,7 +42815,7 @@
         "pcb_smtpad_273",
         "pcb_port_249"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -42837,7 +42837,7 @@
         "pcb_smtpad_183",
         "pcb_port_183"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -42905,7 +42905,7 @@
         "pcb_smtpad_250",
         "pcb_port_267"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -42927,7 +42927,7 @@
         "pcb_smtpad_183",
         "pcb_port_183"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -42967,7 +42967,7 @@
         "pcb_smtpad_271",
         "pcb_port_250"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -42989,7 +42989,7 @@
         "pcb_smtpad_187",
         "pcb_port_187"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -43057,7 +43057,7 @@
         "pcb_smtpad_250",
         "pcb_port_267"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -43079,7 +43079,7 @@
         "pcb_smtpad_187",
         "pcb_port_187"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -43119,7 +43119,7 @@
         "pcb_smtpad_267",
         "pcb_port_252"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -43141,7 +43141,7 @@
         "pcb_smtpad_191",
         "pcb_port_191"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -43209,7 +43209,7 @@
         "pcb_smtpad_250",
         "pcb_port_267"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -43231,7 +43231,7 @@
         "pcb_smtpad_191",
         "pcb_port_191"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -43271,7 +43271,7 @@
         "pcb_smtpad_265",
         "pcb_port_253"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -43293,7 +43293,7 @@
         "pcb_smtpad_195",
         "pcb_port_195"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -43361,7 +43361,7 @@
         "pcb_smtpad_250",
         "pcb_port_267"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -43383,7 +43383,7 @@
         "pcb_smtpad_195",
         "pcb_port_195"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -43419,7 +43419,7 @@
         "pcb_smtpad_263",
         "pcb_port_254"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -43441,7 +43441,7 @@
         "pcb_smtpad_199",
         "pcb_port_199"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -43509,7 +43509,7 @@
         "pcb_smtpad_250",
         "pcb_port_267"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -43531,7 +43531,7 @@
         "pcb_smtpad_199",
         "pcb_port_199"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -43567,7 +43567,7 @@
         "pcb_smtpad_261",
         "pcb_port_255"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -43589,7 +43589,7 @@
         "pcb_smtpad_203",
         "pcb_port_203"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -43657,7 +43657,7 @@
         "pcb_smtpad_250",
         "pcb_port_267"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -43679,7 +43679,7 @@
         "pcb_smtpad_203",
         "pcb_port_203"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -43715,7 +43715,7 @@
         "pcb_smtpad_257",
         "pcb_port_257"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -43737,7 +43737,7 @@
         "pcb_smtpad_207",
         "pcb_port_207"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -43805,7 +43805,7 @@
         "pcb_smtpad_250",
         "pcb_port_267"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -43827,7 +43827,7 @@
         "pcb_smtpad_207",
         "pcb_port_207"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -43863,7 +43863,7 @@
         "pcb_smtpad_255",
         "pcb_port_258"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -43885,7 +43885,7 @@
         "pcb_smtpad_211",
         "pcb_port_211"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -43953,7 +43953,7 @@
         "pcb_smtpad_250",
         "pcb_port_267"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -43975,7 +43975,7 @@
         "pcb_smtpad_211",
         "pcb_port_211"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -44015,7 +44015,7 @@
         "pcb_smtpad_283",
         "pcb_port_244"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -44037,7 +44037,7 @@
         "pcb_smtpad_215",
         "pcb_port_215"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -44089,7 +44089,7 @@
         "pcb_smtpad_252",
         "pcb_port_268"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -44111,7 +44111,7 @@
         "pcb_smtpad_215",
         "pcb_port_215"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -44151,7 +44151,7 @@
         "pcb_smtpad_281",
         "pcb_port_245"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -44173,7 +44173,7 @@
         "pcb_smtpad_219",
         "pcb_port_219"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -44225,7 +44225,7 @@
         "pcb_smtpad_252",
         "pcb_port_268"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -44247,7 +44247,7 @@
         "pcb_smtpad_219",
         "pcb_port_219"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -44287,7 +44287,7 @@
         "pcb_smtpad_277",
         "pcb_port_247"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -44309,7 +44309,7 @@
         "pcb_smtpad_223",
         "pcb_port_223"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -44361,7 +44361,7 @@
         "pcb_smtpad_252",
         "pcb_port_268"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -44383,7 +44383,7 @@
         "pcb_smtpad_223",
         "pcb_port_223"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -44423,7 +44423,7 @@
         "pcb_smtpad_275",
         "pcb_port_248"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -44445,7 +44445,7 @@
         "pcb_smtpad_227",
         "pcb_port_227"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -44497,7 +44497,7 @@
         "pcb_smtpad_252",
         "pcb_port_268"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -44519,7 +44519,7 @@
         "pcb_smtpad_227",
         "pcb_port_227"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -44559,7 +44559,7 @@
         "pcb_smtpad_273",
         "pcb_port_249"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -44581,7 +44581,7 @@
         "pcb_smtpad_231",
         "pcb_port_231"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -44633,7 +44633,7 @@
         "pcb_smtpad_252",
         "pcb_port_268"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -44655,7 +44655,7 @@
         "pcb_smtpad_231",
         "pcb_port_231"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -44695,7 +44695,7 @@
         "pcb_smtpad_271",
         "pcb_port_250"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -44717,7 +44717,7 @@
         "pcb_smtpad_235",
         "pcb_port_235"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -44769,7 +44769,7 @@
         "pcb_smtpad_252",
         "pcb_port_268"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -44791,7 +44791,7 @@
         "pcb_smtpad_235",
         "pcb_port_235"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -44831,7 +44831,7 @@
         "pcb_smtpad_267",
         "pcb_port_252"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -44853,7 +44853,7 @@
         "pcb_smtpad_239",
         "pcb_port_239"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -44905,7 +44905,7 @@
         "pcb_smtpad_252",
         "pcb_port_268"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -44927,7 +44927,7 @@
         "pcb_smtpad_239",
         "pcb_port_239"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -44967,7 +44967,7 @@
         "pcb_smtpad_265",
         "pcb_port_253"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -44989,7 +44989,7 @@
         "pcb_smtpad_243",
         "pcb_port_243"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -45041,7 +45041,7 @@
         "pcb_smtpad_252",
         "pcb_port_268"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -45063,7 +45063,7 @@
         "pcb_smtpad_243",
         "pcb_port_243"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -45139,7 +45139,7 @@
         "pcb_smtpad_244",
         "pcb_port_264"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -45215,7 +45215,7 @@
         "pcb_smtpad_245",
         "pcb_port_263"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -45287,7 +45287,7 @@
         "pcb_smtpad_246",
         "pcb_port_265"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -45307,7 +45307,7 @@
         "pcb_smtpad_247",
         "pcb_port_262"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -45325,7 +45325,7 @@
         "pcb_smtpad_248",
         "pcb_port_266"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -45343,7 +45343,7 @@
         "pcb_smtpad_249",
         "pcb_port_261"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -45411,7 +45411,7 @@
         "pcb_smtpad_250",
         "pcb_port_267"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -45439,7 +45439,7 @@
         "pcb_smtpad_251",
         "pcb_port_260"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -45491,7 +45491,7 @@
         "pcb_smtpad_252",
         "pcb_port_268"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -45523,7 +45523,7 @@
         "pcb_smtpad_253",
         "pcb_port_259"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -45541,7 +45541,7 @@
         "pcb_smtpad_254",
         "pcb_port_269"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -45577,7 +45577,7 @@
         "pcb_smtpad_255",
         "pcb_port_258"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -45595,7 +45595,7 @@
         "pcb_smtpad_256",
         "pcb_port_270"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -45631,7 +45631,7 @@
         "pcb_smtpad_257",
         "pcb_port_257"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -45649,7 +45649,7 @@
         "pcb_smtpad_258",
         "pcb_port_271"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -45667,7 +45667,7 @@
         "pcb_smtpad_259",
         "pcb_port_256"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -45685,7 +45685,7 @@
         "pcb_smtpad_260",
         "pcb_port_272"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -45721,7 +45721,7 @@
         "pcb_smtpad_261",
         "pcb_port_255"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -45739,7 +45739,7 @@
         "pcb_smtpad_262",
         "pcb_port_273"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -45775,7 +45775,7 @@
         "pcb_smtpad_263",
         "pcb_port_254"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -45793,7 +45793,7 @@
         "pcb_smtpad_264",
         "pcb_port_274"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -45833,7 +45833,7 @@
         "pcb_smtpad_265",
         "pcb_port_253"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -45851,7 +45851,7 @@
         "pcb_smtpad_266",
         "pcb_port_275"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -45891,7 +45891,7 @@
         "pcb_smtpad_267",
         "pcb_port_252"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -45909,7 +45909,7 @@
         "pcb_smtpad_268",
         "pcb_port_276"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -45927,7 +45927,7 @@
         "pcb_smtpad_269",
         "pcb_port_251"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -45945,7 +45945,7 @@
         "pcb_smtpad_270",
         "pcb_port_277"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -45985,7 +45985,7 @@
         "pcb_smtpad_271",
         "pcb_port_250"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -46003,7 +46003,7 @@
         "pcb_smtpad_272",
         "pcb_port_278"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -46043,7 +46043,7 @@
         "pcb_smtpad_273",
         "pcb_port_249"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -46061,7 +46061,7 @@
         "pcb_smtpad_274",
         "pcb_port_279"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -46101,7 +46101,7 @@
         "pcb_smtpad_275",
         "pcb_port_248"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -46119,7 +46119,7 @@
         "pcb_smtpad_276",
         "pcb_port_280"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -46159,7 +46159,7 @@
         "pcb_smtpad_277",
         "pcb_port_247"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -46177,7 +46177,7 @@
         "pcb_smtpad_278",
         "pcb_port_281"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -46195,7 +46195,7 @@
         "pcb_smtpad_279",
         "pcb_port_246"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -46213,7 +46213,7 @@
         "pcb_smtpad_280",
         "pcb_port_282"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -46253,7 +46253,7 @@
         "pcb_smtpad_281",
         "pcb_port_245"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -46271,7 +46271,7 @@
         "pcb_smtpad_282",
         "pcb_port_283"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -46311,7 +46311,7 @@
         "pcb_smtpad_283",
         "pcb_port_244"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -46329,7 +46329,7 @@
         "pcb_smtpad_284",
         "pcb_port_284"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -46347,7 +46347,7 @@
         "pcb_smtpad_285",
         "pcb_port_285"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -46365,7 +46365,7 @@
         "pcb_smtpad_286",
         "pcb_port_286"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -46383,7 +46383,7 @@
         "pcb_smtpad_287",
         "pcb_port_287"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -46401,7 +46401,7 @@
         "pcb_smtpad_288",
         "pcb_port_288"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -46419,7 +46419,7 @@
         "pcb_smtpad_289",
         "pcb_port_289"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -46437,7 +46437,7 @@
         "pcb_smtpad_290",
         "pcb_port_290"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -46455,7 +46455,7 @@
         "pcb_smtpad_291",
         "pcb_port_291"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -46473,7 +46473,7 @@
         "pcb_smtpad_292",
         "pcb_port_292"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -46485,7 +46485,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46497,7 +46497,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46509,7 +46509,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46521,7 +46521,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46533,7 +46533,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46545,7 +46545,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46557,7 +46557,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46569,7 +46569,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46581,7 +46581,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46593,7 +46593,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46605,7 +46605,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46617,7 +46617,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46629,7 +46629,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46641,7 +46641,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46653,7 +46653,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46665,7 +46665,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46677,7 +46677,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46689,7 +46689,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46701,7 +46701,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46713,7 +46713,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46725,7 +46725,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46737,7 +46737,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46749,7 +46749,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46761,7 +46761,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46773,7 +46773,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46785,7 +46785,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46797,7 +46797,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46809,7 +46809,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46821,7 +46821,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46833,7 +46833,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46845,7 +46845,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46857,7 +46857,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46869,7 +46869,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46881,7 +46881,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46893,7 +46893,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46905,7 +46905,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46917,7 +46917,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46929,7 +46929,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46941,7 +46941,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46953,7 +46953,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46965,7 +46965,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46977,7 +46977,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -46989,7 +46989,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47001,7 +47001,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47013,7 +47013,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47025,7 +47025,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47037,7 +47037,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47049,7 +47049,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47061,7 +47061,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47073,7 +47073,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47085,7 +47085,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47097,7 +47097,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47109,7 +47109,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47121,7 +47121,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47133,7 +47133,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47145,7 +47145,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47157,7 +47157,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47169,7 +47169,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47181,7 +47181,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47193,7 +47193,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47205,7 +47205,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47217,7 +47217,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47229,7 +47229,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47241,7 +47241,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47253,7 +47253,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47265,7 +47265,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47277,7 +47277,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47289,7 +47289,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47301,7 +47301,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47313,7 +47313,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47325,7 +47325,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47337,7 +47337,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47349,7 +47349,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47361,7 +47361,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47373,7 +47373,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47385,7 +47385,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47397,7 +47397,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47409,7 +47409,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47421,7 +47421,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47433,7 +47433,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47445,7 +47445,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47457,7 +47457,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47469,7 +47469,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47481,7 +47481,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47493,7 +47493,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47505,7 +47505,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47517,7 +47517,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47529,7 +47529,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47541,7 +47541,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47553,7 +47553,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47565,7 +47565,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47577,7 +47577,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47589,7 +47589,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47601,7 +47601,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47613,7 +47613,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47625,7 +47625,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47637,7 +47637,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47649,7 +47649,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47661,7 +47661,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47673,7 +47673,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47685,7 +47685,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47697,7 +47697,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47709,7 +47709,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47721,7 +47721,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47733,7 +47733,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47745,7 +47745,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47757,7 +47757,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47769,7 +47769,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47781,7 +47781,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47793,7 +47793,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47805,7 +47805,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47817,7 +47817,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47829,7 +47829,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47841,7 +47841,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47853,7 +47853,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47865,7 +47865,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47877,7 +47877,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47889,7 +47889,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47901,7 +47901,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47913,7 +47913,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47925,7 +47925,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47937,7 +47937,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47949,7 +47949,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47961,7 +47961,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47973,7 +47973,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47985,7 +47985,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -47997,7 +47997,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48009,7 +48009,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48021,7 +48021,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48033,7 +48033,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48045,7 +48045,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48057,7 +48057,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48069,7 +48069,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48081,7 +48081,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48093,7 +48093,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48105,7 +48105,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48117,7 +48117,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48129,7 +48129,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48141,7 +48141,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48153,7 +48153,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48165,7 +48165,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48177,7 +48177,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48189,7 +48189,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48201,7 +48201,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48213,7 +48213,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48225,7 +48225,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48237,7 +48237,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48249,7 +48249,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48261,7 +48261,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48273,7 +48273,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48285,7 +48285,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48297,7 +48297,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48309,7 +48309,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48321,7 +48321,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48333,7 +48333,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48345,7 +48345,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48357,7 +48357,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48369,7 +48369,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48381,7 +48381,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48393,7 +48393,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48405,7 +48405,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48417,7 +48417,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48429,7 +48429,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48441,7 +48441,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48453,7 +48453,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48465,7 +48465,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48477,7 +48477,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48489,7 +48489,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48501,7 +48501,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48513,7 +48513,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48525,7 +48525,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48537,7 +48537,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48549,7 +48549,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48561,7 +48561,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48573,7 +48573,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48585,7 +48585,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48597,7 +48597,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48609,7 +48609,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48621,7 +48621,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48633,7 +48633,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48645,7 +48645,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48657,7 +48657,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -48669,7 +48669,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     }
   ],
   "connMap": {

--- a/fixtures/legacy/assets/simplifiedpathsolver8.json
+++ b/fixtures/legacy/assets/simplifiedpathsolver8.json
@@ -25586,7 +25586,7 @@
         "pcb_smtpad_283",
         "pcb_port_244"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -25608,7 +25608,7 @@
         "pcb_smtpad_3",
         "pcb_port_3"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -25684,7 +25684,7 @@
         "pcb_smtpad_245",
         "pcb_port_263"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -25706,7 +25706,7 @@
         "pcb_smtpad_3",
         "pcb_port_3"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -25746,7 +25746,7 @@
         "pcb_smtpad_281",
         "pcb_port_245"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -25768,7 +25768,7 @@
         "pcb_smtpad_7",
         "pcb_port_7"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -25844,7 +25844,7 @@
         "pcb_smtpad_245",
         "pcb_port_263"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -25866,7 +25866,7 @@
         "pcb_smtpad_7",
         "pcb_port_7"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -25906,7 +25906,7 @@
         "pcb_smtpad_277",
         "pcb_port_247"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -25928,7 +25928,7 @@
         "pcb_smtpad_11",
         "pcb_port_11"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -26004,7 +26004,7 @@
         "pcb_smtpad_245",
         "pcb_port_263"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -26026,7 +26026,7 @@
         "pcb_smtpad_11",
         "pcb_port_11"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -26066,7 +26066,7 @@
         "pcb_smtpad_275",
         "pcb_port_248"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -26088,7 +26088,7 @@
         "pcb_smtpad_15",
         "pcb_port_15"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -26164,7 +26164,7 @@
         "pcb_smtpad_245",
         "pcb_port_263"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -26186,7 +26186,7 @@
         "pcb_smtpad_15",
         "pcb_port_15"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -26226,7 +26226,7 @@
         "pcb_smtpad_273",
         "pcb_port_249"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -26248,7 +26248,7 @@
         "pcb_smtpad_19",
         "pcb_port_19"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -26324,7 +26324,7 @@
         "pcb_smtpad_245",
         "pcb_port_263"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -26346,7 +26346,7 @@
         "pcb_smtpad_19",
         "pcb_port_19"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -26386,7 +26386,7 @@
         "pcb_smtpad_271",
         "pcb_port_250"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -26408,7 +26408,7 @@
         "pcb_smtpad_23",
         "pcb_port_23"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -26484,7 +26484,7 @@
         "pcb_smtpad_245",
         "pcb_port_263"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -26506,7 +26506,7 @@
         "pcb_smtpad_23",
         "pcb_port_23"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -26546,7 +26546,7 @@
         "pcb_smtpad_267",
         "pcb_port_252"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -26568,7 +26568,7 @@
         "pcb_smtpad_27",
         "pcb_port_27"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -26644,7 +26644,7 @@
         "pcb_smtpad_245",
         "pcb_port_263"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -26666,7 +26666,7 @@
         "pcb_smtpad_27",
         "pcb_port_27"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -26706,7 +26706,7 @@
         "pcb_smtpad_265",
         "pcb_port_253"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -26728,7 +26728,7 @@
         "pcb_smtpad_31",
         "pcb_port_31"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -26804,7 +26804,7 @@
         "pcb_smtpad_245",
         "pcb_port_263"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -26826,7 +26826,7 @@
         "pcb_smtpad_31",
         "pcb_port_31"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -26862,7 +26862,7 @@
         "pcb_smtpad_263",
         "pcb_port_254"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -26884,7 +26884,7 @@
         "pcb_smtpad_35",
         "pcb_port_35"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -26960,7 +26960,7 @@
         "pcb_smtpad_245",
         "pcb_port_263"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -26982,7 +26982,7 @@
         "pcb_smtpad_35",
         "pcb_port_35"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -27018,7 +27018,7 @@
         "pcb_smtpad_261",
         "pcb_port_255"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -27040,7 +27040,7 @@
         "pcb_smtpad_39",
         "pcb_port_39"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -27116,7 +27116,7 @@
         "pcb_smtpad_245",
         "pcb_port_263"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -27138,7 +27138,7 @@
         "pcb_smtpad_39",
         "pcb_port_39"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -27174,7 +27174,7 @@
         "pcb_smtpad_257",
         "pcb_port_257"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -27196,7 +27196,7 @@
         "pcb_smtpad_43",
         "pcb_port_43"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -27272,7 +27272,7 @@
         "pcb_smtpad_245",
         "pcb_port_263"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -27294,7 +27294,7 @@
         "pcb_smtpad_43",
         "pcb_port_43"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -27330,7 +27330,7 @@
         "pcb_smtpad_255",
         "pcb_port_258"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -27352,7 +27352,7 @@
         "pcb_smtpad_47",
         "pcb_port_47"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -27428,7 +27428,7 @@
         "pcb_smtpad_245",
         "pcb_port_263"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -27450,7 +27450,7 @@
         "pcb_smtpad_47",
         "pcb_port_47"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -27482,7 +27482,7 @@
         "pcb_smtpad_253",
         "pcb_port_259"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -27504,7 +27504,7 @@
         "pcb_smtpad_51",
         "pcb_port_51"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -27580,7 +27580,7 @@
         "pcb_smtpad_245",
         "pcb_port_263"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -27602,7 +27602,7 @@
         "pcb_smtpad_51",
         "pcb_port_51"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -27630,7 +27630,7 @@
         "pcb_smtpad_251",
         "pcb_port_260"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -27652,7 +27652,7 @@
         "pcb_smtpad_55",
         "pcb_port_55"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -27728,7 +27728,7 @@
         "pcb_smtpad_245",
         "pcb_port_263"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -27750,7 +27750,7 @@
         "pcb_smtpad_55",
         "pcb_port_55"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -27790,7 +27790,7 @@
         "pcb_smtpad_283",
         "pcb_port_244"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -27812,7 +27812,7 @@
         "pcb_smtpad_59",
         "pcb_port_59"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -27888,7 +27888,7 @@
         "pcb_smtpad_244",
         "pcb_port_264"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -27910,7 +27910,7 @@
         "pcb_smtpad_59",
         "pcb_port_59"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -27950,7 +27950,7 @@
         "pcb_smtpad_281",
         "pcb_port_245"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -27972,7 +27972,7 @@
         "pcb_smtpad_63",
         "pcb_port_63"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -28048,7 +28048,7 @@
         "pcb_smtpad_244",
         "pcb_port_264"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -28070,7 +28070,7 @@
         "pcb_smtpad_63",
         "pcb_port_63"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -28110,7 +28110,7 @@
         "pcb_smtpad_277",
         "pcb_port_247"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -28132,7 +28132,7 @@
         "pcb_smtpad_67",
         "pcb_port_67"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -28208,7 +28208,7 @@
         "pcb_smtpad_244",
         "pcb_port_264"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -28230,7 +28230,7 @@
         "pcb_smtpad_67",
         "pcb_port_67"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -28270,7 +28270,7 @@
         "pcb_smtpad_275",
         "pcb_port_248"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -28292,7 +28292,7 @@
         "pcb_smtpad_71",
         "pcb_port_71"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -28368,7 +28368,7 @@
         "pcb_smtpad_244",
         "pcb_port_264"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -28390,7 +28390,7 @@
         "pcb_smtpad_71",
         "pcb_port_71"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -28430,7 +28430,7 @@
         "pcb_smtpad_273",
         "pcb_port_249"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -28452,7 +28452,7 @@
         "pcb_smtpad_75",
         "pcb_port_75"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -28528,7 +28528,7 @@
         "pcb_smtpad_244",
         "pcb_port_264"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -28550,7 +28550,7 @@
         "pcb_smtpad_75",
         "pcb_port_75"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -28590,7 +28590,7 @@
         "pcb_smtpad_271",
         "pcb_port_250"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -28612,7 +28612,7 @@
         "pcb_smtpad_79",
         "pcb_port_79"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -28688,7 +28688,7 @@
         "pcb_smtpad_244",
         "pcb_port_264"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -28710,7 +28710,7 @@
         "pcb_smtpad_79",
         "pcb_port_79"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -28750,7 +28750,7 @@
         "pcb_smtpad_267",
         "pcb_port_252"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -28772,7 +28772,7 @@
         "pcb_smtpad_83",
         "pcb_port_83"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -28848,7 +28848,7 @@
         "pcb_smtpad_244",
         "pcb_port_264"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -28870,7 +28870,7 @@
         "pcb_smtpad_83",
         "pcb_port_83"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -28910,7 +28910,7 @@
         "pcb_smtpad_265",
         "pcb_port_253"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -28932,7 +28932,7 @@
         "pcb_smtpad_87",
         "pcb_port_87"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -29008,7 +29008,7 @@
         "pcb_smtpad_244",
         "pcb_port_264"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -29030,7 +29030,7 @@
         "pcb_smtpad_87",
         "pcb_port_87"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -29066,7 +29066,7 @@
         "pcb_smtpad_263",
         "pcb_port_254"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -29088,7 +29088,7 @@
         "pcb_smtpad_91",
         "pcb_port_91"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -29164,7 +29164,7 @@
         "pcb_smtpad_244",
         "pcb_port_264"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -29186,7 +29186,7 @@
         "pcb_smtpad_91",
         "pcb_port_91"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -29222,7 +29222,7 @@
         "pcb_smtpad_261",
         "pcb_port_255"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -29244,7 +29244,7 @@
         "pcb_smtpad_95",
         "pcb_port_95"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -29320,7 +29320,7 @@
         "pcb_smtpad_244",
         "pcb_port_264"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -29342,7 +29342,7 @@
         "pcb_smtpad_95",
         "pcb_port_95"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -29378,7 +29378,7 @@
         "pcb_smtpad_257",
         "pcb_port_257"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -29400,7 +29400,7 @@
         "pcb_smtpad_99",
         "pcb_port_99"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -29476,7 +29476,7 @@
         "pcb_smtpad_244",
         "pcb_port_264"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -29498,7 +29498,7 @@
         "pcb_smtpad_99",
         "pcb_port_99"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -29534,7 +29534,7 @@
         "pcb_smtpad_255",
         "pcb_port_258"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -29556,7 +29556,7 @@
         "pcb_smtpad_103",
         "pcb_port_103"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -29632,7 +29632,7 @@
         "pcb_smtpad_244",
         "pcb_port_264"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -29654,7 +29654,7 @@
         "pcb_smtpad_103",
         "pcb_port_103"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -29686,7 +29686,7 @@
         "pcb_smtpad_253",
         "pcb_port_259"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -29708,7 +29708,7 @@
         "pcb_smtpad_107",
         "pcb_port_107"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -29784,7 +29784,7 @@
         "pcb_smtpad_244",
         "pcb_port_264"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -29806,7 +29806,7 @@
         "pcb_smtpad_107",
         "pcb_port_107"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -29834,7 +29834,7 @@
         "pcb_smtpad_251",
         "pcb_port_260"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -29856,7 +29856,7 @@
         "pcb_smtpad_111",
         "pcb_port_111"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -29932,7 +29932,7 @@
         "pcb_smtpad_244",
         "pcb_port_264"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -29954,7 +29954,7 @@
         "pcb_smtpad_111",
         "pcb_port_111"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -29994,7 +29994,7 @@
         "pcb_smtpad_283",
         "pcb_port_244"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -30016,7 +30016,7 @@
         "pcb_smtpad_115",
         "pcb_port_115"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -30088,7 +30088,7 @@
         "pcb_smtpad_246",
         "pcb_port_265"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -30110,7 +30110,7 @@
         "pcb_smtpad_115",
         "pcb_port_115"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -30150,7 +30150,7 @@
         "pcb_smtpad_281",
         "pcb_port_245"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -30172,7 +30172,7 @@
         "pcb_smtpad_119",
         "pcb_port_119"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -30244,7 +30244,7 @@
         "pcb_smtpad_246",
         "pcb_port_265"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -30266,7 +30266,7 @@
         "pcb_smtpad_119",
         "pcb_port_119"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -30306,7 +30306,7 @@
         "pcb_smtpad_277",
         "pcb_port_247"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -30328,7 +30328,7 @@
         "pcb_smtpad_123",
         "pcb_port_123"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -30400,7 +30400,7 @@
         "pcb_smtpad_246",
         "pcb_port_265"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -30422,7 +30422,7 @@
         "pcb_smtpad_123",
         "pcb_port_123"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -30462,7 +30462,7 @@
         "pcb_smtpad_275",
         "pcb_port_248"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -30484,7 +30484,7 @@
         "pcb_smtpad_127",
         "pcb_port_127"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -30556,7 +30556,7 @@
         "pcb_smtpad_246",
         "pcb_port_265"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -30578,7 +30578,7 @@
         "pcb_smtpad_127",
         "pcb_port_127"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -30618,7 +30618,7 @@
         "pcb_smtpad_273",
         "pcb_port_249"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -30640,7 +30640,7 @@
         "pcb_smtpad_131",
         "pcb_port_131"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -30712,7 +30712,7 @@
         "pcb_smtpad_246",
         "pcb_port_265"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -30734,7 +30734,7 @@
         "pcb_smtpad_131",
         "pcb_port_131"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -30774,7 +30774,7 @@
         "pcb_smtpad_271",
         "pcb_port_250"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -30796,7 +30796,7 @@
         "pcb_smtpad_135",
         "pcb_port_135"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -30868,7 +30868,7 @@
         "pcb_smtpad_246",
         "pcb_port_265"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -30890,7 +30890,7 @@
         "pcb_smtpad_135",
         "pcb_port_135"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -30930,7 +30930,7 @@
         "pcb_smtpad_267",
         "pcb_port_252"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -30952,7 +30952,7 @@
         "pcb_smtpad_139",
         "pcb_port_139"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -31024,7 +31024,7 @@
         "pcb_smtpad_246",
         "pcb_port_265"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -31046,7 +31046,7 @@
         "pcb_smtpad_139",
         "pcb_port_139"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -31086,7 +31086,7 @@
         "pcb_smtpad_265",
         "pcb_port_253"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -31108,7 +31108,7 @@
         "pcb_smtpad_143",
         "pcb_port_143"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -31180,7 +31180,7 @@
         "pcb_smtpad_246",
         "pcb_port_265"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -31202,7 +31202,7 @@
         "pcb_smtpad_143",
         "pcb_port_143"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -31238,7 +31238,7 @@
         "pcb_smtpad_263",
         "pcb_port_254"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -31260,7 +31260,7 @@
         "pcb_smtpad_147",
         "pcb_port_147"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -31332,7 +31332,7 @@
         "pcb_smtpad_246",
         "pcb_port_265"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -31354,7 +31354,7 @@
         "pcb_smtpad_147",
         "pcb_port_147"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -31390,7 +31390,7 @@
         "pcb_smtpad_261",
         "pcb_port_255"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -31412,7 +31412,7 @@
         "pcb_smtpad_151",
         "pcb_port_151"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -31484,7 +31484,7 @@
         "pcb_smtpad_246",
         "pcb_port_265"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -31506,7 +31506,7 @@
         "pcb_smtpad_151",
         "pcb_port_151"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -31542,7 +31542,7 @@
         "pcb_smtpad_257",
         "pcb_port_257"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -31564,7 +31564,7 @@
         "pcb_smtpad_155",
         "pcb_port_155"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -31636,7 +31636,7 @@
         "pcb_smtpad_246",
         "pcb_port_265"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -31658,7 +31658,7 @@
         "pcb_smtpad_155",
         "pcb_port_155"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -31694,7 +31694,7 @@
         "pcb_smtpad_255",
         "pcb_port_258"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -31716,7 +31716,7 @@
         "pcb_smtpad_159",
         "pcb_port_159"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -31788,7 +31788,7 @@
         "pcb_smtpad_246",
         "pcb_port_265"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -31810,7 +31810,7 @@
         "pcb_smtpad_159",
         "pcb_port_159"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -31842,7 +31842,7 @@
         "pcb_smtpad_253",
         "pcb_port_259"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -31864,7 +31864,7 @@
         "pcb_smtpad_163",
         "pcb_port_163"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -31936,7 +31936,7 @@
         "pcb_smtpad_246",
         "pcb_port_265"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -31958,7 +31958,7 @@
         "pcb_smtpad_163",
         "pcb_port_163"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -31998,7 +31998,7 @@
         "pcb_smtpad_283",
         "pcb_port_244"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -32020,7 +32020,7 @@
         "pcb_smtpad_167",
         "pcb_port_167"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -32088,7 +32088,7 @@
         "pcb_smtpad_250",
         "pcb_port_267"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -32110,7 +32110,7 @@
         "pcb_smtpad_167",
         "pcb_port_167"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -32150,7 +32150,7 @@
         "pcb_smtpad_281",
         "pcb_port_245"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -32172,7 +32172,7 @@
         "pcb_smtpad_171",
         "pcb_port_171"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -32240,7 +32240,7 @@
         "pcb_smtpad_250",
         "pcb_port_267"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -32262,7 +32262,7 @@
         "pcb_smtpad_171",
         "pcb_port_171"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -32302,7 +32302,7 @@
         "pcb_smtpad_277",
         "pcb_port_247"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -32324,7 +32324,7 @@
         "pcb_smtpad_175",
         "pcb_port_175"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -32392,7 +32392,7 @@
         "pcb_smtpad_250",
         "pcb_port_267"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -32414,7 +32414,7 @@
         "pcb_smtpad_175",
         "pcb_port_175"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -32454,7 +32454,7 @@
         "pcb_smtpad_275",
         "pcb_port_248"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -32476,7 +32476,7 @@
         "pcb_smtpad_179",
         "pcb_port_179"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -32544,7 +32544,7 @@
         "pcb_smtpad_250",
         "pcb_port_267"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -32566,7 +32566,7 @@
         "pcb_smtpad_179",
         "pcb_port_179"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -32606,7 +32606,7 @@
         "pcb_smtpad_273",
         "pcb_port_249"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -32628,7 +32628,7 @@
         "pcb_smtpad_183",
         "pcb_port_183"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -32696,7 +32696,7 @@
         "pcb_smtpad_250",
         "pcb_port_267"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -32718,7 +32718,7 @@
         "pcb_smtpad_183",
         "pcb_port_183"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -32758,7 +32758,7 @@
         "pcb_smtpad_271",
         "pcb_port_250"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -32780,7 +32780,7 @@
         "pcb_smtpad_187",
         "pcb_port_187"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -32848,7 +32848,7 @@
         "pcb_smtpad_250",
         "pcb_port_267"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -32870,7 +32870,7 @@
         "pcb_smtpad_187",
         "pcb_port_187"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -32910,7 +32910,7 @@
         "pcb_smtpad_267",
         "pcb_port_252"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -32932,7 +32932,7 @@
         "pcb_smtpad_191",
         "pcb_port_191"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -33000,7 +33000,7 @@
         "pcb_smtpad_250",
         "pcb_port_267"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -33022,7 +33022,7 @@
         "pcb_smtpad_191",
         "pcb_port_191"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -33062,7 +33062,7 @@
         "pcb_smtpad_265",
         "pcb_port_253"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -33084,7 +33084,7 @@
         "pcb_smtpad_195",
         "pcb_port_195"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -33152,7 +33152,7 @@
         "pcb_smtpad_250",
         "pcb_port_267"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -33174,7 +33174,7 @@
         "pcb_smtpad_195",
         "pcb_port_195"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -33210,7 +33210,7 @@
         "pcb_smtpad_263",
         "pcb_port_254"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -33232,7 +33232,7 @@
         "pcb_smtpad_199",
         "pcb_port_199"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -33300,7 +33300,7 @@
         "pcb_smtpad_250",
         "pcb_port_267"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -33322,7 +33322,7 @@
         "pcb_smtpad_199",
         "pcb_port_199"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -33358,7 +33358,7 @@
         "pcb_smtpad_261",
         "pcb_port_255"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -33380,7 +33380,7 @@
         "pcb_smtpad_203",
         "pcb_port_203"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -33448,7 +33448,7 @@
         "pcb_smtpad_250",
         "pcb_port_267"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -33470,7 +33470,7 @@
         "pcb_smtpad_203",
         "pcb_port_203"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -33506,7 +33506,7 @@
         "pcb_smtpad_257",
         "pcb_port_257"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -33528,7 +33528,7 @@
         "pcb_smtpad_207",
         "pcb_port_207"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -33596,7 +33596,7 @@
         "pcb_smtpad_250",
         "pcb_port_267"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -33618,7 +33618,7 @@
         "pcb_smtpad_207",
         "pcb_port_207"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -33654,7 +33654,7 @@
         "pcb_smtpad_255",
         "pcb_port_258"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -33676,7 +33676,7 @@
         "pcb_smtpad_211",
         "pcb_port_211"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -33744,7 +33744,7 @@
         "pcb_smtpad_250",
         "pcb_port_267"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -33766,7 +33766,7 @@
         "pcb_smtpad_211",
         "pcb_port_211"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -33806,7 +33806,7 @@
         "pcb_smtpad_283",
         "pcb_port_244"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -33828,7 +33828,7 @@
         "pcb_smtpad_215",
         "pcb_port_215"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -33880,7 +33880,7 @@
         "pcb_smtpad_252",
         "pcb_port_268"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -33902,7 +33902,7 @@
         "pcb_smtpad_215",
         "pcb_port_215"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -33942,7 +33942,7 @@
         "pcb_smtpad_281",
         "pcb_port_245"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -33964,7 +33964,7 @@
         "pcb_smtpad_219",
         "pcb_port_219"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -34016,7 +34016,7 @@
         "pcb_smtpad_252",
         "pcb_port_268"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -34038,7 +34038,7 @@
         "pcb_smtpad_219",
         "pcb_port_219"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -34078,7 +34078,7 @@
         "pcb_smtpad_277",
         "pcb_port_247"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -34100,7 +34100,7 @@
         "pcb_smtpad_223",
         "pcb_port_223"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -34152,7 +34152,7 @@
         "pcb_smtpad_252",
         "pcb_port_268"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -34174,7 +34174,7 @@
         "pcb_smtpad_223",
         "pcb_port_223"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -34214,7 +34214,7 @@
         "pcb_smtpad_275",
         "pcb_port_248"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -34236,7 +34236,7 @@
         "pcb_smtpad_227",
         "pcb_port_227"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -34288,7 +34288,7 @@
         "pcb_smtpad_252",
         "pcb_port_268"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -34310,7 +34310,7 @@
         "pcb_smtpad_227",
         "pcb_port_227"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -34350,7 +34350,7 @@
         "pcb_smtpad_273",
         "pcb_port_249"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -34372,7 +34372,7 @@
         "pcb_smtpad_231",
         "pcb_port_231"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -34424,7 +34424,7 @@
         "pcb_smtpad_252",
         "pcb_port_268"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -34446,7 +34446,7 @@
         "pcb_smtpad_231",
         "pcb_port_231"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -34486,7 +34486,7 @@
         "pcb_smtpad_271",
         "pcb_port_250"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -34508,7 +34508,7 @@
         "pcb_smtpad_235",
         "pcb_port_235"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -34560,7 +34560,7 @@
         "pcb_smtpad_252",
         "pcb_port_268"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -34582,7 +34582,7 @@
         "pcb_smtpad_235",
         "pcb_port_235"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -34622,7 +34622,7 @@
         "pcb_smtpad_267",
         "pcb_port_252"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -34644,7 +34644,7 @@
         "pcb_smtpad_239",
         "pcb_port_239"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -34696,7 +34696,7 @@
         "pcb_smtpad_252",
         "pcb_port_268"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -34718,7 +34718,7 @@
         "pcb_smtpad_239",
         "pcb_port_239"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -34758,7 +34758,7 @@
         "pcb_smtpad_265",
         "pcb_port_253"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -34780,7 +34780,7 @@
         "pcb_smtpad_243",
         "pcb_port_243"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -34832,7 +34832,7 @@
         "pcb_smtpad_252",
         "pcb_port_268"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -34854,7 +34854,7 @@
         "pcb_smtpad_243",
         "pcb_port_243"
       ],
-      "zLayers": [1]
+      "__zLayers": [1]
     },
     {
       "type": "rect",
@@ -34930,7 +34930,7 @@
         "pcb_smtpad_244",
         "pcb_port_264"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35006,7 +35006,7 @@
         "pcb_smtpad_245",
         "pcb_port_263"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35078,7 +35078,7 @@
         "pcb_smtpad_246",
         "pcb_port_265"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35098,7 +35098,7 @@
         "pcb_smtpad_247",
         "pcb_port_262"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35116,7 +35116,7 @@
         "pcb_smtpad_248",
         "pcb_port_266"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35134,7 +35134,7 @@
         "pcb_smtpad_249",
         "pcb_port_261"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35202,7 +35202,7 @@
         "pcb_smtpad_250",
         "pcb_port_267"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35230,7 +35230,7 @@
         "pcb_smtpad_251",
         "pcb_port_260"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35282,7 +35282,7 @@
         "pcb_smtpad_252",
         "pcb_port_268"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35314,7 +35314,7 @@
         "pcb_smtpad_253",
         "pcb_port_259"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35332,7 +35332,7 @@
         "pcb_smtpad_254",
         "pcb_port_269"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35368,7 +35368,7 @@
         "pcb_smtpad_255",
         "pcb_port_258"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35386,7 +35386,7 @@
         "pcb_smtpad_256",
         "pcb_port_270"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35422,7 +35422,7 @@
         "pcb_smtpad_257",
         "pcb_port_257"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35440,7 +35440,7 @@
         "pcb_smtpad_258",
         "pcb_port_271"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35458,7 +35458,7 @@
         "pcb_smtpad_259",
         "pcb_port_256"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35476,7 +35476,7 @@
         "pcb_smtpad_260",
         "pcb_port_272"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35512,7 +35512,7 @@
         "pcb_smtpad_261",
         "pcb_port_255"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35530,7 +35530,7 @@
         "pcb_smtpad_262",
         "pcb_port_273"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35566,7 +35566,7 @@
         "pcb_smtpad_263",
         "pcb_port_254"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35584,7 +35584,7 @@
         "pcb_smtpad_264",
         "pcb_port_274"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35624,7 +35624,7 @@
         "pcb_smtpad_265",
         "pcb_port_253"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35642,7 +35642,7 @@
         "pcb_smtpad_266",
         "pcb_port_275"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35682,7 +35682,7 @@
         "pcb_smtpad_267",
         "pcb_port_252"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35700,7 +35700,7 @@
         "pcb_smtpad_268",
         "pcb_port_276"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35718,7 +35718,7 @@
         "pcb_smtpad_269",
         "pcb_port_251"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35736,7 +35736,7 @@
         "pcb_smtpad_270",
         "pcb_port_277"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35776,7 +35776,7 @@
         "pcb_smtpad_271",
         "pcb_port_250"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35794,7 +35794,7 @@
         "pcb_smtpad_272",
         "pcb_port_278"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35834,7 +35834,7 @@
         "pcb_smtpad_273",
         "pcb_port_249"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35852,7 +35852,7 @@
         "pcb_smtpad_274",
         "pcb_port_279"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35892,7 +35892,7 @@
         "pcb_smtpad_275",
         "pcb_port_248"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35910,7 +35910,7 @@
         "pcb_smtpad_276",
         "pcb_port_280"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35950,7 +35950,7 @@
         "pcb_smtpad_277",
         "pcb_port_247"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35968,7 +35968,7 @@
         "pcb_smtpad_278",
         "pcb_port_281"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -35986,7 +35986,7 @@
         "pcb_smtpad_279",
         "pcb_port_246"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -36004,7 +36004,7 @@
         "pcb_smtpad_280",
         "pcb_port_282"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -36044,7 +36044,7 @@
         "pcb_smtpad_281",
         "pcb_port_245"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -36062,7 +36062,7 @@
         "pcb_smtpad_282",
         "pcb_port_283"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -36102,7 +36102,7 @@
         "pcb_smtpad_283",
         "pcb_port_244"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -36120,7 +36120,7 @@
         "pcb_smtpad_284",
         "pcb_port_284"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -36138,7 +36138,7 @@
         "pcb_smtpad_285",
         "pcb_port_285"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -36156,7 +36156,7 @@
         "pcb_smtpad_286",
         "pcb_port_286"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -36174,7 +36174,7 @@
         "pcb_smtpad_287",
         "pcb_port_287"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -36192,7 +36192,7 @@
         "pcb_smtpad_288",
         "pcb_port_288"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -36210,7 +36210,7 @@
         "pcb_smtpad_289",
         "pcb_port_289"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -36228,7 +36228,7 @@
         "pcb_smtpad_290",
         "pcb_port_290"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -36246,7 +36246,7 @@
         "pcb_smtpad_291",
         "pcb_port_291"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -36264,7 +36264,7 @@
         "pcb_smtpad_292",
         "pcb_port_292"
       ],
-      "zLayers": [0]
+      "__zLayers": [0]
     },
     {
       "type": "rect",
@@ -36276,7 +36276,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36288,7 +36288,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36300,7 +36300,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36312,7 +36312,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36324,7 +36324,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36336,7 +36336,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36348,7 +36348,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36360,7 +36360,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36372,7 +36372,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36384,7 +36384,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36396,7 +36396,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36408,7 +36408,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36420,7 +36420,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36432,7 +36432,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36444,7 +36444,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36456,7 +36456,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36468,7 +36468,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36480,7 +36480,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36492,7 +36492,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36504,7 +36504,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36516,7 +36516,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36528,7 +36528,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36540,7 +36540,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36552,7 +36552,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36564,7 +36564,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36576,7 +36576,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36588,7 +36588,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36600,7 +36600,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36612,7 +36612,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36624,7 +36624,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36636,7 +36636,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36648,7 +36648,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36660,7 +36660,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36672,7 +36672,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36684,7 +36684,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36696,7 +36696,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36708,7 +36708,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36720,7 +36720,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36732,7 +36732,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36744,7 +36744,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36756,7 +36756,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36768,7 +36768,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36780,7 +36780,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36792,7 +36792,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36804,7 +36804,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36816,7 +36816,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36828,7 +36828,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36840,7 +36840,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36852,7 +36852,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36864,7 +36864,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36876,7 +36876,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36888,7 +36888,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36900,7 +36900,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36912,7 +36912,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36924,7 +36924,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36936,7 +36936,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36948,7 +36948,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36960,7 +36960,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36972,7 +36972,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36984,7 +36984,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -36996,7 +36996,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37008,7 +37008,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37020,7 +37020,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37032,7 +37032,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37044,7 +37044,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37056,7 +37056,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37068,7 +37068,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37080,7 +37080,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37092,7 +37092,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37104,7 +37104,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37116,7 +37116,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37128,7 +37128,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37140,7 +37140,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37152,7 +37152,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37164,7 +37164,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37176,7 +37176,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37188,7 +37188,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37200,7 +37200,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37212,7 +37212,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37224,7 +37224,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37236,7 +37236,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37248,7 +37248,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37260,7 +37260,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37272,7 +37272,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37284,7 +37284,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37296,7 +37296,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37308,7 +37308,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37320,7 +37320,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37332,7 +37332,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37344,7 +37344,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37356,7 +37356,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37368,7 +37368,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37380,7 +37380,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37392,7 +37392,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37404,7 +37404,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37416,7 +37416,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37428,7 +37428,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37440,7 +37440,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37452,7 +37452,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37464,7 +37464,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37476,7 +37476,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37488,7 +37488,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37500,7 +37500,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37512,7 +37512,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37524,7 +37524,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37536,7 +37536,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37548,7 +37548,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37560,7 +37560,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37572,7 +37572,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37584,7 +37584,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37596,7 +37596,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37608,7 +37608,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37620,7 +37620,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37632,7 +37632,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37644,7 +37644,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37656,7 +37656,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37668,7 +37668,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37680,7 +37680,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37692,7 +37692,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37704,7 +37704,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37716,7 +37716,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37728,7 +37728,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37740,7 +37740,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37752,7 +37752,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37764,7 +37764,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37776,7 +37776,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37788,7 +37788,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37800,7 +37800,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37812,7 +37812,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37824,7 +37824,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37836,7 +37836,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37848,7 +37848,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37860,7 +37860,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37872,7 +37872,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37884,7 +37884,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37896,7 +37896,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37908,7 +37908,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37920,7 +37920,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37932,7 +37932,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37944,7 +37944,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37956,7 +37956,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37968,7 +37968,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37980,7 +37980,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -37992,7 +37992,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38004,7 +38004,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38016,7 +38016,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38028,7 +38028,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38040,7 +38040,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38052,7 +38052,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38064,7 +38064,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38076,7 +38076,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38088,7 +38088,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38100,7 +38100,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38112,7 +38112,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38124,7 +38124,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38136,7 +38136,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38148,7 +38148,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38160,7 +38160,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38172,7 +38172,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38184,7 +38184,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38196,7 +38196,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38208,7 +38208,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38220,7 +38220,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38232,7 +38232,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38244,7 +38244,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38256,7 +38256,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38268,7 +38268,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38280,7 +38280,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38292,7 +38292,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38304,7 +38304,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38316,7 +38316,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38328,7 +38328,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38340,7 +38340,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38352,7 +38352,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38364,7 +38364,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38376,7 +38376,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38388,7 +38388,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38400,7 +38400,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38412,7 +38412,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38424,7 +38424,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38436,7 +38436,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38448,7 +38448,7 @@
       "width": 2.9999939999999996,
       "height": 2.9999939999999996,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     },
     {
       "type": "rect",
@@ -38460,7 +38460,7 @@
       "width": 4.1999916,
       "height": 4.1999916,
       "connectedTo": [],
-      "zLayers": [0, 1, 2, 1]
+      "__zLayers": [0, 1, 2, 1]
     }
   ],
   "connMap": {

--- a/fixtures/legacy/assets/simplifiedpathsolver9.json
+++ b/fixtures/legacy/assets/simplifiedpathsolver9.json
@@ -76673,7 +76673,7 @@
           "pcb_smtpad_283",
           "pcb_port_244"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -76699,7 +76699,7 @@
           "pcb_smtpad_3",
           "pcb_port_3"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -76779,7 +76779,7 @@
           "pcb_smtpad_245",
           "pcb_port_263"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -76805,7 +76805,7 @@
           "pcb_smtpad_3",
           "pcb_port_3"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -76849,7 +76849,7 @@
           "pcb_smtpad_281",
           "pcb_port_245"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -76875,7 +76875,7 @@
           "pcb_smtpad_7",
           "pcb_port_7"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -76955,7 +76955,7 @@
           "pcb_smtpad_245",
           "pcb_port_263"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -76981,7 +76981,7 @@
           "pcb_smtpad_7",
           "pcb_port_7"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -77025,7 +77025,7 @@
           "pcb_smtpad_277",
           "pcb_port_247"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -77051,7 +77051,7 @@
           "pcb_smtpad_11",
           "pcb_port_11"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -77131,7 +77131,7 @@
           "pcb_smtpad_245",
           "pcb_port_263"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -77157,7 +77157,7 @@
           "pcb_smtpad_11",
           "pcb_port_11"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -77201,7 +77201,7 @@
           "pcb_smtpad_275",
           "pcb_port_248"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -77227,7 +77227,7 @@
           "pcb_smtpad_15",
           "pcb_port_15"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -77307,7 +77307,7 @@
           "pcb_smtpad_245",
           "pcb_port_263"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -77333,7 +77333,7 @@
           "pcb_smtpad_15",
           "pcb_port_15"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -77377,7 +77377,7 @@
           "pcb_smtpad_273",
           "pcb_port_249"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -77403,7 +77403,7 @@
           "pcb_smtpad_19",
           "pcb_port_19"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -77483,7 +77483,7 @@
           "pcb_smtpad_245",
           "pcb_port_263"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -77509,7 +77509,7 @@
           "pcb_smtpad_19",
           "pcb_port_19"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -77553,7 +77553,7 @@
           "pcb_smtpad_271",
           "pcb_port_250"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -77579,7 +77579,7 @@
           "pcb_smtpad_23",
           "pcb_port_23"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -77659,7 +77659,7 @@
           "pcb_smtpad_245",
           "pcb_port_263"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -77685,7 +77685,7 @@
           "pcb_smtpad_23",
           "pcb_port_23"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -77729,7 +77729,7 @@
           "pcb_smtpad_267",
           "pcb_port_252"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -77755,7 +77755,7 @@
           "pcb_smtpad_27",
           "pcb_port_27"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -77835,7 +77835,7 @@
           "pcb_smtpad_245",
           "pcb_port_263"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -77861,7 +77861,7 @@
           "pcb_smtpad_27",
           "pcb_port_27"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -77905,7 +77905,7 @@
           "pcb_smtpad_265",
           "pcb_port_253"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -77931,7 +77931,7 @@
           "pcb_smtpad_31",
           "pcb_port_31"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -78011,7 +78011,7 @@
           "pcb_smtpad_245",
           "pcb_port_263"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -78037,7 +78037,7 @@
           "pcb_smtpad_31",
           "pcb_port_31"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -78077,7 +78077,7 @@
           "pcb_smtpad_263",
           "pcb_port_254"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -78103,7 +78103,7 @@
           "pcb_smtpad_35",
           "pcb_port_35"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -78183,7 +78183,7 @@
           "pcb_smtpad_245",
           "pcb_port_263"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -78209,7 +78209,7 @@
           "pcb_smtpad_35",
           "pcb_port_35"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -78249,7 +78249,7 @@
           "pcb_smtpad_261",
           "pcb_port_255"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -78275,7 +78275,7 @@
           "pcb_smtpad_39",
           "pcb_port_39"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -78355,7 +78355,7 @@
           "pcb_smtpad_245",
           "pcb_port_263"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -78381,7 +78381,7 @@
           "pcb_smtpad_39",
           "pcb_port_39"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -78421,7 +78421,7 @@
           "pcb_smtpad_257",
           "pcb_port_257"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -78447,7 +78447,7 @@
           "pcb_smtpad_43",
           "pcb_port_43"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -78527,7 +78527,7 @@
           "pcb_smtpad_245",
           "pcb_port_263"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -78553,7 +78553,7 @@
           "pcb_smtpad_43",
           "pcb_port_43"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -78593,7 +78593,7 @@
           "pcb_smtpad_255",
           "pcb_port_258"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -78619,7 +78619,7 @@
           "pcb_smtpad_47",
           "pcb_port_47"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -78699,7 +78699,7 @@
           "pcb_smtpad_245",
           "pcb_port_263"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -78725,7 +78725,7 @@
           "pcb_smtpad_47",
           "pcb_port_47"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -78761,7 +78761,7 @@
           "pcb_smtpad_253",
           "pcb_port_259"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -78787,7 +78787,7 @@
           "pcb_smtpad_51",
           "pcb_port_51"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -78867,7 +78867,7 @@
           "pcb_smtpad_245",
           "pcb_port_263"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -78893,7 +78893,7 @@
           "pcb_smtpad_51",
           "pcb_port_51"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -78925,7 +78925,7 @@
           "pcb_smtpad_251",
           "pcb_port_260"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -78951,7 +78951,7 @@
           "pcb_smtpad_55",
           "pcb_port_55"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -79031,7 +79031,7 @@
           "pcb_smtpad_245",
           "pcb_port_263"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -79057,7 +79057,7 @@
           "pcb_smtpad_55",
           "pcb_port_55"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -79101,7 +79101,7 @@
           "pcb_smtpad_283",
           "pcb_port_244"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -79127,7 +79127,7 @@
           "pcb_smtpad_59",
           "pcb_port_59"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -79207,7 +79207,7 @@
           "pcb_smtpad_244",
           "pcb_port_264"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -79233,7 +79233,7 @@
           "pcb_smtpad_59",
           "pcb_port_59"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -79277,7 +79277,7 @@
           "pcb_smtpad_281",
           "pcb_port_245"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -79303,7 +79303,7 @@
           "pcb_smtpad_63",
           "pcb_port_63"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -79383,7 +79383,7 @@
           "pcb_smtpad_244",
           "pcb_port_264"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -79409,7 +79409,7 @@
           "pcb_smtpad_63",
           "pcb_port_63"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -79453,7 +79453,7 @@
           "pcb_smtpad_277",
           "pcb_port_247"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -79479,7 +79479,7 @@
           "pcb_smtpad_67",
           "pcb_port_67"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -79559,7 +79559,7 @@
           "pcb_smtpad_244",
           "pcb_port_264"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -79585,7 +79585,7 @@
           "pcb_smtpad_67",
           "pcb_port_67"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -79629,7 +79629,7 @@
           "pcb_smtpad_275",
           "pcb_port_248"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -79655,7 +79655,7 @@
           "pcb_smtpad_71",
           "pcb_port_71"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -79735,7 +79735,7 @@
           "pcb_smtpad_244",
           "pcb_port_264"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -79761,7 +79761,7 @@
           "pcb_smtpad_71",
           "pcb_port_71"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -79805,7 +79805,7 @@
           "pcb_smtpad_273",
           "pcb_port_249"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -79831,7 +79831,7 @@
           "pcb_smtpad_75",
           "pcb_port_75"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -79911,7 +79911,7 @@
           "pcb_smtpad_244",
           "pcb_port_264"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -79937,7 +79937,7 @@
           "pcb_smtpad_75",
           "pcb_port_75"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -79981,7 +79981,7 @@
           "pcb_smtpad_271",
           "pcb_port_250"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -80007,7 +80007,7 @@
           "pcb_smtpad_79",
           "pcb_port_79"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -80087,7 +80087,7 @@
           "pcb_smtpad_244",
           "pcb_port_264"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -80113,7 +80113,7 @@
           "pcb_smtpad_79",
           "pcb_port_79"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -80157,7 +80157,7 @@
           "pcb_smtpad_267",
           "pcb_port_252"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -80183,7 +80183,7 @@
           "pcb_smtpad_83",
           "pcb_port_83"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -80263,7 +80263,7 @@
           "pcb_smtpad_244",
           "pcb_port_264"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -80289,7 +80289,7 @@
           "pcb_smtpad_83",
           "pcb_port_83"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -80333,7 +80333,7 @@
           "pcb_smtpad_265",
           "pcb_port_253"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -80359,7 +80359,7 @@
           "pcb_smtpad_87",
           "pcb_port_87"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -80439,7 +80439,7 @@
           "pcb_smtpad_244",
           "pcb_port_264"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -80465,7 +80465,7 @@
           "pcb_smtpad_87",
           "pcb_port_87"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -80505,7 +80505,7 @@
           "pcb_smtpad_263",
           "pcb_port_254"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -80531,7 +80531,7 @@
           "pcb_smtpad_91",
           "pcb_port_91"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -80611,7 +80611,7 @@
           "pcb_smtpad_244",
           "pcb_port_264"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -80637,7 +80637,7 @@
           "pcb_smtpad_91",
           "pcb_port_91"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -80677,7 +80677,7 @@
           "pcb_smtpad_261",
           "pcb_port_255"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -80703,7 +80703,7 @@
           "pcb_smtpad_95",
           "pcb_port_95"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -80783,7 +80783,7 @@
           "pcb_smtpad_244",
           "pcb_port_264"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -80809,7 +80809,7 @@
           "pcb_smtpad_95",
           "pcb_port_95"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -80849,7 +80849,7 @@
           "pcb_smtpad_257",
           "pcb_port_257"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -80875,7 +80875,7 @@
           "pcb_smtpad_99",
           "pcb_port_99"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -80955,7 +80955,7 @@
           "pcb_smtpad_244",
           "pcb_port_264"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -80981,7 +80981,7 @@
           "pcb_smtpad_99",
           "pcb_port_99"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -81021,7 +81021,7 @@
           "pcb_smtpad_255",
           "pcb_port_258"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -81047,7 +81047,7 @@
           "pcb_smtpad_103",
           "pcb_port_103"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -81127,7 +81127,7 @@
           "pcb_smtpad_244",
           "pcb_port_264"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -81153,7 +81153,7 @@
           "pcb_smtpad_103",
           "pcb_port_103"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -81189,7 +81189,7 @@
           "pcb_smtpad_253",
           "pcb_port_259"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -81215,7 +81215,7 @@
           "pcb_smtpad_107",
           "pcb_port_107"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -81295,7 +81295,7 @@
           "pcb_smtpad_244",
           "pcb_port_264"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -81321,7 +81321,7 @@
           "pcb_smtpad_107",
           "pcb_port_107"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -81353,7 +81353,7 @@
           "pcb_smtpad_251",
           "pcb_port_260"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -81379,7 +81379,7 @@
           "pcb_smtpad_111",
           "pcb_port_111"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -81459,7 +81459,7 @@
           "pcb_smtpad_244",
           "pcb_port_264"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -81485,7 +81485,7 @@
           "pcb_smtpad_111",
           "pcb_port_111"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -81529,7 +81529,7 @@
           "pcb_smtpad_283",
           "pcb_port_244"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -81555,7 +81555,7 @@
           "pcb_smtpad_115",
           "pcb_port_115"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -81631,7 +81631,7 @@
           "pcb_smtpad_246",
           "pcb_port_265"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -81657,7 +81657,7 @@
           "pcb_smtpad_115",
           "pcb_port_115"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -81701,7 +81701,7 @@
           "pcb_smtpad_281",
           "pcb_port_245"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -81727,7 +81727,7 @@
           "pcb_smtpad_119",
           "pcb_port_119"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -81803,7 +81803,7 @@
           "pcb_smtpad_246",
           "pcb_port_265"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -81829,7 +81829,7 @@
           "pcb_smtpad_119",
           "pcb_port_119"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -81873,7 +81873,7 @@
           "pcb_smtpad_277",
           "pcb_port_247"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -81899,7 +81899,7 @@
           "pcb_smtpad_123",
           "pcb_port_123"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -81975,7 +81975,7 @@
           "pcb_smtpad_246",
           "pcb_port_265"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -82001,7 +82001,7 @@
           "pcb_smtpad_123",
           "pcb_port_123"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -82045,7 +82045,7 @@
           "pcb_smtpad_275",
           "pcb_port_248"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -82071,7 +82071,7 @@
           "pcb_smtpad_127",
           "pcb_port_127"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -82147,7 +82147,7 @@
           "pcb_smtpad_246",
           "pcb_port_265"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -82173,7 +82173,7 @@
           "pcb_smtpad_127",
           "pcb_port_127"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -82217,7 +82217,7 @@
           "pcb_smtpad_273",
           "pcb_port_249"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -82243,7 +82243,7 @@
           "pcb_smtpad_131",
           "pcb_port_131"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -82319,7 +82319,7 @@
           "pcb_smtpad_246",
           "pcb_port_265"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -82345,7 +82345,7 @@
           "pcb_smtpad_131",
           "pcb_port_131"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -82389,7 +82389,7 @@
           "pcb_smtpad_271",
           "pcb_port_250"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -82415,7 +82415,7 @@
           "pcb_smtpad_135",
           "pcb_port_135"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -82491,7 +82491,7 @@
           "pcb_smtpad_246",
           "pcb_port_265"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -82517,7 +82517,7 @@
           "pcb_smtpad_135",
           "pcb_port_135"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -82561,7 +82561,7 @@
           "pcb_smtpad_267",
           "pcb_port_252"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -82587,7 +82587,7 @@
           "pcb_smtpad_139",
           "pcb_port_139"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -82663,7 +82663,7 @@
           "pcb_smtpad_246",
           "pcb_port_265"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -82689,7 +82689,7 @@
           "pcb_smtpad_139",
           "pcb_port_139"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -82733,7 +82733,7 @@
           "pcb_smtpad_265",
           "pcb_port_253"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -82759,7 +82759,7 @@
           "pcb_smtpad_143",
           "pcb_port_143"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -82835,7 +82835,7 @@
           "pcb_smtpad_246",
           "pcb_port_265"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -82861,7 +82861,7 @@
           "pcb_smtpad_143",
           "pcb_port_143"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -82901,7 +82901,7 @@
           "pcb_smtpad_263",
           "pcb_port_254"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -82927,7 +82927,7 @@
           "pcb_smtpad_147",
           "pcb_port_147"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -83003,7 +83003,7 @@
           "pcb_smtpad_246",
           "pcb_port_265"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -83029,7 +83029,7 @@
           "pcb_smtpad_147",
           "pcb_port_147"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -83069,7 +83069,7 @@
           "pcb_smtpad_261",
           "pcb_port_255"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -83095,7 +83095,7 @@
           "pcb_smtpad_151",
           "pcb_port_151"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -83171,7 +83171,7 @@
           "pcb_smtpad_246",
           "pcb_port_265"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -83197,7 +83197,7 @@
           "pcb_smtpad_151",
           "pcb_port_151"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -83237,7 +83237,7 @@
           "pcb_smtpad_257",
           "pcb_port_257"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -83263,7 +83263,7 @@
           "pcb_smtpad_155",
           "pcb_port_155"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -83339,7 +83339,7 @@
           "pcb_smtpad_246",
           "pcb_port_265"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -83365,7 +83365,7 @@
           "pcb_smtpad_155",
           "pcb_port_155"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -83405,7 +83405,7 @@
           "pcb_smtpad_255",
           "pcb_port_258"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -83431,7 +83431,7 @@
           "pcb_smtpad_159",
           "pcb_port_159"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -83507,7 +83507,7 @@
           "pcb_smtpad_246",
           "pcb_port_265"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -83533,7 +83533,7 @@
           "pcb_smtpad_159",
           "pcb_port_159"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -83569,7 +83569,7 @@
           "pcb_smtpad_253",
           "pcb_port_259"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -83595,7 +83595,7 @@
           "pcb_smtpad_163",
           "pcb_port_163"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -83671,7 +83671,7 @@
           "pcb_smtpad_246",
           "pcb_port_265"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -83697,7 +83697,7 @@
           "pcb_smtpad_163",
           "pcb_port_163"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -83741,7 +83741,7 @@
           "pcb_smtpad_283",
           "pcb_port_244"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -83767,7 +83767,7 @@
           "pcb_smtpad_167",
           "pcb_port_167"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -83839,7 +83839,7 @@
           "pcb_smtpad_250",
           "pcb_port_267"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -83865,7 +83865,7 @@
           "pcb_smtpad_167",
           "pcb_port_167"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -83909,7 +83909,7 @@
           "pcb_smtpad_281",
           "pcb_port_245"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -83935,7 +83935,7 @@
           "pcb_smtpad_171",
           "pcb_port_171"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -84007,7 +84007,7 @@
           "pcb_smtpad_250",
           "pcb_port_267"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -84033,7 +84033,7 @@
           "pcb_smtpad_171",
           "pcb_port_171"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -84077,7 +84077,7 @@
           "pcb_smtpad_277",
           "pcb_port_247"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -84103,7 +84103,7 @@
           "pcb_smtpad_175",
           "pcb_port_175"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -84175,7 +84175,7 @@
           "pcb_smtpad_250",
           "pcb_port_267"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -84201,7 +84201,7 @@
           "pcb_smtpad_175",
           "pcb_port_175"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -84245,7 +84245,7 @@
           "pcb_smtpad_275",
           "pcb_port_248"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -84271,7 +84271,7 @@
           "pcb_smtpad_179",
           "pcb_port_179"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -84343,7 +84343,7 @@
           "pcb_smtpad_250",
           "pcb_port_267"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -84369,7 +84369,7 @@
           "pcb_smtpad_179",
           "pcb_port_179"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -84413,7 +84413,7 @@
           "pcb_smtpad_273",
           "pcb_port_249"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -84439,7 +84439,7 @@
           "pcb_smtpad_183",
           "pcb_port_183"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -84511,7 +84511,7 @@
           "pcb_smtpad_250",
           "pcb_port_267"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -84537,7 +84537,7 @@
           "pcb_smtpad_183",
           "pcb_port_183"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -84581,7 +84581,7 @@
           "pcb_smtpad_271",
           "pcb_port_250"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -84607,7 +84607,7 @@
           "pcb_smtpad_187",
           "pcb_port_187"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -84679,7 +84679,7 @@
           "pcb_smtpad_250",
           "pcb_port_267"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -84705,7 +84705,7 @@
           "pcb_smtpad_187",
           "pcb_port_187"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -84749,7 +84749,7 @@
           "pcb_smtpad_267",
           "pcb_port_252"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -84775,7 +84775,7 @@
           "pcb_smtpad_191",
           "pcb_port_191"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -84847,7 +84847,7 @@
           "pcb_smtpad_250",
           "pcb_port_267"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -84873,7 +84873,7 @@
           "pcb_smtpad_191",
           "pcb_port_191"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -84917,7 +84917,7 @@
           "pcb_smtpad_265",
           "pcb_port_253"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -84943,7 +84943,7 @@
           "pcb_smtpad_195",
           "pcb_port_195"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -85015,7 +85015,7 @@
           "pcb_smtpad_250",
           "pcb_port_267"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -85041,7 +85041,7 @@
           "pcb_smtpad_195",
           "pcb_port_195"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -85081,7 +85081,7 @@
           "pcb_smtpad_263",
           "pcb_port_254"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -85107,7 +85107,7 @@
           "pcb_smtpad_199",
           "pcb_port_199"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -85179,7 +85179,7 @@
           "pcb_smtpad_250",
           "pcb_port_267"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -85205,7 +85205,7 @@
           "pcb_smtpad_199",
           "pcb_port_199"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -85245,7 +85245,7 @@
           "pcb_smtpad_261",
           "pcb_port_255"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -85271,7 +85271,7 @@
           "pcb_smtpad_203",
           "pcb_port_203"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -85343,7 +85343,7 @@
           "pcb_smtpad_250",
           "pcb_port_267"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -85369,7 +85369,7 @@
           "pcb_smtpad_203",
           "pcb_port_203"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -85409,7 +85409,7 @@
           "pcb_smtpad_257",
           "pcb_port_257"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -85435,7 +85435,7 @@
           "pcb_smtpad_207",
           "pcb_port_207"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -85507,7 +85507,7 @@
           "pcb_smtpad_250",
           "pcb_port_267"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -85533,7 +85533,7 @@
           "pcb_smtpad_207",
           "pcb_port_207"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -85573,7 +85573,7 @@
           "pcb_smtpad_255",
           "pcb_port_258"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -85599,7 +85599,7 @@
           "pcb_smtpad_211",
           "pcb_port_211"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -85671,7 +85671,7 @@
           "pcb_smtpad_250",
           "pcb_port_267"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -85697,7 +85697,7 @@
           "pcb_smtpad_211",
           "pcb_port_211"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -85741,7 +85741,7 @@
           "pcb_smtpad_283",
           "pcb_port_244"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -85767,7 +85767,7 @@
           "pcb_smtpad_215",
           "pcb_port_215"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -85823,7 +85823,7 @@
           "pcb_smtpad_252",
           "pcb_port_268"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -85849,7 +85849,7 @@
           "pcb_smtpad_215",
           "pcb_port_215"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -85893,7 +85893,7 @@
           "pcb_smtpad_281",
           "pcb_port_245"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -85919,7 +85919,7 @@
           "pcb_smtpad_219",
           "pcb_port_219"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -85975,7 +85975,7 @@
           "pcb_smtpad_252",
           "pcb_port_268"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -86001,7 +86001,7 @@
           "pcb_smtpad_219",
           "pcb_port_219"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -86045,7 +86045,7 @@
           "pcb_smtpad_277",
           "pcb_port_247"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -86071,7 +86071,7 @@
           "pcb_smtpad_223",
           "pcb_port_223"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -86127,7 +86127,7 @@
           "pcb_smtpad_252",
           "pcb_port_268"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -86153,7 +86153,7 @@
           "pcb_smtpad_223",
           "pcb_port_223"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -86197,7 +86197,7 @@
           "pcb_smtpad_275",
           "pcb_port_248"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -86223,7 +86223,7 @@
           "pcb_smtpad_227",
           "pcb_port_227"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -86279,7 +86279,7 @@
           "pcb_smtpad_252",
           "pcb_port_268"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -86305,7 +86305,7 @@
           "pcb_smtpad_227",
           "pcb_port_227"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -86349,7 +86349,7 @@
           "pcb_smtpad_273",
           "pcb_port_249"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -86375,7 +86375,7 @@
           "pcb_smtpad_231",
           "pcb_port_231"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -86431,7 +86431,7 @@
           "pcb_smtpad_252",
           "pcb_port_268"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -86457,7 +86457,7 @@
           "pcb_smtpad_231",
           "pcb_port_231"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -86501,7 +86501,7 @@
           "pcb_smtpad_271",
           "pcb_port_250"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -86527,7 +86527,7 @@
           "pcb_smtpad_235",
           "pcb_port_235"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -86583,7 +86583,7 @@
           "pcb_smtpad_252",
           "pcb_port_268"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -86609,7 +86609,7 @@
           "pcb_smtpad_235",
           "pcb_port_235"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -86653,7 +86653,7 @@
           "pcb_smtpad_267",
           "pcb_port_252"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -86679,7 +86679,7 @@
           "pcb_smtpad_239",
           "pcb_port_239"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -86735,7 +86735,7 @@
           "pcb_smtpad_252",
           "pcb_port_268"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -86761,7 +86761,7 @@
           "pcb_smtpad_239",
           "pcb_port_239"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -86805,7 +86805,7 @@
           "pcb_smtpad_265",
           "pcb_port_253"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -86831,7 +86831,7 @@
           "pcb_smtpad_243",
           "pcb_port_243"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -86887,7 +86887,7 @@
           "pcb_smtpad_252",
           "pcb_port_268"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -86913,7 +86913,7 @@
           "pcb_smtpad_243",
           "pcb_port_243"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -86993,7 +86993,7 @@
           "pcb_smtpad_244",
           "pcb_port_264"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -87073,7 +87073,7 @@
           "pcb_smtpad_245",
           "pcb_port_263"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -87149,7 +87149,7 @@
           "pcb_smtpad_246",
           "pcb_port_265"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -87173,7 +87173,7 @@
           "pcb_smtpad_247",
           "pcb_port_262"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -87195,7 +87195,7 @@
           "pcb_smtpad_248",
           "pcb_port_266"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -87217,7 +87217,7 @@
           "pcb_smtpad_249",
           "pcb_port_261"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -87289,7 +87289,7 @@
           "pcb_smtpad_250",
           "pcb_port_267"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -87321,7 +87321,7 @@
           "pcb_smtpad_251",
           "pcb_port_260"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -87377,7 +87377,7 @@
           "pcb_smtpad_252",
           "pcb_port_268"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -87413,7 +87413,7 @@
           "pcb_smtpad_253",
           "pcb_port_259"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -87435,7 +87435,7 @@
           "pcb_smtpad_254",
           "pcb_port_269"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -87475,7 +87475,7 @@
           "pcb_smtpad_255",
           "pcb_port_258"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -87497,7 +87497,7 @@
           "pcb_smtpad_256",
           "pcb_port_270"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -87537,7 +87537,7 @@
           "pcb_smtpad_257",
           "pcb_port_257"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -87559,7 +87559,7 @@
           "pcb_smtpad_258",
           "pcb_port_271"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -87581,7 +87581,7 @@
           "pcb_smtpad_259",
           "pcb_port_256"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -87603,7 +87603,7 @@
           "pcb_smtpad_260",
           "pcb_port_272"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -87643,7 +87643,7 @@
           "pcb_smtpad_261",
           "pcb_port_255"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -87665,7 +87665,7 @@
           "pcb_smtpad_262",
           "pcb_port_273"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -87705,7 +87705,7 @@
           "pcb_smtpad_263",
           "pcb_port_254"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -87727,7 +87727,7 @@
           "pcb_smtpad_264",
           "pcb_port_274"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -87771,7 +87771,7 @@
           "pcb_smtpad_265",
           "pcb_port_253"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -87793,7 +87793,7 @@
           "pcb_smtpad_266",
           "pcb_port_275"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -87837,7 +87837,7 @@
           "pcb_smtpad_267",
           "pcb_port_252"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -87859,7 +87859,7 @@
           "pcb_smtpad_268",
           "pcb_port_276"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -87881,7 +87881,7 @@
           "pcb_smtpad_269",
           "pcb_port_251"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -87903,7 +87903,7 @@
           "pcb_smtpad_270",
           "pcb_port_277"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -87947,7 +87947,7 @@
           "pcb_smtpad_271",
           "pcb_port_250"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -87969,7 +87969,7 @@
           "pcb_smtpad_272",
           "pcb_port_278"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -88013,7 +88013,7 @@
           "pcb_smtpad_273",
           "pcb_port_249"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -88035,7 +88035,7 @@
           "pcb_smtpad_274",
           "pcb_port_279"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -88079,7 +88079,7 @@
           "pcb_smtpad_275",
           "pcb_port_248"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -88101,7 +88101,7 @@
           "pcb_smtpad_276",
           "pcb_port_280"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -88145,7 +88145,7 @@
           "pcb_smtpad_277",
           "pcb_port_247"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -88167,7 +88167,7 @@
           "pcb_smtpad_278",
           "pcb_port_281"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -88189,7 +88189,7 @@
           "pcb_smtpad_279",
           "pcb_port_246"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -88211,7 +88211,7 @@
           "pcb_smtpad_280",
           "pcb_port_282"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -88255,7 +88255,7 @@
           "pcb_smtpad_281",
           "pcb_port_245"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -88277,7 +88277,7 @@
           "pcb_smtpad_282",
           "pcb_port_283"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -88321,7 +88321,7 @@
           "pcb_smtpad_283",
           "pcb_port_244"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -88343,7 +88343,7 @@
           "pcb_smtpad_284",
           "pcb_port_284"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -88365,7 +88365,7 @@
           "pcb_smtpad_285",
           "pcb_port_285"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -88387,7 +88387,7 @@
           "pcb_smtpad_286",
           "pcb_port_286"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -88409,7 +88409,7 @@
           "pcb_smtpad_287",
           "pcb_port_287"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -88431,7 +88431,7 @@
           "pcb_smtpad_288",
           "pcb_port_288"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -88453,7 +88453,7 @@
           "pcb_smtpad_289",
           "pcb_port_289"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -88475,7 +88475,7 @@
           "pcb_smtpad_290",
           "pcb_port_290"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -88497,7 +88497,7 @@
           "pcb_smtpad_291",
           "pcb_port_291"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -88519,7 +88519,7 @@
           "pcb_smtpad_292",
           "pcb_port_292"
         ],
-        "zLayers": [
+        "__zLayers": [
           1
         ]
       },
@@ -88538,7 +88538,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -88560,7 +88560,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -88582,7 +88582,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -88604,7 +88604,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -88626,7 +88626,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -88648,7 +88648,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -88670,7 +88670,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -88692,7 +88692,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -88714,7 +88714,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -88736,7 +88736,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -88758,7 +88758,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -88780,7 +88780,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -88802,7 +88802,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -88824,7 +88824,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -88846,7 +88846,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -88868,7 +88868,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -88890,7 +88890,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -88912,7 +88912,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -88934,7 +88934,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -88956,7 +88956,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -88978,7 +88978,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89000,7 +89000,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89022,7 +89022,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89044,7 +89044,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89066,7 +89066,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89088,7 +89088,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89110,7 +89110,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89132,7 +89132,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89154,7 +89154,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89176,7 +89176,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89198,7 +89198,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89220,7 +89220,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89242,7 +89242,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89264,7 +89264,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89286,7 +89286,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89308,7 +89308,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89330,7 +89330,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89352,7 +89352,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89374,7 +89374,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89396,7 +89396,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89418,7 +89418,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89440,7 +89440,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89462,7 +89462,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89484,7 +89484,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89506,7 +89506,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89528,7 +89528,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89550,7 +89550,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89572,7 +89572,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89594,7 +89594,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89616,7 +89616,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89638,7 +89638,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89660,7 +89660,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89682,7 +89682,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89704,7 +89704,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89726,7 +89726,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89748,7 +89748,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89770,7 +89770,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89792,7 +89792,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89814,7 +89814,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89836,7 +89836,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89858,7 +89858,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89880,7 +89880,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89902,7 +89902,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89924,7 +89924,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89946,7 +89946,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89968,7 +89968,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -89990,7 +89990,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90012,7 +90012,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90034,7 +90034,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90056,7 +90056,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90078,7 +90078,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90100,7 +90100,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90122,7 +90122,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90144,7 +90144,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90166,7 +90166,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90188,7 +90188,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90210,7 +90210,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90232,7 +90232,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90254,7 +90254,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90276,7 +90276,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90298,7 +90298,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90320,7 +90320,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90342,7 +90342,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90364,7 +90364,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90386,7 +90386,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90408,7 +90408,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90430,7 +90430,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90452,7 +90452,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90474,7 +90474,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90496,7 +90496,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90518,7 +90518,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90540,7 +90540,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90562,7 +90562,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90584,7 +90584,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90606,7 +90606,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90628,7 +90628,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90650,7 +90650,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90672,7 +90672,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90694,7 +90694,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90716,7 +90716,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90738,7 +90738,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90760,7 +90760,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90782,7 +90782,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90804,7 +90804,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90826,7 +90826,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90848,7 +90848,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90870,7 +90870,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90892,7 +90892,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90914,7 +90914,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90936,7 +90936,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90958,7 +90958,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -90980,7 +90980,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91002,7 +91002,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91024,7 +91024,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91046,7 +91046,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91068,7 +91068,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91090,7 +91090,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91112,7 +91112,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91134,7 +91134,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91156,7 +91156,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91178,7 +91178,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91200,7 +91200,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91222,7 +91222,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91244,7 +91244,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91266,7 +91266,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91288,7 +91288,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91310,7 +91310,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91332,7 +91332,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91354,7 +91354,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91376,7 +91376,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91398,7 +91398,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91420,7 +91420,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91442,7 +91442,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91464,7 +91464,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91486,7 +91486,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91508,7 +91508,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91530,7 +91530,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91552,7 +91552,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91574,7 +91574,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91596,7 +91596,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91618,7 +91618,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91640,7 +91640,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91662,7 +91662,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91684,7 +91684,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91706,7 +91706,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91728,7 +91728,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91750,7 +91750,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91772,7 +91772,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91794,7 +91794,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91816,7 +91816,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91838,7 +91838,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91860,7 +91860,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91882,7 +91882,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91904,7 +91904,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91926,7 +91926,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91948,7 +91948,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91970,7 +91970,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -91992,7 +91992,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -92014,7 +92014,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -92036,7 +92036,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -92058,7 +92058,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -92080,7 +92080,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -92102,7 +92102,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -92124,7 +92124,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -92146,7 +92146,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -92168,7 +92168,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -92190,7 +92190,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -92212,7 +92212,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -92234,7 +92234,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -92256,7 +92256,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -92278,7 +92278,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -92300,7 +92300,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -92322,7 +92322,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -92344,7 +92344,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -92366,7 +92366,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -92388,7 +92388,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -92410,7 +92410,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -92432,7 +92432,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -92454,7 +92454,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -92476,7 +92476,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -92498,7 +92498,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -92520,7 +92520,7 @@
         "width": 2.9999939999999996,
         "height": 2.9999939999999996,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -92542,7 +92542,7 @@
         "width": 4.1999916,
         "height": 4.1999916,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -92564,7 +92564,7 @@
         "width": 2.2,
         "height": 2.2,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -92586,7 +92586,7 @@
         "width": 2.2,
         "height": 2.2,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -92608,7 +92608,7 @@
         "width": 2.2,
         "height": 2.2,
         "connectedTo": [],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,

--- a/fixtures/legacy/assets/viaremoval01.json
+++ b/fixtures/legacy/assets/viaremoval01.json
@@ -106653,7 +106653,7 @@
           "pcb_smtpad_0",
           "connectivity_net8698"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -106672,7 +106672,7 @@
           "pcb_smtpad_1",
           "connectivity_net8699"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -106691,7 +106691,7 @@
           "pcb_smtpad_2",
           "connectivity_net8700"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -106710,7 +106710,7 @@
           "pcb_smtpad_3",
           "connectivity_net8701"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -106729,7 +106729,7 @@
           "pcb_smtpad_4",
           "connectivity_net8702"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -106748,7 +106748,7 @@
           "pcb_smtpad_5",
           "connectivity_net8703"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -106767,7 +106767,7 @@
           "pcb_smtpad_6",
           "connectivity_net8669"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -106786,7 +106786,7 @@
           "pcb_smtpad_7",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -106805,7 +106805,7 @@
           "pcb_smtpad_8",
           "connectivity_net8670"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -106824,7 +106824,7 @@
           "pcb_smtpad_9",
           "connectivity_net8697"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -106843,7 +106843,7 @@
           "pcb_smtpad_10",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -106862,7 +106862,7 @@
           "pcb_smtpad_11",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -106881,7 +106881,7 @@
           "pcb_smtpad_12",
           "connectivity_net8671"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -106900,7 +106900,7 @@
           "pcb_smtpad_13",
           "connectivity_net8696"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -106919,7 +106919,7 @@
           "pcb_smtpad_14",
           "connectivity_net8672"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -106938,7 +106938,7 @@
           "pcb_smtpad_15",
           "connectivity_net8695"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -106957,7 +106957,7 @@
           "pcb_smtpad_16",
           "connectivity_net8673"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -106976,7 +106976,7 @@
           "pcb_smtpad_17",
           "connectivity_net8694"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -106995,7 +106995,7 @@
           "pcb_smtpad_18",
           "connectivity_net8674"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107014,7 +107014,7 @@
           "pcb_smtpad_19",
           "connectivity_net8693"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107033,7 +107033,7 @@
           "pcb_smtpad_20",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107052,7 +107052,7 @@
           "pcb_smtpad_21",
           "connectivity_net8692"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107071,7 +107071,7 @@
           "pcb_smtpad_22",
           "connectivity_net8675"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107090,7 +107090,7 @@
           "pcb_smtpad_23",
           "connectivity_net6"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107109,7 +107109,7 @@
           "pcb_smtpad_24",
           "connectivity_net8676"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107128,7 +107128,7 @@
           "pcb_smtpad_25",
           "connectivity_net9"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107147,7 +107147,7 @@
           "pcb_smtpad_26",
           "connectivity_net8677"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107166,7 +107166,7 @@
           "pcb_smtpad_27",
           "connectivity_net8691"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107185,7 +107185,7 @@
           "pcb_smtpad_28",
           "connectivity_net8678"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107204,7 +107204,7 @@
           "pcb_smtpad_29",
           "connectivity_net8690"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107223,7 +107223,7 @@
           "pcb_smtpad_30",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107242,7 +107242,7 @@
           "pcb_smtpad_31",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107261,7 +107261,7 @@
           "pcb_smtpad_32",
           "connectivity_net8679"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107280,7 +107280,7 @@
           "pcb_smtpad_33",
           "connectivity_net8689"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107299,7 +107299,7 @@
           "pcb_smtpad_34",
           "connectivity_net4094"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107318,7 +107318,7 @@
           "pcb_smtpad_35",
           "connectivity_net8688"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107337,7 +107337,7 @@
           "pcb_smtpad_36",
           "connectivity_net8680"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107356,7 +107356,7 @@
           "pcb_smtpad_37",
           "connectivity_net8687"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107375,7 +107375,7 @@
           "pcb_smtpad_38",
           "connectivity_net8681"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107394,7 +107394,7 @@
           "pcb_smtpad_39",
           "connectivity_net8686"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107413,7 +107413,7 @@
           "pcb_smtpad_40",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107432,7 +107432,7 @@
           "pcb_smtpad_41",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107451,7 +107451,7 @@
           "pcb_smtpad_42",
           "connectivity_net8682"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107470,7 +107470,7 @@
           "pcb_smtpad_43",
           "connectivity_net8685"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107489,7 +107489,7 @@
           "pcb_smtpad_44",
           "connectivity_net8683"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107508,7 +107508,7 @@
           "pcb_smtpad_45",
           "connectivity_net8684"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107527,7 +107527,7 @@
           "pcb_smtpad_46",
           "connectivity_net24"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107546,7 +107546,7 @@
           "pcb_smtpad_47",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107565,7 +107565,7 @@
           "pcb_smtpad_48",
           "connectivity_net4094"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107584,7 +107584,7 @@
           "pcb_smtpad_49",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107603,7 +107603,7 @@
           "pcb_smtpad_50",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107622,7 +107622,7 @@
           "pcb_smtpad_50",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107641,7 +107641,7 @@
           "pcb_smtpad_50",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107660,7 +107660,7 @@
           "pcb_smtpad_50",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107679,7 +107679,7 @@
           "pcb_smtpad_51",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107698,7 +107698,7 @@
           "pcb_smtpad_51",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107717,7 +107717,7 @@
           "pcb_smtpad_51",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107736,7 +107736,7 @@
           "pcb_smtpad_51",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107755,7 +107755,7 @@
           "pcb_smtpad_52",
           "connectivity_net35"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107774,7 +107774,7 @@
           "pcb_smtpad_53",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107793,7 +107793,7 @@
           "pcb_smtpad_54",
           "connectivity_net24"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107812,7 +107812,7 @@
           "pcb_smtpad_55",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107831,7 +107831,7 @@
           "pcb_smtpad_56",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107850,7 +107850,7 @@
           "pcb_smtpad_56",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107869,7 +107869,7 @@
           "pcb_smtpad_56",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107888,7 +107888,7 @@
           "pcb_smtpad_56",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107907,7 +107907,7 @@
           "pcb_smtpad_57",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107926,7 +107926,7 @@
           "pcb_smtpad_57",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107945,7 +107945,7 @@
           "pcb_smtpad_57",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107964,7 +107964,7 @@
           "pcb_smtpad_57",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -107983,7 +107983,7 @@
           "pcb_smtpad_58",
           "connectivity_net46"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108002,7 +108002,7 @@
           "pcb_smtpad_59",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108021,7 +108021,7 @@
           "pcb_smtpad_60",
           "connectivity_net35"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108040,7 +108040,7 @@
           "pcb_smtpad_61",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108059,7 +108059,7 @@
           "pcb_smtpad_62",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108078,7 +108078,7 @@
           "pcb_smtpad_62",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108097,7 +108097,7 @@
           "pcb_smtpad_62",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108116,7 +108116,7 @@
           "pcb_smtpad_62",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108135,7 +108135,7 @@
           "pcb_smtpad_63",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108154,7 +108154,7 @@
           "pcb_smtpad_63",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108173,7 +108173,7 @@
           "pcb_smtpad_63",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108192,7 +108192,7 @@
           "pcb_smtpad_63",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108211,7 +108211,7 @@
           "pcb_smtpad_64",
           "connectivity_net57"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108230,7 +108230,7 @@
           "pcb_smtpad_65",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108249,7 +108249,7 @@
           "pcb_smtpad_66",
           "connectivity_net46"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108268,7 +108268,7 @@
           "pcb_smtpad_67",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108287,7 +108287,7 @@
           "pcb_smtpad_68",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108306,7 +108306,7 @@
           "pcb_smtpad_68",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108325,7 +108325,7 @@
           "pcb_smtpad_68",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108344,7 +108344,7 @@
           "pcb_smtpad_68",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108363,7 +108363,7 @@
           "pcb_smtpad_69",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108382,7 +108382,7 @@
           "pcb_smtpad_69",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108401,7 +108401,7 @@
           "pcb_smtpad_69",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108420,7 +108420,7 @@
           "pcb_smtpad_69",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108439,7 +108439,7 @@
           "pcb_smtpad_70",
           "connectivity_net68"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108458,7 +108458,7 @@
           "pcb_smtpad_71",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108477,7 +108477,7 @@
           "pcb_smtpad_72",
           "connectivity_net57"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108496,7 +108496,7 @@
           "pcb_smtpad_73",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108515,7 +108515,7 @@
           "pcb_smtpad_74",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108534,7 +108534,7 @@
           "pcb_smtpad_74",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108553,7 +108553,7 @@
           "pcb_smtpad_74",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108572,7 +108572,7 @@
           "pcb_smtpad_74",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108591,7 +108591,7 @@
           "pcb_smtpad_75",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108610,7 +108610,7 @@
           "pcb_smtpad_75",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108629,7 +108629,7 @@
           "pcb_smtpad_75",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108648,7 +108648,7 @@
           "pcb_smtpad_75",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108667,7 +108667,7 @@
           "pcb_smtpad_76",
           "connectivity_net79"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108686,7 +108686,7 @@
           "pcb_smtpad_77",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108705,7 +108705,7 @@
           "pcb_smtpad_78",
           "connectivity_net68"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108724,7 +108724,7 @@
           "pcb_smtpad_79",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108743,7 +108743,7 @@
           "pcb_smtpad_80",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108762,7 +108762,7 @@
           "pcb_smtpad_80",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108781,7 +108781,7 @@
           "pcb_smtpad_80",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108800,7 +108800,7 @@
           "pcb_smtpad_80",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108819,7 +108819,7 @@
           "pcb_smtpad_81",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108838,7 +108838,7 @@
           "pcb_smtpad_81",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108857,7 +108857,7 @@
           "pcb_smtpad_81",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108876,7 +108876,7 @@
           "pcb_smtpad_81",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108895,7 +108895,7 @@
           "pcb_smtpad_82",
           "connectivity_net90"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108914,7 +108914,7 @@
           "pcb_smtpad_83",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108933,7 +108933,7 @@
           "pcb_smtpad_84",
           "connectivity_net79"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108952,7 +108952,7 @@
           "pcb_smtpad_85",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108971,7 +108971,7 @@
           "pcb_smtpad_86",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -108990,7 +108990,7 @@
           "pcb_smtpad_86",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109009,7 +109009,7 @@
           "pcb_smtpad_86",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109028,7 +109028,7 @@
           "pcb_smtpad_86",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109047,7 +109047,7 @@
           "pcb_smtpad_87",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109066,7 +109066,7 @@
           "pcb_smtpad_87",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109085,7 +109085,7 @@
           "pcb_smtpad_87",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109104,7 +109104,7 @@
           "pcb_smtpad_87",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109123,7 +109123,7 @@
           "pcb_smtpad_88",
           "connectivity_net101"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109142,7 +109142,7 @@
           "pcb_smtpad_89",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109161,7 +109161,7 @@
           "pcb_smtpad_90",
           "connectivity_net90"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109180,7 +109180,7 @@
           "pcb_smtpad_91",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109199,7 +109199,7 @@
           "pcb_smtpad_92",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109218,7 +109218,7 @@
           "pcb_smtpad_92",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109237,7 +109237,7 @@
           "pcb_smtpad_92",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109256,7 +109256,7 @@
           "pcb_smtpad_92",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109275,7 +109275,7 @@
           "pcb_smtpad_93",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109294,7 +109294,7 @@
           "pcb_smtpad_93",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109313,7 +109313,7 @@
           "pcb_smtpad_93",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109332,7 +109332,7 @@
           "pcb_smtpad_93",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109351,7 +109351,7 @@
           "pcb_smtpad_94",
           "connectivity_net112"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109370,7 +109370,7 @@
           "pcb_smtpad_95",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109389,7 +109389,7 @@
           "pcb_smtpad_96",
           "connectivity_net101"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109408,7 +109408,7 @@
           "pcb_smtpad_97",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109427,7 +109427,7 @@
           "pcb_smtpad_98",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109446,7 +109446,7 @@
           "pcb_smtpad_98",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109465,7 +109465,7 @@
           "pcb_smtpad_98",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109484,7 +109484,7 @@
           "pcb_smtpad_98",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109503,7 +109503,7 @@
           "pcb_smtpad_99",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109522,7 +109522,7 @@
           "pcb_smtpad_99",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109541,7 +109541,7 @@
           "pcb_smtpad_99",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109560,7 +109560,7 @@
           "pcb_smtpad_99",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109579,7 +109579,7 @@
           "pcb_smtpad_100",
           "connectivity_net123"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109598,7 +109598,7 @@
           "pcb_smtpad_101",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109617,7 +109617,7 @@
           "pcb_smtpad_102",
           "connectivity_net112"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109636,7 +109636,7 @@
           "pcb_smtpad_103",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109655,7 +109655,7 @@
           "pcb_smtpad_104",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109674,7 +109674,7 @@
           "pcb_smtpad_104",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109693,7 +109693,7 @@
           "pcb_smtpad_104",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109712,7 +109712,7 @@
           "pcb_smtpad_104",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109731,7 +109731,7 @@
           "pcb_smtpad_105",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109750,7 +109750,7 @@
           "pcb_smtpad_105",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109769,7 +109769,7 @@
           "pcb_smtpad_105",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109788,7 +109788,7 @@
           "pcb_smtpad_105",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109807,7 +109807,7 @@
           "pcb_smtpad_106",
           "connectivity_net134"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109826,7 +109826,7 @@
           "pcb_smtpad_107",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109845,7 +109845,7 @@
           "pcb_smtpad_108",
           "connectivity_net123"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109864,7 +109864,7 @@
           "pcb_smtpad_109",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109883,7 +109883,7 @@
           "pcb_smtpad_110",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109902,7 +109902,7 @@
           "pcb_smtpad_110",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109921,7 +109921,7 @@
           "pcb_smtpad_110",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109940,7 +109940,7 @@
           "pcb_smtpad_110",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109959,7 +109959,7 @@
           "pcb_smtpad_111",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109978,7 +109978,7 @@
           "pcb_smtpad_111",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -109997,7 +109997,7 @@
           "pcb_smtpad_111",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110016,7 +110016,7 @@
           "pcb_smtpad_111",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110035,7 +110035,7 @@
           "pcb_smtpad_112",
           "connectivity_net145"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110054,7 +110054,7 @@
           "pcb_smtpad_113",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110073,7 +110073,7 @@
           "pcb_smtpad_114",
           "connectivity_net134"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110092,7 +110092,7 @@
           "pcb_smtpad_115",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110111,7 +110111,7 @@
           "pcb_smtpad_116",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110130,7 +110130,7 @@
           "pcb_smtpad_116",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110149,7 +110149,7 @@
           "pcb_smtpad_116",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110168,7 +110168,7 @@
           "pcb_smtpad_116",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110187,7 +110187,7 @@
           "pcb_smtpad_117",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110206,7 +110206,7 @@
           "pcb_smtpad_117",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110225,7 +110225,7 @@
           "pcb_smtpad_117",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110244,7 +110244,7 @@
           "pcb_smtpad_117",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110263,7 +110263,7 @@
           "pcb_smtpad_118",
           "connectivity_net156"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110282,7 +110282,7 @@
           "pcb_smtpad_119",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110301,7 +110301,7 @@
           "pcb_smtpad_120",
           "connectivity_net145"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110320,7 +110320,7 @@
           "pcb_smtpad_121",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110339,7 +110339,7 @@
           "pcb_smtpad_122",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110358,7 +110358,7 @@
           "pcb_smtpad_122",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110377,7 +110377,7 @@
           "pcb_smtpad_122",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110396,7 +110396,7 @@
           "pcb_smtpad_122",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110415,7 +110415,7 @@
           "pcb_smtpad_123",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110434,7 +110434,7 @@
           "pcb_smtpad_123",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110453,7 +110453,7 @@
           "pcb_smtpad_123",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110472,7 +110472,7 @@
           "pcb_smtpad_123",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110491,7 +110491,7 @@
           "pcb_smtpad_124",
           "connectivity_net167"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110510,7 +110510,7 @@
           "pcb_smtpad_125",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110529,7 +110529,7 @@
           "pcb_smtpad_126",
           "connectivity_net156"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110548,7 +110548,7 @@
           "pcb_smtpad_127",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110567,7 +110567,7 @@
           "pcb_smtpad_128",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110586,7 +110586,7 @@
           "pcb_smtpad_128",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110605,7 +110605,7 @@
           "pcb_smtpad_128",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110624,7 +110624,7 @@
           "pcb_smtpad_128",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110643,7 +110643,7 @@
           "pcb_smtpad_129",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110662,7 +110662,7 @@
           "pcb_smtpad_129",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110681,7 +110681,7 @@
           "pcb_smtpad_129",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110700,7 +110700,7 @@
           "pcb_smtpad_129",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110719,7 +110719,7 @@
           "pcb_smtpad_130",
           "connectivity_net178"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110738,7 +110738,7 @@
           "pcb_smtpad_131",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110757,7 +110757,7 @@
           "pcb_smtpad_132",
           "connectivity_net167"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110776,7 +110776,7 @@
           "pcb_smtpad_133",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110795,7 +110795,7 @@
           "pcb_smtpad_134",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110814,7 +110814,7 @@
           "pcb_smtpad_134",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110833,7 +110833,7 @@
           "pcb_smtpad_134",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110852,7 +110852,7 @@
           "pcb_smtpad_134",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110871,7 +110871,7 @@
           "pcb_smtpad_135",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110890,7 +110890,7 @@
           "pcb_smtpad_135",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110909,7 +110909,7 @@
           "pcb_smtpad_135",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110928,7 +110928,7 @@
           "pcb_smtpad_135",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110947,7 +110947,7 @@
           "pcb_smtpad_136",
           "connectivity_net189"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110966,7 +110966,7 @@
           "pcb_smtpad_137",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -110985,7 +110985,7 @@
           "pcb_smtpad_138",
           "connectivity_net178"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111004,7 +111004,7 @@
           "pcb_smtpad_139",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111023,7 +111023,7 @@
           "pcb_smtpad_140",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111042,7 +111042,7 @@
           "pcb_smtpad_140",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111061,7 +111061,7 @@
           "pcb_smtpad_140",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111080,7 +111080,7 @@
           "pcb_smtpad_140",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111099,7 +111099,7 @@
           "pcb_smtpad_141",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111118,7 +111118,7 @@
           "pcb_smtpad_141",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111137,7 +111137,7 @@
           "pcb_smtpad_141",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111156,7 +111156,7 @@
           "pcb_smtpad_141",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111175,7 +111175,7 @@
           "pcb_smtpad_142",
           "connectivity_net200"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111194,7 +111194,7 @@
           "pcb_smtpad_143",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111213,7 +111213,7 @@
           "pcb_smtpad_144",
           "connectivity_net189"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111232,7 +111232,7 @@
           "pcb_smtpad_145",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111251,7 +111251,7 @@
           "pcb_smtpad_146",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111270,7 +111270,7 @@
           "pcb_smtpad_146",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111289,7 +111289,7 @@
           "pcb_smtpad_146",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111308,7 +111308,7 @@
           "pcb_smtpad_146",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111327,7 +111327,7 @@
           "pcb_smtpad_147",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111346,7 +111346,7 @@
           "pcb_smtpad_147",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111365,7 +111365,7 @@
           "pcb_smtpad_147",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111384,7 +111384,7 @@
           "pcb_smtpad_147",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111403,7 +111403,7 @@
           "pcb_smtpad_148",
           "connectivity_net211"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111422,7 +111422,7 @@
           "pcb_smtpad_149",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111441,7 +111441,7 @@
           "pcb_smtpad_150",
           "connectivity_net200"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111460,7 +111460,7 @@
           "pcb_smtpad_151",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111479,7 +111479,7 @@
           "pcb_smtpad_152",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111498,7 +111498,7 @@
           "pcb_smtpad_152",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111517,7 +111517,7 @@
           "pcb_smtpad_152",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111536,7 +111536,7 @@
           "pcb_smtpad_152",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111555,7 +111555,7 @@
           "pcb_smtpad_153",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111574,7 +111574,7 @@
           "pcb_smtpad_153",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111593,7 +111593,7 @@
           "pcb_smtpad_153",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111612,7 +111612,7 @@
           "pcb_smtpad_153",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111631,7 +111631,7 @@
           "pcb_smtpad_154",
           "connectivity_net222"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111650,7 +111650,7 @@
           "pcb_smtpad_155",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111669,7 +111669,7 @@
           "pcb_smtpad_156",
           "connectivity_net211"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111688,7 +111688,7 @@
           "pcb_smtpad_157",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111707,7 +111707,7 @@
           "pcb_smtpad_158",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111726,7 +111726,7 @@
           "pcb_smtpad_158",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111745,7 +111745,7 @@
           "pcb_smtpad_158",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111764,7 +111764,7 @@
           "pcb_smtpad_158",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111783,7 +111783,7 @@
           "pcb_smtpad_159",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111802,7 +111802,7 @@
           "pcb_smtpad_159",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111821,7 +111821,7 @@
           "pcb_smtpad_159",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111840,7 +111840,7 @@
           "pcb_smtpad_159",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111859,7 +111859,7 @@
           "pcb_smtpad_160",
           "connectivity_net233"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111878,7 +111878,7 @@
           "pcb_smtpad_161",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111897,7 +111897,7 @@
           "pcb_smtpad_162",
           "connectivity_net222"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111916,7 +111916,7 @@
           "pcb_smtpad_163",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111935,7 +111935,7 @@
           "pcb_smtpad_164",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111954,7 +111954,7 @@
           "pcb_smtpad_164",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111973,7 +111973,7 @@
           "pcb_smtpad_164",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -111992,7 +111992,7 @@
           "pcb_smtpad_164",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112011,7 +112011,7 @@
           "pcb_smtpad_165",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112030,7 +112030,7 @@
           "pcb_smtpad_165",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112049,7 +112049,7 @@
           "pcb_smtpad_165",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112068,7 +112068,7 @@
           "pcb_smtpad_165",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112087,7 +112087,7 @@
           "pcb_smtpad_166",
           "connectivity_net244"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112106,7 +112106,7 @@
           "pcb_smtpad_167",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112125,7 +112125,7 @@
           "pcb_smtpad_168",
           "connectivity_net233"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112144,7 +112144,7 @@
           "pcb_smtpad_169",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112163,7 +112163,7 @@
           "pcb_smtpad_170",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112182,7 +112182,7 @@
           "pcb_smtpad_170",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112201,7 +112201,7 @@
           "pcb_smtpad_170",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112220,7 +112220,7 @@
           "pcb_smtpad_170",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112239,7 +112239,7 @@
           "pcb_smtpad_171",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112258,7 +112258,7 @@
           "pcb_smtpad_171",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112277,7 +112277,7 @@
           "pcb_smtpad_171",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112296,7 +112296,7 @@
           "pcb_smtpad_171",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112315,7 +112315,7 @@
           "pcb_smtpad_172",
           "connectivity_net255"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112334,7 +112334,7 @@
           "pcb_smtpad_173",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112353,7 +112353,7 @@
           "pcb_smtpad_174",
           "connectivity_net244"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112372,7 +112372,7 @@
           "pcb_smtpad_175",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112391,7 +112391,7 @@
           "pcb_smtpad_176",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112410,7 +112410,7 @@
           "pcb_smtpad_176",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112429,7 +112429,7 @@
           "pcb_smtpad_176",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112448,7 +112448,7 @@
           "pcb_smtpad_176",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112467,7 +112467,7 @@
           "pcb_smtpad_177",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112486,7 +112486,7 @@
           "pcb_smtpad_177",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112505,7 +112505,7 @@
           "pcb_smtpad_177",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112524,7 +112524,7 @@
           "pcb_smtpad_177",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112543,7 +112543,7 @@
           "pcb_smtpad_178",
           "connectivity_net266"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112562,7 +112562,7 @@
           "pcb_smtpad_179",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112581,7 +112581,7 @@
           "pcb_smtpad_180",
           "connectivity_net255"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112600,7 +112600,7 @@
           "pcb_smtpad_181",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112619,7 +112619,7 @@
           "pcb_smtpad_182",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112638,7 +112638,7 @@
           "pcb_smtpad_182",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112657,7 +112657,7 @@
           "pcb_smtpad_182",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112676,7 +112676,7 @@
           "pcb_smtpad_182",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112695,7 +112695,7 @@
           "pcb_smtpad_183",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112714,7 +112714,7 @@
           "pcb_smtpad_183",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112733,7 +112733,7 @@
           "pcb_smtpad_183",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112752,7 +112752,7 @@
           "pcb_smtpad_183",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112771,7 +112771,7 @@
           "pcb_smtpad_184",
           "connectivity_net277"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112790,7 +112790,7 @@
           "pcb_smtpad_185",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112809,7 +112809,7 @@
           "pcb_smtpad_186",
           "connectivity_net266"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112828,7 +112828,7 @@
           "pcb_smtpad_187",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112847,7 +112847,7 @@
           "pcb_smtpad_188",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112866,7 +112866,7 @@
           "pcb_smtpad_188",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112885,7 +112885,7 @@
           "pcb_smtpad_188",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112904,7 +112904,7 @@
           "pcb_smtpad_188",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112923,7 +112923,7 @@
           "pcb_smtpad_189",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112942,7 +112942,7 @@
           "pcb_smtpad_189",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112961,7 +112961,7 @@
           "pcb_smtpad_189",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112980,7 +112980,7 @@
           "pcb_smtpad_189",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -112999,7 +112999,7 @@
           "pcb_smtpad_190",
           "connectivity_net288"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113018,7 +113018,7 @@
           "pcb_smtpad_191",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113037,7 +113037,7 @@
           "pcb_smtpad_192",
           "connectivity_net277"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113056,7 +113056,7 @@
           "pcb_smtpad_193",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113075,7 +113075,7 @@
           "pcb_smtpad_194",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113094,7 +113094,7 @@
           "pcb_smtpad_194",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113113,7 +113113,7 @@
           "pcb_smtpad_194",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113132,7 +113132,7 @@
           "pcb_smtpad_194",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113151,7 +113151,7 @@
           "pcb_smtpad_195",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113170,7 +113170,7 @@
           "pcb_smtpad_195",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113189,7 +113189,7 @@
           "pcb_smtpad_195",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113208,7 +113208,7 @@
           "pcb_smtpad_195",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113227,7 +113227,7 @@
           "pcb_smtpad_196",
           "connectivity_net299"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113246,7 +113246,7 @@
           "pcb_smtpad_197",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113265,7 +113265,7 @@
           "pcb_smtpad_198",
           "connectivity_net288"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113284,7 +113284,7 @@
           "pcb_smtpad_199",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113303,7 +113303,7 @@
           "pcb_smtpad_200",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113322,7 +113322,7 @@
           "pcb_smtpad_200",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113341,7 +113341,7 @@
           "pcb_smtpad_200",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113360,7 +113360,7 @@
           "pcb_smtpad_200",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113379,7 +113379,7 @@
           "pcb_smtpad_201",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113398,7 +113398,7 @@
           "pcb_smtpad_201",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113417,7 +113417,7 @@
           "pcb_smtpad_201",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113436,7 +113436,7 @@
           "pcb_smtpad_201",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113455,7 +113455,7 @@
           "pcb_smtpad_202",
           "connectivity_net310"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113474,7 +113474,7 @@
           "pcb_smtpad_203",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113493,7 +113493,7 @@
           "pcb_smtpad_204",
           "connectivity_net299"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113512,7 +113512,7 @@
           "pcb_smtpad_205",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113531,7 +113531,7 @@
           "pcb_smtpad_206",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113550,7 +113550,7 @@
           "pcb_smtpad_206",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113569,7 +113569,7 @@
           "pcb_smtpad_206",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113588,7 +113588,7 @@
           "pcb_smtpad_206",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113607,7 +113607,7 @@
           "pcb_smtpad_207",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113626,7 +113626,7 @@
           "pcb_smtpad_207",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113645,7 +113645,7 @@
           "pcb_smtpad_207",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113664,7 +113664,7 @@
           "pcb_smtpad_207",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113683,7 +113683,7 @@
           "pcb_smtpad_208",
           "connectivity_net321"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113702,7 +113702,7 @@
           "pcb_smtpad_209",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113721,7 +113721,7 @@
           "pcb_smtpad_210",
           "connectivity_net310"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113740,7 +113740,7 @@
           "pcb_smtpad_211",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113759,7 +113759,7 @@
           "pcb_smtpad_212",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113778,7 +113778,7 @@
           "pcb_smtpad_212",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113797,7 +113797,7 @@
           "pcb_smtpad_212",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113816,7 +113816,7 @@
           "pcb_smtpad_212",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113835,7 +113835,7 @@
           "pcb_smtpad_213",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113854,7 +113854,7 @@
           "pcb_smtpad_213",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113873,7 +113873,7 @@
           "pcb_smtpad_213",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113892,7 +113892,7 @@
           "pcb_smtpad_213",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113911,7 +113911,7 @@
           "pcb_smtpad_214",
           "connectivity_net332"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113930,7 +113930,7 @@
           "pcb_smtpad_215",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113949,7 +113949,7 @@
           "pcb_smtpad_216",
           "connectivity_net321"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113968,7 +113968,7 @@
           "pcb_smtpad_217",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113987,7 +113987,7 @@
           "pcb_smtpad_218",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114006,7 +114006,7 @@
           "pcb_smtpad_218",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114025,7 +114025,7 @@
           "pcb_smtpad_218",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114044,7 +114044,7 @@
           "pcb_smtpad_218",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114063,7 +114063,7 @@
           "pcb_smtpad_219",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114082,7 +114082,7 @@
           "pcb_smtpad_219",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114101,7 +114101,7 @@
           "pcb_smtpad_219",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114120,7 +114120,7 @@
           "pcb_smtpad_219",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114139,7 +114139,7 @@
           "pcb_smtpad_220",
           "connectivity_net343"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114158,7 +114158,7 @@
           "pcb_smtpad_221",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114177,7 +114177,7 @@
           "pcb_smtpad_222",
           "connectivity_net332"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114196,7 +114196,7 @@
           "pcb_smtpad_223",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114215,7 +114215,7 @@
           "pcb_smtpad_224",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114234,7 +114234,7 @@
           "pcb_smtpad_224",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114253,7 +114253,7 @@
           "pcb_smtpad_224",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114272,7 +114272,7 @@
           "pcb_smtpad_224",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114291,7 +114291,7 @@
           "pcb_smtpad_225",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114310,7 +114310,7 @@
           "pcb_smtpad_225",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114329,7 +114329,7 @@
           "pcb_smtpad_225",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114348,7 +114348,7 @@
           "pcb_smtpad_225",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114367,7 +114367,7 @@
           "pcb_smtpad_226",
           "connectivity_net354"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114386,7 +114386,7 @@
           "pcb_smtpad_227",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114405,7 +114405,7 @@
           "pcb_smtpad_228",
           "connectivity_net343"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114424,7 +114424,7 @@
           "pcb_smtpad_229",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114443,7 +114443,7 @@
           "pcb_smtpad_230",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114462,7 +114462,7 @@
           "pcb_smtpad_230",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114481,7 +114481,7 @@
           "pcb_smtpad_230",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114500,7 +114500,7 @@
           "pcb_smtpad_230",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114519,7 +114519,7 @@
           "pcb_smtpad_231",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114538,7 +114538,7 @@
           "pcb_smtpad_231",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114557,7 +114557,7 @@
           "pcb_smtpad_231",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114576,7 +114576,7 @@
           "pcb_smtpad_231",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114595,7 +114595,7 @@
           "pcb_smtpad_232",
           "connectivity_net365"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114614,7 +114614,7 @@
           "pcb_smtpad_233",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114633,7 +114633,7 @@
           "pcb_smtpad_234",
           "connectivity_net354"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114652,7 +114652,7 @@
           "pcb_smtpad_235",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114671,7 +114671,7 @@
           "pcb_smtpad_236",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114690,7 +114690,7 @@
           "pcb_smtpad_236",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114709,7 +114709,7 @@
           "pcb_smtpad_236",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114728,7 +114728,7 @@
           "pcb_smtpad_236",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114747,7 +114747,7 @@
           "pcb_smtpad_237",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114766,7 +114766,7 @@
           "pcb_smtpad_237",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114785,7 +114785,7 @@
           "pcb_smtpad_237",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114804,7 +114804,7 @@
           "pcb_smtpad_237",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114823,7 +114823,7 @@
           "pcb_smtpad_238",
           "connectivity_net376"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114842,7 +114842,7 @@
           "pcb_smtpad_239",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114861,7 +114861,7 @@
           "pcb_smtpad_240",
           "connectivity_net365"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114880,7 +114880,7 @@
           "pcb_smtpad_241",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114899,7 +114899,7 @@
           "pcb_smtpad_242",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114918,7 +114918,7 @@
           "pcb_smtpad_242",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114937,7 +114937,7 @@
           "pcb_smtpad_242",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114956,7 +114956,7 @@
           "pcb_smtpad_242",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114975,7 +114975,7 @@
           "pcb_smtpad_243",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -114994,7 +114994,7 @@
           "pcb_smtpad_243",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115013,7 +115013,7 @@
           "pcb_smtpad_243",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115032,7 +115032,7 @@
           "pcb_smtpad_243",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115051,7 +115051,7 @@
           "pcb_smtpad_244",
           "connectivity_net387"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115070,7 +115070,7 @@
           "pcb_smtpad_245",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115089,7 +115089,7 @@
           "pcb_smtpad_246",
           "connectivity_net376"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115108,7 +115108,7 @@
           "pcb_smtpad_247",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115127,7 +115127,7 @@
           "pcb_smtpad_248",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115146,7 +115146,7 @@
           "pcb_smtpad_248",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115165,7 +115165,7 @@
           "pcb_smtpad_248",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115184,7 +115184,7 @@
           "pcb_smtpad_248",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115203,7 +115203,7 @@
           "pcb_smtpad_249",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115222,7 +115222,7 @@
           "pcb_smtpad_249",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115241,7 +115241,7 @@
           "pcb_smtpad_249",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115260,7 +115260,7 @@
           "pcb_smtpad_249",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115279,7 +115279,7 @@
           "pcb_smtpad_250",
           "connectivity_net398"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115298,7 +115298,7 @@
           "pcb_smtpad_251",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115317,7 +115317,7 @@
           "pcb_smtpad_252",
           "connectivity_net387"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115336,7 +115336,7 @@
           "pcb_smtpad_253",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115355,7 +115355,7 @@
           "pcb_smtpad_254",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115374,7 +115374,7 @@
           "pcb_smtpad_254",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115393,7 +115393,7 @@
           "pcb_smtpad_254",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115412,7 +115412,7 @@
           "pcb_smtpad_254",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115431,7 +115431,7 @@
           "pcb_smtpad_255",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115450,7 +115450,7 @@
           "pcb_smtpad_255",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115469,7 +115469,7 @@
           "pcb_smtpad_255",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115488,7 +115488,7 @@
           "pcb_smtpad_255",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115507,7 +115507,7 @@
           "pcb_smtpad_256",
           "connectivity_net409"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115526,7 +115526,7 @@
           "pcb_smtpad_257",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115545,7 +115545,7 @@
           "pcb_smtpad_258",
           "connectivity_net398"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115564,7 +115564,7 @@
           "pcb_smtpad_259",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115583,7 +115583,7 @@
           "pcb_smtpad_260",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115602,7 +115602,7 @@
           "pcb_smtpad_260",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115621,7 +115621,7 @@
           "pcb_smtpad_260",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115640,7 +115640,7 @@
           "pcb_smtpad_260",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115659,7 +115659,7 @@
           "pcb_smtpad_261",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115678,7 +115678,7 @@
           "pcb_smtpad_261",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115697,7 +115697,7 @@
           "pcb_smtpad_261",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115716,7 +115716,7 @@
           "pcb_smtpad_261",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115735,7 +115735,7 @@
           "pcb_smtpad_262",
           "connectivity_net420"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115754,7 +115754,7 @@
           "pcb_smtpad_263",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115773,7 +115773,7 @@
           "pcb_smtpad_264",
           "connectivity_net409"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115792,7 +115792,7 @@
           "pcb_smtpad_265",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115811,7 +115811,7 @@
           "pcb_smtpad_266",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115830,7 +115830,7 @@
           "pcb_smtpad_266",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115849,7 +115849,7 @@
           "pcb_smtpad_266",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115868,7 +115868,7 @@
           "pcb_smtpad_266",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115887,7 +115887,7 @@
           "pcb_smtpad_267",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115906,7 +115906,7 @@
           "pcb_smtpad_267",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115925,7 +115925,7 @@
           "pcb_smtpad_267",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115944,7 +115944,7 @@
           "pcb_smtpad_267",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115963,7 +115963,7 @@
           "pcb_smtpad_268",
           "connectivity_net431"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -115982,7 +115982,7 @@
           "pcb_smtpad_269",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116001,7 +116001,7 @@
           "pcb_smtpad_270",
           "connectivity_net420"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116020,7 +116020,7 @@
           "pcb_smtpad_271",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116039,7 +116039,7 @@
           "pcb_smtpad_272",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116058,7 +116058,7 @@
           "pcb_smtpad_272",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116077,7 +116077,7 @@
           "pcb_smtpad_272",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116096,7 +116096,7 @@
           "pcb_smtpad_272",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116115,7 +116115,7 @@
           "pcb_smtpad_273",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116134,7 +116134,7 @@
           "pcb_smtpad_273",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116153,7 +116153,7 @@
           "pcb_smtpad_273",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116172,7 +116172,7 @@
           "pcb_smtpad_273",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116191,7 +116191,7 @@
           "pcb_smtpad_274",
           "connectivity_net442"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116210,7 +116210,7 @@
           "pcb_smtpad_275",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116229,7 +116229,7 @@
           "pcb_smtpad_276",
           "connectivity_net431"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116248,7 +116248,7 @@
           "pcb_smtpad_277",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116267,7 +116267,7 @@
           "pcb_smtpad_278",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116286,7 +116286,7 @@
           "pcb_smtpad_278",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116305,7 +116305,7 @@
           "pcb_smtpad_278",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116324,7 +116324,7 @@
           "pcb_smtpad_278",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116343,7 +116343,7 @@
           "pcb_smtpad_279",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116362,7 +116362,7 @@
           "pcb_smtpad_279",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116381,7 +116381,7 @@
           "pcb_smtpad_279",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116400,7 +116400,7 @@
           "pcb_smtpad_279",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116419,7 +116419,7 @@
           "pcb_smtpad_280",
           "connectivity_net453"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116438,7 +116438,7 @@
           "pcb_smtpad_281",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116457,7 +116457,7 @@
           "pcb_smtpad_282",
           "connectivity_net442"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116476,7 +116476,7 @@
           "pcb_smtpad_283",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116495,7 +116495,7 @@
           "pcb_smtpad_284",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116514,7 +116514,7 @@
           "pcb_smtpad_284",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116533,7 +116533,7 @@
           "pcb_smtpad_284",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116552,7 +116552,7 @@
           "pcb_smtpad_284",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116571,7 +116571,7 @@
           "pcb_smtpad_285",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116590,7 +116590,7 @@
           "pcb_smtpad_285",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116609,7 +116609,7 @@
           "pcb_smtpad_285",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116628,7 +116628,7 @@
           "pcb_smtpad_285",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116647,7 +116647,7 @@
           "pcb_smtpad_286",
           "connectivity_net464"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116666,7 +116666,7 @@
           "pcb_smtpad_287",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116685,7 +116685,7 @@
           "pcb_smtpad_288",
           "connectivity_net453"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116704,7 +116704,7 @@
           "pcb_smtpad_289",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116723,7 +116723,7 @@
           "pcb_smtpad_290",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116742,7 +116742,7 @@
           "pcb_smtpad_290",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116761,7 +116761,7 @@
           "pcb_smtpad_290",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116780,7 +116780,7 @@
           "pcb_smtpad_290",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116799,7 +116799,7 @@
           "pcb_smtpad_291",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116818,7 +116818,7 @@
           "pcb_smtpad_291",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116837,7 +116837,7 @@
           "pcb_smtpad_291",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116856,7 +116856,7 @@
           "pcb_smtpad_291",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116875,7 +116875,7 @@
           "pcb_smtpad_292",
           "connectivity_net475"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116894,7 +116894,7 @@
           "pcb_smtpad_293",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116913,7 +116913,7 @@
           "pcb_smtpad_294",
           "connectivity_net464"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116932,7 +116932,7 @@
           "pcb_smtpad_295",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116951,7 +116951,7 @@
           "pcb_smtpad_296",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116970,7 +116970,7 @@
           "pcb_smtpad_296",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -116989,7 +116989,7 @@
           "pcb_smtpad_296",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117008,7 +117008,7 @@
           "pcb_smtpad_296",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117027,7 +117027,7 @@
           "pcb_smtpad_297",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117046,7 +117046,7 @@
           "pcb_smtpad_297",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117065,7 +117065,7 @@
           "pcb_smtpad_297",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117084,7 +117084,7 @@
           "pcb_smtpad_297",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117103,7 +117103,7 @@
           "pcb_smtpad_298",
           "connectivity_net486"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117122,7 +117122,7 @@
           "pcb_smtpad_299",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117141,7 +117141,7 @@
           "pcb_smtpad_300",
           "connectivity_net475"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117160,7 +117160,7 @@
           "pcb_smtpad_301",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117179,7 +117179,7 @@
           "pcb_smtpad_302",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117198,7 +117198,7 @@
           "pcb_smtpad_302",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117217,7 +117217,7 @@
           "pcb_smtpad_302",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117236,7 +117236,7 @@
           "pcb_smtpad_302",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117255,7 +117255,7 @@
           "pcb_smtpad_303",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117274,7 +117274,7 @@
           "pcb_smtpad_303",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117293,7 +117293,7 @@
           "pcb_smtpad_303",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117312,7 +117312,7 @@
           "pcb_smtpad_303",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117331,7 +117331,7 @@
           "pcb_smtpad_304",
           "connectivity_net497"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117350,7 +117350,7 @@
           "pcb_smtpad_305",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117369,7 +117369,7 @@
           "pcb_smtpad_306",
           "connectivity_net486"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117388,7 +117388,7 @@
           "pcb_smtpad_307",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117407,7 +117407,7 @@
           "pcb_smtpad_308",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117426,7 +117426,7 @@
           "pcb_smtpad_308",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117445,7 +117445,7 @@
           "pcb_smtpad_308",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117464,7 +117464,7 @@
           "pcb_smtpad_308",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117483,7 +117483,7 @@
           "pcb_smtpad_309",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117502,7 +117502,7 @@
           "pcb_smtpad_309",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117521,7 +117521,7 @@
           "pcb_smtpad_309",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117540,7 +117540,7 @@
           "pcb_smtpad_309",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117559,7 +117559,7 @@
           "pcb_smtpad_310",
           "connectivity_net508"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117578,7 +117578,7 @@
           "pcb_smtpad_311",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117597,7 +117597,7 @@
           "pcb_smtpad_312",
           "connectivity_net497"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117616,7 +117616,7 @@
           "pcb_smtpad_313",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117635,7 +117635,7 @@
           "pcb_smtpad_314",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117654,7 +117654,7 @@
           "pcb_smtpad_314",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117673,7 +117673,7 @@
           "pcb_smtpad_314",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117692,7 +117692,7 @@
           "pcb_smtpad_314",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117711,7 +117711,7 @@
           "pcb_smtpad_315",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117730,7 +117730,7 @@
           "pcb_smtpad_315",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117749,7 +117749,7 @@
           "pcb_smtpad_315",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117768,7 +117768,7 @@
           "pcb_smtpad_315",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117787,7 +117787,7 @@
           "pcb_smtpad_316",
           "connectivity_net519"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117806,7 +117806,7 @@
           "pcb_smtpad_317",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117825,7 +117825,7 @@
           "pcb_smtpad_318",
           "connectivity_net508"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117844,7 +117844,7 @@
           "pcb_smtpad_319",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117863,7 +117863,7 @@
           "pcb_smtpad_320",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117882,7 +117882,7 @@
           "pcb_smtpad_320",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117901,7 +117901,7 @@
           "pcb_smtpad_320",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117920,7 +117920,7 @@
           "pcb_smtpad_320",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117939,7 +117939,7 @@
           "pcb_smtpad_321",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117958,7 +117958,7 @@
           "pcb_smtpad_321",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117977,7 +117977,7 @@
           "pcb_smtpad_321",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -117996,7 +117996,7 @@
           "pcb_smtpad_321",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118015,7 +118015,7 @@
           "pcb_smtpad_322",
           "connectivity_net530"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118034,7 +118034,7 @@
           "pcb_smtpad_323",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118053,7 +118053,7 @@
           "pcb_smtpad_324",
           "connectivity_net519"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118072,7 +118072,7 @@
           "pcb_smtpad_325",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118091,7 +118091,7 @@
           "pcb_smtpad_326",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118110,7 +118110,7 @@
           "pcb_smtpad_326",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118129,7 +118129,7 @@
           "pcb_smtpad_326",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118148,7 +118148,7 @@
           "pcb_smtpad_326",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118167,7 +118167,7 @@
           "pcb_smtpad_327",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118186,7 +118186,7 @@
           "pcb_smtpad_327",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118205,7 +118205,7 @@
           "pcb_smtpad_327",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118224,7 +118224,7 @@
           "pcb_smtpad_327",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118243,7 +118243,7 @@
           "pcb_smtpad_328",
           "connectivity_net541"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118262,7 +118262,7 @@
           "pcb_smtpad_329",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118281,7 +118281,7 @@
           "pcb_smtpad_330",
           "connectivity_net530"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118300,7 +118300,7 @@
           "pcb_smtpad_331",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118319,7 +118319,7 @@
           "pcb_smtpad_332",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118338,7 +118338,7 @@
           "pcb_smtpad_332",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118357,7 +118357,7 @@
           "pcb_smtpad_332",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118376,7 +118376,7 @@
           "pcb_smtpad_332",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118395,7 +118395,7 @@
           "pcb_smtpad_333",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118414,7 +118414,7 @@
           "pcb_smtpad_333",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118433,7 +118433,7 @@
           "pcb_smtpad_333",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118452,7 +118452,7 @@
           "pcb_smtpad_333",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118471,7 +118471,7 @@
           "pcb_smtpad_334",
           "connectivity_net552"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118490,7 +118490,7 @@
           "pcb_smtpad_335",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118509,7 +118509,7 @@
           "pcb_smtpad_336",
           "connectivity_net541"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118528,7 +118528,7 @@
           "pcb_smtpad_337",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118547,7 +118547,7 @@
           "pcb_smtpad_338",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118566,7 +118566,7 @@
           "pcb_smtpad_338",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118585,7 +118585,7 @@
           "pcb_smtpad_338",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118604,7 +118604,7 @@
           "pcb_smtpad_338",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118623,7 +118623,7 @@
           "pcb_smtpad_339",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118642,7 +118642,7 @@
           "pcb_smtpad_339",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118661,7 +118661,7 @@
           "pcb_smtpad_339",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118680,7 +118680,7 @@
           "pcb_smtpad_339",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118699,7 +118699,7 @@
           "pcb_smtpad_340",
           "connectivity_net563"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118718,7 +118718,7 @@
           "pcb_smtpad_341",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118737,7 +118737,7 @@
           "pcb_smtpad_342",
           "connectivity_net552"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118756,7 +118756,7 @@
           "pcb_smtpad_343",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118775,7 +118775,7 @@
           "pcb_smtpad_344",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118794,7 +118794,7 @@
           "pcb_smtpad_344",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118813,7 +118813,7 @@
           "pcb_smtpad_344",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118832,7 +118832,7 @@
           "pcb_smtpad_344",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118851,7 +118851,7 @@
           "pcb_smtpad_345",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118870,7 +118870,7 @@
           "pcb_smtpad_345",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118889,7 +118889,7 @@
           "pcb_smtpad_345",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118908,7 +118908,7 @@
           "pcb_smtpad_345",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118927,7 +118927,7 @@
           "pcb_smtpad_346",
           "connectivity_net574"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118946,7 +118946,7 @@
           "pcb_smtpad_347",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118965,7 +118965,7 @@
           "pcb_smtpad_348",
           "connectivity_net563"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -118984,7 +118984,7 @@
           "pcb_smtpad_349",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119003,7 +119003,7 @@
           "pcb_smtpad_350",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119022,7 +119022,7 @@
           "pcb_smtpad_350",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119041,7 +119041,7 @@
           "pcb_smtpad_350",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119060,7 +119060,7 @@
           "pcb_smtpad_350",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119079,7 +119079,7 @@
           "pcb_smtpad_351",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119098,7 +119098,7 @@
           "pcb_smtpad_351",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119117,7 +119117,7 @@
           "pcb_smtpad_351",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119136,7 +119136,7 @@
           "pcb_smtpad_351",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119155,7 +119155,7 @@
           "pcb_smtpad_352",
           "connectivity_net585"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119174,7 +119174,7 @@
           "pcb_smtpad_353",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119193,7 +119193,7 @@
           "pcb_smtpad_354",
           "connectivity_net574"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119212,7 +119212,7 @@
           "pcb_smtpad_355",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119231,7 +119231,7 @@
           "pcb_smtpad_356",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119250,7 +119250,7 @@
           "pcb_smtpad_356",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119269,7 +119269,7 @@
           "pcb_smtpad_356",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119288,7 +119288,7 @@
           "pcb_smtpad_356",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119307,7 +119307,7 @@
           "pcb_smtpad_357",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119326,7 +119326,7 @@
           "pcb_smtpad_357",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119345,7 +119345,7 @@
           "pcb_smtpad_357",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119364,7 +119364,7 @@
           "pcb_smtpad_357",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119383,7 +119383,7 @@
           "pcb_smtpad_358",
           "connectivity_net596"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119402,7 +119402,7 @@
           "pcb_smtpad_359",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119421,7 +119421,7 @@
           "pcb_smtpad_360",
           "connectivity_net585"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119440,7 +119440,7 @@
           "pcb_smtpad_361",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119459,7 +119459,7 @@
           "pcb_smtpad_362",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119478,7 +119478,7 @@
           "pcb_smtpad_362",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119497,7 +119497,7 @@
           "pcb_smtpad_362",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119516,7 +119516,7 @@
           "pcb_smtpad_362",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119535,7 +119535,7 @@
           "pcb_smtpad_363",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119554,7 +119554,7 @@
           "pcb_smtpad_363",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119573,7 +119573,7 @@
           "pcb_smtpad_363",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119592,7 +119592,7 @@
           "pcb_smtpad_363",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119611,7 +119611,7 @@
           "pcb_smtpad_364",
           "connectivity_net607"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119630,7 +119630,7 @@
           "pcb_smtpad_365",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119649,7 +119649,7 @@
           "pcb_smtpad_366",
           "connectivity_net596"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119668,7 +119668,7 @@
           "pcb_smtpad_367",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119687,7 +119687,7 @@
           "pcb_smtpad_368",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119706,7 +119706,7 @@
           "pcb_smtpad_368",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119725,7 +119725,7 @@
           "pcb_smtpad_368",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119744,7 +119744,7 @@
           "pcb_smtpad_368",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119763,7 +119763,7 @@
           "pcb_smtpad_369",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119782,7 +119782,7 @@
           "pcb_smtpad_369",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119801,7 +119801,7 @@
           "pcb_smtpad_369",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119820,7 +119820,7 @@
           "pcb_smtpad_369",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119839,7 +119839,7 @@
           "pcb_smtpad_370",
           "connectivity_net618"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119858,7 +119858,7 @@
           "pcb_smtpad_371",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119877,7 +119877,7 @@
           "pcb_smtpad_372",
           "connectivity_net607"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119896,7 +119896,7 @@
           "pcb_smtpad_373",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119915,7 +119915,7 @@
           "pcb_smtpad_374",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119934,7 +119934,7 @@
           "pcb_smtpad_374",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119953,7 +119953,7 @@
           "pcb_smtpad_374",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119972,7 +119972,7 @@
           "pcb_smtpad_374",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -119991,7 +119991,7 @@
           "pcb_smtpad_375",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120010,7 +120010,7 @@
           "pcb_smtpad_375",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120029,7 +120029,7 @@
           "pcb_smtpad_375",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120048,7 +120048,7 @@
           "pcb_smtpad_375",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120067,7 +120067,7 @@
           "pcb_smtpad_376",
           "connectivity_net629"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120086,7 +120086,7 @@
           "pcb_smtpad_377",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120105,7 +120105,7 @@
           "pcb_smtpad_378",
           "connectivity_net618"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120124,7 +120124,7 @@
           "pcb_smtpad_379",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120143,7 +120143,7 @@
           "pcb_smtpad_380",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120162,7 +120162,7 @@
           "pcb_smtpad_380",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120181,7 +120181,7 @@
           "pcb_smtpad_380",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120200,7 +120200,7 @@
           "pcb_smtpad_380",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120219,7 +120219,7 @@
           "pcb_smtpad_381",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120238,7 +120238,7 @@
           "pcb_smtpad_381",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120257,7 +120257,7 @@
           "pcb_smtpad_381",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120276,7 +120276,7 @@
           "pcb_smtpad_381",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120295,7 +120295,7 @@
           "pcb_smtpad_382",
           "connectivity_net640"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120314,7 +120314,7 @@
           "pcb_smtpad_383",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120333,7 +120333,7 @@
           "pcb_smtpad_384",
           "connectivity_net629"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120352,7 +120352,7 @@
           "pcb_smtpad_385",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120371,7 +120371,7 @@
           "pcb_smtpad_386",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120390,7 +120390,7 @@
           "pcb_smtpad_386",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120409,7 +120409,7 @@
           "pcb_smtpad_386",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120428,7 +120428,7 @@
           "pcb_smtpad_386",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120447,7 +120447,7 @@
           "pcb_smtpad_387",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120466,7 +120466,7 @@
           "pcb_smtpad_387",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120485,7 +120485,7 @@
           "pcb_smtpad_387",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120504,7 +120504,7 @@
           "pcb_smtpad_387",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120523,7 +120523,7 @@
           "pcb_smtpad_388",
           "connectivity_net651"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120542,7 +120542,7 @@
           "pcb_smtpad_389",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120561,7 +120561,7 @@
           "pcb_smtpad_390",
           "connectivity_net640"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120580,7 +120580,7 @@
           "pcb_smtpad_391",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120599,7 +120599,7 @@
           "pcb_smtpad_392",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120618,7 +120618,7 @@
           "pcb_smtpad_392",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120637,7 +120637,7 @@
           "pcb_smtpad_392",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120656,7 +120656,7 @@
           "pcb_smtpad_392",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120675,7 +120675,7 @@
           "pcb_smtpad_393",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120694,7 +120694,7 @@
           "pcb_smtpad_393",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120713,7 +120713,7 @@
           "pcb_smtpad_393",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120732,7 +120732,7 @@
           "pcb_smtpad_393",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120751,7 +120751,7 @@
           "pcb_smtpad_394",
           "connectivity_net662"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120770,7 +120770,7 @@
           "pcb_smtpad_395",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120789,7 +120789,7 @@
           "pcb_smtpad_396",
           "connectivity_net651"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120808,7 +120808,7 @@
           "pcb_smtpad_397",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120827,7 +120827,7 @@
           "pcb_smtpad_398",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120846,7 +120846,7 @@
           "pcb_smtpad_398",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120865,7 +120865,7 @@
           "pcb_smtpad_398",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120884,7 +120884,7 @@
           "pcb_smtpad_398",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120903,7 +120903,7 @@
           "pcb_smtpad_399",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120922,7 +120922,7 @@
           "pcb_smtpad_399",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120941,7 +120941,7 @@
           "pcb_smtpad_399",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120960,7 +120960,7 @@
           "pcb_smtpad_399",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120979,7 +120979,7 @@
           "pcb_smtpad_400",
           "connectivity_net673"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -120998,7 +120998,7 @@
           "pcb_smtpad_401",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121017,7 +121017,7 @@
           "pcb_smtpad_402",
           "connectivity_net662"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121036,7 +121036,7 @@
           "pcb_smtpad_403",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121055,7 +121055,7 @@
           "pcb_smtpad_404",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121074,7 +121074,7 @@
           "pcb_smtpad_404",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121093,7 +121093,7 @@
           "pcb_smtpad_404",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121112,7 +121112,7 @@
           "pcb_smtpad_404",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121131,7 +121131,7 @@
           "pcb_smtpad_405",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121150,7 +121150,7 @@
           "pcb_smtpad_405",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121169,7 +121169,7 @@
           "pcb_smtpad_405",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121188,7 +121188,7 @@
           "pcb_smtpad_405",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121207,7 +121207,7 @@
           "pcb_smtpad_406",
           "connectivity_net684"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121226,7 +121226,7 @@
           "pcb_smtpad_407",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121245,7 +121245,7 @@
           "pcb_smtpad_408",
           "connectivity_net673"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121264,7 +121264,7 @@
           "pcb_smtpad_409",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121283,7 +121283,7 @@
           "pcb_smtpad_410",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121302,7 +121302,7 @@
           "pcb_smtpad_410",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121321,7 +121321,7 @@
           "pcb_smtpad_410",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121340,7 +121340,7 @@
           "pcb_smtpad_410",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121359,7 +121359,7 @@
           "pcb_smtpad_411",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121378,7 +121378,7 @@
           "pcb_smtpad_411",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121397,7 +121397,7 @@
           "pcb_smtpad_411",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121416,7 +121416,7 @@
           "pcb_smtpad_411",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121435,7 +121435,7 @@
           "pcb_smtpad_412",
           "connectivity_net695"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121454,7 +121454,7 @@
           "pcb_smtpad_413",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121473,7 +121473,7 @@
           "pcb_smtpad_414",
           "connectivity_net684"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121492,7 +121492,7 @@
           "pcb_smtpad_415",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121511,7 +121511,7 @@
           "pcb_smtpad_416",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121530,7 +121530,7 @@
           "pcb_smtpad_416",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121549,7 +121549,7 @@
           "pcb_smtpad_416",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121568,7 +121568,7 @@
           "pcb_smtpad_416",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121587,7 +121587,7 @@
           "pcb_smtpad_417",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121606,7 +121606,7 @@
           "pcb_smtpad_417",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121625,7 +121625,7 @@
           "pcb_smtpad_417",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121644,7 +121644,7 @@
           "pcb_smtpad_417",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121663,7 +121663,7 @@
           "pcb_smtpad_418",
           "connectivity_net706"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121682,7 +121682,7 @@
           "pcb_smtpad_419",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121701,7 +121701,7 @@
           "pcb_smtpad_420",
           "connectivity_net695"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121720,7 +121720,7 @@
           "pcb_smtpad_421",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121739,7 +121739,7 @@
           "pcb_smtpad_422",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121758,7 +121758,7 @@
           "pcb_smtpad_422",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121777,7 +121777,7 @@
           "pcb_smtpad_422",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121796,7 +121796,7 @@
           "pcb_smtpad_422",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121815,7 +121815,7 @@
           "pcb_smtpad_423",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121834,7 +121834,7 @@
           "pcb_smtpad_423",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121853,7 +121853,7 @@
           "pcb_smtpad_423",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121872,7 +121872,7 @@
           "pcb_smtpad_423",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121891,7 +121891,7 @@
           "pcb_smtpad_424",
           "connectivity_net717"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121910,7 +121910,7 @@
           "pcb_smtpad_425",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121929,7 +121929,7 @@
           "pcb_smtpad_426",
           "connectivity_net706"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121948,7 +121948,7 @@
           "pcb_smtpad_427",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121967,7 +121967,7 @@
           "pcb_smtpad_428",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -121986,7 +121986,7 @@
           "pcb_smtpad_428",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122005,7 +122005,7 @@
           "pcb_smtpad_428",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122024,7 +122024,7 @@
           "pcb_smtpad_428",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122043,7 +122043,7 @@
           "pcb_smtpad_429",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122062,7 +122062,7 @@
           "pcb_smtpad_429",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122081,7 +122081,7 @@
           "pcb_smtpad_429",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122100,7 +122100,7 @@
           "pcb_smtpad_429",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122119,7 +122119,7 @@
           "pcb_smtpad_430",
           "connectivity_net728"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122138,7 +122138,7 @@
           "pcb_smtpad_431",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122157,7 +122157,7 @@
           "pcb_smtpad_432",
           "connectivity_net717"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122176,7 +122176,7 @@
           "pcb_smtpad_433",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122195,7 +122195,7 @@
           "pcb_smtpad_434",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122214,7 +122214,7 @@
           "pcb_smtpad_434",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122233,7 +122233,7 @@
           "pcb_smtpad_434",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122252,7 +122252,7 @@
           "pcb_smtpad_434",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122271,7 +122271,7 @@
           "pcb_smtpad_435",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122290,7 +122290,7 @@
           "pcb_smtpad_435",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122309,7 +122309,7 @@
           "pcb_smtpad_435",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122328,7 +122328,7 @@
           "pcb_smtpad_435",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122347,7 +122347,7 @@
           "pcb_smtpad_436",
           "connectivity_net739"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122366,7 +122366,7 @@
           "pcb_smtpad_437",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122385,7 +122385,7 @@
           "pcb_smtpad_438",
           "connectivity_net728"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122404,7 +122404,7 @@
           "pcb_smtpad_439",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122423,7 +122423,7 @@
           "pcb_smtpad_440",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122442,7 +122442,7 @@
           "pcb_smtpad_440",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122461,7 +122461,7 @@
           "pcb_smtpad_440",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122480,7 +122480,7 @@
           "pcb_smtpad_440",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122499,7 +122499,7 @@
           "pcb_smtpad_441",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122518,7 +122518,7 @@
           "pcb_smtpad_441",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122537,7 +122537,7 @@
           "pcb_smtpad_441",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122556,7 +122556,7 @@
           "pcb_smtpad_441",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122575,7 +122575,7 @@
           "pcb_smtpad_442",
           "connectivity_net750"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122594,7 +122594,7 @@
           "pcb_smtpad_443",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122613,7 +122613,7 @@
           "pcb_smtpad_444",
           "connectivity_net739"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122632,7 +122632,7 @@
           "pcb_smtpad_445",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122651,7 +122651,7 @@
           "pcb_smtpad_446",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122670,7 +122670,7 @@
           "pcb_smtpad_446",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122689,7 +122689,7 @@
           "pcb_smtpad_446",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122708,7 +122708,7 @@
           "pcb_smtpad_446",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122727,7 +122727,7 @@
           "pcb_smtpad_447",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122746,7 +122746,7 @@
           "pcb_smtpad_447",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122765,7 +122765,7 @@
           "pcb_smtpad_447",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122784,7 +122784,7 @@
           "pcb_smtpad_447",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122803,7 +122803,7 @@
           "pcb_smtpad_448",
           "connectivity_net761"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122822,7 +122822,7 @@
           "pcb_smtpad_449",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122841,7 +122841,7 @@
           "pcb_smtpad_450",
           "connectivity_net750"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122860,7 +122860,7 @@
           "pcb_smtpad_451",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122879,7 +122879,7 @@
           "pcb_smtpad_452",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122898,7 +122898,7 @@
           "pcb_smtpad_452",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122917,7 +122917,7 @@
           "pcb_smtpad_452",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122936,7 +122936,7 @@
           "pcb_smtpad_452",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122955,7 +122955,7 @@
           "pcb_smtpad_453",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122974,7 +122974,7 @@
           "pcb_smtpad_453",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -122993,7 +122993,7 @@
           "pcb_smtpad_453",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123012,7 +123012,7 @@
           "pcb_smtpad_453",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123031,7 +123031,7 @@
           "pcb_smtpad_454",
           "connectivity_net772"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123050,7 +123050,7 @@
           "pcb_smtpad_455",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123069,7 +123069,7 @@
           "pcb_smtpad_456",
           "connectivity_net761"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123088,7 +123088,7 @@
           "pcb_smtpad_457",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123107,7 +123107,7 @@
           "pcb_smtpad_458",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123126,7 +123126,7 @@
           "pcb_smtpad_458",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123145,7 +123145,7 @@
           "pcb_smtpad_458",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123164,7 +123164,7 @@
           "pcb_smtpad_458",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123183,7 +123183,7 @@
           "pcb_smtpad_459",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123202,7 +123202,7 @@
           "pcb_smtpad_459",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123221,7 +123221,7 @@
           "pcb_smtpad_459",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123240,7 +123240,7 @@
           "pcb_smtpad_459",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123259,7 +123259,7 @@
           "pcb_smtpad_460",
           "connectivity_net783"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123278,7 +123278,7 @@
           "pcb_smtpad_461",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123297,7 +123297,7 @@
           "pcb_smtpad_462",
           "connectivity_net772"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123316,7 +123316,7 @@
           "pcb_smtpad_463",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123335,7 +123335,7 @@
           "pcb_smtpad_464",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123354,7 +123354,7 @@
           "pcb_smtpad_464",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123373,7 +123373,7 @@
           "pcb_smtpad_464",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123392,7 +123392,7 @@
           "pcb_smtpad_464",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123411,7 +123411,7 @@
           "pcb_smtpad_465",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123430,7 +123430,7 @@
           "pcb_smtpad_465",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123449,7 +123449,7 @@
           "pcb_smtpad_465",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123468,7 +123468,7 @@
           "pcb_smtpad_465",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123487,7 +123487,7 @@
           "pcb_smtpad_466",
           "connectivity_net794"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123506,7 +123506,7 @@
           "pcb_smtpad_467",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123525,7 +123525,7 @@
           "pcb_smtpad_468",
           "connectivity_net783"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123544,7 +123544,7 @@
           "pcb_smtpad_469",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123563,7 +123563,7 @@
           "pcb_smtpad_470",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123582,7 +123582,7 @@
           "pcb_smtpad_470",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123601,7 +123601,7 @@
           "pcb_smtpad_470",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123620,7 +123620,7 @@
           "pcb_smtpad_470",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123639,7 +123639,7 @@
           "pcb_smtpad_471",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123658,7 +123658,7 @@
           "pcb_smtpad_471",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123677,7 +123677,7 @@
           "pcb_smtpad_471",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123696,7 +123696,7 @@
           "pcb_smtpad_471",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123715,7 +123715,7 @@
           "pcb_smtpad_472",
           "connectivity_net805"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123734,7 +123734,7 @@
           "pcb_smtpad_473",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123753,7 +123753,7 @@
           "pcb_smtpad_474",
           "connectivity_net794"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123772,7 +123772,7 @@
           "pcb_smtpad_475",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123791,7 +123791,7 @@
           "pcb_smtpad_476",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123810,7 +123810,7 @@
           "pcb_smtpad_476",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123829,7 +123829,7 @@
           "pcb_smtpad_476",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123848,7 +123848,7 @@
           "pcb_smtpad_476",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123867,7 +123867,7 @@
           "pcb_smtpad_477",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123886,7 +123886,7 @@
           "pcb_smtpad_477",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123905,7 +123905,7 @@
           "pcb_smtpad_477",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123924,7 +123924,7 @@
           "pcb_smtpad_477",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123943,7 +123943,7 @@
           "pcb_smtpad_478",
           "connectivity_net816"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123962,7 +123962,7 @@
           "pcb_smtpad_479",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -123981,7 +123981,7 @@
           "pcb_smtpad_480",
           "connectivity_net805"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124000,7 +124000,7 @@
           "pcb_smtpad_481",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124019,7 +124019,7 @@
           "pcb_smtpad_482",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124038,7 +124038,7 @@
           "pcb_smtpad_482",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124057,7 +124057,7 @@
           "pcb_smtpad_482",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124076,7 +124076,7 @@
           "pcb_smtpad_482",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124095,7 +124095,7 @@
           "pcb_smtpad_483",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124114,7 +124114,7 @@
           "pcb_smtpad_483",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124133,7 +124133,7 @@
           "pcb_smtpad_483",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124152,7 +124152,7 @@
           "pcb_smtpad_483",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124171,7 +124171,7 @@
           "pcb_smtpad_484",
           "connectivity_net827"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124190,7 +124190,7 @@
           "pcb_smtpad_485",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124209,7 +124209,7 @@
           "pcb_smtpad_486",
           "connectivity_net816"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124228,7 +124228,7 @@
           "pcb_smtpad_487",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124247,7 +124247,7 @@
           "pcb_smtpad_488",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124266,7 +124266,7 @@
           "pcb_smtpad_488",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124285,7 +124285,7 @@
           "pcb_smtpad_488",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124304,7 +124304,7 @@
           "pcb_smtpad_488",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124323,7 +124323,7 @@
           "pcb_smtpad_489",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124342,7 +124342,7 @@
           "pcb_smtpad_489",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124361,7 +124361,7 @@
           "pcb_smtpad_489",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124380,7 +124380,7 @@
           "pcb_smtpad_489",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124399,7 +124399,7 @@
           "pcb_smtpad_490",
           "connectivity_net838"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124418,7 +124418,7 @@
           "pcb_smtpad_491",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124437,7 +124437,7 @@
           "pcb_smtpad_492",
           "connectivity_net827"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124456,7 +124456,7 @@
           "pcb_smtpad_493",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124475,7 +124475,7 @@
           "pcb_smtpad_494",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124494,7 +124494,7 @@
           "pcb_smtpad_494",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124513,7 +124513,7 @@
           "pcb_smtpad_494",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124532,7 +124532,7 @@
           "pcb_smtpad_494",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124551,7 +124551,7 @@
           "pcb_smtpad_495",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124570,7 +124570,7 @@
           "pcb_smtpad_495",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124589,7 +124589,7 @@
           "pcb_smtpad_495",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124608,7 +124608,7 @@
           "pcb_smtpad_495",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124627,7 +124627,7 @@
           "pcb_smtpad_496",
           "connectivity_net849"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124646,7 +124646,7 @@
           "pcb_smtpad_497",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124665,7 +124665,7 @@
           "pcb_smtpad_498",
           "connectivity_net838"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124684,7 +124684,7 @@
           "pcb_smtpad_499",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124703,7 +124703,7 @@
           "pcb_smtpad_500",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124722,7 +124722,7 @@
           "pcb_smtpad_500",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124741,7 +124741,7 @@
           "pcb_smtpad_500",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124760,7 +124760,7 @@
           "pcb_smtpad_500",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124779,7 +124779,7 @@
           "pcb_smtpad_501",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124798,7 +124798,7 @@
           "pcb_smtpad_501",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124817,7 +124817,7 @@
           "pcb_smtpad_501",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124836,7 +124836,7 @@
           "pcb_smtpad_501",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124855,7 +124855,7 @@
           "pcb_smtpad_502",
           "connectivity_net860"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124874,7 +124874,7 @@
           "pcb_smtpad_503",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124893,7 +124893,7 @@
           "pcb_smtpad_504",
           "connectivity_net849"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124912,7 +124912,7 @@
           "pcb_smtpad_505",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124931,7 +124931,7 @@
           "pcb_smtpad_506",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124950,7 +124950,7 @@
           "pcb_smtpad_506",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124969,7 +124969,7 @@
           "pcb_smtpad_506",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -124988,7 +124988,7 @@
           "pcb_smtpad_506",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125007,7 +125007,7 @@
           "pcb_smtpad_507",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125026,7 +125026,7 @@
           "pcb_smtpad_507",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125045,7 +125045,7 @@
           "pcb_smtpad_507",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125064,7 +125064,7 @@
           "pcb_smtpad_507",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125083,7 +125083,7 @@
           "pcb_smtpad_508",
           "connectivity_net871"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125102,7 +125102,7 @@
           "pcb_smtpad_509",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125121,7 +125121,7 @@
           "pcb_smtpad_510",
           "connectivity_net860"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125140,7 +125140,7 @@
           "pcb_smtpad_511",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125159,7 +125159,7 @@
           "pcb_smtpad_512",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125178,7 +125178,7 @@
           "pcb_smtpad_512",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125197,7 +125197,7 @@
           "pcb_smtpad_512",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125216,7 +125216,7 @@
           "pcb_smtpad_512",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125235,7 +125235,7 @@
           "pcb_smtpad_513",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125254,7 +125254,7 @@
           "pcb_smtpad_513",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125273,7 +125273,7 @@
           "pcb_smtpad_513",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125292,7 +125292,7 @@
           "pcb_smtpad_513",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125311,7 +125311,7 @@
           "pcb_smtpad_514",
           "connectivity_net882"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125330,7 +125330,7 @@
           "pcb_smtpad_515",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125349,7 +125349,7 @@
           "pcb_smtpad_516",
           "connectivity_net871"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125368,7 +125368,7 @@
           "pcb_smtpad_517",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125387,7 +125387,7 @@
           "pcb_smtpad_518",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125406,7 +125406,7 @@
           "pcb_smtpad_518",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125425,7 +125425,7 @@
           "pcb_smtpad_518",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125444,7 +125444,7 @@
           "pcb_smtpad_518",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125463,7 +125463,7 @@
           "pcb_smtpad_519",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125482,7 +125482,7 @@
           "pcb_smtpad_519",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125501,7 +125501,7 @@
           "pcb_smtpad_519",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125520,7 +125520,7 @@
           "pcb_smtpad_519",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125539,7 +125539,7 @@
           "pcb_smtpad_520",
           "connectivity_net893"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125558,7 +125558,7 @@
           "pcb_smtpad_521",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125577,7 +125577,7 @@
           "pcb_smtpad_522",
           "connectivity_net882"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125596,7 +125596,7 @@
           "pcb_smtpad_523",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125615,7 +125615,7 @@
           "pcb_smtpad_524",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125634,7 +125634,7 @@
           "pcb_smtpad_524",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125653,7 +125653,7 @@
           "pcb_smtpad_524",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125672,7 +125672,7 @@
           "pcb_smtpad_524",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125691,7 +125691,7 @@
           "pcb_smtpad_525",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125710,7 +125710,7 @@
           "pcb_smtpad_525",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125729,7 +125729,7 @@
           "pcb_smtpad_525",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125748,7 +125748,7 @@
           "pcb_smtpad_525",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125767,7 +125767,7 @@
           "pcb_smtpad_526",
           "connectivity_net904"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125786,7 +125786,7 @@
           "pcb_smtpad_527",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125805,7 +125805,7 @@
           "pcb_smtpad_528",
           "connectivity_net893"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125824,7 +125824,7 @@
           "pcb_smtpad_529",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125843,7 +125843,7 @@
           "pcb_smtpad_530",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125862,7 +125862,7 @@
           "pcb_smtpad_530",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125881,7 +125881,7 @@
           "pcb_smtpad_530",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125900,7 +125900,7 @@
           "pcb_smtpad_530",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125919,7 +125919,7 @@
           "pcb_smtpad_531",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125938,7 +125938,7 @@
           "pcb_smtpad_531",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125957,7 +125957,7 @@
           "pcb_smtpad_531",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125976,7 +125976,7 @@
           "pcb_smtpad_531",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -125995,7 +125995,7 @@
           "pcb_smtpad_532",
           "connectivity_net915"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126014,7 +126014,7 @@
           "pcb_smtpad_533",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126033,7 +126033,7 @@
           "pcb_smtpad_534",
           "connectivity_net904"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126052,7 +126052,7 @@
           "pcb_smtpad_535",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126071,7 +126071,7 @@
           "pcb_smtpad_536",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126090,7 +126090,7 @@
           "pcb_smtpad_536",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126109,7 +126109,7 @@
           "pcb_smtpad_536",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126128,7 +126128,7 @@
           "pcb_smtpad_536",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126147,7 +126147,7 @@
           "pcb_smtpad_537",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126166,7 +126166,7 @@
           "pcb_smtpad_537",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126185,7 +126185,7 @@
           "pcb_smtpad_537",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126204,7 +126204,7 @@
           "pcb_smtpad_537",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126223,7 +126223,7 @@
           "pcb_smtpad_538",
           "connectivity_net926"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126242,7 +126242,7 @@
           "pcb_smtpad_539",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126261,7 +126261,7 @@
           "pcb_smtpad_540",
           "connectivity_net915"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126280,7 +126280,7 @@
           "pcb_smtpad_541",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126299,7 +126299,7 @@
           "pcb_smtpad_542",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126318,7 +126318,7 @@
           "pcb_smtpad_542",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126337,7 +126337,7 @@
           "pcb_smtpad_542",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126356,7 +126356,7 @@
           "pcb_smtpad_542",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126375,7 +126375,7 @@
           "pcb_smtpad_543",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126394,7 +126394,7 @@
           "pcb_smtpad_543",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126413,7 +126413,7 @@
           "pcb_smtpad_543",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126432,7 +126432,7 @@
           "pcb_smtpad_543",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126451,7 +126451,7 @@
           "pcb_smtpad_544",
           "connectivity_net937"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126470,7 +126470,7 @@
           "pcb_smtpad_545",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126489,7 +126489,7 @@
           "pcb_smtpad_546",
           "connectivity_net926"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126508,7 +126508,7 @@
           "pcb_smtpad_547",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126527,7 +126527,7 @@
           "pcb_smtpad_548",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126546,7 +126546,7 @@
           "pcb_smtpad_548",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126565,7 +126565,7 @@
           "pcb_smtpad_548",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126584,7 +126584,7 @@
           "pcb_smtpad_548",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126603,7 +126603,7 @@
           "pcb_smtpad_549",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126622,7 +126622,7 @@
           "pcb_smtpad_549",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126641,7 +126641,7 @@
           "pcb_smtpad_549",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126660,7 +126660,7 @@
           "pcb_smtpad_549",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126679,7 +126679,7 @@
           "pcb_smtpad_550",
           "connectivity_net948"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126698,7 +126698,7 @@
           "pcb_smtpad_551",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126717,7 +126717,7 @@
           "pcb_smtpad_552",
           "connectivity_net937"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126736,7 +126736,7 @@
           "pcb_smtpad_553",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126755,7 +126755,7 @@
           "pcb_smtpad_554",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126774,7 +126774,7 @@
           "pcb_smtpad_554",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126793,7 +126793,7 @@
           "pcb_smtpad_554",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126812,7 +126812,7 @@
           "pcb_smtpad_554",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126831,7 +126831,7 @@
           "pcb_smtpad_555",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126850,7 +126850,7 @@
           "pcb_smtpad_555",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126869,7 +126869,7 @@
           "pcb_smtpad_555",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126888,7 +126888,7 @@
           "pcb_smtpad_555",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126907,7 +126907,7 @@
           "pcb_smtpad_556",
           "connectivity_net959"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126926,7 +126926,7 @@
           "pcb_smtpad_557",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126945,7 +126945,7 @@
           "pcb_smtpad_558",
           "connectivity_net948"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126964,7 +126964,7 @@
           "pcb_smtpad_559",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -126983,7 +126983,7 @@
           "pcb_smtpad_560",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127002,7 +127002,7 @@
           "pcb_smtpad_560",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127021,7 +127021,7 @@
           "pcb_smtpad_560",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127040,7 +127040,7 @@
           "pcb_smtpad_560",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127059,7 +127059,7 @@
           "pcb_smtpad_561",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127078,7 +127078,7 @@
           "pcb_smtpad_561",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127097,7 +127097,7 @@
           "pcb_smtpad_561",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127116,7 +127116,7 @@
           "pcb_smtpad_561",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127135,7 +127135,7 @@
           "pcb_smtpad_562",
           "connectivity_net970"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127154,7 +127154,7 @@
           "pcb_smtpad_563",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127173,7 +127173,7 @@
           "pcb_smtpad_564",
           "connectivity_net959"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127192,7 +127192,7 @@
           "pcb_smtpad_565",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127211,7 +127211,7 @@
           "pcb_smtpad_566",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127230,7 +127230,7 @@
           "pcb_smtpad_566",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127249,7 +127249,7 @@
           "pcb_smtpad_566",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127268,7 +127268,7 @@
           "pcb_smtpad_566",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127287,7 +127287,7 @@
           "pcb_smtpad_567",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127306,7 +127306,7 @@
           "pcb_smtpad_567",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127325,7 +127325,7 @@
           "pcb_smtpad_567",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127344,7 +127344,7 @@
           "pcb_smtpad_567",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127363,7 +127363,7 @@
           "pcb_smtpad_568",
           "connectivity_net981"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127382,7 +127382,7 @@
           "pcb_smtpad_569",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127401,7 +127401,7 @@
           "pcb_smtpad_570",
           "connectivity_net970"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127420,7 +127420,7 @@
           "pcb_smtpad_571",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127439,7 +127439,7 @@
           "pcb_smtpad_572",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127458,7 +127458,7 @@
           "pcb_smtpad_572",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127477,7 +127477,7 @@
           "pcb_smtpad_572",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127496,7 +127496,7 @@
           "pcb_smtpad_572",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127515,7 +127515,7 @@
           "pcb_smtpad_573",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127534,7 +127534,7 @@
           "pcb_smtpad_573",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127553,7 +127553,7 @@
           "pcb_smtpad_573",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127572,7 +127572,7 @@
           "pcb_smtpad_573",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127591,7 +127591,7 @@
           "pcb_smtpad_574",
           "connectivity_net992"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127610,7 +127610,7 @@
           "pcb_smtpad_575",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127629,7 +127629,7 @@
           "pcb_smtpad_576",
           "connectivity_net981"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127648,7 +127648,7 @@
           "pcb_smtpad_577",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127667,7 +127667,7 @@
           "pcb_smtpad_578",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127686,7 +127686,7 @@
           "pcb_smtpad_578",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127705,7 +127705,7 @@
           "pcb_smtpad_578",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127724,7 +127724,7 @@
           "pcb_smtpad_578",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127743,7 +127743,7 @@
           "pcb_smtpad_579",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127762,7 +127762,7 @@
           "pcb_smtpad_579",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127781,7 +127781,7 @@
           "pcb_smtpad_579",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127800,7 +127800,7 @@
           "pcb_smtpad_579",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127819,7 +127819,7 @@
           "pcb_smtpad_580",
           "connectivity_net1003"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127838,7 +127838,7 @@
           "pcb_smtpad_581",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127857,7 +127857,7 @@
           "pcb_smtpad_582",
           "connectivity_net992"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127876,7 +127876,7 @@
           "pcb_smtpad_583",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127895,7 +127895,7 @@
           "pcb_smtpad_584",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127914,7 +127914,7 @@
           "pcb_smtpad_584",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127933,7 +127933,7 @@
           "pcb_smtpad_584",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127952,7 +127952,7 @@
           "pcb_smtpad_584",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127971,7 +127971,7 @@
           "pcb_smtpad_585",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -127990,7 +127990,7 @@
           "pcb_smtpad_585",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128009,7 +128009,7 @@
           "pcb_smtpad_585",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128028,7 +128028,7 @@
           "pcb_smtpad_585",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128047,7 +128047,7 @@
           "pcb_smtpad_586",
           "connectivity_net1014"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128066,7 +128066,7 @@
           "pcb_smtpad_587",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128085,7 +128085,7 @@
           "pcb_smtpad_588",
           "connectivity_net1003"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128104,7 +128104,7 @@
           "pcb_smtpad_589",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128123,7 +128123,7 @@
           "pcb_smtpad_590",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128142,7 +128142,7 @@
           "pcb_smtpad_590",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128161,7 +128161,7 @@
           "pcb_smtpad_590",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128180,7 +128180,7 @@
           "pcb_smtpad_590",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128199,7 +128199,7 @@
           "pcb_smtpad_591",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128218,7 +128218,7 @@
           "pcb_smtpad_591",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128237,7 +128237,7 @@
           "pcb_smtpad_591",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128256,7 +128256,7 @@
           "pcb_smtpad_591",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128275,7 +128275,7 @@
           "pcb_smtpad_592",
           "connectivity_net1025"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128294,7 +128294,7 @@
           "pcb_smtpad_593",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128313,7 +128313,7 @@
           "pcb_smtpad_594",
           "connectivity_net1014"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128332,7 +128332,7 @@
           "pcb_smtpad_595",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128351,7 +128351,7 @@
           "pcb_smtpad_596",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128370,7 +128370,7 @@
           "pcb_smtpad_596",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128389,7 +128389,7 @@
           "pcb_smtpad_596",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128408,7 +128408,7 @@
           "pcb_smtpad_596",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128427,7 +128427,7 @@
           "pcb_smtpad_597",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128446,7 +128446,7 @@
           "pcb_smtpad_597",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128465,7 +128465,7 @@
           "pcb_smtpad_597",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128484,7 +128484,7 @@
           "pcb_smtpad_597",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128503,7 +128503,7 @@
           "pcb_smtpad_598",
           "connectivity_net1036"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128522,7 +128522,7 @@
           "pcb_smtpad_599",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128541,7 +128541,7 @@
           "pcb_smtpad_600",
           "connectivity_net1025"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128560,7 +128560,7 @@
           "pcb_smtpad_601",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128579,7 +128579,7 @@
           "pcb_smtpad_602",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128598,7 +128598,7 @@
           "pcb_smtpad_602",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128617,7 +128617,7 @@
           "pcb_smtpad_602",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128636,7 +128636,7 @@
           "pcb_smtpad_602",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128655,7 +128655,7 @@
           "pcb_smtpad_603",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128674,7 +128674,7 @@
           "pcb_smtpad_603",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128693,7 +128693,7 @@
           "pcb_smtpad_603",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128712,7 +128712,7 @@
           "pcb_smtpad_603",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128731,7 +128731,7 @@
           "pcb_smtpad_604",
           "connectivity_net1047"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128750,7 +128750,7 @@
           "pcb_smtpad_605",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128769,7 +128769,7 @@
           "pcb_smtpad_606",
           "connectivity_net1036"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128788,7 +128788,7 @@
           "pcb_smtpad_607",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128807,7 +128807,7 @@
           "pcb_smtpad_608",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128826,7 +128826,7 @@
           "pcb_smtpad_608",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128845,7 +128845,7 @@
           "pcb_smtpad_608",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128864,7 +128864,7 @@
           "pcb_smtpad_608",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128883,7 +128883,7 @@
           "pcb_smtpad_609",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128902,7 +128902,7 @@
           "pcb_smtpad_609",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128921,7 +128921,7 @@
           "pcb_smtpad_609",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128940,7 +128940,7 @@
           "pcb_smtpad_609",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128959,7 +128959,7 @@
           "pcb_smtpad_610",
           "connectivity_net1058"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128978,7 +128978,7 @@
           "pcb_smtpad_611",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -128997,7 +128997,7 @@
           "pcb_smtpad_612",
           "connectivity_net1047"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129016,7 +129016,7 @@
           "pcb_smtpad_613",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129035,7 +129035,7 @@
           "pcb_smtpad_614",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129054,7 +129054,7 @@
           "pcb_smtpad_614",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129073,7 +129073,7 @@
           "pcb_smtpad_614",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129092,7 +129092,7 @@
           "pcb_smtpad_614",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129111,7 +129111,7 @@
           "pcb_smtpad_615",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129130,7 +129130,7 @@
           "pcb_smtpad_615",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129149,7 +129149,7 @@
           "pcb_smtpad_615",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129168,7 +129168,7 @@
           "pcb_smtpad_615",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129187,7 +129187,7 @@
           "pcb_smtpad_616",
           "connectivity_net1069"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129206,7 +129206,7 @@
           "pcb_smtpad_617",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129225,7 +129225,7 @@
           "pcb_smtpad_618",
           "connectivity_net1058"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129244,7 +129244,7 @@
           "pcb_smtpad_619",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129263,7 +129263,7 @@
           "pcb_smtpad_620",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129282,7 +129282,7 @@
           "pcb_smtpad_620",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129301,7 +129301,7 @@
           "pcb_smtpad_620",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129320,7 +129320,7 @@
           "pcb_smtpad_620",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129339,7 +129339,7 @@
           "pcb_smtpad_621",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129358,7 +129358,7 @@
           "pcb_smtpad_621",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129377,7 +129377,7 @@
           "pcb_smtpad_621",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129396,7 +129396,7 @@
           "pcb_smtpad_621",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129415,7 +129415,7 @@
           "pcb_smtpad_622",
           "connectivity_net1080"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129434,7 +129434,7 @@
           "pcb_smtpad_623",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129453,7 +129453,7 @@
           "pcb_smtpad_624",
           "connectivity_net1069"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129472,7 +129472,7 @@
           "pcb_smtpad_625",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129491,7 +129491,7 @@
           "pcb_smtpad_626",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129510,7 +129510,7 @@
           "pcb_smtpad_626",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129529,7 +129529,7 @@
           "pcb_smtpad_626",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129548,7 +129548,7 @@
           "pcb_smtpad_626",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129567,7 +129567,7 @@
           "pcb_smtpad_627",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129586,7 +129586,7 @@
           "pcb_smtpad_627",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129605,7 +129605,7 @@
           "pcb_smtpad_627",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129624,7 +129624,7 @@
           "pcb_smtpad_627",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129643,7 +129643,7 @@
           "pcb_smtpad_628",
           "connectivity_net1091"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129662,7 +129662,7 @@
           "pcb_smtpad_629",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129681,7 +129681,7 @@
           "pcb_smtpad_630",
           "connectivity_net1080"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129700,7 +129700,7 @@
           "pcb_smtpad_631",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129719,7 +129719,7 @@
           "pcb_smtpad_632",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129738,7 +129738,7 @@
           "pcb_smtpad_632",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129757,7 +129757,7 @@
           "pcb_smtpad_632",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129776,7 +129776,7 @@
           "pcb_smtpad_632",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129795,7 +129795,7 @@
           "pcb_smtpad_633",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129814,7 +129814,7 @@
           "pcb_smtpad_633",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129833,7 +129833,7 @@
           "pcb_smtpad_633",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129852,7 +129852,7 @@
           "pcb_smtpad_633",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129871,7 +129871,7 @@
           "pcb_smtpad_634",
           "connectivity_net1102"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129890,7 +129890,7 @@
           "pcb_smtpad_635",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129909,7 +129909,7 @@
           "pcb_smtpad_636",
           "connectivity_net1091"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129928,7 +129928,7 @@
           "pcb_smtpad_637",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129947,7 +129947,7 @@
           "pcb_smtpad_638",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129966,7 +129966,7 @@
           "pcb_smtpad_638",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -129985,7 +129985,7 @@
           "pcb_smtpad_638",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130004,7 +130004,7 @@
           "pcb_smtpad_638",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130023,7 +130023,7 @@
           "pcb_smtpad_639",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130042,7 +130042,7 @@
           "pcb_smtpad_639",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130061,7 +130061,7 @@
           "pcb_smtpad_639",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130080,7 +130080,7 @@
           "pcb_smtpad_639",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130099,7 +130099,7 @@
           "pcb_smtpad_640",
           "connectivity_net1113"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130118,7 +130118,7 @@
           "pcb_smtpad_641",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130137,7 +130137,7 @@
           "pcb_smtpad_642",
           "connectivity_net1102"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130156,7 +130156,7 @@
           "pcb_smtpad_643",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130175,7 +130175,7 @@
           "pcb_smtpad_644",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130194,7 +130194,7 @@
           "pcb_smtpad_644",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130213,7 +130213,7 @@
           "pcb_smtpad_644",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130232,7 +130232,7 @@
           "pcb_smtpad_644",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130251,7 +130251,7 @@
           "pcb_smtpad_645",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130270,7 +130270,7 @@
           "pcb_smtpad_645",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130289,7 +130289,7 @@
           "pcb_smtpad_645",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130308,7 +130308,7 @@
           "pcb_smtpad_645",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130327,7 +130327,7 @@
           "pcb_smtpad_646",
           "connectivity_net1124"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130346,7 +130346,7 @@
           "pcb_smtpad_647",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130365,7 +130365,7 @@
           "pcb_smtpad_648",
           "connectivity_net1113"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130384,7 +130384,7 @@
           "pcb_smtpad_649",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130403,7 +130403,7 @@
           "pcb_smtpad_650",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130422,7 +130422,7 @@
           "pcb_smtpad_650",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130441,7 +130441,7 @@
           "pcb_smtpad_650",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130460,7 +130460,7 @@
           "pcb_smtpad_650",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130479,7 +130479,7 @@
           "pcb_smtpad_651",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130498,7 +130498,7 @@
           "pcb_smtpad_651",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130517,7 +130517,7 @@
           "pcb_smtpad_651",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130536,7 +130536,7 @@
           "pcb_smtpad_651",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130555,7 +130555,7 @@
           "pcb_smtpad_652",
           "connectivity_net1135"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130574,7 +130574,7 @@
           "pcb_smtpad_653",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130593,7 +130593,7 @@
           "pcb_smtpad_654",
           "connectivity_net1124"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130612,7 +130612,7 @@
           "pcb_smtpad_655",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130631,7 +130631,7 @@
           "pcb_smtpad_656",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130650,7 +130650,7 @@
           "pcb_smtpad_656",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130669,7 +130669,7 @@
           "pcb_smtpad_656",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130688,7 +130688,7 @@
           "pcb_smtpad_656",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130707,7 +130707,7 @@
           "pcb_smtpad_657",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130726,7 +130726,7 @@
           "pcb_smtpad_657",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130745,7 +130745,7 @@
           "pcb_smtpad_657",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130764,7 +130764,7 @@
           "pcb_smtpad_657",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130783,7 +130783,7 @@
           "pcb_smtpad_658",
           "connectivity_net1146"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130802,7 +130802,7 @@
           "pcb_smtpad_659",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130821,7 +130821,7 @@
           "pcb_smtpad_660",
           "connectivity_net1135"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130840,7 +130840,7 @@
           "pcb_smtpad_661",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130859,7 +130859,7 @@
           "pcb_smtpad_662",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130878,7 +130878,7 @@
           "pcb_smtpad_662",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130897,7 +130897,7 @@
           "pcb_smtpad_662",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130916,7 +130916,7 @@
           "pcb_smtpad_662",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130935,7 +130935,7 @@
           "pcb_smtpad_663",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130954,7 +130954,7 @@
           "pcb_smtpad_663",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130973,7 +130973,7 @@
           "pcb_smtpad_663",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -130992,7 +130992,7 @@
           "pcb_smtpad_663",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131011,7 +131011,7 @@
           "pcb_smtpad_664",
           "connectivity_net1157"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131030,7 +131030,7 @@
           "pcb_smtpad_665",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131049,7 +131049,7 @@
           "pcb_smtpad_666",
           "connectivity_net1146"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131068,7 +131068,7 @@
           "pcb_smtpad_667",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131087,7 +131087,7 @@
           "pcb_smtpad_668",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131106,7 +131106,7 @@
           "pcb_smtpad_668",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131125,7 +131125,7 @@
           "pcb_smtpad_668",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131144,7 +131144,7 @@
           "pcb_smtpad_668",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131163,7 +131163,7 @@
           "pcb_smtpad_669",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131182,7 +131182,7 @@
           "pcb_smtpad_669",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131201,7 +131201,7 @@
           "pcb_smtpad_669",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131220,7 +131220,7 @@
           "pcb_smtpad_669",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131239,7 +131239,7 @@
           "pcb_smtpad_670",
           "connectivity_net1168"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131258,7 +131258,7 @@
           "pcb_smtpad_671",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131277,7 +131277,7 @@
           "pcb_smtpad_672",
           "connectivity_net1157"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131296,7 +131296,7 @@
           "pcb_smtpad_673",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131315,7 +131315,7 @@
           "pcb_smtpad_674",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131334,7 +131334,7 @@
           "pcb_smtpad_674",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131353,7 +131353,7 @@
           "pcb_smtpad_674",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131372,7 +131372,7 @@
           "pcb_smtpad_674",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131391,7 +131391,7 @@
           "pcb_smtpad_675",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131410,7 +131410,7 @@
           "pcb_smtpad_675",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131429,7 +131429,7 @@
           "pcb_smtpad_675",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131448,7 +131448,7 @@
           "pcb_smtpad_675",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131467,7 +131467,7 @@
           "pcb_smtpad_676",
           "connectivity_net1179"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131486,7 +131486,7 @@
           "pcb_smtpad_677",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131505,7 +131505,7 @@
           "pcb_smtpad_678",
           "connectivity_net1168"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131524,7 +131524,7 @@
           "pcb_smtpad_679",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131543,7 +131543,7 @@
           "pcb_smtpad_680",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131562,7 +131562,7 @@
           "pcb_smtpad_680",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131581,7 +131581,7 @@
           "pcb_smtpad_680",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131600,7 +131600,7 @@
           "pcb_smtpad_680",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131619,7 +131619,7 @@
           "pcb_smtpad_681",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131638,7 +131638,7 @@
           "pcb_smtpad_681",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131657,7 +131657,7 @@
           "pcb_smtpad_681",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131676,7 +131676,7 @@
           "pcb_smtpad_681",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131695,7 +131695,7 @@
           "pcb_smtpad_682",
           "connectivity_net1190"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131714,7 +131714,7 @@
           "pcb_smtpad_683",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131733,7 +131733,7 @@
           "pcb_smtpad_684",
           "connectivity_net1179"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131752,7 +131752,7 @@
           "pcb_smtpad_685",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131771,7 +131771,7 @@
           "pcb_smtpad_686",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131790,7 +131790,7 @@
           "pcb_smtpad_686",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131809,7 +131809,7 @@
           "pcb_smtpad_686",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131828,7 +131828,7 @@
           "pcb_smtpad_686",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131847,7 +131847,7 @@
           "pcb_smtpad_687",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131866,7 +131866,7 @@
           "pcb_smtpad_687",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131885,7 +131885,7 @@
           "pcb_smtpad_687",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131904,7 +131904,7 @@
           "pcb_smtpad_687",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131923,7 +131923,7 @@
           "pcb_smtpad_688",
           "connectivity_net1201"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131942,7 +131942,7 @@
           "pcb_smtpad_689",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131961,7 +131961,7 @@
           "pcb_smtpad_690",
           "connectivity_net1190"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131980,7 +131980,7 @@
           "pcb_smtpad_691",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -131999,7 +131999,7 @@
           "pcb_smtpad_692",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132018,7 +132018,7 @@
           "pcb_smtpad_692",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132037,7 +132037,7 @@
           "pcb_smtpad_692",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132056,7 +132056,7 @@
           "pcb_smtpad_692",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132075,7 +132075,7 @@
           "pcb_smtpad_693",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132094,7 +132094,7 @@
           "pcb_smtpad_693",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132113,7 +132113,7 @@
           "pcb_smtpad_693",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132132,7 +132132,7 @@
           "pcb_smtpad_693",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132151,7 +132151,7 @@
           "pcb_smtpad_694",
           "connectivity_net1212"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132170,7 +132170,7 @@
           "pcb_smtpad_695",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132189,7 +132189,7 @@
           "pcb_smtpad_696",
           "connectivity_net1201"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132208,7 +132208,7 @@
           "pcb_smtpad_697",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132227,7 +132227,7 @@
           "pcb_smtpad_698",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132246,7 +132246,7 @@
           "pcb_smtpad_698",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132265,7 +132265,7 @@
           "pcb_smtpad_698",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132284,7 +132284,7 @@
           "pcb_smtpad_698",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132303,7 +132303,7 @@
           "pcb_smtpad_699",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132322,7 +132322,7 @@
           "pcb_smtpad_699",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132341,7 +132341,7 @@
           "pcb_smtpad_699",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132360,7 +132360,7 @@
           "pcb_smtpad_699",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132379,7 +132379,7 @@
           "pcb_smtpad_700",
           "connectivity_net1223"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132398,7 +132398,7 @@
           "pcb_smtpad_701",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132417,7 +132417,7 @@
           "pcb_smtpad_702",
           "connectivity_net1212"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132436,7 +132436,7 @@
           "pcb_smtpad_703",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132455,7 +132455,7 @@
           "pcb_smtpad_704",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132474,7 +132474,7 @@
           "pcb_smtpad_704",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132493,7 +132493,7 @@
           "pcb_smtpad_704",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132512,7 +132512,7 @@
           "pcb_smtpad_704",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132531,7 +132531,7 @@
           "pcb_smtpad_705",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132550,7 +132550,7 @@
           "pcb_smtpad_705",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132569,7 +132569,7 @@
           "pcb_smtpad_705",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132588,7 +132588,7 @@
           "pcb_smtpad_705",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132607,7 +132607,7 @@
           "pcb_smtpad_706",
           "connectivity_net1234"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132626,7 +132626,7 @@
           "pcb_smtpad_707",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132645,7 +132645,7 @@
           "pcb_smtpad_708",
           "connectivity_net1223"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132664,7 +132664,7 @@
           "pcb_smtpad_709",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132683,7 +132683,7 @@
           "pcb_smtpad_710",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132702,7 +132702,7 @@
           "pcb_smtpad_710",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132721,7 +132721,7 @@
           "pcb_smtpad_710",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132740,7 +132740,7 @@
           "pcb_smtpad_710",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132759,7 +132759,7 @@
           "pcb_smtpad_711",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132778,7 +132778,7 @@
           "pcb_smtpad_711",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132797,7 +132797,7 @@
           "pcb_smtpad_711",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132816,7 +132816,7 @@
           "pcb_smtpad_711",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132835,7 +132835,7 @@
           "pcb_smtpad_712",
           "connectivity_net1245"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132854,7 +132854,7 @@
           "pcb_smtpad_713",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132873,7 +132873,7 @@
           "pcb_smtpad_714",
           "connectivity_net1234"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132892,7 +132892,7 @@
           "pcb_smtpad_715",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132911,7 +132911,7 @@
           "pcb_smtpad_716",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132930,7 +132930,7 @@
           "pcb_smtpad_716",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132949,7 +132949,7 @@
           "pcb_smtpad_716",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132968,7 +132968,7 @@
           "pcb_smtpad_716",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132987,7 +132987,7 @@
           "pcb_smtpad_717",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133006,7 +133006,7 @@
           "pcb_smtpad_717",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133025,7 +133025,7 @@
           "pcb_smtpad_717",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133044,7 +133044,7 @@
           "pcb_smtpad_717",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133063,7 +133063,7 @@
           "pcb_smtpad_718",
           "connectivity_net1256"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133082,7 +133082,7 @@
           "pcb_smtpad_719",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133101,7 +133101,7 @@
           "pcb_smtpad_720",
           "connectivity_net1245"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133120,7 +133120,7 @@
           "pcb_smtpad_721",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133139,7 +133139,7 @@
           "pcb_smtpad_722",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133158,7 +133158,7 @@
           "pcb_smtpad_722",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133177,7 +133177,7 @@
           "pcb_smtpad_722",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133196,7 +133196,7 @@
           "pcb_smtpad_722",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133215,7 +133215,7 @@
           "pcb_smtpad_723",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133234,7 +133234,7 @@
           "pcb_smtpad_723",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133253,7 +133253,7 @@
           "pcb_smtpad_723",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133272,7 +133272,7 @@
           "pcb_smtpad_723",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133291,7 +133291,7 @@
           "pcb_smtpad_724",
           "connectivity_net1267"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133310,7 +133310,7 @@
           "pcb_smtpad_725",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133329,7 +133329,7 @@
           "pcb_smtpad_726",
           "connectivity_net1256"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133348,7 +133348,7 @@
           "pcb_smtpad_727",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133367,7 +133367,7 @@
           "pcb_smtpad_728",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133386,7 +133386,7 @@
           "pcb_smtpad_728",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133405,7 +133405,7 @@
           "pcb_smtpad_728",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133424,7 +133424,7 @@
           "pcb_smtpad_728",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133443,7 +133443,7 @@
           "pcb_smtpad_729",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133462,7 +133462,7 @@
           "pcb_smtpad_729",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133481,7 +133481,7 @@
           "pcb_smtpad_729",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133500,7 +133500,7 @@
           "pcb_smtpad_729",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133519,7 +133519,7 @@
           "pcb_smtpad_730",
           "connectivity_net1278"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133538,7 +133538,7 @@
           "pcb_smtpad_731",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133557,7 +133557,7 @@
           "pcb_smtpad_732",
           "connectivity_net1267"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133576,7 +133576,7 @@
           "pcb_smtpad_733",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133595,7 +133595,7 @@
           "pcb_smtpad_734",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133614,7 +133614,7 @@
           "pcb_smtpad_734",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133633,7 +133633,7 @@
           "pcb_smtpad_734",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133652,7 +133652,7 @@
           "pcb_smtpad_734",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133671,7 +133671,7 @@
           "pcb_smtpad_735",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133690,7 +133690,7 @@
           "pcb_smtpad_735",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133709,7 +133709,7 @@
           "pcb_smtpad_735",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133728,7 +133728,7 @@
           "pcb_smtpad_735",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133747,7 +133747,7 @@
           "pcb_smtpad_736",
           "connectivity_net1289"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133766,7 +133766,7 @@
           "pcb_smtpad_737",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133785,7 +133785,7 @@
           "pcb_smtpad_738",
           "connectivity_net1278"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133804,7 +133804,7 @@
           "pcb_smtpad_739",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133823,7 +133823,7 @@
           "pcb_smtpad_740",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133842,7 +133842,7 @@
           "pcb_smtpad_740",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133861,7 +133861,7 @@
           "pcb_smtpad_740",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133880,7 +133880,7 @@
           "pcb_smtpad_740",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133899,7 +133899,7 @@
           "pcb_smtpad_741",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133918,7 +133918,7 @@
           "pcb_smtpad_741",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133937,7 +133937,7 @@
           "pcb_smtpad_741",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133956,7 +133956,7 @@
           "pcb_smtpad_741",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133975,7 +133975,7 @@
           "pcb_smtpad_742",
           "connectivity_net1300"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -133994,7 +133994,7 @@
           "pcb_smtpad_743",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134013,7 +134013,7 @@
           "pcb_smtpad_744",
           "connectivity_net1289"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134032,7 +134032,7 @@
           "pcb_smtpad_745",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134051,7 +134051,7 @@
           "pcb_smtpad_746",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134070,7 +134070,7 @@
           "pcb_smtpad_746",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134089,7 +134089,7 @@
           "pcb_smtpad_746",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134108,7 +134108,7 @@
           "pcb_smtpad_746",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134127,7 +134127,7 @@
           "pcb_smtpad_747",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134146,7 +134146,7 @@
           "pcb_smtpad_747",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134165,7 +134165,7 @@
           "pcb_smtpad_747",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134184,7 +134184,7 @@
           "pcb_smtpad_747",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134203,7 +134203,7 @@
           "pcb_smtpad_748",
           "connectivity_net1311"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134222,7 +134222,7 @@
           "pcb_smtpad_749",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134241,7 +134241,7 @@
           "pcb_smtpad_750",
           "connectivity_net1300"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134260,7 +134260,7 @@
           "pcb_smtpad_751",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134279,7 +134279,7 @@
           "pcb_smtpad_752",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134298,7 +134298,7 @@
           "pcb_smtpad_752",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134317,7 +134317,7 @@
           "pcb_smtpad_752",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134336,7 +134336,7 @@
           "pcb_smtpad_752",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134355,7 +134355,7 @@
           "pcb_smtpad_753",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134374,7 +134374,7 @@
           "pcb_smtpad_753",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134393,7 +134393,7 @@
           "pcb_smtpad_753",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134412,7 +134412,7 @@
           "pcb_smtpad_753",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134431,7 +134431,7 @@
           "pcb_smtpad_754",
           "connectivity_net1322"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134450,7 +134450,7 @@
           "pcb_smtpad_755",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134469,7 +134469,7 @@
           "pcb_smtpad_756",
           "connectivity_net1311"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134488,7 +134488,7 @@
           "pcb_smtpad_757",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134507,7 +134507,7 @@
           "pcb_smtpad_758",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134526,7 +134526,7 @@
           "pcb_smtpad_758",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134545,7 +134545,7 @@
           "pcb_smtpad_758",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134564,7 +134564,7 @@
           "pcb_smtpad_758",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134583,7 +134583,7 @@
           "pcb_smtpad_759",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134602,7 +134602,7 @@
           "pcb_smtpad_759",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134621,7 +134621,7 @@
           "pcb_smtpad_759",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134640,7 +134640,7 @@
           "pcb_smtpad_759",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134659,7 +134659,7 @@
           "pcb_smtpad_760",
           "connectivity_net1333"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134678,7 +134678,7 @@
           "pcb_smtpad_761",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134697,7 +134697,7 @@
           "pcb_smtpad_762",
           "connectivity_net1322"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134716,7 +134716,7 @@
           "pcb_smtpad_763",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134735,7 +134735,7 @@
           "pcb_smtpad_764",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134754,7 +134754,7 @@
           "pcb_smtpad_764",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134773,7 +134773,7 @@
           "pcb_smtpad_764",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134792,7 +134792,7 @@
           "pcb_smtpad_764",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134811,7 +134811,7 @@
           "pcb_smtpad_765",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134830,7 +134830,7 @@
           "pcb_smtpad_765",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134849,7 +134849,7 @@
           "pcb_smtpad_765",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134868,7 +134868,7 @@
           "pcb_smtpad_765",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134887,7 +134887,7 @@
           "pcb_smtpad_766",
           "connectivity_net1344"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134906,7 +134906,7 @@
           "pcb_smtpad_767",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134925,7 +134925,7 @@
           "pcb_smtpad_768",
           "connectivity_net1333"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134944,7 +134944,7 @@
           "pcb_smtpad_769",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134963,7 +134963,7 @@
           "pcb_smtpad_770",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -134982,7 +134982,7 @@
           "pcb_smtpad_770",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135001,7 +135001,7 @@
           "pcb_smtpad_770",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135020,7 +135020,7 @@
           "pcb_smtpad_770",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135039,7 +135039,7 @@
           "pcb_smtpad_771",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135058,7 +135058,7 @@
           "pcb_smtpad_771",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135077,7 +135077,7 @@
           "pcb_smtpad_771",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135096,7 +135096,7 @@
           "pcb_smtpad_771",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135115,7 +135115,7 @@
           "pcb_smtpad_772",
           "connectivity_net1355"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135134,7 +135134,7 @@
           "pcb_smtpad_773",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135153,7 +135153,7 @@
           "pcb_smtpad_774",
           "connectivity_net1344"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135172,7 +135172,7 @@
           "pcb_smtpad_775",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135191,7 +135191,7 @@
           "pcb_smtpad_776",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135210,7 +135210,7 @@
           "pcb_smtpad_776",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135229,7 +135229,7 @@
           "pcb_smtpad_776",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135248,7 +135248,7 @@
           "pcb_smtpad_776",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135267,7 +135267,7 @@
           "pcb_smtpad_777",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135286,7 +135286,7 @@
           "pcb_smtpad_777",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135305,7 +135305,7 @@
           "pcb_smtpad_777",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135324,7 +135324,7 @@
           "pcb_smtpad_777",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135343,7 +135343,7 @@
           "pcb_smtpad_778",
           "connectivity_net1366"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135362,7 +135362,7 @@
           "pcb_smtpad_779",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135381,7 +135381,7 @@
           "pcb_smtpad_780",
           "connectivity_net1355"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135400,7 +135400,7 @@
           "pcb_smtpad_781",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135419,7 +135419,7 @@
           "pcb_smtpad_782",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135438,7 +135438,7 @@
           "pcb_smtpad_782",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135457,7 +135457,7 @@
           "pcb_smtpad_782",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135476,7 +135476,7 @@
           "pcb_smtpad_782",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135495,7 +135495,7 @@
           "pcb_smtpad_783",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135514,7 +135514,7 @@
           "pcb_smtpad_783",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135533,7 +135533,7 @@
           "pcb_smtpad_783",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135552,7 +135552,7 @@
           "pcb_smtpad_783",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135571,7 +135571,7 @@
           "pcb_smtpad_784",
           "connectivity_net1377"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135590,7 +135590,7 @@
           "pcb_smtpad_785",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135609,7 +135609,7 @@
           "pcb_smtpad_786",
           "connectivity_net1366"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135628,7 +135628,7 @@
           "pcb_smtpad_787",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135647,7 +135647,7 @@
           "pcb_smtpad_788",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135666,7 +135666,7 @@
           "pcb_smtpad_788",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135685,7 +135685,7 @@
           "pcb_smtpad_788",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135704,7 +135704,7 @@
           "pcb_smtpad_788",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135723,7 +135723,7 @@
           "pcb_smtpad_789",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135742,7 +135742,7 @@
           "pcb_smtpad_789",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135761,7 +135761,7 @@
           "pcb_smtpad_789",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135780,7 +135780,7 @@
           "pcb_smtpad_789",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135799,7 +135799,7 @@
           "pcb_smtpad_790",
           "connectivity_net1388"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135818,7 +135818,7 @@
           "pcb_smtpad_791",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135837,7 +135837,7 @@
           "pcb_smtpad_792",
           "connectivity_net1377"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135856,7 +135856,7 @@
           "pcb_smtpad_793",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135875,7 +135875,7 @@
           "pcb_smtpad_794",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135894,7 +135894,7 @@
           "pcb_smtpad_794",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135913,7 +135913,7 @@
           "pcb_smtpad_794",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135932,7 +135932,7 @@
           "pcb_smtpad_794",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135951,7 +135951,7 @@
           "pcb_smtpad_795",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135970,7 +135970,7 @@
           "pcb_smtpad_795",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -135989,7 +135989,7 @@
           "pcb_smtpad_795",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136008,7 +136008,7 @@
           "pcb_smtpad_795",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136027,7 +136027,7 @@
           "pcb_smtpad_796",
           "connectivity_net1399"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136046,7 +136046,7 @@
           "pcb_smtpad_797",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136065,7 +136065,7 @@
           "pcb_smtpad_798",
           "connectivity_net1388"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136084,7 +136084,7 @@
           "pcb_smtpad_799",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136103,7 +136103,7 @@
           "pcb_smtpad_800",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136122,7 +136122,7 @@
           "pcb_smtpad_800",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136141,7 +136141,7 @@
           "pcb_smtpad_800",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136160,7 +136160,7 @@
           "pcb_smtpad_800",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136179,7 +136179,7 @@
           "pcb_smtpad_801",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136198,7 +136198,7 @@
           "pcb_smtpad_801",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136217,7 +136217,7 @@
           "pcb_smtpad_801",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136236,7 +136236,7 @@
           "pcb_smtpad_801",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136255,7 +136255,7 @@
           "pcb_smtpad_802",
           "connectivity_net1410"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136274,7 +136274,7 @@
           "pcb_smtpad_803",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136293,7 +136293,7 @@
           "pcb_smtpad_804",
           "connectivity_net1399"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136312,7 +136312,7 @@
           "pcb_smtpad_805",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136331,7 +136331,7 @@
           "pcb_smtpad_806",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136350,7 +136350,7 @@
           "pcb_smtpad_806",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136369,7 +136369,7 @@
           "pcb_smtpad_806",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136388,7 +136388,7 @@
           "pcb_smtpad_806",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136407,7 +136407,7 @@
           "pcb_smtpad_807",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136426,7 +136426,7 @@
           "pcb_smtpad_807",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136445,7 +136445,7 @@
           "pcb_smtpad_807",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136464,7 +136464,7 @@
           "pcb_smtpad_807",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136483,7 +136483,7 @@
           "pcb_smtpad_808",
           "connectivity_net1421"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136502,7 +136502,7 @@
           "pcb_smtpad_809",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136521,7 +136521,7 @@
           "pcb_smtpad_810",
           "connectivity_net1410"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136540,7 +136540,7 @@
           "pcb_smtpad_811",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136559,7 +136559,7 @@
           "pcb_smtpad_812",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136578,7 +136578,7 @@
           "pcb_smtpad_812",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136597,7 +136597,7 @@
           "pcb_smtpad_812",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136616,7 +136616,7 @@
           "pcb_smtpad_812",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136635,7 +136635,7 @@
           "pcb_smtpad_813",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136654,7 +136654,7 @@
           "pcb_smtpad_813",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136673,7 +136673,7 @@
           "pcb_smtpad_813",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136692,7 +136692,7 @@
           "pcb_smtpad_813",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136711,7 +136711,7 @@
           "pcb_smtpad_814",
           "connectivity_net1432"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136730,7 +136730,7 @@
           "pcb_smtpad_815",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136749,7 +136749,7 @@
           "pcb_smtpad_816",
           "connectivity_net1421"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136768,7 +136768,7 @@
           "pcb_smtpad_817",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136787,7 +136787,7 @@
           "pcb_smtpad_818",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136806,7 +136806,7 @@
           "pcb_smtpad_818",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136825,7 +136825,7 @@
           "pcb_smtpad_818",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136844,7 +136844,7 @@
           "pcb_smtpad_818",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136863,7 +136863,7 @@
           "pcb_smtpad_819",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136882,7 +136882,7 @@
           "pcb_smtpad_819",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136901,7 +136901,7 @@
           "pcb_smtpad_819",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136920,7 +136920,7 @@
           "pcb_smtpad_819",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136939,7 +136939,7 @@
           "pcb_smtpad_820",
           "connectivity_net1443"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136958,7 +136958,7 @@
           "pcb_smtpad_821",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136977,7 +136977,7 @@
           "pcb_smtpad_822",
           "connectivity_net1432"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -136996,7 +136996,7 @@
           "pcb_smtpad_823",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137015,7 +137015,7 @@
           "pcb_smtpad_824",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137034,7 +137034,7 @@
           "pcb_smtpad_824",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137053,7 +137053,7 @@
           "pcb_smtpad_824",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137072,7 +137072,7 @@
           "pcb_smtpad_824",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137091,7 +137091,7 @@
           "pcb_smtpad_825",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137110,7 +137110,7 @@
           "pcb_smtpad_825",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137129,7 +137129,7 @@
           "pcb_smtpad_825",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137148,7 +137148,7 @@
           "pcb_smtpad_825",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137167,7 +137167,7 @@
           "pcb_smtpad_826",
           "connectivity_net1454"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137186,7 +137186,7 @@
           "pcb_smtpad_827",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137205,7 +137205,7 @@
           "pcb_smtpad_828",
           "connectivity_net1443"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137224,7 +137224,7 @@
           "pcb_smtpad_829",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137243,7 +137243,7 @@
           "pcb_smtpad_830",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137262,7 +137262,7 @@
           "pcb_smtpad_830",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137281,7 +137281,7 @@
           "pcb_smtpad_830",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137300,7 +137300,7 @@
           "pcb_smtpad_830",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137319,7 +137319,7 @@
           "pcb_smtpad_831",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137338,7 +137338,7 @@
           "pcb_smtpad_831",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137357,7 +137357,7 @@
           "pcb_smtpad_831",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137376,7 +137376,7 @@
           "pcb_smtpad_831",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137395,7 +137395,7 @@
           "pcb_smtpad_832",
           "connectivity_net1465"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137414,7 +137414,7 @@
           "pcb_smtpad_833",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137433,7 +137433,7 @@
           "pcb_smtpad_834",
           "connectivity_net1454"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137452,7 +137452,7 @@
           "pcb_smtpad_835",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137471,7 +137471,7 @@
           "pcb_smtpad_836",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137490,7 +137490,7 @@
           "pcb_smtpad_836",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137509,7 +137509,7 @@
           "pcb_smtpad_836",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137528,7 +137528,7 @@
           "pcb_smtpad_836",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137547,7 +137547,7 @@
           "pcb_smtpad_837",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137566,7 +137566,7 @@
           "pcb_smtpad_837",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137585,7 +137585,7 @@
           "pcb_smtpad_837",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137604,7 +137604,7 @@
           "pcb_smtpad_837",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137623,7 +137623,7 @@
           "pcb_smtpad_838",
           "connectivity_net1476"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137642,7 +137642,7 @@
           "pcb_smtpad_839",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137661,7 +137661,7 @@
           "pcb_smtpad_840",
           "connectivity_net1465"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137680,7 +137680,7 @@
           "pcb_smtpad_841",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137699,7 +137699,7 @@
           "pcb_smtpad_842",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137718,7 +137718,7 @@
           "pcb_smtpad_842",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137737,7 +137737,7 @@
           "pcb_smtpad_842",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137756,7 +137756,7 @@
           "pcb_smtpad_842",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137775,7 +137775,7 @@
           "pcb_smtpad_843",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137794,7 +137794,7 @@
           "pcb_smtpad_843",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137813,7 +137813,7 @@
           "pcb_smtpad_843",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137832,7 +137832,7 @@
           "pcb_smtpad_843",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137851,7 +137851,7 @@
           "pcb_smtpad_844",
           "connectivity_net1487"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137870,7 +137870,7 @@
           "pcb_smtpad_845",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137889,7 +137889,7 @@
           "pcb_smtpad_846",
           "connectivity_net1476"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137908,7 +137908,7 @@
           "pcb_smtpad_847",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137927,7 +137927,7 @@
           "pcb_smtpad_848",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137946,7 +137946,7 @@
           "pcb_smtpad_848",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137965,7 +137965,7 @@
           "pcb_smtpad_848",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -137984,7 +137984,7 @@
           "pcb_smtpad_848",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138003,7 +138003,7 @@
           "pcb_smtpad_849",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138022,7 +138022,7 @@
           "pcb_smtpad_849",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138041,7 +138041,7 @@
           "pcb_smtpad_849",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138060,7 +138060,7 @@
           "pcb_smtpad_849",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138079,7 +138079,7 @@
           "pcb_smtpad_850",
           "connectivity_net1498"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138098,7 +138098,7 @@
           "pcb_smtpad_851",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138117,7 +138117,7 @@
           "pcb_smtpad_852",
           "connectivity_net1487"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138136,7 +138136,7 @@
           "pcb_smtpad_853",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138155,7 +138155,7 @@
           "pcb_smtpad_854",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138174,7 +138174,7 @@
           "pcb_smtpad_854",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138193,7 +138193,7 @@
           "pcb_smtpad_854",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138212,7 +138212,7 @@
           "pcb_smtpad_854",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138231,7 +138231,7 @@
           "pcb_smtpad_855",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138250,7 +138250,7 @@
           "pcb_smtpad_855",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138269,7 +138269,7 @@
           "pcb_smtpad_855",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138288,7 +138288,7 @@
           "pcb_smtpad_855",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138307,7 +138307,7 @@
           "pcb_smtpad_856",
           "connectivity_net1509"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138326,7 +138326,7 @@
           "pcb_smtpad_857",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138345,7 +138345,7 @@
           "pcb_smtpad_858",
           "connectivity_net1498"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138364,7 +138364,7 @@
           "pcb_smtpad_859",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138383,7 +138383,7 @@
           "pcb_smtpad_860",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138402,7 +138402,7 @@
           "pcb_smtpad_860",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138421,7 +138421,7 @@
           "pcb_smtpad_860",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138440,7 +138440,7 @@
           "pcb_smtpad_860",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138459,7 +138459,7 @@
           "pcb_smtpad_861",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138478,7 +138478,7 @@
           "pcb_smtpad_861",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138497,7 +138497,7 @@
           "pcb_smtpad_861",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138516,7 +138516,7 @@
           "pcb_smtpad_861",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138535,7 +138535,7 @@
           "pcb_smtpad_862",
           "connectivity_net1520"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138554,7 +138554,7 @@
           "pcb_smtpad_863",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138573,7 +138573,7 @@
           "pcb_smtpad_864",
           "connectivity_net1509"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138592,7 +138592,7 @@
           "pcb_smtpad_865",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138611,7 +138611,7 @@
           "pcb_smtpad_866",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138630,7 +138630,7 @@
           "pcb_smtpad_866",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138649,7 +138649,7 @@
           "pcb_smtpad_866",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138668,7 +138668,7 @@
           "pcb_smtpad_866",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138687,7 +138687,7 @@
           "pcb_smtpad_867",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138706,7 +138706,7 @@
           "pcb_smtpad_867",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138725,7 +138725,7 @@
           "pcb_smtpad_867",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138744,7 +138744,7 @@
           "pcb_smtpad_867",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138763,7 +138763,7 @@
           "pcb_smtpad_868",
           "connectivity_net1531"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138782,7 +138782,7 @@
           "pcb_smtpad_869",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138801,7 +138801,7 @@
           "pcb_smtpad_870",
           "connectivity_net1520"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138820,7 +138820,7 @@
           "pcb_smtpad_871",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138839,7 +138839,7 @@
           "pcb_smtpad_872",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138858,7 +138858,7 @@
           "pcb_smtpad_872",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138877,7 +138877,7 @@
           "pcb_smtpad_872",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138896,7 +138896,7 @@
           "pcb_smtpad_872",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138915,7 +138915,7 @@
           "pcb_smtpad_873",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138934,7 +138934,7 @@
           "pcb_smtpad_873",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138953,7 +138953,7 @@
           "pcb_smtpad_873",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138972,7 +138972,7 @@
           "pcb_smtpad_873",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -138991,7 +138991,7 @@
           "pcb_smtpad_874",
           "connectivity_net1542"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139010,7 +139010,7 @@
           "pcb_smtpad_875",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139029,7 +139029,7 @@
           "pcb_smtpad_876",
           "connectivity_net1531"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139048,7 +139048,7 @@
           "pcb_smtpad_877",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139067,7 +139067,7 @@
           "pcb_smtpad_878",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139086,7 +139086,7 @@
           "pcb_smtpad_878",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139105,7 +139105,7 @@
           "pcb_smtpad_878",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139124,7 +139124,7 @@
           "pcb_smtpad_878",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139143,7 +139143,7 @@
           "pcb_smtpad_879",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139162,7 +139162,7 @@
           "pcb_smtpad_879",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139181,7 +139181,7 @@
           "pcb_smtpad_879",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139200,7 +139200,7 @@
           "pcb_smtpad_879",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139219,7 +139219,7 @@
           "pcb_smtpad_880",
           "connectivity_net1553"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139238,7 +139238,7 @@
           "pcb_smtpad_881",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139257,7 +139257,7 @@
           "pcb_smtpad_882",
           "connectivity_net1542"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139276,7 +139276,7 @@
           "pcb_smtpad_883",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139295,7 +139295,7 @@
           "pcb_smtpad_884",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139314,7 +139314,7 @@
           "pcb_smtpad_884",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139333,7 +139333,7 @@
           "pcb_smtpad_884",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139352,7 +139352,7 @@
           "pcb_smtpad_884",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139371,7 +139371,7 @@
           "pcb_smtpad_885",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139390,7 +139390,7 @@
           "pcb_smtpad_885",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139409,7 +139409,7 @@
           "pcb_smtpad_885",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139428,7 +139428,7 @@
           "pcb_smtpad_885",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139447,7 +139447,7 @@
           "pcb_smtpad_886",
           "connectivity_net1564"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139466,7 +139466,7 @@
           "pcb_smtpad_887",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139485,7 +139485,7 @@
           "pcb_smtpad_888",
           "connectivity_net1553"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139504,7 +139504,7 @@
           "pcb_smtpad_889",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139523,7 +139523,7 @@
           "pcb_smtpad_890",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139542,7 +139542,7 @@
           "pcb_smtpad_890",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139561,7 +139561,7 @@
           "pcb_smtpad_890",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139580,7 +139580,7 @@
           "pcb_smtpad_890",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139599,7 +139599,7 @@
           "pcb_smtpad_891",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139618,7 +139618,7 @@
           "pcb_smtpad_891",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139637,7 +139637,7 @@
           "pcb_smtpad_891",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139656,7 +139656,7 @@
           "pcb_smtpad_891",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139675,7 +139675,7 @@
           "pcb_smtpad_892",
           "connectivity_net1575"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139694,7 +139694,7 @@
           "pcb_smtpad_893",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139713,7 +139713,7 @@
           "pcb_smtpad_894",
           "connectivity_net1564"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139732,7 +139732,7 @@
           "pcb_smtpad_895",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139751,7 +139751,7 @@
           "pcb_smtpad_896",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139770,7 +139770,7 @@
           "pcb_smtpad_896",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139789,7 +139789,7 @@
           "pcb_smtpad_896",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139808,7 +139808,7 @@
           "pcb_smtpad_896",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139827,7 +139827,7 @@
           "pcb_smtpad_897",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139846,7 +139846,7 @@
           "pcb_smtpad_897",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139865,7 +139865,7 @@
           "pcb_smtpad_897",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139884,7 +139884,7 @@
           "pcb_smtpad_897",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139903,7 +139903,7 @@
           "pcb_smtpad_898",
           "connectivity_net1586"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139922,7 +139922,7 @@
           "pcb_smtpad_899",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139941,7 +139941,7 @@
           "pcb_smtpad_900",
           "connectivity_net1575"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139960,7 +139960,7 @@
           "pcb_smtpad_901",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139979,7 +139979,7 @@
           "pcb_smtpad_902",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -139998,7 +139998,7 @@
           "pcb_smtpad_902",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140017,7 +140017,7 @@
           "pcb_smtpad_902",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140036,7 +140036,7 @@
           "pcb_smtpad_902",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140055,7 +140055,7 @@
           "pcb_smtpad_903",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140074,7 +140074,7 @@
           "pcb_smtpad_903",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140093,7 +140093,7 @@
           "pcb_smtpad_903",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140112,7 +140112,7 @@
           "pcb_smtpad_903",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140131,7 +140131,7 @@
           "pcb_smtpad_904",
           "connectivity_net1597"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140150,7 +140150,7 @@
           "pcb_smtpad_905",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140169,7 +140169,7 @@
           "pcb_smtpad_906",
           "connectivity_net1586"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140188,7 +140188,7 @@
           "pcb_smtpad_907",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140207,7 +140207,7 @@
           "pcb_smtpad_908",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140226,7 +140226,7 @@
           "pcb_smtpad_908",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140245,7 +140245,7 @@
           "pcb_smtpad_908",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140264,7 +140264,7 @@
           "pcb_smtpad_908",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140283,7 +140283,7 @@
           "pcb_smtpad_909",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140302,7 +140302,7 @@
           "pcb_smtpad_909",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140321,7 +140321,7 @@
           "pcb_smtpad_909",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140340,7 +140340,7 @@
           "pcb_smtpad_909",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140359,7 +140359,7 @@
           "pcb_smtpad_910",
           "connectivity_net1608"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140378,7 +140378,7 @@
           "pcb_smtpad_911",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140397,7 +140397,7 @@
           "pcb_smtpad_912",
           "connectivity_net1597"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140416,7 +140416,7 @@
           "pcb_smtpad_913",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140435,7 +140435,7 @@
           "pcb_smtpad_914",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140454,7 +140454,7 @@
           "pcb_smtpad_914",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140473,7 +140473,7 @@
           "pcb_smtpad_914",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140492,7 +140492,7 @@
           "pcb_smtpad_914",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140511,7 +140511,7 @@
           "pcb_smtpad_915",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140530,7 +140530,7 @@
           "pcb_smtpad_915",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140549,7 +140549,7 @@
           "pcb_smtpad_915",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140568,7 +140568,7 @@
           "pcb_smtpad_915",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140587,7 +140587,7 @@
           "pcb_smtpad_916",
           "connectivity_net1619"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140606,7 +140606,7 @@
           "pcb_smtpad_917",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140625,7 +140625,7 @@
           "pcb_smtpad_918",
           "connectivity_net1608"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140644,7 +140644,7 @@
           "pcb_smtpad_919",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140663,7 +140663,7 @@
           "pcb_smtpad_920",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140682,7 +140682,7 @@
           "pcb_smtpad_920",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140701,7 +140701,7 @@
           "pcb_smtpad_920",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140720,7 +140720,7 @@
           "pcb_smtpad_920",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140739,7 +140739,7 @@
           "pcb_smtpad_921",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140758,7 +140758,7 @@
           "pcb_smtpad_921",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140777,7 +140777,7 @@
           "pcb_smtpad_921",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140796,7 +140796,7 @@
           "pcb_smtpad_921",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140815,7 +140815,7 @@
           "pcb_smtpad_922",
           "connectivity_net1630"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140834,7 +140834,7 @@
           "pcb_smtpad_923",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140853,7 +140853,7 @@
           "pcb_smtpad_924",
           "connectivity_net1619"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140872,7 +140872,7 @@
           "pcb_smtpad_925",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140891,7 +140891,7 @@
           "pcb_smtpad_926",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140910,7 +140910,7 @@
           "pcb_smtpad_926",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140929,7 +140929,7 @@
           "pcb_smtpad_926",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140948,7 +140948,7 @@
           "pcb_smtpad_926",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140967,7 +140967,7 @@
           "pcb_smtpad_927",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -140986,7 +140986,7 @@
           "pcb_smtpad_927",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141005,7 +141005,7 @@
           "pcb_smtpad_927",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141024,7 +141024,7 @@
           "pcb_smtpad_927",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141043,7 +141043,7 @@
           "pcb_smtpad_928",
           "connectivity_net1641"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141062,7 +141062,7 @@
           "pcb_smtpad_929",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141081,7 +141081,7 @@
           "pcb_smtpad_930",
           "connectivity_net1630"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141100,7 +141100,7 @@
           "pcb_smtpad_931",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141119,7 +141119,7 @@
           "pcb_smtpad_932",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141138,7 +141138,7 @@
           "pcb_smtpad_932",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141157,7 +141157,7 @@
           "pcb_smtpad_932",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141176,7 +141176,7 @@
           "pcb_smtpad_932",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141195,7 +141195,7 @@
           "pcb_smtpad_933",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141214,7 +141214,7 @@
           "pcb_smtpad_933",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141233,7 +141233,7 @@
           "pcb_smtpad_933",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141252,7 +141252,7 @@
           "pcb_smtpad_933",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141271,7 +141271,7 @@
           "pcb_smtpad_934",
           "connectivity_net1652"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141290,7 +141290,7 @@
           "pcb_smtpad_935",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141309,7 +141309,7 @@
           "pcb_smtpad_936",
           "connectivity_net1641"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141328,7 +141328,7 @@
           "pcb_smtpad_937",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141347,7 +141347,7 @@
           "pcb_smtpad_938",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141366,7 +141366,7 @@
           "pcb_smtpad_938",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141385,7 +141385,7 @@
           "pcb_smtpad_938",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141404,7 +141404,7 @@
           "pcb_smtpad_938",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141423,7 +141423,7 @@
           "pcb_smtpad_939",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141442,7 +141442,7 @@
           "pcb_smtpad_939",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141461,7 +141461,7 @@
           "pcb_smtpad_939",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141480,7 +141480,7 @@
           "pcb_smtpad_939",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141499,7 +141499,7 @@
           "pcb_smtpad_940",
           "connectivity_net1663"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141518,7 +141518,7 @@
           "pcb_smtpad_941",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141537,7 +141537,7 @@
           "pcb_smtpad_942",
           "connectivity_net1652"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141556,7 +141556,7 @@
           "pcb_smtpad_943",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141575,7 +141575,7 @@
           "pcb_smtpad_944",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141594,7 +141594,7 @@
           "pcb_smtpad_944",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141613,7 +141613,7 @@
           "pcb_smtpad_944",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141632,7 +141632,7 @@
           "pcb_smtpad_944",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141651,7 +141651,7 @@
           "pcb_smtpad_945",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141670,7 +141670,7 @@
           "pcb_smtpad_945",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141689,7 +141689,7 @@
           "pcb_smtpad_945",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141708,7 +141708,7 @@
           "pcb_smtpad_945",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141727,7 +141727,7 @@
           "pcb_smtpad_946",
           "connectivity_net1674"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141746,7 +141746,7 @@
           "pcb_smtpad_947",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141765,7 +141765,7 @@
           "pcb_smtpad_948",
           "connectivity_net1663"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141784,7 +141784,7 @@
           "pcb_smtpad_949",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141803,7 +141803,7 @@
           "pcb_smtpad_950",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141822,7 +141822,7 @@
           "pcb_smtpad_950",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141841,7 +141841,7 @@
           "pcb_smtpad_950",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141860,7 +141860,7 @@
           "pcb_smtpad_950",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141879,7 +141879,7 @@
           "pcb_smtpad_951",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141898,7 +141898,7 @@
           "pcb_smtpad_951",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141917,7 +141917,7 @@
           "pcb_smtpad_951",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141936,7 +141936,7 @@
           "pcb_smtpad_951",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141955,7 +141955,7 @@
           "pcb_smtpad_952",
           "connectivity_net1685"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141974,7 +141974,7 @@
           "pcb_smtpad_953",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -141993,7 +141993,7 @@
           "pcb_smtpad_954",
           "connectivity_net1674"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142012,7 +142012,7 @@
           "pcb_smtpad_955",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142031,7 +142031,7 @@
           "pcb_smtpad_956",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142050,7 +142050,7 @@
           "pcb_smtpad_956",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142069,7 +142069,7 @@
           "pcb_smtpad_956",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142088,7 +142088,7 @@
           "pcb_smtpad_956",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142107,7 +142107,7 @@
           "pcb_smtpad_957",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142126,7 +142126,7 @@
           "pcb_smtpad_957",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142145,7 +142145,7 @@
           "pcb_smtpad_957",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142164,7 +142164,7 @@
           "pcb_smtpad_957",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142183,7 +142183,7 @@
           "pcb_smtpad_958",
           "connectivity_net1696"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142202,7 +142202,7 @@
           "pcb_smtpad_959",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142221,7 +142221,7 @@
           "pcb_smtpad_960",
           "connectivity_net1685"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142240,7 +142240,7 @@
           "pcb_smtpad_961",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142259,7 +142259,7 @@
           "pcb_smtpad_962",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142278,7 +142278,7 @@
           "pcb_smtpad_962",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142297,7 +142297,7 @@
           "pcb_smtpad_962",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142316,7 +142316,7 @@
           "pcb_smtpad_962",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142335,7 +142335,7 @@
           "pcb_smtpad_963",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142354,7 +142354,7 @@
           "pcb_smtpad_963",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142373,7 +142373,7 @@
           "pcb_smtpad_963",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142392,7 +142392,7 @@
           "pcb_smtpad_963",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142411,7 +142411,7 @@
           "pcb_smtpad_964",
           "connectivity_net1707"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142430,7 +142430,7 @@
           "pcb_smtpad_965",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142449,7 +142449,7 @@
           "pcb_smtpad_966",
           "connectivity_net1696"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142468,7 +142468,7 @@
           "pcb_smtpad_967",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142487,7 +142487,7 @@
           "pcb_smtpad_968",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142506,7 +142506,7 @@
           "pcb_smtpad_968",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142525,7 +142525,7 @@
           "pcb_smtpad_968",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142544,7 +142544,7 @@
           "pcb_smtpad_968",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142563,7 +142563,7 @@
           "pcb_smtpad_969",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142582,7 +142582,7 @@
           "pcb_smtpad_969",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142601,7 +142601,7 @@
           "pcb_smtpad_969",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142620,7 +142620,7 @@
           "pcb_smtpad_969",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142639,7 +142639,7 @@
           "pcb_smtpad_970",
           "connectivity_net1718"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142658,7 +142658,7 @@
           "pcb_smtpad_971",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142677,7 +142677,7 @@
           "pcb_smtpad_972",
           "connectivity_net1707"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142696,7 +142696,7 @@
           "pcb_smtpad_973",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142715,7 +142715,7 @@
           "pcb_smtpad_974",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142734,7 +142734,7 @@
           "pcb_smtpad_974",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142753,7 +142753,7 @@
           "pcb_smtpad_974",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142772,7 +142772,7 @@
           "pcb_smtpad_974",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142791,7 +142791,7 @@
           "pcb_smtpad_975",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142810,7 +142810,7 @@
           "pcb_smtpad_975",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142829,7 +142829,7 @@
           "pcb_smtpad_975",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142848,7 +142848,7 @@
           "pcb_smtpad_975",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142867,7 +142867,7 @@
           "pcb_smtpad_976",
           "connectivity_net1729"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142886,7 +142886,7 @@
           "pcb_smtpad_977",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142905,7 +142905,7 @@
           "pcb_smtpad_978",
           "connectivity_net1718"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142924,7 +142924,7 @@
           "pcb_smtpad_979",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142943,7 +142943,7 @@
           "pcb_smtpad_980",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142962,7 +142962,7 @@
           "pcb_smtpad_980",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -142981,7 +142981,7 @@
           "pcb_smtpad_980",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143000,7 +143000,7 @@
           "pcb_smtpad_980",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143019,7 +143019,7 @@
           "pcb_smtpad_981",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143038,7 +143038,7 @@
           "pcb_smtpad_981",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143057,7 +143057,7 @@
           "pcb_smtpad_981",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143076,7 +143076,7 @@
           "pcb_smtpad_981",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143095,7 +143095,7 @@
           "pcb_smtpad_982",
           "connectivity_net1740"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143114,7 +143114,7 @@
           "pcb_smtpad_983",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143133,7 +143133,7 @@
           "pcb_smtpad_984",
           "connectivity_net1729"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143152,7 +143152,7 @@
           "pcb_smtpad_985",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143171,7 +143171,7 @@
           "pcb_smtpad_986",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143190,7 +143190,7 @@
           "pcb_smtpad_986",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143209,7 +143209,7 @@
           "pcb_smtpad_986",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143228,7 +143228,7 @@
           "pcb_smtpad_986",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143247,7 +143247,7 @@
           "pcb_smtpad_987",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143266,7 +143266,7 @@
           "pcb_smtpad_987",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143285,7 +143285,7 @@
           "pcb_smtpad_987",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143304,7 +143304,7 @@
           "pcb_smtpad_987",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143323,7 +143323,7 @@
           "pcb_smtpad_988",
           "connectivity_net1751"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143342,7 +143342,7 @@
           "pcb_smtpad_989",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143361,7 +143361,7 @@
           "pcb_smtpad_990",
           "connectivity_net1740"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143380,7 +143380,7 @@
           "pcb_smtpad_991",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143399,7 +143399,7 @@
           "pcb_smtpad_992",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143418,7 +143418,7 @@
           "pcb_smtpad_992",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143437,7 +143437,7 @@
           "pcb_smtpad_992",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143456,7 +143456,7 @@
           "pcb_smtpad_992",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143475,7 +143475,7 @@
           "pcb_smtpad_993",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143494,7 +143494,7 @@
           "pcb_smtpad_993",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143513,7 +143513,7 @@
           "pcb_smtpad_993",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143532,7 +143532,7 @@
           "pcb_smtpad_993",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143551,7 +143551,7 @@
           "pcb_smtpad_994",
           "connectivity_net1762"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143570,7 +143570,7 @@
           "pcb_smtpad_995",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143589,7 +143589,7 @@
           "pcb_smtpad_996",
           "connectivity_net1751"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143608,7 +143608,7 @@
           "pcb_smtpad_997",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143627,7 +143627,7 @@
           "pcb_smtpad_998",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143646,7 +143646,7 @@
           "pcb_smtpad_998",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143665,7 +143665,7 @@
           "pcb_smtpad_998",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143684,7 +143684,7 @@
           "pcb_smtpad_998",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143703,7 +143703,7 @@
           "pcb_smtpad_999",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143722,7 +143722,7 @@
           "pcb_smtpad_999",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143741,7 +143741,7 @@
           "pcb_smtpad_999",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143760,7 +143760,7 @@
           "pcb_smtpad_999",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143779,7 +143779,7 @@
           "pcb_smtpad_1000",
           "connectivity_net1773"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143798,7 +143798,7 @@
           "pcb_smtpad_1001",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143817,7 +143817,7 @@
           "pcb_smtpad_1002",
           "connectivity_net1762"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143836,7 +143836,7 @@
           "pcb_smtpad_1003",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143855,7 +143855,7 @@
           "pcb_smtpad_1004",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143874,7 +143874,7 @@
           "pcb_smtpad_1004",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143893,7 +143893,7 @@
           "pcb_smtpad_1004",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143912,7 +143912,7 @@
           "pcb_smtpad_1004",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143931,7 +143931,7 @@
           "pcb_smtpad_1005",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143950,7 +143950,7 @@
           "pcb_smtpad_1005",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143969,7 +143969,7 @@
           "pcb_smtpad_1005",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -143988,7 +143988,7 @@
           "pcb_smtpad_1005",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144007,7 +144007,7 @@
           "pcb_smtpad_1006",
           "connectivity_net1784"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144026,7 +144026,7 @@
           "pcb_smtpad_1007",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144045,7 +144045,7 @@
           "pcb_smtpad_1008",
           "connectivity_net1773"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144064,7 +144064,7 @@
           "pcb_smtpad_1009",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144083,7 +144083,7 @@
           "pcb_smtpad_1010",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144102,7 +144102,7 @@
           "pcb_smtpad_1010",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144121,7 +144121,7 @@
           "pcb_smtpad_1010",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144140,7 +144140,7 @@
           "pcb_smtpad_1010",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144159,7 +144159,7 @@
           "pcb_smtpad_1011",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144178,7 +144178,7 @@
           "pcb_smtpad_1011",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144197,7 +144197,7 @@
           "pcb_smtpad_1011",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144216,7 +144216,7 @@
           "pcb_smtpad_1011",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144235,7 +144235,7 @@
           "pcb_smtpad_1012",
           "connectivity_net1795"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144254,7 +144254,7 @@
           "pcb_smtpad_1013",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144273,7 +144273,7 @@
           "pcb_smtpad_1014",
           "connectivity_net1784"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144292,7 +144292,7 @@
           "pcb_smtpad_1015",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144311,7 +144311,7 @@
           "pcb_smtpad_1016",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144330,7 +144330,7 @@
           "pcb_smtpad_1016",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144349,7 +144349,7 @@
           "pcb_smtpad_1016",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144368,7 +144368,7 @@
           "pcb_smtpad_1016",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144387,7 +144387,7 @@
           "pcb_smtpad_1017",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144406,7 +144406,7 @@
           "pcb_smtpad_1017",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144425,7 +144425,7 @@
           "pcb_smtpad_1017",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144444,7 +144444,7 @@
           "pcb_smtpad_1017",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144463,7 +144463,7 @@
           "pcb_smtpad_1018",
           "connectivity_net1806"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144482,7 +144482,7 @@
           "pcb_smtpad_1019",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144501,7 +144501,7 @@
           "pcb_smtpad_1020",
           "connectivity_net1795"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144520,7 +144520,7 @@
           "pcb_smtpad_1021",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144539,7 +144539,7 @@
           "pcb_smtpad_1022",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144558,7 +144558,7 @@
           "pcb_smtpad_1022",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144577,7 +144577,7 @@
           "pcb_smtpad_1022",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144596,7 +144596,7 @@
           "pcb_smtpad_1022",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144615,7 +144615,7 @@
           "pcb_smtpad_1023",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144634,7 +144634,7 @@
           "pcb_smtpad_1023",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144653,7 +144653,7 @@
           "pcb_smtpad_1023",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144672,7 +144672,7 @@
           "pcb_smtpad_1023",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144691,7 +144691,7 @@
           "pcb_smtpad_1024",
           "connectivity_net1817"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144710,7 +144710,7 @@
           "pcb_smtpad_1025",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144729,7 +144729,7 @@
           "pcb_smtpad_1026",
           "connectivity_net1806"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144748,7 +144748,7 @@
           "pcb_smtpad_1027",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144767,7 +144767,7 @@
           "pcb_smtpad_1028",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144786,7 +144786,7 @@
           "pcb_smtpad_1028",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144805,7 +144805,7 @@
           "pcb_smtpad_1028",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144824,7 +144824,7 @@
           "pcb_smtpad_1028",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144843,7 +144843,7 @@
           "pcb_smtpad_1029",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144862,7 +144862,7 @@
           "pcb_smtpad_1029",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144881,7 +144881,7 @@
           "pcb_smtpad_1029",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144900,7 +144900,7 @@
           "pcb_smtpad_1029",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144919,7 +144919,7 @@
           "pcb_smtpad_1030",
           "connectivity_net1828"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144938,7 +144938,7 @@
           "pcb_smtpad_1031",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144957,7 +144957,7 @@
           "pcb_smtpad_1032",
           "connectivity_net1817"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144976,7 +144976,7 @@
           "pcb_smtpad_1033",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -144995,7 +144995,7 @@
           "pcb_smtpad_1034",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145014,7 +145014,7 @@
           "pcb_smtpad_1034",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145033,7 +145033,7 @@
           "pcb_smtpad_1034",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145052,7 +145052,7 @@
           "pcb_smtpad_1034",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145071,7 +145071,7 @@
           "pcb_smtpad_1035",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145090,7 +145090,7 @@
           "pcb_smtpad_1035",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145109,7 +145109,7 @@
           "pcb_smtpad_1035",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145128,7 +145128,7 @@
           "pcb_smtpad_1035",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145147,7 +145147,7 @@
           "pcb_smtpad_1036",
           "connectivity_net1839"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145166,7 +145166,7 @@
           "pcb_smtpad_1037",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145185,7 +145185,7 @@
           "pcb_smtpad_1038",
           "connectivity_net1828"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145204,7 +145204,7 @@
           "pcb_smtpad_1039",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145223,7 +145223,7 @@
           "pcb_smtpad_1040",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145242,7 +145242,7 @@
           "pcb_smtpad_1040",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145261,7 +145261,7 @@
           "pcb_smtpad_1040",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145280,7 +145280,7 @@
           "pcb_smtpad_1040",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145299,7 +145299,7 @@
           "pcb_smtpad_1041",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145318,7 +145318,7 @@
           "pcb_smtpad_1041",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145337,7 +145337,7 @@
           "pcb_smtpad_1041",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145356,7 +145356,7 @@
           "pcb_smtpad_1041",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145375,7 +145375,7 @@
           "pcb_smtpad_1042",
           "connectivity_net1850"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145394,7 +145394,7 @@
           "pcb_smtpad_1043",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145413,7 +145413,7 @@
           "pcb_smtpad_1044",
           "connectivity_net1839"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145432,7 +145432,7 @@
           "pcb_smtpad_1045",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145451,7 +145451,7 @@
           "pcb_smtpad_1046",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145470,7 +145470,7 @@
           "pcb_smtpad_1046",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145489,7 +145489,7 @@
           "pcb_smtpad_1046",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145508,7 +145508,7 @@
           "pcb_smtpad_1046",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145527,7 +145527,7 @@
           "pcb_smtpad_1047",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145546,7 +145546,7 @@
           "pcb_smtpad_1047",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145565,7 +145565,7 @@
           "pcb_smtpad_1047",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145584,7 +145584,7 @@
           "pcb_smtpad_1047",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145603,7 +145603,7 @@
           "pcb_smtpad_1048",
           "connectivity_net1861"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145622,7 +145622,7 @@
           "pcb_smtpad_1049",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145641,7 +145641,7 @@
           "pcb_smtpad_1050",
           "connectivity_net1850"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145660,7 +145660,7 @@
           "pcb_smtpad_1051",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145679,7 +145679,7 @@
           "pcb_smtpad_1052",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145698,7 +145698,7 @@
           "pcb_smtpad_1052",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145717,7 +145717,7 @@
           "pcb_smtpad_1052",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145736,7 +145736,7 @@
           "pcb_smtpad_1052",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145755,7 +145755,7 @@
           "pcb_smtpad_1053",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145774,7 +145774,7 @@
           "pcb_smtpad_1053",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145793,7 +145793,7 @@
           "pcb_smtpad_1053",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145812,7 +145812,7 @@
           "pcb_smtpad_1053",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145831,7 +145831,7 @@
           "pcb_smtpad_1054",
           "connectivity_net1872"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145850,7 +145850,7 @@
           "pcb_smtpad_1055",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145869,7 +145869,7 @@
           "pcb_smtpad_1056",
           "connectivity_net1861"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145888,7 +145888,7 @@
           "pcb_smtpad_1057",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145907,7 +145907,7 @@
           "pcb_smtpad_1058",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145926,7 +145926,7 @@
           "pcb_smtpad_1058",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145945,7 +145945,7 @@
           "pcb_smtpad_1058",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145964,7 +145964,7 @@
           "pcb_smtpad_1058",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -145983,7 +145983,7 @@
           "pcb_smtpad_1059",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146002,7 +146002,7 @@
           "pcb_smtpad_1059",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146021,7 +146021,7 @@
           "pcb_smtpad_1059",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146040,7 +146040,7 @@
           "pcb_smtpad_1059",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146059,7 +146059,7 @@
           "pcb_smtpad_1060",
           "connectivity_net1883"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146078,7 +146078,7 @@
           "pcb_smtpad_1061",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146097,7 +146097,7 @@
           "pcb_smtpad_1062",
           "connectivity_net1872"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146116,7 +146116,7 @@
           "pcb_smtpad_1063",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146135,7 +146135,7 @@
           "pcb_smtpad_1064",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146154,7 +146154,7 @@
           "pcb_smtpad_1064",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146173,7 +146173,7 @@
           "pcb_smtpad_1064",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146192,7 +146192,7 @@
           "pcb_smtpad_1064",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146211,7 +146211,7 @@
           "pcb_smtpad_1065",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146230,7 +146230,7 @@
           "pcb_smtpad_1065",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146249,7 +146249,7 @@
           "pcb_smtpad_1065",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146268,7 +146268,7 @@
           "pcb_smtpad_1065",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146287,7 +146287,7 @@
           "pcb_smtpad_1066",
           "connectivity_net1894"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146306,7 +146306,7 @@
           "pcb_smtpad_1067",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146325,7 +146325,7 @@
           "pcb_smtpad_1068",
           "connectivity_net1883"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146344,7 +146344,7 @@
           "pcb_smtpad_1069",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146363,7 +146363,7 @@
           "pcb_smtpad_1070",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146382,7 +146382,7 @@
           "pcb_smtpad_1070",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146401,7 +146401,7 @@
           "pcb_smtpad_1070",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146420,7 +146420,7 @@
           "pcb_smtpad_1070",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146439,7 +146439,7 @@
           "pcb_smtpad_1071",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146458,7 +146458,7 @@
           "pcb_smtpad_1071",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146477,7 +146477,7 @@
           "pcb_smtpad_1071",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146496,7 +146496,7 @@
           "pcb_smtpad_1071",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146515,7 +146515,7 @@
           "pcb_smtpad_1072",
           "connectivity_net1905"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146534,7 +146534,7 @@
           "pcb_smtpad_1073",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146553,7 +146553,7 @@
           "pcb_smtpad_1074",
           "connectivity_net1894"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146572,7 +146572,7 @@
           "pcb_smtpad_1075",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146591,7 +146591,7 @@
           "pcb_smtpad_1076",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146610,7 +146610,7 @@
           "pcb_smtpad_1076",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146629,7 +146629,7 @@
           "pcb_smtpad_1076",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146648,7 +146648,7 @@
           "pcb_smtpad_1076",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146667,7 +146667,7 @@
           "pcb_smtpad_1077",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146686,7 +146686,7 @@
           "pcb_smtpad_1077",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146705,7 +146705,7 @@
           "pcb_smtpad_1077",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146724,7 +146724,7 @@
           "pcb_smtpad_1077",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146743,7 +146743,7 @@
           "pcb_smtpad_1078",
           "connectivity_net1916"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146762,7 +146762,7 @@
           "pcb_smtpad_1079",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146781,7 +146781,7 @@
           "pcb_smtpad_1080",
           "connectivity_net1905"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146800,7 +146800,7 @@
           "pcb_smtpad_1081",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146819,7 +146819,7 @@
           "pcb_smtpad_1082",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146838,7 +146838,7 @@
           "pcb_smtpad_1082",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146857,7 +146857,7 @@
           "pcb_smtpad_1082",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146876,7 +146876,7 @@
           "pcb_smtpad_1082",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146895,7 +146895,7 @@
           "pcb_smtpad_1083",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146914,7 +146914,7 @@
           "pcb_smtpad_1083",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146933,7 +146933,7 @@
           "pcb_smtpad_1083",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146952,7 +146952,7 @@
           "pcb_smtpad_1083",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146971,7 +146971,7 @@
           "pcb_smtpad_1084",
           "connectivity_net1927"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -146990,7 +146990,7 @@
           "pcb_smtpad_1085",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147009,7 +147009,7 @@
           "pcb_smtpad_1086",
           "connectivity_net1916"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147028,7 +147028,7 @@
           "pcb_smtpad_1087",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147047,7 +147047,7 @@
           "pcb_smtpad_1088",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147066,7 +147066,7 @@
           "pcb_smtpad_1088",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147085,7 +147085,7 @@
           "pcb_smtpad_1088",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147104,7 +147104,7 @@
           "pcb_smtpad_1088",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147123,7 +147123,7 @@
           "pcb_smtpad_1089",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147142,7 +147142,7 @@
           "pcb_smtpad_1089",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147161,7 +147161,7 @@
           "pcb_smtpad_1089",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147180,7 +147180,7 @@
           "pcb_smtpad_1089",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147199,7 +147199,7 @@
           "pcb_smtpad_1090",
           "connectivity_net1938"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147218,7 +147218,7 @@
           "pcb_smtpad_1091",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147237,7 +147237,7 @@
           "pcb_smtpad_1092",
           "connectivity_net1927"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147256,7 +147256,7 @@
           "pcb_smtpad_1093",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147275,7 +147275,7 @@
           "pcb_smtpad_1094",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147294,7 +147294,7 @@
           "pcb_smtpad_1094",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147313,7 +147313,7 @@
           "pcb_smtpad_1094",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147332,7 +147332,7 @@
           "pcb_smtpad_1094",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147351,7 +147351,7 @@
           "pcb_smtpad_1095",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147370,7 +147370,7 @@
           "pcb_smtpad_1095",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147389,7 +147389,7 @@
           "pcb_smtpad_1095",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147408,7 +147408,7 @@
           "pcb_smtpad_1095",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147427,7 +147427,7 @@
           "pcb_smtpad_1096",
           "connectivity_net1949"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147446,7 +147446,7 @@
           "pcb_smtpad_1097",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147465,7 +147465,7 @@
           "pcb_smtpad_1098",
           "connectivity_net1938"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147484,7 +147484,7 @@
           "pcb_smtpad_1099",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147503,7 +147503,7 @@
           "pcb_smtpad_1100",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147522,7 +147522,7 @@
           "pcb_smtpad_1100",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147541,7 +147541,7 @@
           "pcb_smtpad_1100",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147560,7 +147560,7 @@
           "pcb_smtpad_1100",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147579,7 +147579,7 @@
           "pcb_smtpad_1101",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147598,7 +147598,7 @@
           "pcb_smtpad_1101",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147617,7 +147617,7 @@
           "pcb_smtpad_1101",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147636,7 +147636,7 @@
           "pcb_smtpad_1101",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147655,7 +147655,7 @@
           "pcb_smtpad_1102",
           "connectivity_net1960"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147674,7 +147674,7 @@
           "pcb_smtpad_1103",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147693,7 +147693,7 @@
           "pcb_smtpad_1104",
           "connectivity_net1949"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147712,7 +147712,7 @@
           "pcb_smtpad_1105",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147731,7 +147731,7 @@
           "pcb_smtpad_1106",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147750,7 +147750,7 @@
           "pcb_smtpad_1106",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147769,7 +147769,7 @@
           "pcb_smtpad_1106",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147788,7 +147788,7 @@
           "pcb_smtpad_1106",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147807,7 +147807,7 @@
           "pcb_smtpad_1107",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147826,7 +147826,7 @@
           "pcb_smtpad_1107",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147845,7 +147845,7 @@
           "pcb_smtpad_1107",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147864,7 +147864,7 @@
           "pcb_smtpad_1107",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147883,7 +147883,7 @@
           "pcb_smtpad_1108",
           "connectivity_net1971"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147902,7 +147902,7 @@
           "pcb_smtpad_1109",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147921,7 +147921,7 @@
           "pcb_smtpad_1110",
           "connectivity_net1960"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147940,7 +147940,7 @@
           "pcb_smtpad_1111",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147959,7 +147959,7 @@
           "pcb_smtpad_1112",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147978,7 +147978,7 @@
           "pcb_smtpad_1112",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -147997,7 +147997,7 @@
           "pcb_smtpad_1112",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148016,7 +148016,7 @@
           "pcb_smtpad_1112",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148035,7 +148035,7 @@
           "pcb_smtpad_1113",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148054,7 +148054,7 @@
           "pcb_smtpad_1113",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148073,7 +148073,7 @@
           "pcb_smtpad_1113",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148092,7 +148092,7 @@
           "pcb_smtpad_1113",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148111,7 +148111,7 @@
           "pcb_smtpad_1114",
           "connectivity_net1982"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148130,7 +148130,7 @@
           "pcb_smtpad_1115",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148149,7 +148149,7 @@
           "pcb_smtpad_1116",
           "connectivity_net1971"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148168,7 +148168,7 @@
           "pcb_smtpad_1117",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148187,7 +148187,7 @@
           "pcb_smtpad_1118",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148206,7 +148206,7 @@
           "pcb_smtpad_1118",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148225,7 +148225,7 @@
           "pcb_smtpad_1118",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148244,7 +148244,7 @@
           "pcb_smtpad_1118",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148263,7 +148263,7 @@
           "pcb_smtpad_1119",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148282,7 +148282,7 @@
           "pcb_smtpad_1119",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148301,7 +148301,7 @@
           "pcb_smtpad_1119",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148320,7 +148320,7 @@
           "pcb_smtpad_1119",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148339,7 +148339,7 @@
           "pcb_smtpad_1120",
           "connectivity_net1993"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148358,7 +148358,7 @@
           "pcb_smtpad_1121",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148377,7 +148377,7 @@
           "pcb_smtpad_1122",
           "connectivity_net1982"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148396,7 +148396,7 @@
           "pcb_smtpad_1123",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148415,7 +148415,7 @@
           "pcb_smtpad_1124",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148434,7 +148434,7 @@
           "pcb_smtpad_1124",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148453,7 +148453,7 @@
           "pcb_smtpad_1124",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148472,7 +148472,7 @@
           "pcb_smtpad_1124",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148491,7 +148491,7 @@
           "pcb_smtpad_1125",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148510,7 +148510,7 @@
           "pcb_smtpad_1125",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148529,7 +148529,7 @@
           "pcb_smtpad_1125",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148548,7 +148548,7 @@
           "pcb_smtpad_1125",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148567,7 +148567,7 @@
           "pcb_smtpad_1126",
           "connectivity_net2004"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148586,7 +148586,7 @@
           "pcb_smtpad_1127",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148605,7 +148605,7 @@
           "pcb_smtpad_1128",
           "connectivity_net1993"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148624,7 +148624,7 @@
           "pcb_smtpad_1129",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148643,7 +148643,7 @@
           "pcb_smtpad_1130",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148662,7 +148662,7 @@
           "pcb_smtpad_1130",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148681,7 +148681,7 @@
           "pcb_smtpad_1130",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148700,7 +148700,7 @@
           "pcb_smtpad_1130",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148719,7 +148719,7 @@
           "pcb_smtpad_1131",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148738,7 +148738,7 @@
           "pcb_smtpad_1131",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148757,7 +148757,7 @@
           "pcb_smtpad_1131",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148776,7 +148776,7 @@
           "pcb_smtpad_1131",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148795,7 +148795,7 @@
           "pcb_smtpad_1132",
           "connectivity_net2015"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148814,7 +148814,7 @@
           "pcb_smtpad_1133",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148833,7 +148833,7 @@
           "pcb_smtpad_1134",
           "connectivity_net2004"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148852,7 +148852,7 @@
           "pcb_smtpad_1135",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148871,7 +148871,7 @@
           "pcb_smtpad_1136",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148890,7 +148890,7 @@
           "pcb_smtpad_1136",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148909,7 +148909,7 @@
           "pcb_smtpad_1136",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148928,7 +148928,7 @@
           "pcb_smtpad_1136",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148947,7 +148947,7 @@
           "pcb_smtpad_1137",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148966,7 +148966,7 @@
           "pcb_smtpad_1137",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -148985,7 +148985,7 @@
           "pcb_smtpad_1137",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149004,7 +149004,7 @@
           "pcb_smtpad_1137",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149023,7 +149023,7 @@
           "pcb_smtpad_1138",
           "connectivity_net2026"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149042,7 +149042,7 @@
           "pcb_smtpad_1139",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149061,7 +149061,7 @@
           "pcb_smtpad_1140",
           "connectivity_net2015"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149080,7 +149080,7 @@
           "pcb_smtpad_1141",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149099,7 +149099,7 @@
           "pcb_smtpad_1142",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149118,7 +149118,7 @@
           "pcb_smtpad_1142",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149137,7 +149137,7 @@
           "pcb_smtpad_1142",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149156,7 +149156,7 @@
           "pcb_smtpad_1142",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149175,7 +149175,7 @@
           "pcb_smtpad_1143",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149194,7 +149194,7 @@
           "pcb_smtpad_1143",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149213,7 +149213,7 @@
           "pcb_smtpad_1143",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149232,7 +149232,7 @@
           "pcb_smtpad_1143",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149251,7 +149251,7 @@
           "pcb_smtpad_1144",
           "connectivity_net2037"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149270,7 +149270,7 @@
           "pcb_smtpad_1145",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149289,7 +149289,7 @@
           "pcb_smtpad_1146",
           "connectivity_net2026"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149308,7 +149308,7 @@
           "pcb_smtpad_1147",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149327,7 +149327,7 @@
           "pcb_smtpad_1148",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149346,7 +149346,7 @@
           "pcb_smtpad_1148",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149365,7 +149365,7 @@
           "pcb_smtpad_1148",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149384,7 +149384,7 @@
           "pcb_smtpad_1148",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149403,7 +149403,7 @@
           "pcb_smtpad_1149",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149422,7 +149422,7 @@
           "pcb_smtpad_1149",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149441,7 +149441,7 @@
           "pcb_smtpad_1149",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149460,7 +149460,7 @@
           "pcb_smtpad_1149",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149479,7 +149479,7 @@
           "pcb_smtpad_1150",
           "connectivity_net2048"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149498,7 +149498,7 @@
           "pcb_smtpad_1151",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149517,7 +149517,7 @@
           "pcb_smtpad_1152",
           "connectivity_net2037"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149536,7 +149536,7 @@
           "pcb_smtpad_1153",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149555,7 +149555,7 @@
           "pcb_smtpad_1154",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149574,7 +149574,7 @@
           "pcb_smtpad_1154",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149593,7 +149593,7 @@
           "pcb_smtpad_1154",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149612,7 +149612,7 @@
           "pcb_smtpad_1154",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149631,7 +149631,7 @@
           "pcb_smtpad_1155",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149650,7 +149650,7 @@
           "pcb_smtpad_1155",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149669,7 +149669,7 @@
           "pcb_smtpad_1155",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149688,7 +149688,7 @@
           "pcb_smtpad_1155",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149707,7 +149707,7 @@
           "pcb_smtpad_1156",
           "connectivity_net2059"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149726,7 +149726,7 @@
           "pcb_smtpad_1157",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149745,7 +149745,7 @@
           "pcb_smtpad_1158",
           "connectivity_net2048"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149764,7 +149764,7 @@
           "pcb_smtpad_1159",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149783,7 +149783,7 @@
           "pcb_smtpad_1160",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149802,7 +149802,7 @@
           "pcb_smtpad_1160",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149821,7 +149821,7 @@
           "pcb_smtpad_1160",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149840,7 +149840,7 @@
           "pcb_smtpad_1160",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149859,7 +149859,7 @@
           "pcb_smtpad_1161",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149878,7 +149878,7 @@
           "pcb_smtpad_1161",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149897,7 +149897,7 @@
           "pcb_smtpad_1161",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149916,7 +149916,7 @@
           "pcb_smtpad_1161",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149935,7 +149935,7 @@
           "pcb_smtpad_1162",
           "connectivity_net2070"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149954,7 +149954,7 @@
           "pcb_smtpad_1163",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149973,7 +149973,7 @@
           "pcb_smtpad_1164",
           "connectivity_net2059"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -149992,7 +149992,7 @@
           "pcb_smtpad_1165",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150011,7 +150011,7 @@
           "pcb_smtpad_1166",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150030,7 +150030,7 @@
           "pcb_smtpad_1166",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150049,7 +150049,7 @@
           "pcb_smtpad_1166",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150068,7 +150068,7 @@
           "pcb_smtpad_1166",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150087,7 +150087,7 @@
           "pcb_smtpad_1167",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150106,7 +150106,7 @@
           "pcb_smtpad_1167",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150125,7 +150125,7 @@
           "pcb_smtpad_1167",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150144,7 +150144,7 @@
           "pcb_smtpad_1167",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150163,7 +150163,7 @@
           "pcb_smtpad_1168",
           "connectivity_net2081"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150182,7 +150182,7 @@
           "pcb_smtpad_1169",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150201,7 +150201,7 @@
           "pcb_smtpad_1170",
           "connectivity_net2070"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150220,7 +150220,7 @@
           "pcb_smtpad_1171",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150239,7 +150239,7 @@
           "pcb_smtpad_1172",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150258,7 +150258,7 @@
           "pcb_smtpad_1172",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150277,7 +150277,7 @@
           "pcb_smtpad_1172",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150296,7 +150296,7 @@
           "pcb_smtpad_1172",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150315,7 +150315,7 @@
           "pcb_smtpad_1173",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150334,7 +150334,7 @@
           "pcb_smtpad_1173",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150353,7 +150353,7 @@
           "pcb_smtpad_1173",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150372,7 +150372,7 @@
           "pcb_smtpad_1173",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150391,7 +150391,7 @@
           "pcb_smtpad_1174",
           "connectivity_net2092"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150410,7 +150410,7 @@
           "pcb_smtpad_1175",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150429,7 +150429,7 @@
           "pcb_smtpad_1176",
           "connectivity_net2081"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150448,7 +150448,7 @@
           "pcb_smtpad_1177",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150467,7 +150467,7 @@
           "pcb_smtpad_1178",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150486,7 +150486,7 @@
           "pcb_smtpad_1178",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150505,7 +150505,7 @@
           "pcb_smtpad_1178",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150524,7 +150524,7 @@
           "pcb_smtpad_1178",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150543,7 +150543,7 @@
           "pcb_smtpad_1179",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150562,7 +150562,7 @@
           "pcb_smtpad_1179",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150581,7 +150581,7 @@
           "pcb_smtpad_1179",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150600,7 +150600,7 @@
           "pcb_smtpad_1179",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150619,7 +150619,7 @@
           "pcb_smtpad_1180",
           "connectivity_net2103"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150638,7 +150638,7 @@
           "pcb_smtpad_1181",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150657,7 +150657,7 @@
           "pcb_smtpad_1182",
           "connectivity_net2092"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150676,7 +150676,7 @@
           "pcb_smtpad_1183",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150695,7 +150695,7 @@
           "pcb_smtpad_1184",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150714,7 +150714,7 @@
           "pcb_smtpad_1184",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150733,7 +150733,7 @@
           "pcb_smtpad_1184",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150752,7 +150752,7 @@
           "pcb_smtpad_1184",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150771,7 +150771,7 @@
           "pcb_smtpad_1185",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150790,7 +150790,7 @@
           "pcb_smtpad_1185",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150809,7 +150809,7 @@
           "pcb_smtpad_1185",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150828,7 +150828,7 @@
           "pcb_smtpad_1185",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150847,7 +150847,7 @@
           "pcb_smtpad_1186",
           "connectivity_net2114"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150866,7 +150866,7 @@
           "pcb_smtpad_1187",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150885,7 +150885,7 @@
           "pcb_smtpad_1188",
           "connectivity_net2103"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150904,7 +150904,7 @@
           "pcb_smtpad_1189",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150923,7 +150923,7 @@
           "pcb_smtpad_1190",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150942,7 +150942,7 @@
           "pcb_smtpad_1190",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150961,7 +150961,7 @@
           "pcb_smtpad_1190",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150980,7 +150980,7 @@
           "pcb_smtpad_1190",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -150999,7 +150999,7 @@
           "pcb_smtpad_1191",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151018,7 +151018,7 @@
           "pcb_smtpad_1191",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151037,7 +151037,7 @@
           "pcb_smtpad_1191",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151056,7 +151056,7 @@
           "pcb_smtpad_1191",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151075,7 +151075,7 @@
           "pcb_smtpad_1192",
           "connectivity_net2125"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151094,7 +151094,7 @@
           "pcb_smtpad_1193",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151113,7 +151113,7 @@
           "pcb_smtpad_1194",
           "connectivity_net2114"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151132,7 +151132,7 @@
           "pcb_smtpad_1195",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151151,7 +151151,7 @@
           "pcb_smtpad_1196",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151170,7 +151170,7 @@
           "pcb_smtpad_1196",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151189,7 +151189,7 @@
           "pcb_smtpad_1196",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151208,7 +151208,7 @@
           "pcb_smtpad_1196",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151227,7 +151227,7 @@
           "pcb_smtpad_1197",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151246,7 +151246,7 @@
           "pcb_smtpad_1197",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151265,7 +151265,7 @@
           "pcb_smtpad_1197",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151284,7 +151284,7 @@
           "pcb_smtpad_1197",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151303,7 +151303,7 @@
           "pcb_smtpad_1198",
           "connectivity_net2136"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151322,7 +151322,7 @@
           "pcb_smtpad_1199",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151341,7 +151341,7 @@
           "pcb_smtpad_1200",
           "connectivity_net2125"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151360,7 +151360,7 @@
           "pcb_smtpad_1201",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151379,7 +151379,7 @@
           "pcb_smtpad_1202",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151398,7 +151398,7 @@
           "pcb_smtpad_1202",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151417,7 +151417,7 @@
           "pcb_smtpad_1202",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151436,7 +151436,7 @@
           "pcb_smtpad_1202",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151455,7 +151455,7 @@
           "pcb_smtpad_1203",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151474,7 +151474,7 @@
           "pcb_smtpad_1203",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151493,7 +151493,7 @@
           "pcb_smtpad_1203",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151512,7 +151512,7 @@
           "pcb_smtpad_1203",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151531,7 +151531,7 @@
           "pcb_smtpad_1204",
           "connectivity_net2147"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151550,7 +151550,7 @@
           "pcb_smtpad_1205",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151569,7 +151569,7 @@
           "pcb_smtpad_1206",
           "connectivity_net2136"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151588,7 +151588,7 @@
           "pcb_smtpad_1207",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151607,7 +151607,7 @@
           "pcb_smtpad_1208",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151626,7 +151626,7 @@
           "pcb_smtpad_1208",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151645,7 +151645,7 @@
           "pcb_smtpad_1208",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151664,7 +151664,7 @@
           "pcb_smtpad_1208",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151683,7 +151683,7 @@
           "pcb_smtpad_1209",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151702,7 +151702,7 @@
           "pcb_smtpad_1209",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151721,7 +151721,7 @@
           "pcb_smtpad_1209",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151740,7 +151740,7 @@
           "pcb_smtpad_1209",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151759,7 +151759,7 @@
           "pcb_smtpad_1210",
           "connectivity_net2158"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151778,7 +151778,7 @@
           "pcb_smtpad_1211",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151797,7 +151797,7 @@
           "pcb_smtpad_1212",
           "connectivity_net2147"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151816,7 +151816,7 @@
           "pcb_smtpad_1213",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151835,7 +151835,7 @@
           "pcb_smtpad_1214",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151854,7 +151854,7 @@
           "pcb_smtpad_1214",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151873,7 +151873,7 @@
           "pcb_smtpad_1214",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151892,7 +151892,7 @@
           "pcb_smtpad_1214",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151911,7 +151911,7 @@
           "pcb_smtpad_1215",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151930,7 +151930,7 @@
           "pcb_smtpad_1215",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151949,7 +151949,7 @@
           "pcb_smtpad_1215",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151968,7 +151968,7 @@
           "pcb_smtpad_1215",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151987,7 +151987,7 @@
           "pcb_smtpad_1216",
           "connectivity_net2169"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152006,7 +152006,7 @@
           "pcb_smtpad_1217",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152025,7 +152025,7 @@
           "pcb_smtpad_1218",
           "connectivity_net2158"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152044,7 +152044,7 @@
           "pcb_smtpad_1219",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152063,7 +152063,7 @@
           "pcb_smtpad_1220",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152082,7 +152082,7 @@
           "pcb_smtpad_1220",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152101,7 +152101,7 @@
           "pcb_smtpad_1220",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152120,7 +152120,7 @@
           "pcb_smtpad_1220",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152139,7 +152139,7 @@
           "pcb_smtpad_1221",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152158,7 +152158,7 @@
           "pcb_smtpad_1221",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152177,7 +152177,7 @@
           "pcb_smtpad_1221",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152196,7 +152196,7 @@
           "pcb_smtpad_1221",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152215,7 +152215,7 @@
           "pcb_smtpad_1222",
           "connectivity_net2180"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152234,7 +152234,7 @@
           "pcb_smtpad_1223",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152253,7 +152253,7 @@
           "pcb_smtpad_1224",
           "connectivity_net2169"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152272,7 +152272,7 @@
           "pcb_smtpad_1225",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152291,7 +152291,7 @@
           "pcb_smtpad_1226",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152310,7 +152310,7 @@
           "pcb_smtpad_1226",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152329,7 +152329,7 @@
           "pcb_smtpad_1226",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152348,7 +152348,7 @@
           "pcb_smtpad_1226",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152367,7 +152367,7 @@
           "pcb_smtpad_1227",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152386,7 +152386,7 @@
           "pcb_smtpad_1227",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152405,7 +152405,7 @@
           "pcb_smtpad_1227",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152424,7 +152424,7 @@
           "pcb_smtpad_1227",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152443,7 +152443,7 @@
           "pcb_smtpad_1228",
           "connectivity_net2191"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152462,7 +152462,7 @@
           "pcb_smtpad_1229",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152481,7 +152481,7 @@
           "pcb_smtpad_1230",
           "connectivity_net2180"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152500,7 +152500,7 @@
           "pcb_smtpad_1231",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152519,7 +152519,7 @@
           "pcb_smtpad_1232",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152538,7 +152538,7 @@
           "pcb_smtpad_1232",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152557,7 +152557,7 @@
           "pcb_smtpad_1232",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152576,7 +152576,7 @@
           "pcb_smtpad_1232",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152595,7 +152595,7 @@
           "pcb_smtpad_1233",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152614,7 +152614,7 @@
           "pcb_smtpad_1233",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152633,7 +152633,7 @@
           "pcb_smtpad_1233",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152652,7 +152652,7 @@
           "pcb_smtpad_1233",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152671,7 +152671,7 @@
           "pcb_smtpad_1234",
           "connectivity_net2202"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152690,7 +152690,7 @@
           "pcb_smtpad_1235",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152709,7 +152709,7 @@
           "pcb_smtpad_1236",
           "connectivity_net2191"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152728,7 +152728,7 @@
           "pcb_smtpad_1237",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152747,7 +152747,7 @@
           "pcb_smtpad_1238",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152766,7 +152766,7 @@
           "pcb_smtpad_1238",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152785,7 +152785,7 @@
           "pcb_smtpad_1238",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152804,7 +152804,7 @@
           "pcb_smtpad_1238",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152823,7 +152823,7 @@
           "pcb_smtpad_1239",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152842,7 +152842,7 @@
           "pcb_smtpad_1239",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152861,7 +152861,7 @@
           "pcb_smtpad_1239",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152880,7 +152880,7 @@
           "pcb_smtpad_1239",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152899,7 +152899,7 @@
           "pcb_smtpad_1240",
           "connectivity_net2213"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152918,7 +152918,7 @@
           "pcb_smtpad_1241",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152937,7 +152937,7 @@
           "pcb_smtpad_1242",
           "connectivity_net2202"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152956,7 +152956,7 @@
           "pcb_smtpad_1243",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152975,7 +152975,7 @@
           "pcb_smtpad_1244",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -152994,7 +152994,7 @@
           "pcb_smtpad_1244",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153013,7 +153013,7 @@
           "pcb_smtpad_1244",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153032,7 +153032,7 @@
           "pcb_smtpad_1244",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153051,7 +153051,7 @@
           "pcb_smtpad_1245",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153070,7 +153070,7 @@
           "pcb_smtpad_1245",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153089,7 +153089,7 @@
           "pcb_smtpad_1245",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153108,7 +153108,7 @@
           "pcb_smtpad_1245",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153127,7 +153127,7 @@
           "pcb_smtpad_1246",
           "connectivity_net2224"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153146,7 +153146,7 @@
           "pcb_smtpad_1247",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153165,7 +153165,7 @@
           "pcb_smtpad_1248",
           "connectivity_net2213"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153184,7 +153184,7 @@
           "pcb_smtpad_1249",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153203,7 +153203,7 @@
           "pcb_smtpad_1250",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153222,7 +153222,7 @@
           "pcb_smtpad_1250",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153241,7 +153241,7 @@
           "pcb_smtpad_1250",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153260,7 +153260,7 @@
           "pcb_smtpad_1250",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153279,7 +153279,7 @@
           "pcb_smtpad_1251",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153298,7 +153298,7 @@
           "pcb_smtpad_1251",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153317,7 +153317,7 @@
           "pcb_smtpad_1251",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153336,7 +153336,7 @@
           "pcb_smtpad_1251",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153355,7 +153355,7 @@
           "pcb_smtpad_1252",
           "connectivity_net2235"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153374,7 +153374,7 @@
           "pcb_smtpad_1253",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153393,7 +153393,7 @@
           "pcb_smtpad_1254",
           "connectivity_net2224"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153412,7 +153412,7 @@
           "pcb_smtpad_1255",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153431,7 +153431,7 @@
           "pcb_smtpad_1256",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153450,7 +153450,7 @@
           "pcb_smtpad_1256",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153469,7 +153469,7 @@
           "pcb_smtpad_1256",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153488,7 +153488,7 @@
           "pcb_smtpad_1256",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153507,7 +153507,7 @@
           "pcb_smtpad_1257",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153526,7 +153526,7 @@
           "pcb_smtpad_1257",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153545,7 +153545,7 @@
           "pcb_smtpad_1257",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153564,7 +153564,7 @@
           "pcb_smtpad_1257",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153583,7 +153583,7 @@
           "pcb_smtpad_1258",
           "connectivity_net2246"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153602,7 +153602,7 @@
           "pcb_smtpad_1259",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153621,7 +153621,7 @@
           "pcb_smtpad_1260",
           "connectivity_net2235"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153640,7 +153640,7 @@
           "pcb_smtpad_1261",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153659,7 +153659,7 @@
           "pcb_smtpad_1262",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153678,7 +153678,7 @@
           "pcb_smtpad_1262",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153697,7 +153697,7 @@
           "pcb_smtpad_1262",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153716,7 +153716,7 @@
           "pcb_smtpad_1262",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153735,7 +153735,7 @@
           "pcb_smtpad_1263",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153754,7 +153754,7 @@
           "pcb_smtpad_1263",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153773,7 +153773,7 @@
           "pcb_smtpad_1263",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153792,7 +153792,7 @@
           "pcb_smtpad_1263",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153811,7 +153811,7 @@
           "pcb_smtpad_1264",
           "connectivity_net2257"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153830,7 +153830,7 @@
           "pcb_smtpad_1265",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153849,7 +153849,7 @@
           "pcb_smtpad_1266",
           "connectivity_net2246"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153868,7 +153868,7 @@
           "pcb_smtpad_1267",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153887,7 +153887,7 @@
           "pcb_smtpad_1268",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153906,7 +153906,7 @@
           "pcb_smtpad_1268",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153925,7 +153925,7 @@
           "pcb_smtpad_1268",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153944,7 +153944,7 @@
           "pcb_smtpad_1268",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153963,7 +153963,7 @@
           "pcb_smtpad_1269",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -153982,7 +153982,7 @@
           "pcb_smtpad_1269",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154001,7 +154001,7 @@
           "pcb_smtpad_1269",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154020,7 +154020,7 @@
           "pcb_smtpad_1269",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154039,7 +154039,7 @@
           "pcb_smtpad_1270",
           "connectivity_net2268"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154058,7 +154058,7 @@
           "pcb_smtpad_1271",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154077,7 +154077,7 @@
           "pcb_smtpad_1272",
           "connectivity_net2257"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154096,7 +154096,7 @@
           "pcb_smtpad_1273",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154115,7 +154115,7 @@
           "pcb_smtpad_1274",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154134,7 +154134,7 @@
           "pcb_smtpad_1274",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154153,7 +154153,7 @@
           "pcb_smtpad_1274",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154172,7 +154172,7 @@
           "pcb_smtpad_1274",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154191,7 +154191,7 @@
           "pcb_smtpad_1275",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154210,7 +154210,7 @@
           "pcb_smtpad_1275",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154229,7 +154229,7 @@
           "pcb_smtpad_1275",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154248,7 +154248,7 @@
           "pcb_smtpad_1275",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154267,7 +154267,7 @@
           "pcb_smtpad_1276",
           "connectivity_net2279"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154286,7 +154286,7 @@
           "pcb_smtpad_1277",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154305,7 +154305,7 @@
           "pcb_smtpad_1278",
           "connectivity_net2268"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154324,7 +154324,7 @@
           "pcb_smtpad_1279",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154343,7 +154343,7 @@
           "pcb_smtpad_1280",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154362,7 +154362,7 @@
           "pcb_smtpad_1280",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154381,7 +154381,7 @@
           "pcb_smtpad_1280",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154400,7 +154400,7 @@
           "pcb_smtpad_1280",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154419,7 +154419,7 @@
           "pcb_smtpad_1281",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154438,7 +154438,7 @@
           "pcb_smtpad_1281",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154457,7 +154457,7 @@
           "pcb_smtpad_1281",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154476,7 +154476,7 @@
           "pcb_smtpad_1281",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154495,7 +154495,7 @@
           "pcb_smtpad_1282",
           "connectivity_net2290"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154514,7 +154514,7 @@
           "pcb_smtpad_1283",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154533,7 +154533,7 @@
           "pcb_smtpad_1284",
           "connectivity_net2279"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154552,7 +154552,7 @@
           "pcb_smtpad_1285",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154571,7 +154571,7 @@
           "pcb_smtpad_1286",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154590,7 +154590,7 @@
           "pcb_smtpad_1286",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154609,7 +154609,7 @@
           "pcb_smtpad_1286",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154628,7 +154628,7 @@
           "pcb_smtpad_1286",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154647,7 +154647,7 @@
           "pcb_smtpad_1287",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154666,7 +154666,7 @@
           "pcb_smtpad_1287",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154685,7 +154685,7 @@
           "pcb_smtpad_1287",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154704,7 +154704,7 @@
           "pcb_smtpad_1287",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154723,7 +154723,7 @@
           "pcb_smtpad_1288",
           "connectivity_net2301"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154742,7 +154742,7 @@
           "pcb_smtpad_1289",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154761,7 +154761,7 @@
           "pcb_smtpad_1290",
           "connectivity_net2290"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154780,7 +154780,7 @@
           "pcb_smtpad_1291",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154799,7 +154799,7 @@
           "pcb_smtpad_1292",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154818,7 +154818,7 @@
           "pcb_smtpad_1292",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154837,7 +154837,7 @@
           "pcb_smtpad_1292",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154856,7 +154856,7 @@
           "pcb_smtpad_1292",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154875,7 +154875,7 @@
           "pcb_smtpad_1293",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154894,7 +154894,7 @@
           "pcb_smtpad_1293",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154913,7 +154913,7 @@
           "pcb_smtpad_1293",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154932,7 +154932,7 @@
           "pcb_smtpad_1293",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154951,7 +154951,7 @@
           "pcb_smtpad_1294",
           "connectivity_net2312"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154970,7 +154970,7 @@
           "pcb_smtpad_1295",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -154989,7 +154989,7 @@
           "pcb_smtpad_1296",
           "connectivity_net2301"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155008,7 +155008,7 @@
           "pcb_smtpad_1297",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155027,7 +155027,7 @@
           "pcb_smtpad_1298",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155046,7 +155046,7 @@
           "pcb_smtpad_1298",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155065,7 +155065,7 @@
           "pcb_smtpad_1298",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155084,7 +155084,7 @@
           "pcb_smtpad_1298",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155103,7 +155103,7 @@
           "pcb_smtpad_1299",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155122,7 +155122,7 @@
           "pcb_smtpad_1299",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155141,7 +155141,7 @@
           "pcb_smtpad_1299",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155160,7 +155160,7 @@
           "pcb_smtpad_1299",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155179,7 +155179,7 @@
           "pcb_smtpad_1300",
           "connectivity_net2323"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155198,7 +155198,7 @@
           "pcb_smtpad_1301",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155217,7 +155217,7 @@
           "pcb_smtpad_1302",
           "connectivity_net2312"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155236,7 +155236,7 @@
           "pcb_smtpad_1303",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155255,7 +155255,7 @@
           "pcb_smtpad_1304",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155274,7 +155274,7 @@
           "pcb_smtpad_1304",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155293,7 +155293,7 @@
           "pcb_smtpad_1304",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155312,7 +155312,7 @@
           "pcb_smtpad_1304",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155331,7 +155331,7 @@
           "pcb_smtpad_1305",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155350,7 +155350,7 @@
           "pcb_smtpad_1305",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155369,7 +155369,7 @@
           "pcb_smtpad_1305",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155388,7 +155388,7 @@
           "pcb_smtpad_1305",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155407,7 +155407,7 @@
           "pcb_smtpad_1306",
           "connectivity_net2334"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155426,7 +155426,7 @@
           "pcb_smtpad_1307",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155445,7 +155445,7 @@
           "pcb_smtpad_1308",
           "connectivity_net2323"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155464,7 +155464,7 @@
           "pcb_smtpad_1309",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155483,7 +155483,7 @@
           "pcb_smtpad_1310",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155502,7 +155502,7 @@
           "pcb_smtpad_1310",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155521,7 +155521,7 @@
           "pcb_smtpad_1310",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155540,7 +155540,7 @@
           "pcb_smtpad_1310",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155559,7 +155559,7 @@
           "pcb_smtpad_1311",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155578,7 +155578,7 @@
           "pcb_smtpad_1311",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155597,7 +155597,7 @@
           "pcb_smtpad_1311",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155616,7 +155616,7 @@
           "pcb_smtpad_1311",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155635,7 +155635,7 @@
           "pcb_smtpad_1312",
           "connectivity_net2345"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155654,7 +155654,7 @@
           "pcb_smtpad_1313",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155673,7 +155673,7 @@
           "pcb_smtpad_1314",
           "connectivity_net2334"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155692,7 +155692,7 @@
           "pcb_smtpad_1315",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155711,7 +155711,7 @@
           "pcb_smtpad_1316",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155730,7 +155730,7 @@
           "pcb_smtpad_1316",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155749,7 +155749,7 @@
           "pcb_smtpad_1316",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155768,7 +155768,7 @@
           "pcb_smtpad_1316",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155787,7 +155787,7 @@
           "pcb_smtpad_1317",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155806,7 +155806,7 @@
           "pcb_smtpad_1317",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155825,7 +155825,7 @@
           "pcb_smtpad_1317",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155844,7 +155844,7 @@
           "pcb_smtpad_1317",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155863,7 +155863,7 @@
           "pcb_smtpad_1318",
           "connectivity_net2356"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155882,7 +155882,7 @@
           "pcb_smtpad_1319",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155901,7 +155901,7 @@
           "pcb_smtpad_1320",
           "connectivity_net2345"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155920,7 +155920,7 @@
           "pcb_smtpad_1321",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155939,7 +155939,7 @@
           "pcb_smtpad_1322",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155958,7 +155958,7 @@
           "pcb_smtpad_1322",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155977,7 +155977,7 @@
           "pcb_smtpad_1322",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -155996,7 +155996,7 @@
           "pcb_smtpad_1322",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156015,7 +156015,7 @@
           "pcb_smtpad_1323",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156034,7 +156034,7 @@
           "pcb_smtpad_1323",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156053,7 +156053,7 @@
           "pcb_smtpad_1323",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156072,7 +156072,7 @@
           "pcb_smtpad_1323",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156091,7 +156091,7 @@
           "pcb_smtpad_1324",
           "connectivity_net2367"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156110,7 +156110,7 @@
           "pcb_smtpad_1325",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156129,7 +156129,7 @@
           "pcb_smtpad_1326",
           "connectivity_net2356"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156148,7 +156148,7 @@
           "pcb_smtpad_1327",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156167,7 +156167,7 @@
           "pcb_smtpad_1328",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156186,7 +156186,7 @@
           "pcb_smtpad_1328",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156205,7 +156205,7 @@
           "pcb_smtpad_1328",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156224,7 +156224,7 @@
           "pcb_smtpad_1328",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156243,7 +156243,7 @@
           "pcb_smtpad_1329",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156262,7 +156262,7 @@
           "pcb_smtpad_1329",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156281,7 +156281,7 @@
           "pcb_smtpad_1329",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156300,7 +156300,7 @@
           "pcb_smtpad_1329",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156319,7 +156319,7 @@
           "pcb_smtpad_1330",
           "connectivity_net2378"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156338,7 +156338,7 @@
           "pcb_smtpad_1331",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156357,7 +156357,7 @@
           "pcb_smtpad_1332",
           "connectivity_net2367"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156376,7 +156376,7 @@
           "pcb_smtpad_1333",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156395,7 +156395,7 @@
           "pcb_smtpad_1334",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156414,7 +156414,7 @@
           "pcb_smtpad_1334",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156433,7 +156433,7 @@
           "pcb_smtpad_1334",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156452,7 +156452,7 @@
           "pcb_smtpad_1334",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156471,7 +156471,7 @@
           "pcb_smtpad_1335",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156490,7 +156490,7 @@
           "pcb_smtpad_1335",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156509,7 +156509,7 @@
           "pcb_smtpad_1335",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156528,7 +156528,7 @@
           "pcb_smtpad_1335",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156547,7 +156547,7 @@
           "pcb_smtpad_1336",
           "connectivity_net2389"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156566,7 +156566,7 @@
           "pcb_smtpad_1337",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156585,7 +156585,7 @@
           "pcb_smtpad_1338",
           "connectivity_net2378"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156604,7 +156604,7 @@
           "pcb_smtpad_1339",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156623,7 +156623,7 @@
           "pcb_smtpad_1340",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156642,7 +156642,7 @@
           "pcb_smtpad_1340",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156661,7 +156661,7 @@
           "pcb_smtpad_1340",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156680,7 +156680,7 @@
           "pcb_smtpad_1340",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156699,7 +156699,7 @@
           "pcb_smtpad_1341",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156718,7 +156718,7 @@
           "pcb_smtpad_1341",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156737,7 +156737,7 @@
           "pcb_smtpad_1341",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156756,7 +156756,7 @@
           "pcb_smtpad_1341",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156775,7 +156775,7 @@
           "pcb_smtpad_1342",
           "connectivity_net2400"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156794,7 +156794,7 @@
           "pcb_smtpad_1343",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156813,7 +156813,7 @@
           "pcb_smtpad_1344",
           "connectivity_net2389"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156832,7 +156832,7 @@
           "pcb_smtpad_1345",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156851,7 +156851,7 @@
           "pcb_smtpad_1346",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156870,7 +156870,7 @@
           "pcb_smtpad_1346",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156889,7 +156889,7 @@
           "pcb_smtpad_1346",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156908,7 +156908,7 @@
           "pcb_smtpad_1346",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156927,7 +156927,7 @@
           "pcb_smtpad_1347",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156946,7 +156946,7 @@
           "pcb_smtpad_1347",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156965,7 +156965,7 @@
           "pcb_smtpad_1347",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -156984,7 +156984,7 @@
           "pcb_smtpad_1347",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157003,7 +157003,7 @@
           "pcb_smtpad_1348",
           "connectivity_net2411"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157022,7 +157022,7 @@
           "pcb_smtpad_1349",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157041,7 +157041,7 @@
           "pcb_smtpad_1350",
           "connectivity_net2400"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157060,7 +157060,7 @@
           "pcb_smtpad_1351",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157079,7 +157079,7 @@
           "pcb_smtpad_1352",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157098,7 +157098,7 @@
           "pcb_smtpad_1352",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157117,7 +157117,7 @@
           "pcb_smtpad_1352",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157136,7 +157136,7 @@
           "pcb_smtpad_1352",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157155,7 +157155,7 @@
           "pcb_smtpad_1353",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157174,7 +157174,7 @@
           "pcb_smtpad_1353",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157193,7 +157193,7 @@
           "pcb_smtpad_1353",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157212,7 +157212,7 @@
           "pcb_smtpad_1353",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157231,7 +157231,7 @@
           "pcb_smtpad_1354",
           "connectivity_net2422"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157250,7 +157250,7 @@
           "pcb_smtpad_1355",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157269,7 +157269,7 @@
           "pcb_smtpad_1356",
           "connectivity_net2411"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157288,7 +157288,7 @@
           "pcb_smtpad_1357",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157307,7 +157307,7 @@
           "pcb_smtpad_1358",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157326,7 +157326,7 @@
           "pcb_smtpad_1358",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157345,7 +157345,7 @@
           "pcb_smtpad_1358",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157364,7 +157364,7 @@
           "pcb_smtpad_1358",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157383,7 +157383,7 @@
           "pcb_smtpad_1359",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157402,7 +157402,7 @@
           "pcb_smtpad_1359",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157421,7 +157421,7 @@
           "pcb_smtpad_1359",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157440,7 +157440,7 @@
           "pcb_smtpad_1359",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157459,7 +157459,7 @@
           "pcb_smtpad_1360",
           "connectivity_net2433"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157478,7 +157478,7 @@
           "pcb_smtpad_1361",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157497,7 +157497,7 @@
           "pcb_smtpad_1362",
           "connectivity_net2422"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157516,7 +157516,7 @@
           "pcb_smtpad_1363",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157535,7 +157535,7 @@
           "pcb_smtpad_1364",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157554,7 +157554,7 @@
           "pcb_smtpad_1364",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157573,7 +157573,7 @@
           "pcb_smtpad_1364",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157592,7 +157592,7 @@
           "pcb_smtpad_1364",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157611,7 +157611,7 @@
           "pcb_smtpad_1365",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157630,7 +157630,7 @@
           "pcb_smtpad_1365",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157649,7 +157649,7 @@
           "pcb_smtpad_1365",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157668,7 +157668,7 @@
           "pcb_smtpad_1365",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157687,7 +157687,7 @@
           "pcb_smtpad_1366",
           "connectivity_net2444"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157706,7 +157706,7 @@
           "pcb_smtpad_1367",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157725,7 +157725,7 @@
           "pcb_smtpad_1368",
           "connectivity_net2433"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157744,7 +157744,7 @@
           "pcb_smtpad_1369",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157763,7 +157763,7 @@
           "pcb_smtpad_1370",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157782,7 +157782,7 @@
           "pcb_smtpad_1370",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157801,7 +157801,7 @@
           "pcb_smtpad_1370",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157820,7 +157820,7 @@
           "pcb_smtpad_1370",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157839,7 +157839,7 @@
           "pcb_smtpad_1371",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157858,7 +157858,7 @@
           "pcb_smtpad_1371",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157877,7 +157877,7 @@
           "pcb_smtpad_1371",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157896,7 +157896,7 @@
           "pcb_smtpad_1371",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157915,7 +157915,7 @@
           "pcb_smtpad_1372",
           "connectivity_net2455"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157934,7 +157934,7 @@
           "pcb_smtpad_1373",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157953,7 +157953,7 @@
           "pcb_smtpad_1374",
           "connectivity_net2444"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157972,7 +157972,7 @@
           "pcb_smtpad_1375",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -157991,7 +157991,7 @@
           "pcb_smtpad_1376",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158010,7 +158010,7 @@
           "pcb_smtpad_1376",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158029,7 +158029,7 @@
           "pcb_smtpad_1376",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158048,7 +158048,7 @@
           "pcb_smtpad_1376",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158067,7 +158067,7 @@
           "pcb_smtpad_1377",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158086,7 +158086,7 @@
           "pcb_smtpad_1377",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158105,7 +158105,7 @@
           "pcb_smtpad_1377",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158124,7 +158124,7 @@
           "pcb_smtpad_1377",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158143,7 +158143,7 @@
           "pcb_smtpad_1378",
           "connectivity_net2466"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158162,7 +158162,7 @@
           "pcb_smtpad_1379",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158181,7 +158181,7 @@
           "pcb_smtpad_1380",
           "connectivity_net2455"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158200,7 +158200,7 @@
           "pcb_smtpad_1381",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158219,7 +158219,7 @@
           "pcb_smtpad_1382",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158238,7 +158238,7 @@
           "pcb_smtpad_1382",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158257,7 +158257,7 @@
           "pcb_smtpad_1382",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158276,7 +158276,7 @@
           "pcb_smtpad_1382",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158295,7 +158295,7 @@
           "pcb_smtpad_1383",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158314,7 +158314,7 @@
           "pcb_smtpad_1383",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158333,7 +158333,7 @@
           "pcb_smtpad_1383",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158352,7 +158352,7 @@
           "pcb_smtpad_1383",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158371,7 +158371,7 @@
           "pcb_smtpad_1384",
           "connectivity_net2477"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158390,7 +158390,7 @@
           "pcb_smtpad_1385",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158409,7 +158409,7 @@
           "pcb_smtpad_1386",
           "connectivity_net2466"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158428,7 +158428,7 @@
           "pcb_smtpad_1387",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158447,7 +158447,7 @@
           "pcb_smtpad_1388",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158466,7 +158466,7 @@
           "pcb_smtpad_1388",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158485,7 +158485,7 @@
           "pcb_smtpad_1388",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158504,7 +158504,7 @@
           "pcb_smtpad_1388",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158523,7 +158523,7 @@
           "pcb_smtpad_1389",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158542,7 +158542,7 @@
           "pcb_smtpad_1389",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158561,7 +158561,7 @@
           "pcb_smtpad_1389",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158580,7 +158580,7 @@
           "pcb_smtpad_1389",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158599,7 +158599,7 @@
           "pcb_smtpad_1390",
           "connectivity_net2488"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158618,7 +158618,7 @@
           "pcb_smtpad_1391",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158637,7 +158637,7 @@
           "pcb_smtpad_1392",
           "connectivity_net2477"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158656,7 +158656,7 @@
           "pcb_smtpad_1393",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158675,7 +158675,7 @@
           "pcb_smtpad_1394",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158694,7 +158694,7 @@
           "pcb_smtpad_1394",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158713,7 +158713,7 @@
           "pcb_smtpad_1394",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158732,7 +158732,7 @@
           "pcb_smtpad_1394",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158751,7 +158751,7 @@
           "pcb_smtpad_1395",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158770,7 +158770,7 @@
           "pcb_smtpad_1395",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158789,7 +158789,7 @@
           "pcb_smtpad_1395",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158808,7 +158808,7 @@
           "pcb_smtpad_1395",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158827,7 +158827,7 @@
           "pcb_smtpad_1396",
           "connectivity_net2499"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158846,7 +158846,7 @@
           "pcb_smtpad_1397",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158865,7 +158865,7 @@
           "pcb_smtpad_1398",
           "connectivity_net2488"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158884,7 +158884,7 @@
           "pcb_smtpad_1399",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158903,7 +158903,7 @@
           "pcb_smtpad_1400",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158922,7 +158922,7 @@
           "pcb_smtpad_1400",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158941,7 +158941,7 @@
           "pcb_smtpad_1400",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158960,7 +158960,7 @@
           "pcb_smtpad_1400",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158979,7 +158979,7 @@
           "pcb_smtpad_1401",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -158998,7 +158998,7 @@
           "pcb_smtpad_1401",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159017,7 +159017,7 @@
           "pcb_smtpad_1401",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159036,7 +159036,7 @@
           "pcb_smtpad_1401",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159055,7 +159055,7 @@
           "pcb_smtpad_1402",
           "connectivity_net2510"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159074,7 +159074,7 @@
           "pcb_smtpad_1403",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159093,7 +159093,7 @@
           "pcb_smtpad_1404",
           "connectivity_net2499"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159112,7 +159112,7 @@
           "pcb_smtpad_1405",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159131,7 +159131,7 @@
           "pcb_smtpad_1406",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159150,7 +159150,7 @@
           "pcb_smtpad_1406",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159169,7 +159169,7 @@
           "pcb_smtpad_1406",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159188,7 +159188,7 @@
           "pcb_smtpad_1406",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159207,7 +159207,7 @@
           "pcb_smtpad_1407",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159226,7 +159226,7 @@
           "pcb_smtpad_1407",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159245,7 +159245,7 @@
           "pcb_smtpad_1407",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159264,7 +159264,7 @@
           "pcb_smtpad_1407",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159283,7 +159283,7 @@
           "pcb_smtpad_1408",
           "connectivity_net2521"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159302,7 +159302,7 @@
           "pcb_smtpad_1409",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159321,7 +159321,7 @@
           "pcb_smtpad_1410",
           "connectivity_net2510"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159340,7 +159340,7 @@
           "pcb_smtpad_1411",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159359,7 +159359,7 @@
           "pcb_smtpad_1412",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159378,7 +159378,7 @@
           "pcb_smtpad_1412",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159397,7 +159397,7 @@
           "pcb_smtpad_1412",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159416,7 +159416,7 @@
           "pcb_smtpad_1412",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159435,7 +159435,7 @@
           "pcb_smtpad_1413",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159454,7 +159454,7 @@
           "pcb_smtpad_1413",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159473,7 +159473,7 @@
           "pcb_smtpad_1413",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159492,7 +159492,7 @@
           "pcb_smtpad_1413",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159511,7 +159511,7 @@
           "pcb_smtpad_1414",
           "connectivity_net2532"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159530,7 +159530,7 @@
           "pcb_smtpad_1415",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159549,7 +159549,7 @@
           "pcb_smtpad_1416",
           "connectivity_net2521"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159568,7 +159568,7 @@
           "pcb_smtpad_1417",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159587,7 +159587,7 @@
           "pcb_smtpad_1418",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159606,7 +159606,7 @@
           "pcb_smtpad_1418",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159625,7 +159625,7 @@
           "pcb_smtpad_1418",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159644,7 +159644,7 @@
           "pcb_smtpad_1418",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159663,7 +159663,7 @@
           "pcb_smtpad_1419",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159682,7 +159682,7 @@
           "pcb_smtpad_1419",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159701,7 +159701,7 @@
           "pcb_smtpad_1419",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159720,7 +159720,7 @@
           "pcb_smtpad_1419",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159739,7 +159739,7 @@
           "pcb_smtpad_1420",
           "connectivity_net2543"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159758,7 +159758,7 @@
           "pcb_smtpad_1421",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159777,7 +159777,7 @@
           "pcb_smtpad_1422",
           "connectivity_net2532"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159796,7 +159796,7 @@
           "pcb_smtpad_1423",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159815,7 +159815,7 @@
           "pcb_smtpad_1424",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159834,7 +159834,7 @@
           "pcb_smtpad_1424",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159853,7 +159853,7 @@
           "pcb_smtpad_1424",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159872,7 +159872,7 @@
           "pcb_smtpad_1424",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159891,7 +159891,7 @@
           "pcb_smtpad_1425",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159910,7 +159910,7 @@
           "pcb_smtpad_1425",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159929,7 +159929,7 @@
           "pcb_smtpad_1425",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159948,7 +159948,7 @@
           "pcb_smtpad_1425",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159967,7 +159967,7 @@
           "pcb_smtpad_1426",
           "connectivity_net2554"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -159986,7 +159986,7 @@
           "pcb_smtpad_1427",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160005,7 +160005,7 @@
           "pcb_smtpad_1428",
           "connectivity_net2543"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160024,7 +160024,7 @@
           "pcb_smtpad_1429",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160043,7 +160043,7 @@
           "pcb_smtpad_1430",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160062,7 +160062,7 @@
           "pcb_smtpad_1430",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160081,7 +160081,7 @@
           "pcb_smtpad_1430",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160100,7 +160100,7 @@
           "pcb_smtpad_1430",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160119,7 +160119,7 @@
           "pcb_smtpad_1431",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160138,7 +160138,7 @@
           "pcb_smtpad_1431",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160157,7 +160157,7 @@
           "pcb_smtpad_1431",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160176,7 +160176,7 @@
           "pcb_smtpad_1431",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160195,7 +160195,7 @@
           "pcb_smtpad_1432",
           "connectivity_net2565"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160214,7 +160214,7 @@
           "pcb_smtpad_1433",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160233,7 +160233,7 @@
           "pcb_smtpad_1434",
           "connectivity_net2554"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160252,7 +160252,7 @@
           "pcb_smtpad_1435",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160271,7 +160271,7 @@
           "pcb_smtpad_1436",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160290,7 +160290,7 @@
           "pcb_smtpad_1436",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160309,7 +160309,7 @@
           "pcb_smtpad_1436",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160328,7 +160328,7 @@
           "pcb_smtpad_1436",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160347,7 +160347,7 @@
           "pcb_smtpad_1437",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160366,7 +160366,7 @@
           "pcb_smtpad_1437",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160385,7 +160385,7 @@
           "pcb_smtpad_1437",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160404,7 +160404,7 @@
           "pcb_smtpad_1437",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160423,7 +160423,7 @@
           "pcb_smtpad_1438",
           "connectivity_net2576"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160442,7 +160442,7 @@
           "pcb_smtpad_1439",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160461,7 +160461,7 @@
           "pcb_smtpad_1440",
           "connectivity_net2565"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160480,7 +160480,7 @@
           "pcb_smtpad_1441",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160499,7 +160499,7 @@
           "pcb_smtpad_1442",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160518,7 +160518,7 @@
           "pcb_smtpad_1442",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160537,7 +160537,7 @@
           "pcb_smtpad_1442",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160556,7 +160556,7 @@
           "pcb_smtpad_1442",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160575,7 +160575,7 @@
           "pcb_smtpad_1443",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160594,7 +160594,7 @@
           "pcb_smtpad_1443",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160613,7 +160613,7 @@
           "pcb_smtpad_1443",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160632,7 +160632,7 @@
           "pcb_smtpad_1443",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160651,7 +160651,7 @@
           "pcb_smtpad_1444",
           "connectivity_net2587"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160670,7 +160670,7 @@
           "pcb_smtpad_1445",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160689,7 +160689,7 @@
           "pcb_smtpad_1446",
           "connectivity_net2576"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160708,7 +160708,7 @@
           "pcb_smtpad_1447",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160727,7 +160727,7 @@
           "pcb_smtpad_1448",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160746,7 +160746,7 @@
           "pcb_smtpad_1448",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160765,7 +160765,7 @@
           "pcb_smtpad_1448",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160784,7 +160784,7 @@
           "pcb_smtpad_1448",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160803,7 +160803,7 @@
           "pcb_smtpad_1449",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160822,7 +160822,7 @@
           "pcb_smtpad_1449",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160841,7 +160841,7 @@
           "pcb_smtpad_1449",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160860,7 +160860,7 @@
           "pcb_smtpad_1449",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160879,7 +160879,7 @@
           "pcb_smtpad_1450",
           "connectivity_net2598"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160898,7 +160898,7 @@
           "pcb_smtpad_1451",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160917,7 +160917,7 @@
           "pcb_smtpad_1452",
           "connectivity_net2587"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160936,7 +160936,7 @@
           "pcb_smtpad_1453",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160955,7 +160955,7 @@
           "pcb_smtpad_1454",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160974,7 +160974,7 @@
           "pcb_smtpad_1454",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -160993,7 +160993,7 @@
           "pcb_smtpad_1454",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161012,7 +161012,7 @@
           "pcb_smtpad_1454",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161031,7 +161031,7 @@
           "pcb_smtpad_1455",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161050,7 +161050,7 @@
           "pcb_smtpad_1455",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161069,7 +161069,7 @@
           "pcb_smtpad_1455",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161088,7 +161088,7 @@
           "pcb_smtpad_1455",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161107,7 +161107,7 @@
           "pcb_smtpad_1456",
           "connectivity_net2609"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161126,7 +161126,7 @@
           "pcb_smtpad_1457",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161145,7 +161145,7 @@
           "pcb_smtpad_1458",
           "connectivity_net2598"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161164,7 +161164,7 @@
           "pcb_smtpad_1459",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161183,7 +161183,7 @@
           "pcb_smtpad_1460",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161202,7 +161202,7 @@
           "pcb_smtpad_1460",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161221,7 +161221,7 @@
           "pcb_smtpad_1460",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161240,7 +161240,7 @@
           "pcb_smtpad_1460",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161259,7 +161259,7 @@
           "pcb_smtpad_1461",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161278,7 +161278,7 @@
           "pcb_smtpad_1461",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161297,7 +161297,7 @@
           "pcb_smtpad_1461",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161316,7 +161316,7 @@
           "pcb_smtpad_1461",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161335,7 +161335,7 @@
           "pcb_smtpad_1462",
           "connectivity_net2620"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161354,7 +161354,7 @@
           "pcb_smtpad_1463",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161373,7 +161373,7 @@
           "pcb_smtpad_1464",
           "connectivity_net2609"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161392,7 +161392,7 @@
           "pcb_smtpad_1465",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161411,7 +161411,7 @@
           "pcb_smtpad_1466",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161430,7 +161430,7 @@
           "pcb_smtpad_1466",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161449,7 +161449,7 @@
           "pcb_smtpad_1466",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161468,7 +161468,7 @@
           "pcb_smtpad_1466",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161487,7 +161487,7 @@
           "pcb_smtpad_1467",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161506,7 +161506,7 @@
           "pcb_smtpad_1467",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161525,7 +161525,7 @@
           "pcb_smtpad_1467",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161544,7 +161544,7 @@
           "pcb_smtpad_1467",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161563,7 +161563,7 @@
           "pcb_smtpad_1468",
           "connectivity_net2631"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161582,7 +161582,7 @@
           "pcb_smtpad_1469",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161601,7 +161601,7 @@
           "pcb_smtpad_1470",
           "connectivity_net2620"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161620,7 +161620,7 @@
           "pcb_smtpad_1471",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161639,7 +161639,7 @@
           "pcb_smtpad_1472",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161658,7 +161658,7 @@
           "pcb_smtpad_1472",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161677,7 +161677,7 @@
           "pcb_smtpad_1472",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161696,7 +161696,7 @@
           "pcb_smtpad_1472",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161715,7 +161715,7 @@
           "pcb_smtpad_1473",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161734,7 +161734,7 @@
           "pcb_smtpad_1473",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161753,7 +161753,7 @@
           "pcb_smtpad_1473",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161772,7 +161772,7 @@
           "pcb_smtpad_1473",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161791,7 +161791,7 @@
           "pcb_smtpad_1474",
           "connectivity_net2642"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161810,7 +161810,7 @@
           "pcb_smtpad_1475",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161829,7 +161829,7 @@
           "pcb_smtpad_1476",
           "connectivity_net2631"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161848,7 +161848,7 @@
           "pcb_smtpad_1477",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161867,7 +161867,7 @@
           "pcb_smtpad_1478",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161886,7 +161886,7 @@
           "pcb_smtpad_1478",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161905,7 +161905,7 @@
           "pcb_smtpad_1478",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161924,7 +161924,7 @@
           "pcb_smtpad_1478",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161943,7 +161943,7 @@
           "pcb_smtpad_1479",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161962,7 +161962,7 @@
           "pcb_smtpad_1479",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -161981,7 +161981,7 @@
           "pcb_smtpad_1479",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162000,7 +162000,7 @@
           "pcb_smtpad_1479",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162019,7 +162019,7 @@
           "pcb_smtpad_1480",
           "connectivity_net2653"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162038,7 +162038,7 @@
           "pcb_smtpad_1481",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162057,7 +162057,7 @@
           "pcb_smtpad_1482",
           "connectivity_net2642"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162076,7 +162076,7 @@
           "pcb_smtpad_1483",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162095,7 +162095,7 @@
           "pcb_smtpad_1484",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162114,7 +162114,7 @@
           "pcb_smtpad_1484",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162133,7 +162133,7 @@
           "pcb_smtpad_1484",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162152,7 +162152,7 @@
           "pcb_smtpad_1484",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162171,7 +162171,7 @@
           "pcb_smtpad_1485",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162190,7 +162190,7 @@
           "pcb_smtpad_1485",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162209,7 +162209,7 @@
           "pcb_smtpad_1485",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162228,7 +162228,7 @@
           "pcb_smtpad_1485",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162247,7 +162247,7 @@
           "pcb_smtpad_1486",
           "connectivity_net2664"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162266,7 +162266,7 @@
           "pcb_smtpad_1487",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162285,7 +162285,7 @@
           "pcb_smtpad_1488",
           "connectivity_net2653"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162304,7 +162304,7 @@
           "pcb_smtpad_1489",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162323,7 +162323,7 @@
           "pcb_smtpad_1490",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162342,7 +162342,7 @@
           "pcb_smtpad_1490",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162361,7 +162361,7 @@
           "pcb_smtpad_1490",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162380,7 +162380,7 @@
           "pcb_smtpad_1490",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162399,7 +162399,7 @@
           "pcb_smtpad_1491",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162418,7 +162418,7 @@
           "pcb_smtpad_1491",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162437,7 +162437,7 @@
           "pcb_smtpad_1491",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162456,7 +162456,7 @@
           "pcb_smtpad_1491",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162475,7 +162475,7 @@
           "pcb_smtpad_1492",
           "connectivity_net2675"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162494,7 +162494,7 @@
           "pcb_smtpad_1493",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162513,7 +162513,7 @@
           "pcb_smtpad_1494",
           "connectivity_net2664"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162532,7 +162532,7 @@
           "pcb_smtpad_1495",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162551,7 +162551,7 @@
           "pcb_smtpad_1496",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162570,7 +162570,7 @@
           "pcb_smtpad_1496",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162589,7 +162589,7 @@
           "pcb_smtpad_1496",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162608,7 +162608,7 @@
           "pcb_smtpad_1496",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162627,7 +162627,7 @@
           "pcb_smtpad_1497",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162646,7 +162646,7 @@
           "pcb_smtpad_1497",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162665,7 +162665,7 @@
           "pcb_smtpad_1497",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162684,7 +162684,7 @@
           "pcb_smtpad_1497",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162703,7 +162703,7 @@
           "pcb_smtpad_1498",
           "connectivity_net2686"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162722,7 +162722,7 @@
           "pcb_smtpad_1499",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162741,7 +162741,7 @@
           "pcb_smtpad_1500",
           "connectivity_net2675"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162760,7 +162760,7 @@
           "pcb_smtpad_1501",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162779,7 +162779,7 @@
           "pcb_smtpad_1502",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162798,7 +162798,7 @@
           "pcb_smtpad_1502",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162817,7 +162817,7 @@
           "pcb_smtpad_1502",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162836,7 +162836,7 @@
           "pcb_smtpad_1502",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162855,7 +162855,7 @@
           "pcb_smtpad_1503",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162874,7 +162874,7 @@
           "pcb_smtpad_1503",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162893,7 +162893,7 @@
           "pcb_smtpad_1503",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162912,7 +162912,7 @@
           "pcb_smtpad_1503",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162931,7 +162931,7 @@
           "pcb_smtpad_1504",
           "connectivity_net2697"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162950,7 +162950,7 @@
           "pcb_smtpad_1505",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162969,7 +162969,7 @@
           "pcb_smtpad_1506",
           "connectivity_net2686"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -162988,7 +162988,7 @@
           "pcb_smtpad_1507",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163007,7 +163007,7 @@
           "pcb_smtpad_1508",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163026,7 +163026,7 @@
           "pcb_smtpad_1508",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163045,7 +163045,7 @@
           "pcb_smtpad_1508",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163064,7 +163064,7 @@
           "pcb_smtpad_1508",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163083,7 +163083,7 @@
           "pcb_smtpad_1509",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163102,7 +163102,7 @@
           "pcb_smtpad_1509",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163121,7 +163121,7 @@
           "pcb_smtpad_1509",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163140,7 +163140,7 @@
           "pcb_smtpad_1509",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163159,7 +163159,7 @@
           "pcb_smtpad_1510",
           "connectivity_net2708"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163178,7 +163178,7 @@
           "pcb_smtpad_1511",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163197,7 +163197,7 @@
           "pcb_smtpad_1512",
           "connectivity_net2697"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163216,7 +163216,7 @@
           "pcb_smtpad_1513",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163235,7 +163235,7 @@
           "pcb_smtpad_1514",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163254,7 +163254,7 @@
           "pcb_smtpad_1514",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163273,7 +163273,7 @@
           "pcb_smtpad_1514",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163292,7 +163292,7 @@
           "pcb_smtpad_1514",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163311,7 +163311,7 @@
           "pcb_smtpad_1515",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163330,7 +163330,7 @@
           "pcb_smtpad_1515",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163349,7 +163349,7 @@
           "pcb_smtpad_1515",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163368,7 +163368,7 @@
           "pcb_smtpad_1515",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163387,7 +163387,7 @@
           "pcb_smtpad_1516",
           "connectivity_net2719"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163406,7 +163406,7 @@
           "pcb_smtpad_1517",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163425,7 +163425,7 @@
           "pcb_smtpad_1518",
           "connectivity_net2708"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163444,7 +163444,7 @@
           "pcb_smtpad_1519",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163463,7 +163463,7 @@
           "pcb_smtpad_1520",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163482,7 +163482,7 @@
           "pcb_smtpad_1520",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163501,7 +163501,7 @@
           "pcb_smtpad_1520",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163520,7 +163520,7 @@
           "pcb_smtpad_1520",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163539,7 +163539,7 @@
           "pcb_smtpad_1521",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163558,7 +163558,7 @@
           "pcb_smtpad_1521",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163577,7 +163577,7 @@
           "pcb_smtpad_1521",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163596,7 +163596,7 @@
           "pcb_smtpad_1521",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163615,7 +163615,7 @@
           "pcb_smtpad_1522",
           "connectivity_net2730"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163634,7 +163634,7 @@
           "pcb_smtpad_1523",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163653,7 +163653,7 @@
           "pcb_smtpad_1524",
           "connectivity_net2719"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163672,7 +163672,7 @@
           "pcb_smtpad_1525",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163691,7 +163691,7 @@
           "pcb_smtpad_1526",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163710,7 +163710,7 @@
           "pcb_smtpad_1526",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163729,7 +163729,7 @@
           "pcb_smtpad_1526",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163748,7 +163748,7 @@
           "pcb_smtpad_1526",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163767,7 +163767,7 @@
           "pcb_smtpad_1527",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163786,7 +163786,7 @@
           "pcb_smtpad_1527",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163805,7 +163805,7 @@
           "pcb_smtpad_1527",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163824,7 +163824,7 @@
           "pcb_smtpad_1527",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163843,7 +163843,7 @@
           "pcb_smtpad_1528",
           "connectivity_net2741"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163862,7 +163862,7 @@
           "pcb_smtpad_1529",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163881,7 +163881,7 @@
           "pcb_smtpad_1530",
           "connectivity_net2730"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163900,7 +163900,7 @@
           "pcb_smtpad_1531",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163919,7 +163919,7 @@
           "pcb_smtpad_1532",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163938,7 +163938,7 @@
           "pcb_smtpad_1532",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163957,7 +163957,7 @@
           "pcb_smtpad_1532",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163976,7 +163976,7 @@
           "pcb_smtpad_1532",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -163995,7 +163995,7 @@
           "pcb_smtpad_1533",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164014,7 +164014,7 @@
           "pcb_smtpad_1533",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164033,7 +164033,7 @@
           "pcb_smtpad_1533",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164052,7 +164052,7 @@
           "pcb_smtpad_1533",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164071,7 +164071,7 @@
           "pcb_smtpad_1534",
           "connectivity_net2752"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164090,7 +164090,7 @@
           "pcb_smtpad_1535",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164109,7 +164109,7 @@
           "pcb_smtpad_1536",
           "connectivity_net2741"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164128,7 +164128,7 @@
           "pcb_smtpad_1537",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164147,7 +164147,7 @@
           "pcb_smtpad_1538",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164166,7 +164166,7 @@
           "pcb_smtpad_1538",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164185,7 +164185,7 @@
           "pcb_smtpad_1538",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164204,7 +164204,7 @@
           "pcb_smtpad_1538",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164223,7 +164223,7 @@
           "pcb_smtpad_1539",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164242,7 +164242,7 @@
           "pcb_smtpad_1539",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164261,7 +164261,7 @@
           "pcb_smtpad_1539",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164280,7 +164280,7 @@
           "pcb_smtpad_1539",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164299,7 +164299,7 @@
           "pcb_smtpad_1540",
           "connectivity_net2763"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164318,7 +164318,7 @@
           "pcb_smtpad_1541",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164337,7 +164337,7 @@
           "pcb_smtpad_1542",
           "connectivity_net2752"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164356,7 +164356,7 @@
           "pcb_smtpad_1543",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164375,7 +164375,7 @@
           "pcb_smtpad_1544",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164394,7 +164394,7 @@
           "pcb_smtpad_1544",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164413,7 +164413,7 @@
           "pcb_smtpad_1544",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164432,7 +164432,7 @@
           "pcb_smtpad_1544",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164451,7 +164451,7 @@
           "pcb_smtpad_1545",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164470,7 +164470,7 @@
           "pcb_smtpad_1545",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164489,7 +164489,7 @@
           "pcb_smtpad_1545",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164508,7 +164508,7 @@
           "pcb_smtpad_1545",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164527,7 +164527,7 @@
           "pcb_smtpad_1546",
           "connectivity_net2774"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164546,7 +164546,7 @@
           "pcb_smtpad_1547",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164565,7 +164565,7 @@
           "pcb_smtpad_1548",
           "connectivity_net2763"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164584,7 +164584,7 @@
           "pcb_smtpad_1549",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164603,7 +164603,7 @@
           "pcb_smtpad_1550",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164622,7 +164622,7 @@
           "pcb_smtpad_1550",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164641,7 +164641,7 @@
           "pcb_smtpad_1550",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164660,7 +164660,7 @@
           "pcb_smtpad_1550",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164679,7 +164679,7 @@
           "pcb_smtpad_1551",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164698,7 +164698,7 @@
           "pcb_smtpad_1551",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164717,7 +164717,7 @@
           "pcb_smtpad_1551",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164736,7 +164736,7 @@
           "pcb_smtpad_1551",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164755,7 +164755,7 @@
           "pcb_smtpad_1552",
           "connectivity_net2785"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164774,7 +164774,7 @@
           "pcb_smtpad_1553",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164793,7 +164793,7 @@
           "pcb_smtpad_1554",
           "connectivity_net2774"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164812,7 +164812,7 @@
           "pcb_smtpad_1555",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164831,7 +164831,7 @@
           "pcb_smtpad_1556",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164850,7 +164850,7 @@
           "pcb_smtpad_1556",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164869,7 +164869,7 @@
           "pcb_smtpad_1556",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164888,7 +164888,7 @@
           "pcb_smtpad_1556",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164907,7 +164907,7 @@
           "pcb_smtpad_1557",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164926,7 +164926,7 @@
           "pcb_smtpad_1557",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164945,7 +164945,7 @@
           "pcb_smtpad_1557",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164964,7 +164964,7 @@
           "pcb_smtpad_1557",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -164983,7 +164983,7 @@
           "pcb_smtpad_1558",
           "connectivity_net2796"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165002,7 +165002,7 @@
           "pcb_smtpad_1559",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165021,7 +165021,7 @@
           "pcb_smtpad_1560",
           "connectivity_net2785"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165040,7 +165040,7 @@
           "pcb_smtpad_1561",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165059,7 +165059,7 @@
           "pcb_smtpad_1562",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165078,7 +165078,7 @@
           "pcb_smtpad_1562",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165097,7 +165097,7 @@
           "pcb_smtpad_1562",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165116,7 +165116,7 @@
           "pcb_smtpad_1562",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165135,7 +165135,7 @@
           "pcb_smtpad_1563",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165154,7 +165154,7 @@
           "pcb_smtpad_1563",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165173,7 +165173,7 @@
           "pcb_smtpad_1563",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165192,7 +165192,7 @@
           "pcb_smtpad_1563",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165211,7 +165211,7 @@
           "pcb_smtpad_1564",
           "connectivity_net2807"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165230,7 +165230,7 @@
           "pcb_smtpad_1565",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165249,7 +165249,7 @@
           "pcb_smtpad_1566",
           "connectivity_net2796"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165268,7 +165268,7 @@
           "pcb_smtpad_1567",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165287,7 +165287,7 @@
           "pcb_smtpad_1568",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165306,7 +165306,7 @@
           "pcb_smtpad_1568",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165325,7 +165325,7 @@
           "pcb_smtpad_1568",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165344,7 +165344,7 @@
           "pcb_smtpad_1568",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165363,7 +165363,7 @@
           "pcb_smtpad_1569",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165382,7 +165382,7 @@
           "pcb_smtpad_1569",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165401,7 +165401,7 @@
           "pcb_smtpad_1569",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165420,7 +165420,7 @@
           "pcb_smtpad_1569",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165439,7 +165439,7 @@
           "pcb_smtpad_1570",
           "connectivity_net2818"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165458,7 +165458,7 @@
           "pcb_smtpad_1571",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165477,7 +165477,7 @@
           "pcb_smtpad_1572",
           "connectivity_net2807"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165496,7 +165496,7 @@
           "pcb_smtpad_1573",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165515,7 +165515,7 @@
           "pcb_smtpad_1574",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165534,7 +165534,7 @@
           "pcb_smtpad_1574",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165553,7 +165553,7 @@
           "pcb_smtpad_1574",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165572,7 +165572,7 @@
           "pcb_smtpad_1574",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165591,7 +165591,7 @@
           "pcb_smtpad_1575",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165610,7 +165610,7 @@
           "pcb_smtpad_1575",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165629,7 +165629,7 @@
           "pcb_smtpad_1575",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165648,7 +165648,7 @@
           "pcb_smtpad_1575",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165667,7 +165667,7 @@
           "pcb_smtpad_1576",
           "connectivity_net2829"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165686,7 +165686,7 @@
           "pcb_smtpad_1577",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165705,7 +165705,7 @@
           "pcb_smtpad_1578",
           "connectivity_net2818"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165724,7 +165724,7 @@
           "pcb_smtpad_1579",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165743,7 +165743,7 @@
           "pcb_smtpad_1580",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165762,7 +165762,7 @@
           "pcb_smtpad_1580",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165781,7 +165781,7 @@
           "pcb_smtpad_1580",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165800,7 +165800,7 @@
           "pcb_smtpad_1580",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165819,7 +165819,7 @@
           "pcb_smtpad_1581",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165838,7 +165838,7 @@
           "pcb_smtpad_1581",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165857,7 +165857,7 @@
           "pcb_smtpad_1581",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165876,7 +165876,7 @@
           "pcb_smtpad_1581",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165895,7 +165895,7 @@
           "pcb_smtpad_1582",
           "connectivity_net2840"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165914,7 +165914,7 @@
           "pcb_smtpad_1583",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165933,7 +165933,7 @@
           "pcb_smtpad_1584",
           "connectivity_net2829"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165952,7 +165952,7 @@
           "pcb_smtpad_1585",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165971,7 +165971,7 @@
           "pcb_smtpad_1586",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -165990,7 +165990,7 @@
           "pcb_smtpad_1586",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166009,7 +166009,7 @@
           "pcb_smtpad_1586",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166028,7 +166028,7 @@
           "pcb_smtpad_1586",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166047,7 +166047,7 @@
           "pcb_smtpad_1587",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166066,7 +166066,7 @@
           "pcb_smtpad_1587",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166085,7 +166085,7 @@
           "pcb_smtpad_1587",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166104,7 +166104,7 @@
           "pcb_smtpad_1587",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166123,7 +166123,7 @@
           "pcb_smtpad_1588",
           "connectivity_net2851"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166142,7 +166142,7 @@
           "pcb_smtpad_1589",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166161,7 +166161,7 @@
           "pcb_smtpad_1590",
           "connectivity_net2840"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166180,7 +166180,7 @@
           "pcb_smtpad_1591",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166199,7 +166199,7 @@
           "pcb_smtpad_1592",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166218,7 +166218,7 @@
           "pcb_smtpad_1592",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166237,7 +166237,7 @@
           "pcb_smtpad_1592",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166256,7 +166256,7 @@
           "pcb_smtpad_1592",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166275,7 +166275,7 @@
           "pcb_smtpad_1593",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166294,7 +166294,7 @@
           "pcb_smtpad_1593",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166313,7 +166313,7 @@
           "pcb_smtpad_1593",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166332,7 +166332,7 @@
           "pcb_smtpad_1593",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166351,7 +166351,7 @@
           "pcb_smtpad_1594",
           "connectivity_net2862"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166370,7 +166370,7 @@
           "pcb_smtpad_1595",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166389,7 +166389,7 @@
           "pcb_smtpad_1596",
           "connectivity_net2851"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166408,7 +166408,7 @@
           "pcb_smtpad_1597",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166427,7 +166427,7 @@
           "pcb_smtpad_1598",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166446,7 +166446,7 @@
           "pcb_smtpad_1598",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166465,7 +166465,7 @@
           "pcb_smtpad_1598",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166484,7 +166484,7 @@
           "pcb_smtpad_1598",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166503,7 +166503,7 @@
           "pcb_smtpad_1599",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166522,7 +166522,7 @@
           "pcb_smtpad_1599",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166541,7 +166541,7 @@
           "pcb_smtpad_1599",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166560,7 +166560,7 @@
           "pcb_smtpad_1599",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166579,7 +166579,7 @@
           "pcb_smtpad_1600",
           "connectivity_net2873"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166598,7 +166598,7 @@
           "pcb_smtpad_1601",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166617,7 +166617,7 @@
           "pcb_smtpad_1602",
           "connectivity_net2862"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166636,7 +166636,7 @@
           "pcb_smtpad_1603",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166655,7 +166655,7 @@
           "pcb_smtpad_1604",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166674,7 +166674,7 @@
           "pcb_smtpad_1604",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166693,7 +166693,7 @@
           "pcb_smtpad_1604",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166712,7 +166712,7 @@
           "pcb_smtpad_1604",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166731,7 +166731,7 @@
           "pcb_smtpad_1605",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166750,7 +166750,7 @@
           "pcb_smtpad_1605",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166769,7 +166769,7 @@
           "pcb_smtpad_1605",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166788,7 +166788,7 @@
           "pcb_smtpad_1605",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166807,7 +166807,7 @@
           "pcb_smtpad_1606",
           "connectivity_net2884"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166826,7 +166826,7 @@
           "pcb_smtpad_1607",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166845,7 +166845,7 @@
           "pcb_smtpad_1608",
           "connectivity_net2873"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166864,7 +166864,7 @@
           "pcb_smtpad_1609",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166883,7 +166883,7 @@
           "pcb_smtpad_1610",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166902,7 +166902,7 @@
           "pcb_smtpad_1610",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166921,7 +166921,7 @@
           "pcb_smtpad_1610",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166940,7 +166940,7 @@
           "pcb_smtpad_1610",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166959,7 +166959,7 @@
           "pcb_smtpad_1611",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166978,7 +166978,7 @@
           "pcb_smtpad_1611",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -166997,7 +166997,7 @@
           "pcb_smtpad_1611",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167016,7 +167016,7 @@
           "pcb_smtpad_1611",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167035,7 +167035,7 @@
           "pcb_smtpad_1612",
           "connectivity_net2895"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167054,7 +167054,7 @@
           "pcb_smtpad_1613",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167073,7 +167073,7 @@
           "pcb_smtpad_1614",
           "connectivity_net2884"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167092,7 +167092,7 @@
           "pcb_smtpad_1615",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167111,7 +167111,7 @@
           "pcb_smtpad_1616",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167130,7 +167130,7 @@
           "pcb_smtpad_1616",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167149,7 +167149,7 @@
           "pcb_smtpad_1616",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167168,7 +167168,7 @@
           "pcb_smtpad_1616",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167187,7 +167187,7 @@
           "pcb_smtpad_1617",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167206,7 +167206,7 @@
           "pcb_smtpad_1617",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167225,7 +167225,7 @@
           "pcb_smtpad_1617",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167244,7 +167244,7 @@
           "pcb_smtpad_1617",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167263,7 +167263,7 @@
           "pcb_smtpad_1618",
           "connectivity_net2906"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167282,7 +167282,7 @@
           "pcb_smtpad_1619",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167301,7 +167301,7 @@
           "pcb_smtpad_1620",
           "connectivity_net2895"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167320,7 +167320,7 @@
           "pcb_smtpad_1621",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167339,7 +167339,7 @@
           "pcb_smtpad_1622",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167358,7 +167358,7 @@
           "pcb_smtpad_1622",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167377,7 +167377,7 @@
           "pcb_smtpad_1622",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167396,7 +167396,7 @@
           "pcb_smtpad_1622",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167415,7 +167415,7 @@
           "pcb_smtpad_1623",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167434,7 +167434,7 @@
           "pcb_smtpad_1623",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167453,7 +167453,7 @@
           "pcb_smtpad_1623",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167472,7 +167472,7 @@
           "pcb_smtpad_1623",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167491,7 +167491,7 @@
           "pcb_smtpad_1624",
           "connectivity_net2917"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167510,7 +167510,7 @@
           "pcb_smtpad_1625",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167529,7 +167529,7 @@
           "pcb_smtpad_1626",
           "connectivity_net2906"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167548,7 +167548,7 @@
           "pcb_smtpad_1627",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167567,7 +167567,7 @@
           "pcb_smtpad_1628",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167586,7 +167586,7 @@
           "pcb_smtpad_1628",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167605,7 +167605,7 @@
           "pcb_smtpad_1628",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167624,7 +167624,7 @@
           "pcb_smtpad_1628",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167643,7 +167643,7 @@
           "pcb_smtpad_1629",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167662,7 +167662,7 @@
           "pcb_smtpad_1629",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167681,7 +167681,7 @@
           "pcb_smtpad_1629",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167700,7 +167700,7 @@
           "pcb_smtpad_1629",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167719,7 +167719,7 @@
           "pcb_smtpad_1630",
           "connectivity_net2928"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167738,7 +167738,7 @@
           "pcb_smtpad_1631",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167757,7 +167757,7 @@
           "pcb_smtpad_1632",
           "connectivity_net2917"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167776,7 +167776,7 @@
           "pcb_smtpad_1633",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167795,7 +167795,7 @@
           "pcb_smtpad_1634",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167814,7 +167814,7 @@
           "pcb_smtpad_1634",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167833,7 +167833,7 @@
           "pcb_smtpad_1634",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167852,7 +167852,7 @@
           "pcb_smtpad_1634",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167871,7 +167871,7 @@
           "pcb_smtpad_1635",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167890,7 +167890,7 @@
           "pcb_smtpad_1635",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167909,7 +167909,7 @@
           "pcb_smtpad_1635",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167928,7 +167928,7 @@
           "pcb_smtpad_1635",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167947,7 +167947,7 @@
           "pcb_smtpad_1636",
           "connectivity_net2939"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167966,7 +167966,7 @@
           "pcb_smtpad_1637",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -167985,7 +167985,7 @@
           "pcb_smtpad_1638",
           "connectivity_net2928"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168004,7 +168004,7 @@
           "pcb_smtpad_1639",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168023,7 +168023,7 @@
           "pcb_smtpad_1640",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168042,7 +168042,7 @@
           "pcb_smtpad_1640",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168061,7 +168061,7 @@
           "pcb_smtpad_1640",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168080,7 +168080,7 @@
           "pcb_smtpad_1640",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168099,7 +168099,7 @@
           "pcb_smtpad_1641",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168118,7 +168118,7 @@
           "pcb_smtpad_1641",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168137,7 +168137,7 @@
           "pcb_smtpad_1641",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168156,7 +168156,7 @@
           "pcb_smtpad_1641",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168175,7 +168175,7 @@
           "pcb_smtpad_1642",
           "connectivity_net2950"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168194,7 +168194,7 @@
           "pcb_smtpad_1643",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168213,7 +168213,7 @@
           "pcb_smtpad_1644",
           "connectivity_net2939"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168232,7 +168232,7 @@
           "pcb_smtpad_1645",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168251,7 +168251,7 @@
           "pcb_smtpad_1646",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168270,7 +168270,7 @@
           "pcb_smtpad_1646",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168289,7 +168289,7 @@
           "pcb_smtpad_1646",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168308,7 +168308,7 @@
           "pcb_smtpad_1646",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168327,7 +168327,7 @@
           "pcb_smtpad_1647",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168346,7 +168346,7 @@
           "pcb_smtpad_1647",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168365,7 +168365,7 @@
           "pcb_smtpad_1647",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168384,7 +168384,7 @@
           "pcb_smtpad_1647",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168403,7 +168403,7 @@
           "pcb_smtpad_1648",
           "connectivity_net2961"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168422,7 +168422,7 @@
           "pcb_smtpad_1649",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168441,7 +168441,7 @@
           "pcb_smtpad_1650",
           "connectivity_net2950"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168460,7 +168460,7 @@
           "pcb_smtpad_1651",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168479,7 +168479,7 @@
           "pcb_smtpad_1652",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168498,7 +168498,7 @@
           "pcb_smtpad_1652",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168517,7 +168517,7 @@
           "pcb_smtpad_1652",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168536,7 +168536,7 @@
           "pcb_smtpad_1652",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168555,7 +168555,7 @@
           "pcb_smtpad_1653",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168574,7 +168574,7 @@
           "pcb_smtpad_1653",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168593,7 +168593,7 @@
           "pcb_smtpad_1653",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168612,7 +168612,7 @@
           "pcb_smtpad_1653",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168631,7 +168631,7 @@
           "pcb_smtpad_1654",
           "connectivity_net2972"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168650,7 +168650,7 @@
           "pcb_smtpad_1655",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168669,7 +168669,7 @@
           "pcb_smtpad_1656",
           "connectivity_net2961"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168688,7 +168688,7 @@
           "pcb_smtpad_1657",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168707,7 +168707,7 @@
           "pcb_smtpad_1658",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168726,7 +168726,7 @@
           "pcb_smtpad_1658",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168745,7 +168745,7 @@
           "pcb_smtpad_1658",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168764,7 +168764,7 @@
           "pcb_smtpad_1658",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168783,7 +168783,7 @@
           "pcb_smtpad_1659",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168802,7 +168802,7 @@
           "pcb_smtpad_1659",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168821,7 +168821,7 @@
           "pcb_smtpad_1659",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168840,7 +168840,7 @@
           "pcb_smtpad_1659",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168859,7 +168859,7 @@
           "pcb_smtpad_1660",
           "connectivity_net2983"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168878,7 +168878,7 @@
           "pcb_smtpad_1661",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168897,7 +168897,7 @@
           "pcb_smtpad_1662",
           "connectivity_net2972"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168916,7 +168916,7 @@
           "pcb_smtpad_1663",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168935,7 +168935,7 @@
           "pcb_smtpad_1664",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168954,7 +168954,7 @@
           "pcb_smtpad_1664",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168973,7 +168973,7 @@
           "pcb_smtpad_1664",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -168992,7 +168992,7 @@
           "pcb_smtpad_1664",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169011,7 +169011,7 @@
           "pcb_smtpad_1665",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169030,7 +169030,7 @@
           "pcb_smtpad_1665",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169049,7 +169049,7 @@
           "pcb_smtpad_1665",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169068,7 +169068,7 @@
           "pcb_smtpad_1665",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169087,7 +169087,7 @@
           "pcb_smtpad_1666",
           "connectivity_net2994"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169106,7 +169106,7 @@
           "pcb_smtpad_1667",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169125,7 +169125,7 @@
           "pcb_smtpad_1668",
           "connectivity_net2983"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169144,7 +169144,7 @@
           "pcb_smtpad_1669",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169163,7 +169163,7 @@
           "pcb_smtpad_1670",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169182,7 +169182,7 @@
           "pcb_smtpad_1670",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169201,7 +169201,7 @@
           "pcb_smtpad_1670",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169220,7 +169220,7 @@
           "pcb_smtpad_1670",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169239,7 +169239,7 @@
           "pcb_smtpad_1671",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169258,7 +169258,7 @@
           "pcb_smtpad_1671",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169277,7 +169277,7 @@
           "pcb_smtpad_1671",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169296,7 +169296,7 @@
           "pcb_smtpad_1671",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169315,7 +169315,7 @@
           "pcb_smtpad_1672",
           "connectivity_net3005"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169334,7 +169334,7 @@
           "pcb_smtpad_1673",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169353,7 +169353,7 @@
           "pcb_smtpad_1674",
           "connectivity_net2994"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169372,7 +169372,7 @@
           "pcb_smtpad_1675",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169391,7 +169391,7 @@
           "pcb_smtpad_1676",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169410,7 +169410,7 @@
           "pcb_smtpad_1676",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169429,7 +169429,7 @@
           "pcb_smtpad_1676",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169448,7 +169448,7 @@
           "pcb_smtpad_1676",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169467,7 +169467,7 @@
           "pcb_smtpad_1677",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169486,7 +169486,7 @@
           "pcb_smtpad_1677",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169505,7 +169505,7 @@
           "pcb_smtpad_1677",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169524,7 +169524,7 @@
           "pcb_smtpad_1677",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169543,7 +169543,7 @@
           "pcb_smtpad_1678",
           "connectivity_net3016"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169562,7 +169562,7 @@
           "pcb_smtpad_1679",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169581,7 +169581,7 @@
           "pcb_smtpad_1680",
           "connectivity_net3005"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169600,7 +169600,7 @@
           "pcb_smtpad_1681",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169619,7 +169619,7 @@
           "pcb_smtpad_1682",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169638,7 +169638,7 @@
           "pcb_smtpad_1682",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169657,7 +169657,7 @@
           "pcb_smtpad_1682",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169676,7 +169676,7 @@
           "pcb_smtpad_1682",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169695,7 +169695,7 @@
           "pcb_smtpad_1683",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169714,7 +169714,7 @@
           "pcb_smtpad_1683",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169733,7 +169733,7 @@
           "pcb_smtpad_1683",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169752,7 +169752,7 @@
           "pcb_smtpad_1683",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169771,7 +169771,7 @@
           "pcb_smtpad_1684",
           "connectivity_net3027"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169790,7 +169790,7 @@
           "pcb_smtpad_1685",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169809,7 +169809,7 @@
           "pcb_smtpad_1686",
           "connectivity_net3016"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169828,7 +169828,7 @@
           "pcb_smtpad_1687",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169847,7 +169847,7 @@
           "pcb_smtpad_1688",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169866,7 +169866,7 @@
           "pcb_smtpad_1688",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169885,7 +169885,7 @@
           "pcb_smtpad_1688",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169904,7 +169904,7 @@
           "pcb_smtpad_1688",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169923,7 +169923,7 @@
           "pcb_smtpad_1689",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169942,7 +169942,7 @@
           "pcb_smtpad_1689",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169961,7 +169961,7 @@
           "pcb_smtpad_1689",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169980,7 +169980,7 @@
           "pcb_smtpad_1689",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -169999,7 +169999,7 @@
           "pcb_smtpad_1690",
           "connectivity_net3038"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170018,7 +170018,7 @@
           "pcb_smtpad_1691",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170037,7 +170037,7 @@
           "pcb_smtpad_1692",
           "connectivity_net3027"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170056,7 +170056,7 @@
           "pcb_smtpad_1693",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170075,7 +170075,7 @@
           "pcb_smtpad_1694",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170094,7 +170094,7 @@
           "pcb_smtpad_1694",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170113,7 +170113,7 @@
           "pcb_smtpad_1694",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170132,7 +170132,7 @@
           "pcb_smtpad_1694",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170151,7 +170151,7 @@
           "pcb_smtpad_1695",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170170,7 +170170,7 @@
           "pcb_smtpad_1695",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170189,7 +170189,7 @@
           "pcb_smtpad_1695",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170208,7 +170208,7 @@
           "pcb_smtpad_1695",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170227,7 +170227,7 @@
           "pcb_smtpad_1696",
           "connectivity_net3049"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170246,7 +170246,7 @@
           "pcb_smtpad_1697",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170265,7 +170265,7 @@
           "pcb_smtpad_1698",
           "connectivity_net3038"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170284,7 +170284,7 @@
           "pcb_smtpad_1699",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170303,7 +170303,7 @@
           "pcb_smtpad_1700",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170322,7 +170322,7 @@
           "pcb_smtpad_1700",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170341,7 +170341,7 @@
           "pcb_smtpad_1700",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170360,7 +170360,7 @@
           "pcb_smtpad_1700",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170379,7 +170379,7 @@
           "pcb_smtpad_1701",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170398,7 +170398,7 @@
           "pcb_smtpad_1701",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170417,7 +170417,7 @@
           "pcb_smtpad_1701",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170436,7 +170436,7 @@
           "pcb_smtpad_1701",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170455,7 +170455,7 @@
           "pcb_smtpad_1702",
           "connectivity_net3060"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170474,7 +170474,7 @@
           "pcb_smtpad_1703",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170493,7 +170493,7 @@
           "pcb_smtpad_1704",
           "connectivity_net3049"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170512,7 +170512,7 @@
           "pcb_smtpad_1705",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170531,7 +170531,7 @@
           "pcb_smtpad_1706",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170550,7 +170550,7 @@
           "pcb_smtpad_1706",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170569,7 +170569,7 @@
           "pcb_smtpad_1706",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170588,7 +170588,7 @@
           "pcb_smtpad_1706",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170607,7 +170607,7 @@
           "pcb_smtpad_1707",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170626,7 +170626,7 @@
           "pcb_smtpad_1707",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170645,7 +170645,7 @@
           "pcb_smtpad_1707",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170664,7 +170664,7 @@
           "pcb_smtpad_1707",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170683,7 +170683,7 @@
           "pcb_smtpad_1708",
           "connectivity_net3071"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170702,7 +170702,7 @@
           "pcb_smtpad_1709",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170721,7 +170721,7 @@
           "pcb_smtpad_1710",
           "connectivity_net3060"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170740,7 +170740,7 @@
           "pcb_smtpad_1711",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170759,7 +170759,7 @@
           "pcb_smtpad_1712",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170778,7 +170778,7 @@
           "pcb_smtpad_1712",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170797,7 +170797,7 @@
           "pcb_smtpad_1712",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170816,7 +170816,7 @@
           "pcb_smtpad_1712",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170835,7 +170835,7 @@
           "pcb_smtpad_1713",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170854,7 +170854,7 @@
           "pcb_smtpad_1713",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170873,7 +170873,7 @@
           "pcb_smtpad_1713",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170892,7 +170892,7 @@
           "pcb_smtpad_1713",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170911,7 +170911,7 @@
           "pcb_smtpad_1714",
           "connectivity_net3082"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170930,7 +170930,7 @@
           "pcb_smtpad_1715",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170949,7 +170949,7 @@
           "pcb_smtpad_1716",
           "connectivity_net3071"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170968,7 +170968,7 @@
           "pcb_smtpad_1717",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170987,7 +170987,7 @@
           "pcb_smtpad_1718",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171006,7 +171006,7 @@
           "pcb_smtpad_1718",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171025,7 +171025,7 @@
           "pcb_smtpad_1718",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171044,7 +171044,7 @@
           "pcb_smtpad_1718",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171063,7 +171063,7 @@
           "pcb_smtpad_1719",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171082,7 +171082,7 @@
           "pcb_smtpad_1719",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171101,7 +171101,7 @@
           "pcb_smtpad_1719",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171120,7 +171120,7 @@
           "pcb_smtpad_1719",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171139,7 +171139,7 @@
           "pcb_smtpad_1720",
           "connectivity_net3093"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171158,7 +171158,7 @@
           "pcb_smtpad_1721",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171177,7 +171177,7 @@
           "pcb_smtpad_1722",
           "connectivity_net3082"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171196,7 +171196,7 @@
           "pcb_smtpad_1723",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171215,7 +171215,7 @@
           "pcb_smtpad_1724",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171234,7 +171234,7 @@
           "pcb_smtpad_1724",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171253,7 +171253,7 @@
           "pcb_smtpad_1724",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171272,7 +171272,7 @@
           "pcb_smtpad_1724",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171291,7 +171291,7 @@
           "pcb_smtpad_1725",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171310,7 +171310,7 @@
           "pcb_smtpad_1725",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171329,7 +171329,7 @@
           "pcb_smtpad_1725",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171348,7 +171348,7 @@
           "pcb_smtpad_1725",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171367,7 +171367,7 @@
           "pcb_smtpad_1726",
           "connectivity_net3104"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171386,7 +171386,7 @@
           "pcb_smtpad_1727",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171405,7 +171405,7 @@
           "pcb_smtpad_1728",
           "connectivity_net3093"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171424,7 +171424,7 @@
           "pcb_smtpad_1729",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171443,7 +171443,7 @@
           "pcb_smtpad_1730",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171462,7 +171462,7 @@
           "pcb_smtpad_1730",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171481,7 +171481,7 @@
           "pcb_smtpad_1730",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171500,7 +171500,7 @@
           "pcb_smtpad_1730",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171519,7 +171519,7 @@
           "pcb_smtpad_1731",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171538,7 +171538,7 @@
           "pcb_smtpad_1731",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171557,7 +171557,7 @@
           "pcb_smtpad_1731",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171576,7 +171576,7 @@
           "pcb_smtpad_1731",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171595,7 +171595,7 @@
           "pcb_smtpad_1732",
           "connectivity_net3115"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171614,7 +171614,7 @@
           "pcb_smtpad_1733",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171633,7 +171633,7 @@
           "pcb_smtpad_1734",
           "connectivity_net3104"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171652,7 +171652,7 @@
           "pcb_smtpad_1735",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171671,7 +171671,7 @@
           "pcb_smtpad_1736",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171690,7 +171690,7 @@
           "pcb_smtpad_1736",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171709,7 +171709,7 @@
           "pcb_smtpad_1736",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171728,7 +171728,7 @@
           "pcb_smtpad_1736",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171747,7 +171747,7 @@
           "pcb_smtpad_1737",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171766,7 +171766,7 @@
           "pcb_smtpad_1737",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171785,7 +171785,7 @@
           "pcb_smtpad_1737",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171804,7 +171804,7 @@
           "pcb_smtpad_1737",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171823,7 +171823,7 @@
           "pcb_smtpad_1738",
           "connectivity_net3126"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171842,7 +171842,7 @@
           "pcb_smtpad_1739",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171861,7 +171861,7 @@
           "pcb_smtpad_1740",
           "connectivity_net3115"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171880,7 +171880,7 @@
           "pcb_smtpad_1741",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171899,7 +171899,7 @@
           "pcb_smtpad_1742",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171918,7 +171918,7 @@
           "pcb_smtpad_1742",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171937,7 +171937,7 @@
           "pcb_smtpad_1742",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171956,7 +171956,7 @@
           "pcb_smtpad_1742",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171975,7 +171975,7 @@
           "pcb_smtpad_1743",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -171994,7 +171994,7 @@
           "pcb_smtpad_1743",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172013,7 +172013,7 @@
           "pcb_smtpad_1743",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172032,7 +172032,7 @@
           "pcb_smtpad_1743",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172051,7 +172051,7 @@
           "pcb_smtpad_1744",
           "connectivity_net3137"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172070,7 +172070,7 @@
           "pcb_smtpad_1745",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172089,7 +172089,7 @@
           "pcb_smtpad_1746",
           "connectivity_net3126"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172108,7 +172108,7 @@
           "pcb_smtpad_1747",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172127,7 +172127,7 @@
           "pcb_smtpad_1748",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172146,7 +172146,7 @@
           "pcb_smtpad_1748",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172165,7 +172165,7 @@
           "pcb_smtpad_1748",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172184,7 +172184,7 @@
           "pcb_smtpad_1748",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172203,7 +172203,7 @@
           "pcb_smtpad_1749",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172222,7 +172222,7 @@
           "pcb_smtpad_1749",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172241,7 +172241,7 @@
           "pcb_smtpad_1749",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172260,7 +172260,7 @@
           "pcb_smtpad_1749",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172279,7 +172279,7 @@
           "pcb_smtpad_1750",
           "connectivity_net3148"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172298,7 +172298,7 @@
           "pcb_smtpad_1751",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172317,7 +172317,7 @@
           "pcb_smtpad_1752",
           "connectivity_net3137"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172336,7 +172336,7 @@
           "pcb_smtpad_1753",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172355,7 +172355,7 @@
           "pcb_smtpad_1754",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172374,7 +172374,7 @@
           "pcb_smtpad_1754",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172393,7 +172393,7 @@
           "pcb_smtpad_1754",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172412,7 +172412,7 @@
           "pcb_smtpad_1754",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172431,7 +172431,7 @@
           "pcb_smtpad_1755",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172450,7 +172450,7 @@
           "pcb_smtpad_1755",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172469,7 +172469,7 @@
           "pcb_smtpad_1755",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172488,7 +172488,7 @@
           "pcb_smtpad_1755",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172507,7 +172507,7 @@
           "pcb_smtpad_1756",
           "connectivity_net3159"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172526,7 +172526,7 @@
           "pcb_smtpad_1757",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172545,7 +172545,7 @@
           "pcb_smtpad_1758",
           "connectivity_net3148"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172564,7 +172564,7 @@
           "pcb_smtpad_1759",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172583,7 +172583,7 @@
           "pcb_smtpad_1760",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172602,7 +172602,7 @@
           "pcb_smtpad_1760",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172621,7 +172621,7 @@
           "pcb_smtpad_1760",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172640,7 +172640,7 @@
           "pcb_smtpad_1760",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172659,7 +172659,7 @@
           "pcb_smtpad_1761",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172678,7 +172678,7 @@
           "pcb_smtpad_1761",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172697,7 +172697,7 @@
           "pcb_smtpad_1761",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172716,7 +172716,7 @@
           "pcb_smtpad_1761",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172735,7 +172735,7 @@
           "pcb_smtpad_1762",
           "connectivity_net3170"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172754,7 +172754,7 @@
           "pcb_smtpad_1763",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172773,7 +172773,7 @@
           "pcb_smtpad_1764",
           "connectivity_net3159"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172792,7 +172792,7 @@
           "pcb_smtpad_1765",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172811,7 +172811,7 @@
           "pcb_smtpad_1766",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172830,7 +172830,7 @@
           "pcb_smtpad_1766",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172849,7 +172849,7 @@
           "pcb_smtpad_1766",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172868,7 +172868,7 @@
           "pcb_smtpad_1766",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172887,7 +172887,7 @@
           "pcb_smtpad_1767",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172906,7 +172906,7 @@
           "pcb_smtpad_1767",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172925,7 +172925,7 @@
           "pcb_smtpad_1767",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172944,7 +172944,7 @@
           "pcb_smtpad_1767",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172963,7 +172963,7 @@
           "pcb_smtpad_1768",
           "connectivity_net3181"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -172982,7 +172982,7 @@
           "pcb_smtpad_1769",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173001,7 +173001,7 @@
           "pcb_smtpad_1770",
           "connectivity_net3170"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173020,7 +173020,7 @@
           "pcb_smtpad_1771",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173039,7 +173039,7 @@
           "pcb_smtpad_1772",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173058,7 +173058,7 @@
           "pcb_smtpad_1772",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173077,7 +173077,7 @@
           "pcb_smtpad_1772",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173096,7 +173096,7 @@
           "pcb_smtpad_1772",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173115,7 +173115,7 @@
           "pcb_smtpad_1773",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173134,7 +173134,7 @@
           "pcb_smtpad_1773",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173153,7 +173153,7 @@
           "pcb_smtpad_1773",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173172,7 +173172,7 @@
           "pcb_smtpad_1773",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173191,7 +173191,7 @@
           "pcb_smtpad_1774",
           "connectivity_net3192"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173210,7 +173210,7 @@
           "pcb_smtpad_1775",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173229,7 +173229,7 @@
           "pcb_smtpad_1776",
           "connectivity_net3181"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173248,7 +173248,7 @@
           "pcb_smtpad_1777",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173267,7 +173267,7 @@
           "pcb_smtpad_1778",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173286,7 +173286,7 @@
           "pcb_smtpad_1778",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173305,7 +173305,7 @@
           "pcb_smtpad_1778",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173324,7 +173324,7 @@
           "pcb_smtpad_1778",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173343,7 +173343,7 @@
           "pcb_smtpad_1779",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173362,7 +173362,7 @@
           "pcb_smtpad_1779",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173381,7 +173381,7 @@
           "pcb_smtpad_1779",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173400,7 +173400,7 @@
           "pcb_smtpad_1779",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173419,7 +173419,7 @@
           "pcb_smtpad_1780",
           "connectivity_net3203"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173438,7 +173438,7 @@
           "pcb_smtpad_1781",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173457,7 +173457,7 @@
           "pcb_smtpad_1782",
           "connectivity_net3192"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173476,7 +173476,7 @@
           "pcb_smtpad_1783",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173495,7 +173495,7 @@
           "pcb_smtpad_1784",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173514,7 +173514,7 @@
           "pcb_smtpad_1784",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173533,7 +173533,7 @@
           "pcb_smtpad_1784",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173552,7 +173552,7 @@
           "pcb_smtpad_1784",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173571,7 +173571,7 @@
           "pcb_smtpad_1785",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173590,7 +173590,7 @@
           "pcb_smtpad_1785",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173609,7 +173609,7 @@
           "pcb_smtpad_1785",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173628,7 +173628,7 @@
           "pcb_smtpad_1785",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173647,7 +173647,7 @@
           "pcb_smtpad_1786",
           "connectivity_net3214"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173666,7 +173666,7 @@
           "pcb_smtpad_1787",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173685,7 +173685,7 @@
           "pcb_smtpad_1788",
           "connectivity_net3203"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173704,7 +173704,7 @@
           "pcb_smtpad_1789",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173723,7 +173723,7 @@
           "pcb_smtpad_1790",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173742,7 +173742,7 @@
           "pcb_smtpad_1790",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173761,7 +173761,7 @@
           "pcb_smtpad_1790",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173780,7 +173780,7 @@
           "pcb_smtpad_1790",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173799,7 +173799,7 @@
           "pcb_smtpad_1791",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173818,7 +173818,7 @@
           "pcb_smtpad_1791",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173837,7 +173837,7 @@
           "pcb_smtpad_1791",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173856,7 +173856,7 @@
           "pcb_smtpad_1791",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173875,7 +173875,7 @@
           "pcb_smtpad_1792",
           "connectivity_net3225"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173894,7 +173894,7 @@
           "pcb_smtpad_1793",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173913,7 +173913,7 @@
           "pcb_smtpad_1794",
           "connectivity_net3214"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173932,7 +173932,7 @@
           "pcb_smtpad_1795",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173951,7 +173951,7 @@
           "pcb_smtpad_1796",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173970,7 +173970,7 @@
           "pcb_smtpad_1796",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -173989,7 +173989,7 @@
           "pcb_smtpad_1796",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174008,7 +174008,7 @@
           "pcb_smtpad_1796",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174027,7 +174027,7 @@
           "pcb_smtpad_1797",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174046,7 +174046,7 @@
           "pcb_smtpad_1797",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174065,7 +174065,7 @@
           "pcb_smtpad_1797",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174084,7 +174084,7 @@
           "pcb_smtpad_1797",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174103,7 +174103,7 @@
           "pcb_smtpad_1798",
           "connectivity_net3236"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174122,7 +174122,7 @@
           "pcb_smtpad_1799",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174141,7 +174141,7 @@
           "pcb_smtpad_1800",
           "connectivity_net3225"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174160,7 +174160,7 @@
           "pcb_smtpad_1801",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174179,7 +174179,7 @@
           "pcb_smtpad_1802",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174198,7 +174198,7 @@
           "pcb_smtpad_1802",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174217,7 +174217,7 @@
           "pcb_smtpad_1802",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174236,7 +174236,7 @@
           "pcb_smtpad_1802",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174255,7 +174255,7 @@
           "pcb_smtpad_1803",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174274,7 +174274,7 @@
           "pcb_smtpad_1803",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174293,7 +174293,7 @@
           "pcb_smtpad_1803",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174312,7 +174312,7 @@
           "pcb_smtpad_1803",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174331,7 +174331,7 @@
           "pcb_smtpad_1804",
           "connectivity_net3247"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174350,7 +174350,7 @@
           "pcb_smtpad_1805",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174369,7 +174369,7 @@
           "pcb_smtpad_1806",
           "connectivity_net3236"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174388,7 +174388,7 @@
           "pcb_smtpad_1807",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174407,7 +174407,7 @@
           "pcb_smtpad_1808",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174426,7 +174426,7 @@
           "pcb_smtpad_1808",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174445,7 +174445,7 @@
           "pcb_smtpad_1808",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174464,7 +174464,7 @@
           "pcb_smtpad_1808",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174483,7 +174483,7 @@
           "pcb_smtpad_1809",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174502,7 +174502,7 @@
           "pcb_smtpad_1809",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174521,7 +174521,7 @@
           "pcb_smtpad_1809",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174540,7 +174540,7 @@
           "pcb_smtpad_1809",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174559,7 +174559,7 @@
           "pcb_smtpad_1810",
           "connectivity_net3258"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174578,7 +174578,7 @@
           "pcb_smtpad_1811",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174597,7 +174597,7 @@
           "pcb_smtpad_1812",
           "connectivity_net3247"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174616,7 +174616,7 @@
           "pcb_smtpad_1813",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174635,7 +174635,7 @@
           "pcb_smtpad_1814",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174654,7 +174654,7 @@
           "pcb_smtpad_1814",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174673,7 +174673,7 @@
           "pcb_smtpad_1814",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174692,7 +174692,7 @@
           "pcb_smtpad_1814",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174711,7 +174711,7 @@
           "pcb_smtpad_1815",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174730,7 +174730,7 @@
           "pcb_smtpad_1815",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174749,7 +174749,7 @@
           "pcb_smtpad_1815",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174768,7 +174768,7 @@
           "pcb_smtpad_1815",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174787,7 +174787,7 @@
           "pcb_smtpad_1816",
           "connectivity_net3269"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174806,7 +174806,7 @@
           "pcb_smtpad_1817",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174825,7 +174825,7 @@
           "pcb_smtpad_1818",
           "connectivity_net3258"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174844,7 +174844,7 @@
           "pcb_smtpad_1819",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174863,7 +174863,7 @@
           "pcb_smtpad_1820",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174882,7 +174882,7 @@
           "pcb_smtpad_1820",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174901,7 +174901,7 @@
           "pcb_smtpad_1820",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174920,7 +174920,7 @@
           "pcb_smtpad_1820",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174939,7 +174939,7 @@
           "pcb_smtpad_1821",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174958,7 +174958,7 @@
           "pcb_smtpad_1821",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174977,7 +174977,7 @@
           "pcb_smtpad_1821",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -174996,7 +174996,7 @@
           "pcb_smtpad_1821",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175015,7 +175015,7 @@
           "pcb_smtpad_1822",
           "connectivity_net3280"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175034,7 +175034,7 @@
           "pcb_smtpad_1823",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175053,7 +175053,7 @@
           "pcb_smtpad_1824",
           "connectivity_net3269"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175072,7 +175072,7 @@
           "pcb_smtpad_1825",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175091,7 +175091,7 @@
           "pcb_smtpad_1826",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175110,7 +175110,7 @@
           "pcb_smtpad_1826",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175129,7 +175129,7 @@
           "pcb_smtpad_1826",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175148,7 +175148,7 @@
           "pcb_smtpad_1826",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175167,7 +175167,7 @@
           "pcb_smtpad_1827",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175186,7 +175186,7 @@
           "pcb_smtpad_1827",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175205,7 +175205,7 @@
           "pcb_smtpad_1827",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175224,7 +175224,7 @@
           "pcb_smtpad_1827",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175243,7 +175243,7 @@
           "pcb_smtpad_1828",
           "connectivity_net3291"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175262,7 +175262,7 @@
           "pcb_smtpad_1829",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175281,7 +175281,7 @@
           "pcb_smtpad_1830",
           "connectivity_net3280"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175300,7 +175300,7 @@
           "pcb_smtpad_1831",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175319,7 +175319,7 @@
           "pcb_smtpad_1832",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175338,7 +175338,7 @@
           "pcb_smtpad_1832",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175357,7 +175357,7 @@
           "pcb_smtpad_1832",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175376,7 +175376,7 @@
           "pcb_smtpad_1832",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175395,7 +175395,7 @@
           "pcb_smtpad_1833",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175414,7 +175414,7 @@
           "pcb_smtpad_1833",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175433,7 +175433,7 @@
           "pcb_smtpad_1833",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175452,7 +175452,7 @@
           "pcb_smtpad_1833",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175471,7 +175471,7 @@
           "pcb_smtpad_1834",
           "connectivity_net3302"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175490,7 +175490,7 @@
           "pcb_smtpad_1835",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175509,7 +175509,7 @@
           "pcb_smtpad_1836",
           "connectivity_net3291"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175528,7 +175528,7 @@
           "pcb_smtpad_1837",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175547,7 +175547,7 @@
           "pcb_smtpad_1838",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175566,7 +175566,7 @@
           "pcb_smtpad_1838",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175585,7 +175585,7 @@
           "pcb_smtpad_1838",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175604,7 +175604,7 @@
           "pcb_smtpad_1838",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175623,7 +175623,7 @@
           "pcb_smtpad_1839",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175642,7 +175642,7 @@
           "pcb_smtpad_1839",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175661,7 +175661,7 @@
           "pcb_smtpad_1839",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175680,7 +175680,7 @@
           "pcb_smtpad_1839",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175699,7 +175699,7 @@
           "pcb_smtpad_1840",
           "connectivity_net3313"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175718,7 +175718,7 @@
           "pcb_smtpad_1841",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175737,7 +175737,7 @@
           "pcb_smtpad_1842",
           "connectivity_net3302"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175756,7 +175756,7 @@
           "pcb_smtpad_1843",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175775,7 +175775,7 @@
           "pcb_smtpad_1844",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175794,7 +175794,7 @@
           "pcb_smtpad_1844",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175813,7 +175813,7 @@
           "pcb_smtpad_1844",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175832,7 +175832,7 @@
           "pcb_smtpad_1844",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175851,7 +175851,7 @@
           "pcb_smtpad_1845",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175870,7 +175870,7 @@
           "pcb_smtpad_1845",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175889,7 +175889,7 @@
           "pcb_smtpad_1845",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175908,7 +175908,7 @@
           "pcb_smtpad_1845",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175927,7 +175927,7 @@
           "pcb_smtpad_1846",
           "connectivity_net3324"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175946,7 +175946,7 @@
           "pcb_smtpad_1847",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175965,7 +175965,7 @@
           "pcb_smtpad_1848",
           "connectivity_net3313"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -175984,7 +175984,7 @@
           "pcb_smtpad_1849",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176003,7 +176003,7 @@
           "pcb_smtpad_1850",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176022,7 +176022,7 @@
           "pcb_smtpad_1850",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176041,7 +176041,7 @@
           "pcb_smtpad_1850",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176060,7 +176060,7 @@
           "pcb_smtpad_1850",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176079,7 +176079,7 @@
           "pcb_smtpad_1851",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176098,7 +176098,7 @@
           "pcb_smtpad_1851",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176117,7 +176117,7 @@
           "pcb_smtpad_1851",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176136,7 +176136,7 @@
           "pcb_smtpad_1851",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176155,7 +176155,7 @@
           "pcb_smtpad_1852",
           "connectivity_net3335"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176174,7 +176174,7 @@
           "pcb_smtpad_1853",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176193,7 +176193,7 @@
           "pcb_smtpad_1854",
           "connectivity_net3324"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176212,7 +176212,7 @@
           "pcb_smtpad_1855",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176231,7 +176231,7 @@
           "pcb_smtpad_1856",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176250,7 +176250,7 @@
           "pcb_smtpad_1856",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176269,7 +176269,7 @@
           "pcb_smtpad_1856",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176288,7 +176288,7 @@
           "pcb_smtpad_1856",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176307,7 +176307,7 @@
           "pcb_smtpad_1857",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176326,7 +176326,7 @@
           "pcb_smtpad_1857",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176345,7 +176345,7 @@
           "pcb_smtpad_1857",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176364,7 +176364,7 @@
           "pcb_smtpad_1857",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176383,7 +176383,7 @@
           "pcb_smtpad_1858",
           "connectivity_net3346"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176402,7 +176402,7 @@
           "pcb_smtpad_1859",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176421,7 +176421,7 @@
           "pcb_smtpad_1860",
           "connectivity_net3335"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176440,7 +176440,7 @@
           "pcb_smtpad_1861",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176459,7 +176459,7 @@
           "pcb_smtpad_1862",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176478,7 +176478,7 @@
           "pcb_smtpad_1862",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176497,7 +176497,7 @@
           "pcb_smtpad_1862",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176516,7 +176516,7 @@
           "pcb_smtpad_1862",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176535,7 +176535,7 @@
           "pcb_smtpad_1863",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176554,7 +176554,7 @@
           "pcb_smtpad_1863",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176573,7 +176573,7 @@
           "pcb_smtpad_1863",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176592,7 +176592,7 @@
           "pcb_smtpad_1863",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176611,7 +176611,7 @@
           "pcb_smtpad_1864",
           "connectivity_net3357"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176630,7 +176630,7 @@
           "pcb_smtpad_1865",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176649,7 +176649,7 @@
           "pcb_smtpad_1866",
           "connectivity_net3346"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176668,7 +176668,7 @@
           "pcb_smtpad_1867",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176687,7 +176687,7 @@
           "pcb_smtpad_1868",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176706,7 +176706,7 @@
           "pcb_smtpad_1868",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176725,7 +176725,7 @@
           "pcb_smtpad_1868",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176744,7 +176744,7 @@
           "pcb_smtpad_1868",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176763,7 +176763,7 @@
           "pcb_smtpad_1869",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176782,7 +176782,7 @@
           "pcb_smtpad_1869",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176801,7 +176801,7 @@
           "pcb_smtpad_1869",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176820,7 +176820,7 @@
           "pcb_smtpad_1869",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176839,7 +176839,7 @@
           "pcb_smtpad_1870",
           "connectivity_net3368"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176858,7 +176858,7 @@
           "pcb_smtpad_1871",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176877,7 +176877,7 @@
           "pcb_smtpad_1872",
           "connectivity_net3357"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176896,7 +176896,7 @@
           "pcb_smtpad_1873",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176915,7 +176915,7 @@
           "pcb_smtpad_1874",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176934,7 +176934,7 @@
           "pcb_smtpad_1874",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176953,7 +176953,7 @@
           "pcb_smtpad_1874",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176972,7 +176972,7 @@
           "pcb_smtpad_1874",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -176991,7 +176991,7 @@
           "pcb_smtpad_1875",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177010,7 +177010,7 @@
           "pcb_smtpad_1875",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177029,7 +177029,7 @@
           "pcb_smtpad_1875",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177048,7 +177048,7 @@
           "pcb_smtpad_1875",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177067,7 +177067,7 @@
           "pcb_smtpad_1876",
           "connectivity_net3379"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177086,7 +177086,7 @@
           "pcb_smtpad_1877",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177105,7 +177105,7 @@
           "pcb_smtpad_1878",
           "connectivity_net3368"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177124,7 +177124,7 @@
           "pcb_smtpad_1879",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177143,7 +177143,7 @@
           "pcb_smtpad_1880",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177162,7 +177162,7 @@
           "pcb_smtpad_1880",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177181,7 +177181,7 @@
           "pcb_smtpad_1880",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177200,7 +177200,7 @@
           "pcb_smtpad_1880",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177219,7 +177219,7 @@
           "pcb_smtpad_1881",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177238,7 +177238,7 @@
           "pcb_smtpad_1881",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177257,7 +177257,7 @@
           "pcb_smtpad_1881",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177276,7 +177276,7 @@
           "pcb_smtpad_1881",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177295,7 +177295,7 @@
           "pcb_smtpad_1882",
           "connectivity_net3390"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177314,7 +177314,7 @@
           "pcb_smtpad_1883",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177333,7 +177333,7 @@
           "pcb_smtpad_1884",
           "connectivity_net3379"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177352,7 +177352,7 @@
           "pcb_smtpad_1885",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177371,7 +177371,7 @@
           "pcb_smtpad_1886",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177390,7 +177390,7 @@
           "pcb_smtpad_1886",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177409,7 +177409,7 @@
           "pcb_smtpad_1886",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177428,7 +177428,7 @@
           "pcb_smtpad_1886",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177447,7 +177447,7 @@
           "pcb_smtpad_1887",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177466,7 +177466,7 @@
           "pcb_smtpad_1887",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177485,7 +177485,7 @@
           "pcb_smtpad_1887",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177504,7 +177504,7 @@
           "pcb_smtpad_1887",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177523,7 +177523,7 @@
           "pcb_smtpad_1888",
           "connectivity_net3401"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177542,7 +177542,7 @@
           "pcb_smtpad_1889",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177561,7 +177561,7 @@
           "pcb_smtpad_1890",
           "connectivity_net3390"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177580,7 +177580,7 @@
           "pcb_smtpad_1891",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177599,7 +177599,7 @@
           "pcb_smtpad_1892",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177618,7 +177618,7 @@
           "pcb_smtpad_1892",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177637,7 +177637,7 @@
           "pcb_smtpad_1892",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177656,7 +177656,7 @@
           "pcb_smtpad_1892",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177675,7 +177675,7 @@
           "pcb_smtpad_1893",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177694,7 +177694,7 @@
           "pcb_smtpad_1893",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177713,7 +177713,7 @@
           "pcb_smtpad_1893",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177732,7 +177732,7 @@
           "pcb_smtpad_1893",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177751,7 +177751,7 @@
           "pcb_smtpad_1894",
           "connectivity_net3412"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177770,7 +177770,7 @@
           "pcb_smtpad_1895",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177789,7 +177789,7 @@
           "pcb_smtpad_1896",
           "connectivity_net3401"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177808,7 +177808,7 @@
           "pcb_smtpad_1897",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177827,7 +177827,7 @@
           "pcb_smtpad_1898",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177846,7 +177846,7 @@
           "pcb_smtpad_1898",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177865,7 +177865,7 @@
           "pcb_smtpad_1898",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177884,7 +177884,7 @@
           "pcb_smtpad_1898",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177903,7 +177903,7 @@
           "pcb_smtpad_1899",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177922,7 +177922,7 @@
           "pcb_smtpad_1899",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177941,7 +177941,7 @@
           "pcb_smtpad_1899",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177960,7 +177960,7 @@
           "pcb_smtpad_1899",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177979,7 +177979,7 @@
           "pcb_smtpad_1900",
           "connectivity_net3423"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -177998,7 +177998,7 @@
           "pcb_smtpad_1901",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178017,7 +178017,7 @@
           "pcb_smtpad_1902",
           "connectivity_net3412"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178036,7 +178036,7 @@
           "pcb_smtpad_1903",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178055,7 +178055,7 @@
           "pcb_smtpad_1904",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178074,7 +178074,7 @@
           "pcb_smtpad_1904",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178093,7 +178093,7 @@
           "pcb_smtpad_1904",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178112,7 +178112,7 @@
           "pcb_smtpad_1904",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178131,7 +178131,7 @@
           "pcb_smtpad_1905",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178150,7 +178150,7 @@
           "pcb_smtpad_1905",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178169,7 +178169,7 @@
           "pcb_smtpad_1905",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178188,7 +178188,7 @@
           "pcb_smtpad_1905",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178207,7 +178207,7 @@
           "pcb_smtpad_1906",
           "connectivity_net3434"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178226,7 +178226,7 @@
           "pcb_smtpad_1907",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178245,7 +178245,7 @@
           "pcb_smtpad_1908",
           "connectivity_net3423"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178264,7 +178264,7 @@
           "pcb_smtpad_1909",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178283,7 +178283,7 @@
           "pcb_smtpad_1910",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178302,7 +178302,7 @@
           "pcb_smtpad_1910",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178321,7 +178321,7 @@
           "pcb_smtpad_1910",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178340,7 +178340,7 @@
           "pcb_smtpad_1910",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178359,7 +178359,7 @@
           "pcb_smtpad_1911",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178378,7 +178378,7 @@
           "pcb_smtpad_1911",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178397,7 +178397,7 @@
           "pcb_smtpad_1911",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178416,7 +178416,7 @@
           "pcb_smtpad_1911",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178435,7 +178435,7 @@
           "pcb_smtpad_1912",
           "connectivity_net3445"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178454,7 +178454,7 @@
           "pcb_smtpad_1913",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178473,7 +178473,7 @@
           "pcb_smtpad_1914",
           "connectivity_net3434"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178492,7 +178492,7 @@
           "pcb_smtpad_1915",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178511,7 +178511,7 @@
           "pcb_smtpad_1916",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178530,7 +178530,7 @@
           "pcb_smtpad_1916",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178549,7 +178549,7 @@
           "pcb_smtpad_1916",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178568,7 +178568,7 @@
           "pcb_smtpad_1916",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178587,7 +178587,7 @@
           "pcb_smtpad_1917",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178606,7 +178606,7 @@
           "pcb_smtpad_1917",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178625,7 +178625,7 @@
           "pcb_smtpad_1917",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178644,7 +178644,7 @@
           "pcb_smtpad_1917",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178663,7 +178663,7 @@
           "pcb_smtpad_1918",
           "connectivity_net3456"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178682,7 +178682,7 @@
           "pcb_smtpad_1919",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178701,7 +178701,7 @@
           "pcb_smtpad_1920",
           "connectivity_net3445"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178720,7 +178720,7 @@
           "pcb_smtpad_1921",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178739,7 +178739,7 @@
           "pcb_smtpad_1922",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178758,7 +178758,7 @@
           "pcb_smtpad_1922",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178777,7 +178777,7 @@
           "pcb_smtpad_1922",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178796,7 +178796,7 @@
           "pcb_smtpad_1922",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178815,7 +178815,7 @@
           "pcb_smtpad_1923",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178834,7 +178834,7 @@
           "pcb_smtpad_1923",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178853,7 +178853,7 @@
           "pcb_smtpad_1923",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178872,7 +178872,7 @@
           "pcb_smtpad_1923",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178891,7 +178891,7 @@
           "pcb_smtpad_1924",
           "connectivity_net3467"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178910,7 +178910,7 @@
           "pcb_smtpad_1925",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178929,7 +178929,7 @@
           "pcb_smtpad_1926",
           "connectivity_net3456"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178948,7 +178948,7 @@
           "pcb_smtpad_1927",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178967,7 +178967,7 @@
           "pcb_smtpad_1928",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -178986,7 +178986,7 @@
           "pcb_smtpad_1928",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179005,7 +179005,7 @@
           "pcb_smtpad_1928",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179024,7 +179024,7 @@
           "pcb_smtpad_1928",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179043,7 +179043,7 @@
           "pcb_smtpad_1929",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179062,7 +179062,7 @@
           "pcb_smtpad_1929",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179081,7 +179081,7 @@
           "pcb_smtpad_1929",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179100,7 +179100,7 @@
           "pcb_smtpad_1929",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179119,7 +179119,7 @@
           "pcb_smtpad_1930",
           "connectivity_net3478"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179138,7 +179138,7 @@
           "pcb_smtpad_1931",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179157,7 +179157,7 @@
           "pcb_smtpad_1932",
           "connectivity_net3467"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179176,7 +179176,7 @@
           "pcb_smtpad_1933",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179195,7 +179195,7 @@
           "pcb_smtpad_1934",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179214,7 +179214,7 @@
           "pcb_smtpad_1934",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179233,7 +179233,7 @@
           "pcb_smtpad_1934",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179252,7 +179252,7 @@
           "pcb_smtpad_1934",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179271,7 +179271,7 @@
           "pcb_smtpad_1935",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179290,7 +179290,7 @@
           "pcb_smtpad_1935",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179309,7 +179309,7 @@
           "pcb_smtpad_1935",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179328,7 +179328,7 @@
           "pcb_smtpad_1935",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179347,7 +179347,7 @@
           "pcb_smtpad_1936",
           "connectivity_net3489"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179366,7 +179366,7 @@
           "pcb_smtpad_1937",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179385,7 +179385,7 @@
           "pcb_smtpad_1938",
           "connectivity_net3478"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179404,7 +179404,7 @@
           "pcb_smtpad_1939",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179423,7 +179423,7 @@
           "pcb_smtpad_1940",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179442,7 +179442,7 @@
           "pcb_smtpad_1940",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179461,7 +179461,7 @@
           "pcb_smtpad_1940",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179480,7 +179480,7 @@
           "pcb_smtpad_1940",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179499,7 +179499,7 @@
           "pcb_smtpad_1941",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179518,7 +179518,7 @@
           "pcb_smtpad_1941",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179537,7 +179537,7 @@
           "pcb_smtpad_1941",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179556,7 +179556,7 @@
           "pcb_smtpad_1941",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179575,7 +179575,7 @@
           "pcb_smtpad_1942",
           "connectivity_net3500"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179594,7 +179594,7 @@
           "pcb_smtpad_1943",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179613,7 +179613,7 @@
           "pcb_smtpad_1944",
           "connectivity_net3489"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179632,7 +179632,7 @@
           "pcb_smtpad_1945",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179651,7 +179651,7 @@
           "pcb_smtpad_1946",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179670,7 +179670,7 @@
           "pcb_smtpad_1946",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179689,7 +179689,7 @@
           "pcb_smtpad_1946",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179708,7 +179708,7 @@
           "pcb_smtpad_1946",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179727,7 +179727,7 @@
           "pcb_smtpad_1947",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179746,7 +179746,7 @@
           "pcb_smtpad_1947",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179765,7 +179765,7 @@
           "pcb_smtpad_1947",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179784,7 +179784,7 @@
           "pcb_smtpad_1947",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179803,7 +179803,7 @@
           "pcb_smtpad_1948",
           "connectivity_net3511"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179822,7 +179822,7 @@
           "pcb_smtpad_1949",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179841,7 +179841,7 @@
           "pcb_smtpad_1950",
           "connectivity_net3500"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179860,7 +179860,7 @@
           "pcb_smtpad_1951",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179879,7 +179879,7 @@
           "pcb_smtpad_1952",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179898,7 +179898,7 @@
           "pcb_smtpad_1952",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179917,7 +179917,7 @@
           "pcb_smtpad_1952",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179936,7 +179936,7 @@
           "pcb_smtpad_1952",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179955,7 +179955,7 @@
           "pcb_smtpad_1953",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179974,7 +179974,7 @@
           "pcb_smtpad_1953",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -179993,7 +179993,7 @@
           "pcb_smtpad_1953",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180012,7 +180012,7 @@
           "pcb_smtpad_1953",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180031,7 +180031,7 @@
           "pcb_smtpad_1954",
           "connectivity_net3522"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180050,7 +180050,7 @@
           "pcb_smtpad_1955",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180069,7 +180069,7 @@
           "pcb_smtpad_1956",
           "connectivity_net3511"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180088,7 +180088,7 @@
           "pcb_smtpad_1957",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180107,7 +180107,7 @@
           "pcb_smtpad_1958",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180126,7 +180126,7 @@
           "pcb_smtpad_1958",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180145,7 +180145,7 @@
           "pcb_smtpad_1958",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180164,7 +180164,7 @@
           "pcb_smtpad_1958",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180183,7 +180183,7 @@
           "pcb_smtpad_1959",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180202,7 +180202,7 @@
           "pcb_smtpad_1959",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180221,7 +180221,7 @@
           "pcb_smtpad_1959",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180240,7 +180240,7 @@
           "pcb_smtpad_1959",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180259,7 +180259,7 @@
           "pcb_smtpad_1960",
           "connectivity_net3533"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180278,7 +180278,7 @@
           "pcb_smtpad_1961",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180297,7 +180297,7 @@
           "pcb_smtpad_1962",
           "connectivity_net3522"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180316,7 +180316,7 @@
           "pcb_smtpad_1963",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180335,7 +180335,7 @@
           "pcb_smtpad_1964",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180354,7 +180354,7 @@
           "pcb_smtpad_1964",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180373,7 +180373,7 @@
           "pcb_smtpad_1964",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180392,7 +180392,7 @@
           "pcb_smtpad_1964",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180411,7 +180411,7 @@
           "pcb_smtpad_1965",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180430,7 +180430,7 @@
           "pcb_smtpad_1965",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180449,7 +180449,7 @@
           "pcb_smtpad_1965",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180468,7 +180468,7 @@
           "pcb_smtpad_1965",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180487,7 +180487,7 @@
           "pcb_smtpad_1966",
           "connectivity_net3544"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180506,7 +180506,7 @@
           "pcb_smtpad_1967",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180525,7 +180525,7 @@
           "pcb_smtpad_1968",
           "connectivity_net3533"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180544,7 +180544,7 @@
           "pcb_smtpad_1969",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180563,7 +180563,7 @@
           "pcb_smtpad_1970",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180582,7 +180582,7 @@
           "pcb_smtpad_1970",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180601,7 +180601,7 @@
           "pcb_smtpad_1970",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180620,7 +180620,7 @@
           "pcb_smtpad_1970",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180639,7 +180639,7 @@
           "pcb_smtpad_1971",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180658,7 +180658,7 @@
           "pcb_smtpad_1971",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180677,7 +180677,7 @@
           "pcb_smtpad_1971",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180696,7 +180696,7 @@
           "pcb_smtpad_1971",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180715,7 +180715,7 @@
           "pcb_smtpad_1972",
           "connectivity_net3555"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180734,7 +180734,7 @@
           "pcb_smtpad_1973",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180753,7 +180753,7 @@
           "pcb_smtpad_1974",
           "connectivity_net3544"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180772,7 +180772,7 @@
           "pcb_smtpad_1975",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180791,7 +180791,7 @@
           "pcb_smtpad_1976",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180810,7 +180810,7 @@
           "pcb_smtpad_1976",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180829,7 +180829,7 @@
           "pcb_smtpad_1976",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180848,7 +180848,7 @@
           "pcb_smtpad_1976",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180867,7 +180867,7 @@
           "pcb_smtpad_1977",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180886,7 +180886,7 @@
           "pcb_smtpad_1977",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180905,7 +180905,7 @@
           "pcb_smtpad_1977",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180924,7 +180924,7 @@
           "pcb_smtpad_1977",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180943,7 +180943,7 @@
           "pcb_smtpad_1978",
           "connectivity_net3566"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180962,7 +180962,7 @@
           "pcb_smtpad_1979",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -180981,7 +180981,7 @@
           "pcb_smtpad_1980",
           "connectivity_net3555"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181000,7 +181000,7 @@
           "pcb_smtpad_1981",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181019,7 +181019,7 @@
           "pcb_smtpad_1982",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181038,7 +181038,7 @@
           "pcb_smtpad_1982",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181057,7 +181057,7 @@
           "pcb_smtpad_1982",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181076,7 +181076,7 @@
           "pcb_smtpad_1982",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181095,7 +181095,7 @@
           "pcb_smtpad_1983",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181114,7 +181114,7 @@
           "pcb_smtpad_1983",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181133,7 +181133,7 @@
           "pcb_smtpad_1983",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181152,7 +181152,7 @@
           "pcb_smtpad_1983",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181171,7 +181171,7 @@
           "pcb_smtpad_1984",
           "connectivity_net3577"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181190,7 +181190,7 @@
           "pcb_smtpad_1985",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181209,7 +181209,7 @@
           "pcb_smtpad_1986",
           "connectivity_net3566"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181228,7 +181228,7 @@
           "pcb_smtpad_1987",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181247,7 +181247,7 @@
           "pcb_smtpad_1988",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181266,7 +181266,7 @@
           "pcb_smtpad_1988",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181285,7 +181285,7 @@
           "pcb_smtpad_1988",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181304,7 +181304,7 @@
           "pcb_smtpad_1988",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181323,7 +181323,7 @@
           "pcb_smtpad_1989",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181342,7 +181342,7 @@
           "pcb_smtpad_1989",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181361,7 +181361,7 @@
           "pcb_smtpad_1989",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181380,7 +181380,7 @@
           "pcb_smtpad_1989",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181399,7 +181399,7 @@
           "pcb_smtpad_1990",
           "connectivity_net3588"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181418,7 +181418,7 @@
           "pcb_smtpad_1991",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181437,7 +181437,7 @@
           "pcb_smtpad_1992",
           "connectivity_net3577"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181456,7 +181456,7 @@
           "pcb_smtpad_1993",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181475,7 +181475,7 @@
           "pcb_smtpad_1994",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181494,7 +181494,7 @@
           "pcb_smtpad_1994",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181513,7 +181513,7 @@
           "pcb_smtpad_1994",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181532,7 +181532,7 @@
           "pcb_smtpad_1994",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181551,7 +181551,7 @@
           "pcb_smtpad_1995",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181570,7 +181570,7 @@
           "pcb_smtpad_1995",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181589,7 +181589,7 @@
           "pcb_smtpad_1995",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181608,7 +181608,7 @@
           "pcb_smtpad_1995",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181627,7 +181627,7 @@
           "pcb_smtpad_1996",
           "connectivity_net3599"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181646,7 +181646,7 @@
           "pcb_smtpad_1997",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181665,7 +181665,7 @@
           "pcb_smtpad_1998",
           "connectivity_net3588"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181684,7 +181684,7 @@
           "pcb_smtpad_1999",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181703,7 +181703,7 @@
           "pcb_smtpad_2000",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181722,7 +181722,7 @@
           "pcb_smtpad_2000",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181741,7 +181741,7 @@
           "pcb_smtpad_2000",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181760,7 +181760,7 @@
           "pcb_smtpad_2000",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181779,7 +181779,7 @@
           "pcb_smtpad_2001",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181798,7 +181798,7 @@
           "pcb_smtpad_2001",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181817,7 +181817,7 @@
           "pcb_smtpad_2001",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181836,7 +181836,7 @@
           "pcb_smtpad_2001",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181855,7 +181855,7 @@
           "pcb_smtpad_2002",
           "connectivity_net3610"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181874,7 +181874,7 @@
           "pcb_smtpad_2003",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181893,7 +181893,7 @@
           "pcb_smtpad_2004",
           "connectivity_net3599"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181912,7 +181912,7 @@
           "pcb_smtpad_2005",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181931,7 +181931,7 @@
           "pcb_smtpad_2006",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181950,7 +181950,7 @@
           "pcb_smtpad_2006",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181969,7 +181969,7 @@
           "pcb_smtpad_2006",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -181988,7 +181988,7 @@
           "pcb_smtpad_2006",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182007,7 +182007,7 @@
           "pcb_smtpad_2007",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182026,7 +182026,7 @@
           "pcb_smtpad_2007",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182045,7 +182045,7 @@
           "pcb_smtpad_2007",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182064,7 +182064,7 @@
           "pcb_smtpad_2007",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182083,7 +182083,7 @@
           "pcb_smtpad_2008",
           "connectivity_net3621"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182102,7 +182102,7 @@
           "pcb_smtpad_2009",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182121,7 +182121,7 @@
           "pcb_smtpad_2010",
           "connectivity_net3610"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182140,7 +182140,7 @@
           "pcb_smtpad_2011",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182159,7 +182159,7 @@
           "pcb_smtpad_2012",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182178,7 +182178,7 @@
           "pcb_smtpad_2012",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182197,7 +182197,7 @@
           "pcb_smtpad_2012",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182216,7 +182216,7 @@
           "pcb_smtpad_2012",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182235,7 +182235,7 @@
           "pcb_smtpad_2013",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182254,7 +182254,7 @@
           "pcb_smtpad_2013",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182273,7 +182273,7 @@
           "pcb_smtpad_2013",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182292,7 +182292,7 @@
           "pcb_smtpad_2013",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182311,7 +182311,7 @@
           "pcb_smtpad_2014",
           "connectivity_net3632"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182330,7 +182330,7 @@
           "pcb_smtpad_2015",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182349,7 +182349,7 @@
           "pcb_smtpad_2016",
           "connectivity_net3621"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182368,7 +182368,7 @@
           "pcb_smtpad_2017",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182387,7 +182387,7 @@
           "pcb_smtpad_2018",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182406,7 +182406,7 @@
           "pcb_smtpad_2018",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182425,7 +182425,7 @@
           "pcb_smtpad_2018",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182444,7 +182444,7 @@
           "pcb_smtpad_2018",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182463,7 +182463,7 @@
           "pcb_smtpad_2019",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182482,7 +182482,7 @@
           "pcb_smtpad_2019",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182501,7 +182501,7 @@
           "pcb_smtpad_2019",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182520,7 +182520,7 @@
           "pcb_smtpad_2019",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182539,7 +182539,7 @@
           "pcb_smtpad_2020",
           "connectivity_net3643"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182558,7 +182558,7 @@
           "pcb_smtpad_2021",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182577,7 +182577,7 @@
           "pcb_smtpad_2022",
           "connectivity_net3632"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182596,7 +182596,7 @@
           "pcb_smtpad_2023",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182615,7 +182615,7 @@
           "pcb_smtpad_2024",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182634,7 +182634,7 @@
           "pcb_smtpad_2024",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182653,7 +182653,7 @@
           "pcb_smtpad_2024",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182672,7 +182672,7 @@
           "pcb_smtpad_2024",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182691,7 +182691,7 @@
           "pcb_smtpad_2025",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182710,7 +182710,7 @@
           "pcb_smtpad_2025",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182729,7 +182729,7 @@
           "pcb_smtpad_2025",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182748,7 +182748,7 @@
           "pcb_smtpad_2025",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182767,7 +182767,7 @@
           "pcb_smtpad_2026",
           "connectivity_net3654"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182786,7 +182786,7 @@
           "pcb_smtpad_2027",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182805,7 +182805,7 @@
           "pcb_smtpad_2028",
           "connectivity_net3643"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182824,7 +182824,7 @@
           "pcb_smtpad_2029",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182843,7 +182843,7 @@
           "pcb_smtpad_2030",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182862,7 +182862,7 @@
           "pcb_smtpad_2030",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182881,7 +182881,7 @@
           "pcb_smtpad_2030",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182900,7 +182900,7 @@
           "pcb_smtpad_2030",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182919,7 +182919,7 @@
           "pcb_smtpad_2031",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182938,7 +182938,7 @@
           "pcb_smtpad_2031",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182957,7 +182957,7 @@
           "pcb_smtpad_2031",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182976,7 +182976,7 @@
           "pcb_smtpad_2031",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -182995,7 +182995,7 @@
           "pcb_smtpad_2032",
           "connectivity_net3665"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183014,7 +183014,7 @@
           "pcb_smtpad_2033",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183033,7 +183033,7 @@
           "pcb_smtpad_2034",
           "connectivity_net3654"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183052,7 +183052,7 @@
           "pcb_smtpad_2035",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183071,7 +183071,7 @@
           "pcb_smtpad_2036",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183090,7 +183090,7 @@
           "pcb_smtpad_2036",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183109,7 +183109,7 @@
           "pcb_smtpad_2036",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183128,7 +183128,7 @@
           "pcb_smtpad_2036",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183147,7 +183147,7 @@
           "pcb_smtpad_2037",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183166,7 +183166,7 @@
           "pcb_smtpad_2037",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183185,7 +183185,7 @@
           "pcb_smtpad_2037",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183204,7 +183204,7 @@
           "pcb_smtpad_2037",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183223,7 +183223,7 @@
           "pcb_smtpad_2038",
           "connectivity_net3676"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183242,7 +183242,7 @@
           "pcb_smtpad_2039",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183261,7 +183261,7 @@
           "pcb_smtpad_2040",
           "connectivity_net3665"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183280,7 +183280,7 @@
           "pcb_smtpad_2041",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183299,7 +183299,7 @@
           "pcb_smtpad_2042",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183318,7 +183318,7 @@
           "pcb_smtpad_2042",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183337,7 +183337,7 @@
           "pcb_smtpad_2042",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183356,7 +183356,7 @@
           "pcb_smtpad_2042",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183375,7 +183375,7 @@
           "pcb_smtpad_2043",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183394,7 +183394,7 @@
           "pcb_smtpad_2043",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183413,7 +183413,7 @@
           "pcb_smtpad_2043",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183432,7 +183432,7 @@
           "pcb_smtpad_2043",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183451,7 +183451,7 @@
           "pcb_smtpad_2044",
           "connectivity_net3687"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183470,7 +183470,7 @@
           "pcb_smtpad_2045",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183489,7 +183489,7 @@
           "pcb_smtpad_2046",
           "connectivity_net3676"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183508,7 +183508,7 @@
           "pcb_smtpad_2047",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183527,7 +183527,7 @@
           "pcb_smtpad_2048",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183546,7 +183546,7 @@
           "pcb_smtpad_2048",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183565,7 +183565,7 @@
           "pcb_smtpad_2048",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183584,7 +183584,7 @@
           "pcb_smtpad_2048",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183603,7 +183603,7 @@
           "pcb_smtpad_2049",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183622,7 +183622,7 @@
           "pcb_smtpad_2049",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183641,7 +183641,7 @@
           "pcb_smtpad_2049",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183660,7 +183660,7 @@
           "pcb_smtpad_2049",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183679,7 +183679,7 @@
           "pcb_smtpad_2050",
           "connectivity_net3698"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183698,7 +183698,7 @@
           "pcb_smtpad_2051",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183717,7 +183717,7 @@
           "pcb_smtpad_2052",
           "connectivity_net3687"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183736,7 +183736,7 @@
           "pcb_smtpad_2053",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183755,7 +183755,7 @@
           "pcb_smtpad_2054",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183774,7 +183774,7 @@
           "pcb_smtpad_2054",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183793,7 +183793,7 @@
           "pcb_smtpad_2054",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183812,7 +183812,7 @@
           "pcb_smtpad_2054",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183831,7 +183831,7 @@
           "pcb_smtpad_2055",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183850,7 +183850,7 @@
           "pcb_smtpad_2055",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183869,7 +183869,7 @@
           "pcb_smtpad_2055",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183888,7 +183888,7 @@
           "pcb_smtpad_2055",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183907,7 +183907,7 @@
           "pcb_smtpad_2056",
           "connectivity_net3709"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183926,7 +183926,7 @@
           "pcb_smtpad_2057",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183945,7 +183945,7 @@
           "pcb_smtpad_2058",
           "connectivity_net3698"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183964,7 +183964,7 @@
           "pcb_smtpad_2059",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -183983,7 +183983,7 @@
           "pcb_smtpad_2060",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184002,7 +184002,7 @@
           "pcb_smtpad_2060",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184021,7 +184021,7 @@
           "pcb_smtpad_2060",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184040,7 +184040,7 @@
           "pcb_smtpad_2060",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184059,7 +184059,7 @@
           "pcb_smtpad_2061",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184078,7 +184078,7 @@
           "pcb_smtpad_2061",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184097,7 +184097,7 @@
           "pcb_smtpad_2061",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184116,7 +184116,7 @@
           "pcb_smtpad_2061",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184135,7 +184135,7 @@
           "pcb_smtpad_2062",
           "connectivity_net3720"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184154,7 +184154,7 @@
           "pcb_smtpad_2063",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184173,7 +184173,7 @@
           "pcb_smtpad_2064",
           "connectivity_net3709"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184192,7 +184192,7 @@
           "pcb_smtpad_2065",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184211,7 +184211,7 @@
           "pcb_smtpad_2066",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184230,7 +184230,7 @@
           "pcb_smtpad_2066",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184249,7 +184249,7 @@
           "pcb_smtpad_2066",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184268,7 +184268,7 @@
           "pcb_smtpad_2066",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184287,7 +184287,7 @@
           "pcb_smtpad_2067",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184306,7 +184306,7 @@
           "pcb_smtpad_2067",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184325,7 +184325,7 @@
           "pcb_smtpad_2067",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184344,7 +184344,7 @@
           "pcb_smtpad_2067",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184363,7 +184363,7 @@
           "pcb_smtpad_2068",
           "connectivity_net3731"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184382,7 +184382,7 @@
           "pcb_smtpad_2069",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184401,7 +184401,7 @@
           "pcb_smtpad_2070",
           "connectivity_net3720"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184420,7 +184420,7 @@
           "pcb_smtpad_2071",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184439,7 +184439,7 @@
           "pcb_smtpad_2072",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184458,7 +184458,7 @@
           "pcb_smtpad_2072",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184477,7 +184477,7 @@
           "pcb_smtpad_2072",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184496,7 +184496,7 @@
           "pcb_smtpad_2072",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184515,7 +184515,7 @@
           "pcb_smtpad_2073",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184534,7 +184534,7 @@
           "pcb_smtpad_2073",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184553,7 +184553,7 @@
           "pcb_smtpad_2073",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184572,7 +184572,7 @@
           "pcb_smtpad_2073",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184591,7 +184591,7 @@
           "pcb_smtpad_2074",
           "connectivity_net3742"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184610,7 +184610,7 @@
           "pcb_smtpad_2075",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184629,7 +184629,7 @@
           "pcb_smtpad_2076",
           "connectivity_net3731"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184648,7 +184648,7 @@
           "pcb_smtpad_2077",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184667,7 +184667,7 @@
           "pcb_smtpad_2078",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184686,7 +184686,7 @@
           "pcb_smtpad_2078",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184705,7 +184705,7 @@
           "pcb_smtpad_2078",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184724,7 +184724,7 @@
           "pcb_smtpad_2078",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184743,7 +184743,7 @@
           "pcb_smtpad_2079",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184762,7 +184762,7 @@
           "pcb_smtpad_2079",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184781,7 +184781,7 @@
           "pcb_smtpad_2079",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184800,7 +184800,7 @@
           "pcb_smtpad_2079",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184819,7 +184819,7 @@
           "pcb_smtpad_2080",
           "connectivity_net3753"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184838,7 +184838,7 @@
           "pcb_smtpad_2081",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184857,7 +184857,7 @@
           "pcb_smtpad_2082",
           "connectivity_net3742"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184876,7 +184876,7 @@
           "pcb_smtpad_2083",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184895,7 +184895,7 @@
           "pcb_smtpad_2084",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184914,7 +184914,7 @@
           "pcb_smtpad_2084",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184933,7 +184933,7 @@
           "pcb_smtpad_2084",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184952,7 +184952,7 @@
           "pcb_smtpad_2084",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184971,7 +184971,7 @@
           "pcb_smtpad_2085",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -184990,7 +184990,7 @@
           "pcb_smtpad_2085",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185009,7 +185009,7 @@
           "pcb_smtpad_2085",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185028,7 +185028,7 @@
           "pcb_smtpad_2085",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185047,7 +185047,7 @@
           "pcb_smtpad_2086",
           "connectivity_net3764"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185066,7 +185066,7 @@
           "pcb_smtpad_2087",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185085,7 +185085,7 @@
           "pcb_smtpad_2088",
           "connectivity_net3753"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185104,7 +185104,7 @@
           "pcb_smtpad_2089",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185123,7 +185123,7 @@
           "pcb_smtpad_2090",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185142,7 +185142,7 @@
           "pcb_smtpad_2090",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185161,7 +185161,7 @@
           "pcb_smtpad_2090",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185180,7 +185180,7 @@
           "pcb_smtpad_2090",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185199,7 +185199,7 @@
           "pcb_smtpad_2091",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185218,7 +185218,7 @@
           "pcb_smtpad_2091",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185237,7 +185237,7 @@
           "pcb_smtpad_2091",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185256,7 +185256,7 @@
           "pcb_smtpad_2091",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185275,7 +185275,7 @@
           "pcb_smtpad_2092",
           "connectivity_net3775"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185294,7 +185294,7 @@
           "pcb_smtpad_2093",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185313,7 +185313,7 @@
           "pcb_smtpad_2094",
           "connectivity_net3764"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185332,7 +185332,7 @@
           "pcb_smtpad_2095",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185351,7 +185351,7 @@
           "pcb_smtpad_2096",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185370,7 +185370,7 @@
           "pcb_smtpad_2096",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185389,7 +185389,7 @@
           "pcb_smtpad_2096",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185408,7 +185408,7 @@
           "pcb_smtpad_2096",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185427,7 +185427,7 @@
           "pcb_smtpad_2097",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185446,7 +185446,7 @@
           "pcb_smtpad_2097",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185465,7 +185465,7 @@
           "pcb_smtpad_2097",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185484,7 +185484,7 @@
           "pcb_smtpad_2097",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185503,7 +185503,7 @@
           "pcb_smtpad_2098",
           "connectivity_net3786"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185522,7 +185522,7 @@
           "pcb_smtpad_2099",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185541,7 +185541,7 @@
           "pcb_smtpad_2100",
           "connectivity_net3775"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185560,7 +185560,7 @@
           "pcb_smtpad_2101",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185579,7 +185579,7 @@
           "pcb_smtpad_2102",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185598,7 +185598,7 @@
           "pcb_smtpad_2102",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185617,7 +185617,7 @@
           "pcb_smtpad_2102",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185636,7 +185636,7 @@
           "pcb_smtpad_2102",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185655,7 +185655,7 @@
           "pcb_smtpad_2103",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185674,7 +185674,7 @@
           "pcb_smtpad_2103",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185693,7 +185693,7 @@
           "pcb_smtpad_2103",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185712,7 +185712,7 @@
           "pcb_smtpad_2103",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185731,7 +185731,7 @@
           "pcb_smtpad_2104",
           "connectivity_net3797"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185750,7 +185750,7 @@
           "pcb_smtpad_2105",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185769,7 +185769,7 @@
           "pcb_smtpad_2106",
           "connectivity_net3786"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185788,7 +185788,7 @@
           "pcb_smtpad_2107",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185807,7 +185807,7 @@
           "pcb_smtpad_2108",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185826,7 +185826,7 @@
           "pcb_smtpad_2108",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185845,7 +185845,7 @@
           "pcb_smtpad_2108",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185864,7 +185864,7 @@
           "pcb_smtpad_2108",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185883,7 +185883,7 @@
           "pcb_smtpad_2109",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185902,7 +185902,7 @@
           "pcb_smtpad_2109",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185921,7 +185921,7 @@
           "pcb_smtpad_2109",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185940,7 +185940,7 @@
           "pcb_smtpad_2109",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185959,7 +185959,7 @@
           "pcb_smtpad_2110",
           "connectivity_net3808"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185978,7 +185978,7 @@
           "pcb_smtpad_2111",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -185997,7 +185997,7 @@
           "pcb_smtpad_2112",
           "connectivity_net3797"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186016,7 +186016,7 @@
           "pcb_smtpad_2113",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186035,7 +186035,7 @@
           "pcb_smtpad_2114",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186054,7 +186054,7 @@
           "pcb_smtpad_2114",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186073,7 +186073,7 @@
           "pcb_smtpad_2114",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186092,7 +186092,7 @@
           "pcb_smtpad_2114",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186111,7 +186111,7 @@
           "pcb_smtpad_2115",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186130,7 +186130,7 @@
           "pcb_smtpad_2115",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186149,7 +186149,7 @@
           "pcb_smtpad_2115",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186168,7 +186168,7 @@
           "pcb_smtpad_2115",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186187,7 +186187,7 @@
           "pcb_smtpad_2116",
           "connectivity_net3819"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186206,7 +186206,7 @@
           "pcb_smtpad_2117",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186225,7 +186225,7 @@
           "pcb_smtpad_2118",
           "connectivity_net3808"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186244,7 +186244,7 @@
           "pcb_smtpad_2119",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186263,7 +186263,7 @@
           "pcb_smtpad_2120",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186282,7 +186282,7 @@
           "pcb_smtpad_2120",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186301,7 +186301,7 @@
           "pcb_smtpad_2120",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186320,7 +186320,7 @@
           "pcb_smtpad_2120",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186339,7 +186339,7 @@
           "pcb_smtpad_2121",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186358,7 +186358,7 @@
           "pcb_smtpad_2121",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186377,7 +186377,7 @@
           "pcb_smtpad_2121",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186396,7 +186396,7 @@
           "pcb_smtpad_2121",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186415,7 +186415,7 @@
           "pcb_smtpad_2122",
           "connectivity_net3830"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186434,7 +186434,7 @@
           "pcb_smtpad_2123",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186453,7 +186453,7 @@
           "pcb_smtpad_2124",
           "connectivity_net3819"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186472,7 +186472,7 @@
           "pcb_smtpad_2125",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186491,7 +186491,7 @@
           "pcb_smtpad_2126",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186510,7 +186510,7 @@
           "pcb_smtpad_2126",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186529,7 +186529,7 @@
           "pcb_smtpad_2126",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186548,7 +186548,7 @@
           "pcb_smtpad_2126",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186567,7 +186567,7 @@
           "pcb_smtpad_2127",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186586,7 +186586,7 @@
           "pcb_smtpad_2127",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186605,7 +186605,7 @@
           "pcb_smtpad_2127",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186624,7 +186624,7 @@
           "pcb_smtpad_2127",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186643,7 +186643,7 @@
           "pcb_smtpad_2128",
           "connectivity_net3841"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186662,7 +186662,7 @@
           "pcb_smtpad_2129",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186681,7 +186681,7 @@
           "pcb_smtpad_2130",
           "connectivity_net3830"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186700,7 +186700,7 @@
           "pcb_smtpad_2131",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186719,7 +186719,7 @@
           "pcb_smtpad_2132",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186738,7 +186738,7 @@
           "pcb_smtpad_2132",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186757,7 +186757,7 @@
           "pcb_smtpad_2132",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186776,7 +186776,7 @@
           "pcb_smtpad_2132",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186795,7 +186795,7 @@
           "pcb_smtpad_2133",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186814,7 +186814,7 @@
           "pcb_smtpad_2133",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186833,7 +186833,7 @@
           "pcb_smtpad_2133",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186852,7 +186852,7 @@
           "pcb_smtpad_2133",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186871,7 +186871,7 @@
           "pcb_smtpad_2134",
           "connectivity_net3852"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186890,7 +186890,7 @@
           "pcb_smtpad_2135",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186909,7 +186909,7 @@
           "pcb_smtpad_2136",
           "connectivity_net3841"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186928,7 +186928,7 @@
           "pcb_smtpad_2137",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186947,7 +186947,7 @@
           "pcb_smtpad_2138",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186966,7 +186966,7 @@
           "pcb_smtpad_2138",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -186985,7 +186985,7 @@
           "pcb_smtpad_2138",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187004,7 +187004,7 @@
           "pcb_smtpad_2138",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187023,7 +187023,7 @@
           "pcb_smtpad_2139",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187042,7 +187042,7 @@
           "pcb_smtpad_2139",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187061,7 +187061,7 @@
           "pcb_smtpad_2139",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187080,7 +187080,7 @@
           "pcb_smtpad_2139",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187099,7 +187099,7 @@
           "pcb_smtpad_2140",
           "connectivity_net3863"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187118,7 +187118,7 @@
           "pcb_smtpad_2141",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187137,7 +187137,7 @@
           "pcb_smtpad_2142",
           "connectivity_net3852"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187156,7 +187156,7 @@
           "pcb_smtpad_2143",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187175,7 +187175,7 @@
           "pcb_smtpad_2144",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187194,7 +187194,7 @@
           "pcb_smtpad_2144",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187213,7 +187213,7 @@
           "pcb_smtpad_2144",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187232,7 +187232,7 @@
           "pcb_smtpad_2144",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187251,7 +187251,7 @@
           "pcb_smtpad_2145",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187270,7 +187270,7 @@
           "pcb_smtpad_2145",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187289,7 +187289,7 @@
           "pcb_smtpad_2145",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187308,7 +187308,7 @@
           "pcb_smtpad_2145",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187327,7 +187327,7 @@
           "pcb_smtpad_2146",
           "connectivity_net3874"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187346,7 +187346,7 @@
           "pcb_smtpad_2147",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187365,7 +187365,7 @@
           "pcb_smtpad_2148",
           "connectivity_net3863"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187384,7 +187384,7 @@
           "pcb_smtpad_2149",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187403,7 +187403,7 @@
           "pcb_smtpad_2150",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187422,7 +187422,7 @@
           "pcb_smtpad_2150",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187441,7 +187441,7 @@
           "pcb_smtpad_2150",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187460,7 +187460,7 @@
           "pcb_smtpad_2150",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187479,7 +187479,7 @@
           "pcb_smtpad_2151",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187498,7 +187498,7 @@
           "pcb_smtpad_2151",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187517,7 +187517,7 @@
           "pcb_smtpad_2151",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187536,7 +187536,7 @@
           "pcb_smtpad_2151",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187555,7 +187555,7 @@
           "pcb_smtpad_2152",
           "connectivity_net3885"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187574,7 +187574,7 @@
           "pcb_smtpad_2153",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187593,7 +187593,7 @@
           "pcb_smtpad_2154",
           "connectivity_net3874"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187612,7 +187612,7 @@
           "pcb_smtpad_2155",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187631,7 +187631,7 @@
           "pcb_smtpad_2156",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187650,7 +187650,7 @@
           "pcb_smtpad_2156",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187669,7 +187669,7 @@
           "pcb_smtpad_2156",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187688,7 +187688,7 @@
           "pcb_smtpad_2156",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187707,7 +187707,7 @@
           "pcb_smtpad_2157",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187726,7 +187726,7 @@
           "pcb_smtpad_2157",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187745,7 +187745,7 @@
           "pcb_smtpad_2157",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187764,7 +187764,7 @@
           "pcb_smtpad_2157",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187783,7 +187783,7 @@
           "pcb_smtpad_2158",
           "connectivity_net3896"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187802,7 +187802,7 @@
           "pcb_smtpad_2159",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187821,7 +187821,7 @@
           "pcb_smtpad_2160",
           "connectivity_net3885"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187840,7 +187840,7 @@
           "pcb_smtpad_2161",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187859,7 +187859,7 @@
           "pcb_smtpad_2162",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187878,7 +187878,7 @@
           "pcb_smtpad_2162",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187897,7 +187897,7 @@
           "pcb_smtpad_2162",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187916,7 +187916,7 @@
           "pcb_smtpad_2162",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187935,7 +187935,7 @@
           "pcb_smtpad_2163",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187954,7 +187954,7 @@
           "pcb_smtpad_2163",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187973,7 +187973,7 @@
           "pcb_smtpad_2163",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -187992,7 +187992,7 @@
           "pcb_smtpad_2163",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188011,7 +188011,7 @@
           "pcb_smtpad_2164",
           "connectivity_net3907"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188030,7 +188030,7 @@
           "pcb_smtpad_2165",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188049,7 +188049,7 @@
           "pcb_smtpad_2166",
           "connectivity_net3896"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188068,7 +188068,7 @@
           "pcb_smtpad_2167",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188087,7 +188087,7 @@
           "pcb_smtpad_2168",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188106,7 +188106,7 @@
           "pcb_smtpad_2168",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188125,7 +188125,7 @@
           "pcb_smtpad_2168",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188144,7 +188144,7 @@
           "pcb_smtpad_2168",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188163,7 +188163,7 @@
           "pcb_smtpad_2169",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188182,7 +188182,7 @@
           "pcb_smtpad_2169",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188201,7 +188201,7 @@
           "pcb_smtpad_2169",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188220,7 +188220,7 @@
           "pcb_smtpad_2169",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188239,7 +188239,7 @@
           "pcb_smtpad_2170",
           "connectivity_net3918"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188258,7 +188258,7 @@
           "pcb_smtpad_2171",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188277,7 +188277,7 @@
           "pcb_smtpad_2172",
           "connectivity_net3907"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188296,7 +188296,7 @@
           "pcb_smtpad_2173",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188315,7 +188315,7 @@
           "pcb_smtpad_2174",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188334,7 +188334,7 @@
           "pcb_smtpad_2174",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188353,7 +188353,7 @@
           "pcb_smtpad_2174",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188372,7 +188372,7 @@
           "pcb_smtpad_2174",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188391,7 +188391,7 @@
           "pcb_smtpad_2175",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188410,7 +188410,7 @@
           "pcb_smtpad_2175",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188429,7 +188429,7 @@
           "pcb_smtpad_2175",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188448,7 +188448,7 @@
           "pcb_smtpad_2175",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188467,7 +188467,7 @@
           "pcb_smtpad_2176",
           "connectivity_net3929"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188486,7 +188486,7 @@
           "pcb_smtpad_2177",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188505,7 +188505,7 @@
           "pcb_smtpad_2178",
           "connectivity_net3918"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188524,7 +188524,7 @@
           "pcb_smtpad_2179",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188543,7 +188543,7 @@
           "pcb_smtpad_2180",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188562,7 +188562,7 @@
           "pcb_smtpad_2180",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188581,7 +188581,7 @@
           "pcb_smtpad_2180",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188600,7 +188600,7 @@
           "pcb_smtpad_2180",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188619,7 +188619,7 @@
           "pcb_smtpad_2181",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188638,7 +188638,7 @@
           "pcb_smtpad_2181",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188657,7 +188657,7 @@
           "pcb_smtpad_2181",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188676,7 +188676,7 @@
           "pcb_smtpad_2181",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188695,7 +188695,7 @@
           "pcb_smtpad_2182",
           "connectivity_net3940"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188714,7 +188714,7 @@
           "pcb_smtpad_2183",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188733,7 +188733,7 @@
           "pcb_smtpad_2184",
           "connectivity_net3929"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188752,7 +188752,7 @@
           "pcb_smtpad_2185",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188771,7 +188771,7 @@
           "pcb_smtpad_2186",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188790,7 +188790,7 @@
           "pcb_smtpad_2186",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188809,7 +188809,7 @@
           "pcb_smtpad_2186",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188828,7 +188828,7 @@
           "pcb_smtpad_2186",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188847,7 +188847,7 @@
           "pcb_smtpad_2187",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188866,7 +188866,7 @@
           "pcb_smtpad_2187",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188885,7 +188885,7 @@
           "pcb_smtpad_2187",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188904,7 +188904,7 @@
           "pcb_smtpad_2187",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188923,7 +188923,7 @@
           "pcb_smtpad_2188",
           "connectivity_net3951"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188942,7 +188942,7 @@
           "pcb_smtpad_2189",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188961,7 +188961,7 @@
           "pcb_smtpad_2190",
           "connectivity_net3940"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188980,7 +188980,7 @@
           "pcb_smtpad_2191",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -188999,7 +188999,7 @@
           "pcb_smtpad_2192",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189018,7 +189018,7 @@
           "pcb_smtpad_2192",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189037,7 +189037,7 @@
           "pcb_smtpad_2192",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189056,7 +189056,7 @@
           "pcb_smtpad_2192",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189075,7 +189075,7 @@
           "pcb_smtpad_2193",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189094,7 +189094,7 @@
           "pcb_smtpad_2193",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189113,7 +189113,7 @@
           "pcb_smtpad_2193",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189132,7 +189132,7 @@
           "pcb_smtpad_2193",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189151,7 +189151,7 @@
           "pcb_smtpad_2194",
           "connectivity_net3962"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189170,7 +189170,7 @@
           "pcb_smtpad_2195",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189189,7 +189189,7 @@
           "pcb_smtpad_2196",
           "connectivity_net3951"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189208,7 +189208,7 @@
           "pcb_smtpad_2197",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189227,7 +189227,7 @@
           "pcb_smtpad_2198",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189246,7 +189246,7 @@
           "pcb_smtpad_2198",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189265,7 +189265,7 @@
           "pcb_smtpad_2198",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189284,7 +189284,7 @@
           "pcb_smtpad_2198",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189303,7 +189303,7 @@
           "pcb_smtpad_2199",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189322,7 +189322,7 @@
           "pcb_smtpad_2199",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189341,7 +189341,7 @@
           "pcb_smtpad_2199",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189360,7 +189360,7 @@
           "pcb_smtpad_2199",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189379,7 +189379,7 @@
           "pcb_smtpad_2200",
           "connectivity_net3973"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189398,7 +189398,7 @@
           "pcb_smtpad_2201",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189417,7 +189417,7 @@
           "pcb_smtpad_2202",
           "connectivity_net3962"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189436,7 +189436,7 @@
           "pcb_smtpad_2203",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189455,7 +189455,7 @@
           "pcb_smtpad_2204",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189474,7 +189474,7 @@
           "pcb_smtpad_2204",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189493,7 +189493,7 @@
           "pcb_smtpad_2204",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189512,7 +189512,7 @@
           "pcb_smtpad_2204",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189531,7 +189531,7 @@
           "pcb_smtpad_2205",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189550,7 +189550,7 @@
           "pcb_smtpad_2205",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189569,7 +189569,7 @@
           "pcb_smtpad_2205",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189588,7 +189588,7 @@
           "pcb_smtpad_2205",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189607,7 +189607,7 @@
           "pcb_smtpad_2206",
           "connectivity_net3984"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189626,7 +189626,7 @@
           "pcb_smtpad_2207",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189645,7 +189645,7 @@
           "pcb_smtpad_2208",
           "connectivity_net3973"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189664,7 +189664,7 @@
           "pcb_smtpad_2209",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189683,7 +189683,7 @@
           "pcb_smtpad_2210",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189702,7 +189702,7 @@
           "pcb_smtpad_2210",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189721,7 +189721,7 @@
           "pcb_smtpad_2210",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189740,7 +189740,7 @@
           "pcb_smtpad_2210",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189759,7 +189759,7 @@
           "pcb_smtpad_2211",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189778,7 +189778,7 @@
           "pcb_smtpad_2211",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189797,7 +189797,7 @@
           "pcb_smtpad_2211",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189816,7 +189816,7 @@
           "pcb_smtpad_2211",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189835,7 +189835,7 @@
           "pcb_smtpad_2212",
           "connectivity_net3995"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189854,7 +189854,7 @@
           "pcb_smtpad_2213",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189873,7 +189873,7 @@
           "pcb_smtpad_2214",
           "connectivity_net3984"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189892,7 +189892,7 @@
           "pcb_smtpad_2215",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189911,7 +189911,7 @@
           "pcb_smtpad_2216",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189930,7 +189930,7 @@
           "pcb_smtpad_2216",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189949,7 +189949,7 @@
           "pcb_smtpad_2216",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189968,7 +189968,7 @@
           "pcb_smtpad_2216",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189987,7 +189987,7 @@
           "pcb_smtpad_2217",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190006,7 +190006,7 @@
           "pcb_smtpad_2217",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190025,7 +190025,7 @@
           "pcb_smtpad_2217",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190044,7 +190044,7 @@
           "pcb_smtpad_2217",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190063,7 +190063,7 @@
           "pcb_smtpad_2218",
           "connectivity_net4006"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190082,7 +190082,7 @@
           "pcb_smtpad_2219",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190101,7 +190101,7 @@
           "pcb_smtpad_2220",
           "connectivity_net3995"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190120,7 +190120,7 @@
           "pcb_smtpad_2221",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190139,7 +190139,7 @@
           "pcb_smtpad_2222",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190158,7 +190158,7 @@
           "pcb_smtpad_2222",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190177,7 +190177,7 @@
           "pcb_smtpad_2222",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190196,7 +190196,7 @@
           "pcb_smtpad_2222",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190215,7 +190215,7 @@
           "pcb_smtpad_2223",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190234,7 +190234,7 @@
           "pcb_smtpad_2223",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190253,7 +190253,7 @@
           "pcb_smtpad_2223",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190272,7 +190272,7 @@
           "pcb_smtpad_2223",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190291,7 +190291,7 @@
           "pcb_smtpad_2224",
           "connectivity_net4017"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190310,7 +190310,7 @@
           "pcb_smtpad_2225",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190329,7 +190329,7 @@
           "pcb_smtpad_2226",
           "connectivity_net4006"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190348,7 +190348,7 @@
           "pcb_smtpad_2227",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190367,7 +190367,7 @@
           "pcb_smtpad_2228",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190386,7 +190386,7 @@
           "pcb_smtpad_2228",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190405,7 +190405,7 @@
           "pcb_smtpad_2228",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190424,7 +190424,7 @@
           "pcb_smtpad_2228",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190443,7 +190443,7 @@
           "pcb_smtpad_2229",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190462,7 +190462,7 @@
           "pcb_smtpad_2229",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190481,7 +190481,7 @@
           "pcb_smtpad_2229",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190500,7 +190500,7 @@
           "pcb_smtpad_2229",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190519,7 +190519,7 @@
           "pcb_smtpad_2230",
           "connectivity_net4028"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190538,7 +190538,7 @@
           "pcb_smtpad_2231",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190557,7 +190557,7 @@
           "pcb_smtpad_2232",
           "connectivity_net4017"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190576,7 +190576,7 @@
           "pcb_smtpad_2233",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190595,7 +190595,7 @@
           "pcb_smtpad_2234",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190614,7 +190614,7 @@
           "pcb_smtpad_2234",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190633,7 +190633,7 @@
           "pcb_smtpad_2234",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190652,7 +190652,7 @@
           "pcb_smtpad_2234",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190671,7 +190671,7 @@
           "pcb_smtpad_2235",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190690,7 +190690,7 @@
           "pcb_smtpad_2235",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190709,7 +190709,7 @@
           "pcb_smtpad_2235",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190728,7 +190728,7 @@
           "pcb_smtpad_2235",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190747,7 +190747,7 @@
           "pcb_smtpad_2236",
           "connectivity_net4039"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190766,7 +190766,7 @@
           "pcb_smtpad_2237",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190785,7 +190785,7 @@
           "pcb_smtpad_2238",
           "connectivity_net4028"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190804,7 +190804,7 @@
           "pcb_smtpad_2239",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190823,7 +190823,7 @@
           "pcb_smtpad_2240",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190842,7 +190842,7 @@
           "pcb_smtpad_2240",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190861,7 +190861,7 @@
           "pcb_smtpad_2240",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190880,7 +190880,7 @@
           "pcb_smtpad_2240",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190899,7 +190899,7 @@
           "pcb_smtpad_2241",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190918,7 +190918,7 @@
           "pcb_smtpad_2241",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190937,7 +190937,7 @@
           "pcb_smtpad_2241",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190956,7 +190956,7 @@
           "pcb_smtpad_2241",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190975,7 +190975,7 @@
           "pcb_smtpad_2242",
           "connectivity_net4050"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -190994,7 +190994,7 @@
           "pcb_smtpad_2243",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191013,7 +191013,7 @@
           "pcb_smtpad_2244",
           "connectivity_net4039"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191032,7 +191032,7 @@
           "pcb_smtpad_2245",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191051,7 +191051,7 @@
           "pcb_smtpad_2246",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191070,7 +191070,7 @@
           "pcb_smtpad_2246",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191089,7 +191089,7 @@
           "pcb_smtpad_2246",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191108,7 +191108,7 @@
           "pcb_smtpad_2246",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191127,7 +191127,7 @@
           "pcb_smtpad_2247",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191146,7 +191146,7 @@
           "pcb_smtpad_2247",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191165,7 +191165,7 @@
           "pcb_smtpad_2247",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191184,7 +191184,7 @@
           "pcb_smtpad_2247",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191203,7 +191203,7 @@
           "pcb_smtpad_2248",
           "connectivity_net4061"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191222,7 +191222,7 @@
           "pcb_smtpad_2249",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191241,7 +191241,7 @@
           "pcb_smtpad_2250",
           "connectivity_net4050"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191260,7 +191260,7 @@
           "pcb_smtpad_2251",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191279,7 +191279,7 @@
           "pcb_smtpad_2252",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191298,7 +191298,7 @@
           "pcb_smtpad_2252",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191317,7 +191317,7 @@
           "pcb_smtpad_2252",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191336,7 +191336,7 @@
           "pcb_smtpad_2252",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191355,7 +191355,7 @@
           "pcb_smtpad_2253",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191374,7 +191374,7 @@
           "pcb_smtpad_2253",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191393,7 +191393,7 @@
           "pcb_smtpad_2253",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191412,7 +191412,7 @@
           "pcb_smtpad_2253",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191431,7 +191431,7 @@
           "pcb_smtpad_2254",
           "connectivity_net4072"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191450,7 +191450,7 @@
           "pcb_smtpad_2255",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191469,7 +191469,7 @@
           "pcb_smtpad_2256",
           "connectivity_net4061"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191488,7 +191488,7 @@
           "pcb_smtpad_2257",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191507,7 +191507,7 @@
           "pcb_smtpad_2258",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191526,7 +191526,7 @@
           "pcb_smtpad_2258",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191545,7 +191545,7 @@
           "pcb_smtpad_2258",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191564,7 +191564,7 @@
           "pcb_smtpad_2258",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191583,7 +191583,7 @@
           "pcb_smtpad_2259",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191602,7 +191602,7 @@
           "pcb_smtpad_2259",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191621,7 +191621,7 @@
           "pcb_smtpad_2259",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191640,7 +191640,7 @@
           "pcb_smtpad_2259",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191659,7 +191659,7 @@
           "pcb_smtpad_2260",
           "connectivity_net4083"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191678,7 +191678,7 @@
           "pcb_smtpad_2261",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191697,7 +191697,7 @@
           "pcb_smtpad_2262",
           "connectivity_net4072"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191716,7 +191716,7 @@
           "pcb_smtpad_2263",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191735,7 +191735,7 @@
           "pcb_smtpad_2264",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191754,7 +191754,7 @@
           "pcb_smtpad_2264",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191773,7 +191773,7 @@
           "pcb_smtpad_2264",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191792,7 +191792,7 @@
           "pcb_smtpad_2264",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191811,7 +191811,7 @@
           "pcb_smtpad_2265",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191830,7 +191830,7 @@
           "pcb_smtpad_2265",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191849,7 +191849,7 @@
           "pcb_smtpad_2265",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191868,7 +191868,7 @@
           "pcb_smtpad_2265",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191887,7 +191887,7 @@
           "pcb_smtpad_2266",
           "connectivity_net8704"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191906,7 +191906,7 @@
           "pcb_smtpad_2267",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191925,7 +191925,7 @@
           "pcb_smtpad_2268",
           "connectivity_net4083"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191944,7 +191944,7 @@
           "pcb_smtpad_2269",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191963,7 +191963,7 @@
           "pcb_smtpad_2270",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -191982,7 +191982,7 @@
           "pcb_smtpad_2270",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -192001,7 +192001,7 @@
           "pcb_smtpad_2270",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -192020,7 +192020,7 @@
           "pcb_smtpad_2270",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -192039,7 +192039,7 @@
           "pcb_smtpad_2271",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -192058,7 +192058,7 @@
           "pcb_smtpad_2271",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -192077,7 +192077,7 @@
           "pcb_smtpad_2271",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -192096,7 +192096,7 @@
           "pcb_smtpad_2271",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -192115,7 +192115,7 @@
           "pcb_smtpad_2272",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -192134,7 +192134,7 @@
           "pcb_smtpad_2273",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -192156,7 +192156,7 @@
           "pcb_plated_hole_0",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -192181,7 +192181,7 @@
           "pcb_plated_hole_1",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -192206,7 +192206,7 @@
           "pcb_plated_hole_2",
           "connectivity_net6"
         ],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -192231,7 +192231,7 @@
           "pcb_plated_hole_3",
           "connectivity_net9"
         ],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,

--- a/fixtures/legacy/assets/viaremoval02.json
+++ b/fixtures/legacy/assets/viaremoval02.json
@@ -18,7 +18,7 @@
           "pcb_smtpad_0",
           "connectivity_net8698"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37,7 +37,7 @@
           "pcb_smtpad_1",
           "connectivity_net8699"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56,7 +56,7 @@
           "pcb_smtpad_2",
           "connectivity_net8700"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75,7 +75,7 @@
           "pcb_smtpad_3",
           "connectivity_net8701"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -94,7 +94,7 @@
           "pcb_smtpad_4",
           "connectivity_net8702"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -113,7 +113,7 @@
           "pcb_smtpad_5",
           "connectivity_net8703"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -132,7 +132,7 @@
           "pcb_smtpad_6",
           "connectivity_net8669"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -151,7 +151,7 @@
           "pcb_smtpad_7",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -170,7 +170,7 @@
           "pcb_smtpad_8",
           "connectivity_net8670"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -189,7 +189,7 @@
           "pcb_smtpad_9",
           "connectivity_net8697"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -208,7 +208,7 @@
           "pcb_smtpad_10",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -227,7 +227,7 @@
           "pcb_smtpad_11",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -246,7 +246,7 @@
           "pcb_smtpad_12",
           "connectivity_net8671"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -265,7 +265,7 @@
           "pcb_smtpad_13",
           "connectivity_net8696"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -284,7 +284,7 @@
           "pcb_smtpad_14",
           "connectivity_net8672"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -303,7 +303,7 @@
           "pcb_smtpad_15",
           "connectivity_net8695"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -322,7 +322,7 @@
           "pcb_smtpad_16",
           "connectivity_net8673"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -341,7 +341,7 @@
           "pcb_smtpad_17",
           "connectivity_net8694"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -360,7 +360,7 @@
           "pcb_smtpad_18",
           "connectivity_net8674"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -379,7 +379,7 @@
           "pcb_smtpad_19",
           "connectivity_net8693"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -398,7 +398,7 @@
           "pcb_smtpad_20",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -417,7 +417,7 @@
           "pcb_smtpad_21",
           "connectivity_net8692"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -436,7 +436,7 @@
           "pcb_smtpad_22",
           "connectivity_net8675"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -455,7 +455,7 @@
           "pcb_smtpad_23",
           "connectivity_net6"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -474,7 +474,7 @@
           "pcb_smtpad_24",
           "connectivity_net8676"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -493,7 +493,7 @@
           "pcb_smtpad_25",
           "connectivity_net9"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -512,7 +512,7 @@
           "pcb_smtpad_26",
           "connectivity_net8677"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -531,7 +531,7 @@
           "pcb_smtpad_27",
           "connectivity_net8691"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -550,7 +550,7 @@
           "pcb_smtpad_28",
           "connectivity_net8678"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -569,7 +569,7 @@
           "pcb_smtpad_29",
           "connectivity_net8690"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -588,7 +588,7 @@
           "pcb_smtpad_30",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -607,7 +607,7 @@
           "pcb_smtpad_31",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -626,7 +626,7 @@
           "pcb_smtpad_32",
           "connectivity_net8679"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -645,7 +645,7 @@
           "pcb_smtpad_33",
           "connectivity_net8689"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -664,7 +664,7 @@
           "pcb_smtpad_34",
           "connectivity_net4094"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -683,7 +683,7 @@
           "pcb_smtpad_35",
           "connectivity_net8688"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -702,7 +702,7 @@
           "pcb_smtpad_36",
           "connectivity_net8680"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -721,7 +721,7 @@
           "pcb_smtpad_37",
           "connectivity_net8687"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -740,7 +740,7 @@
           "pcb_smtpad_38",
           "connectivity_net8681"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -759,7 +759,7 @@
           "pcb_smtpad_39",
           "connectivity_net8686"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -778,7 +778,7 @@
           "pcb_smtpad_40",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -797,7 +797,7 @@
           "pcb_smtpad_41",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -816,7 +816,7 @@
           "pcb_smtpad_42",
           "connectivity_net8682"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -835,7 +835,7 @@
           "pcb_smtpad_43",
           "connectivity_net8685"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -854,7 +854,7 @@
           "pcb_smtpad_44",
           "connectivity_net8683"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -873,7 +873,7 @@
           "pcb_smtpad_45",
           "connectivity_net8684"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -892,7 +892,7 @@
           "pcb_smtpad_46",
           "connectivity_net24"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -911,7 +911,7 @@
           "pcb_smtpad_47",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -930,7 +930,7 @@
           "pcb_smtpad_48",
           "connectivity_net4094"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -949,7 +949,7 @@
           "pcb_smtpad_49",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -968,7 +968,7 @@
           "pcb_smtpad_50",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -987,7 +987,7 @@
           "pcb_smtpad_50",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1006,7 +1006,7 @@
           "pcb_smtpad_50",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1025,7 +1025,7 @@
           "pcb_smtpad_50",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1044,7 +1044,7 @@
           "pcb_smtpad_51",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1063,7 +1063,7 @@
           "pcb_smtpad_51",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1082,7 +1082,7 @@
           "pcb_smtpad_51",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1101,7 +1101,7 @@
           "pcb_smtpad_51",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1120,7 +1120,7 @@
           "pcb_smtpad_52",
           "connectivity_net35"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1139,7 +1139,7 @@
           "pcb_smtpad_53",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1158,7 +1158,7 @@
           "pcb_smtpad_54",
           "connectivity_net24"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1177,7 +1177,7 @@
           "pcb_smtpad_55",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1196,7 +1196,7 @@
           "pcb_smtpad_56",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1215,7 +1215,7 @@
           "pcb_smtpad_56",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1234,7 +1234,7 @@
           "pcb_smtpad_56",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1253,7 +1253,7 @@
           "pcb_smtpad_56",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1272,7 +1272,7 @@
           "pcb_smtpad_57",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1291,7 +1291,7 @@
           "pcb_smtpad_57",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1310,7 +1310,7 @@
           "pcb_smtpad_57",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1329,7 +1329,7 @@
           "pcb_smtpad_57",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1348,7 +1348,7 @@
           "pcb_smtpad_58",
           "connectivity_net46"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1367,7 +1367,7 @@
           "pcb_smtpad_59",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1386,7 +1386,7 @@
           "pcb_smtpad_60",
           "connectivity_net35"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1405,7 +1405,7 @@
           "pcb_smtpad_61",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1424,7 +1424,7 @@
           "pcb_smtpad_62",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1443,7 +1443,7 @@
           "pcb_smtpad_62",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1462,7 +1462,7 @@
           "pcb_smtpad_62",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1481,7 +1481,7 @@
           "pcb_smtpad_62",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1500,7 +1500,7 @@
           "pcb_smtpad_63",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1519,7 +1519,7 @@
           "pcb_smtpad_63",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1538,7 +1538,7 @@
           "pcb_smtpad_63",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1557,7 +1557,7 @@
           "pcb_smtpad_63",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1576,7 +1576,7 @@
           "pcb_smtpad_64",
           "connectivity_net57"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1595,7 +1595,7 @@
           "pcb_smtpad_65",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1614,7 +1614,7 @@
           "pcb_smtpad_66",
           "connectivity_net46"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1633,7 +1633,7 @@
           "pcb_smtpad_67",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1652,7 +1652,7 @@
           "pcb_smtpad_68",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1671,7 +1671,7 @@
           "pcb_smtpad_68",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1690,7 +1690,7 @@
           "pcb_smtpad_68",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1709,7 +1709,7 @@
           "pcb_smtpad_68",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1728,7 +1728,7 @@
           "pcb_smtpad_69",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1747,7 +1747,7 @@
           "pcb_smtpad_69",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1766,7 +1766,7 @@
           "pcb_smtpad_69",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1785,7 +1785,7 @@
           "pcb_smtpad_69",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1804,7 +1804,7 @@
           "pcb_smtpad_70",
           "connectivity_net68"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1823,7 +1823,7 @@
           "pcb_smtpad_71",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1842,7 +1842,7 @@
           "pcb_smtpad_72",
           "connectivity_net57"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1861,7 +1861,7 @@
           "pcb_smtpad_73",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1880,7 +1880,7 @@
           "pcb_smtpad_74",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1899,7 +1899,7 @@
           "pcb_smtpad_74",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1918,7 +1918,7 @@
           "pcb_smtpad_74",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1937,7 +1937,7 @@
           "pcb_smtpad_74",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1956,7 +1956,7 @@
           "pcb_smtpad_75",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1975,7 +1975,7 @@
           "pcb_smtpad_75",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -1994,7 +1994,7 @@
           "pcb_smtpad_75",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2013,7 +2013,7 @@
           "pcb_smtpad_75",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2032,7 +2032,7 @@
           "pcb_smtpad_76",
           "connectivity_net79"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2051,7 +2051,7 @@
           "pcb_smtpad_77",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2070,7 +2070,7 @@
           "pcb_smtpad_78",
           "connectivity_net68"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2089,7 +2089,7 @@
           "pcb_smtpad_79",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2108,7 +2108,7 @@
           "pcb_smtpad_80",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2127,7 +2127,7 @@
           "pcb_smtpad_80",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2146,7 +2146,7 @@
           "pcb_smtpad_80",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2165,7 +2165,7 @@
           "pcb_smtpad_80",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2184,7 +2184,7 @@
           "pcb_smtpad_81",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2203,7 +2203,7 @@
           "pcb_smtpad_81",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2222,7 +2222,7 @@
           "pcb_smtpad_81",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2241,7 +2241,7 @@
           "pcb_smtpad_81",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2260,7 +2260,7 @@
           "pcb_smtpad_82",
           "connectivity_net90"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2279,7 +2279,7 @@
           "pcb_smtpad_83",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2298,7 +2298,7 @@
           "pcb_smtpad_84",
           "connectivity_net79"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2317,7 +2317,7 @@
           "pcb_smtpad_85",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2336,7 +2336,7 @@
           "pcb_smtpad_86",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2355,7 +2355,7 @@
           "pcb_smtpad_86",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2374,7 +2374,7 @@
           "pcb_smtpad_86",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2393,7 +2393,7 @@
           "pcb_smtpad_86",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2412,7 +2412,7 @@
           "pcb_smtpad_87",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2431,7 +2431,7 @@
           "pcb_smtpad_87",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2450,7 +2450,7 @@
           "pcb_smtpad_87",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2469,7 +2469,7 @@
           "pcb_smtpad_87",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2488,7 +2488,7 @@
           "pcb_smtpad_88",
           "connectivity_net101"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2507,7 +2507,7 @@
           "pcb_smtpad_89",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2526,7 +2526,7 @@
           "pcb_smtpad_90",
           "connectivity_net90"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2545,7 +2545,7 @@
           "pcb_smtpad_91",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2564,7 +2564,7 @@
           "pcb_smtpad_92",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2583,7 +2583,7 @@
           "pcb_smtpad_92",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2602,7 +2602,7 @@
           "pcb_smtpad_92",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2621,7 +2621,7 @@
           "pcb_smtpad_92",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2640,7 +2640,7 @@
           "pcb_smtpad_93",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2659,7 +2659,7 @@
           "pcb_smtpad_93",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2678,7 +2678,7 @@
           "pcb_smtpad_93",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2697,7 +2697,7 @@
           "pcb_smtpad_93",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2716,7 +2716,7 @@
           "pcb_smtpad_94",
           "connectivity_net112"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2735,7 +2735,7 @@
           "pcb_smtpad_95",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2754,7 +2754,7 @@
           "pcb_smtpad_96",
           "connectivity_net101"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2773,7 +2773,7 @@
           "pcb_smtpad_97",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2792,7 +2792,7 @@
           "pcb_smtpad_98",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2811,7 +2811,7 @@
           "pcb_smtpad_98",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2830,7 +2830,7 @@
           "pcb_smtpad_98",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2849,7 +2849,7 @@
           "pcb_smtpad_98",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2868,7 +2868,7 @@
           "pcb_smtpad_99",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2887,7 +2887,7 @@
           "pcb_smtpad_99",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2906,7 +2906,7 @@
           "pcb_smtpad_99",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2925,7 +2925,7 @@
           "pcb_smtpad_99",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2944,7 +2944,7 @@
           "pcb_smtpad_100",
           "connectivity_net123"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2963,7 +2963,7 @@
           "pcb_smtpad_101",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -2982,7 +2982,7 @@
           "pcb_smtpad_102",
           "connectivity_net112"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3001,7 +3001,7 @@
           "pcb_smtpad_103",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3020,7 +3020,7 @@
           "pcb_smtpad_104",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3039,7 +3039,7 @@
           "pcb_smtpad_104",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3058,7 +3058,7 @@
           "pcb_smtpad_104",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3077,7 +3077,7 @@
           "pcb_smtpad_104",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3096,7 +3096,7 @@
           "pcb_smtpad_105",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3115,7 +3115,7 @@
           "pcb_smtpad_105",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3134,7 +3134,7 @@
           "pcb_smtpad_105",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3153,7 +3153,7 @@
           "pcb_smtpad_105",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3172,7 +3172,7 @@
           "pcb_smtpad_106",
           "connectivity_net134"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3191,7 +3191,7 @@
           "pcb_smtpad_107",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3210,7 +3210,7 @@
           "pcb_smtpad_108",
           "connectivity_net123"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3229,7 +3229,7 @@
           "pcb_smtpad_109",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3248,7 +3248,7 @@
           "pcb_smtpad_110",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3267,7 +3267,7 @@
           "pcb_smtpad_110",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3286,7 +3286,7 @@
           "pcb_smtpad_110",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3305,7 +3305,7 @@
           "pcb_smtpad_110",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3324,7 +3324,7 @@
           "pcb_smtpad_111",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3343,7 +3343,7 @@
           "pcb_smtpad_111",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3362,7 +3362,7 @@
           "pcb_smtpad_111",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3381,7 +3381,7 @@
           "pcb_smtpad_111",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3400,7 +3400,7 @@
           "pcb_smtpad_112",
           "connectivity_net145"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3419,7 +3419,7 @@
           "pcb_smtpad_113",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3438,7 +3438,7 @@
           "pcb_smtpad_114",
           "connectivity_net134"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3457,7 +3457,7 @@
           "pcb_smtpad_115",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3476,7 +3476,7 @@
           "pcb_smtpad_116",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3495,7 +3495,7 @@
           "pcb_smtpad_116",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3514,7 +3514,7 @@
           "pcb_smtpad_116",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3533,7 +3533,7 @@
           "pcb_smtpad_116",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3552,7 +3552,7 @@
           "pcb_smtpad_117",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3571,7 +3571,7 @@
           "pcb_smtpad_117",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3590,7 +3590,7 @@
           "pcb_smtpad_117",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3609,7 +3609,7 @@
           "pcb_smtpad_117",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3628,7 +3628,7 @@
           "pcb_smtpad_118",
           "connectivity_net156"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3647,7 +3647,7 @@
           "pcb_smtpad_119",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3666,7 +3666,7 @@
           "pcb_smtpad_120",
           "connectivity_net145"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3685,7 +3685,7 @@
           "pcb_smtpad_121",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3704,7 +3704,7 @@
           "pcb_smtpad_122",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3723,7 +3723,7 @@
           "pcb_smtpad_122",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3742,7 +3742,7 @@
           "pcb_smtpad_122",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3761,7 +3761,7 @@
           "pcb_smtpad_122",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3780,7 +3780,7 @@
           "pcb_smtpad_123",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3799,7 +3799,7 @@
           "pcb_smtpad_123",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3818,7 +3818,7 @@
           "pcb_smtpad_123",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3837,7 +3837,7 @@
           "pcb_smtpad_123",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3856,7 +3856,7 @@
           "pcb_smtpad_124",
           "connectivity_net167"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3875,7 +3875,7 @@
           "pcb_smtpad_125",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3894,7 +3894,7 @@
           "pcb_smtpad_126",
           "connectivity_net156"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3913,7 +3913,7 @@
           "pcb_smtpad_127",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3932,7 +3932,7 @@
           "pcb_smtpad_128",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3951,7 +3951,7 @@
           "pcb_smtpad_128",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3970,7 +3970,7 @@
           "pcb_smtpad_128",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -3989,7 +3989,7 @@
           "pcb_smtpad_128",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4008,7 +4008,7 @@
           "pcb_smtpad_129",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4027,7 +4027,7 @@
           "pcb_smtpad_129",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4046,7 +4046,7 @@
           "pcb_smtpad_129",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4065,7 +4065,7 @@
           "pcb_smtpad_129",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4084,7 +4084,7 @@
           "pcb_smtpad_130",
           "connectivity_net178"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4103,7 +4103,7 @@
           "pcb_smtpad_131",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4122,7 +4122,7 @@
           "pcb_smtpad_132",
           "connectivity_net167"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4141,7 +4141,7 @@
           "pcb_smtpad_133",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4160,7 +4160,7 @@
           "pcb_smtpad_134",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4179,7 +4179,7 @@
           "pcb_smtpad_134",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4198,7 +4198,7 @@
           "pcb_smtpad_134",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4217,7 +4217,7 @@
           "pcb_smtpad_134",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4236,7 +4236,7 @@
           "pcb_smtpad_135",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4255,7 +4255,7 @@
           "pcb_smtpad_135",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4274,7 +4274,7 @@
           "pcb_smtpad_135",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4293,7 +4293,7 @@
           "pcb_smtpad_135",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4312,7 +4312,7 @@
           "pcb_smtpad_136",
           "connectivity_net189"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4331,7 +4331,7 @@
           "pcb_smtpad_137",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4350,7 +4350,7 @@
           "pcb_smtpad_138",
           "connectivity_net178"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4369,7 +4369,7 @@
           "pcb_smtpad_139",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4388,7 +4388,7 @@
           "pcb_smtpad_140",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4407,7 +4407,7 @@
           "pcb_smtpad_140",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4426,7 +4426,7 @@
           "pcb_smtpad_140",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4445,7 +4445,7 @@
           "pcb_smtpad_140",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4464,7 +4464,7 @@
           "pcb_smtpad_141",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4483,7 +4483,7 @@
           "pcb_smtpad_141",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4502,7 +4502,7 @@
           "pcb_smtpad_141",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4521,7 +4521,7 @@
           "pcb_smtpad_141",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4540,7 +4540,7 @@
           "pcb_smtpad_142",
           "connectivity_net200"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4559,7 +4559,7 @@
           "pcb_smtpad_143",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4578,7 +4578,7 @@
           "pcb_smtpad_144",
           "connectivity_net189"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4597,7 +4597,7 @@
           "pcb_smtpad_145",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4616,7 +4616,7 @@
           "pcb_smtpad_146",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4635,7 +4635,7 @@
           "pcb_smtpad_146",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4654,7 +4654,7 @@
           "pcb_smtpad_146",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4673,7 +4673,7 @@
           "pcb_smtpad_146",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4692,7 +4692,7 @@
           "pcb_smtpad_147",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4711,7 +4711,7 @@
           "pcb_smtpad_147",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4730,7 +4730,7 @@
           "pcb_smtpad_147",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4749,7 +4749,7 @@
           "pcb_smtpad_147",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4768,7 +4768,7 @@
           "pcb_smtpad_148",
           "connectivity_net211"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4787,7 +4787,7 @@
           "pcb_smtpad_149",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4806,7 +4806,7 @@
           "pcb_smtpad_150",
           "connectivity_net200"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4825,7 +4825,7 @@
           "pcb_smtpad_151",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4844,7 +4844,7 @@
           "pcb_smtpad_152",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4863,7 +4863,7 @@
           "pcb_smtpad_152",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4882,7 +4882,7 @@
           "pcb_smtpad_152",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4901,7 +4901,7 @@
           "pcb_smtpad_152",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4920,7 +4920,7 @@
           "pcb_smtpad_153",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4939,7 +4939,7 @@
           "pcb_smtpad_153",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4958,7 +4958,7 @@
           "pcb_smtpad_153",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4977,7 +4977,7 @@
           "pcb_smtpad_153",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -4996,7 +4996,7 @@
           "pcb_smtpad_154",
           "connectivity_net222"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5015,7 +5015,7 @@
           "pcb_smtpad_155",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5034,7 +5034,7 @@
           "pcb_smtpad_156",
           "connectivity_net211"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5053,7 +5053,7 @@
           "pcb_smtpad_157",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5072,7 +5072,7 @@
           "pcb_smtpad_158",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5091,7 +5091,7 @@
           "pcb_smtpad_158",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5110,7 +5110,7 @@
           "pcb_smtpad_158",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5129,7 +5129,7 @@
           "pcb_smtpad_158",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5148,7 +5148,7 @@
           "pcb_smtpad_159",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5167,7 +5167,7 @@
           "pcb_smtpad_159",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5186,7 +5186,7 @@
           "pcb_smtpad_159",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5205,7 +5205,7 @@
           "pcb_smtpad_159",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5224,7 +5224,7 @@
           "pcb_smtpad_160",
           "connectivity_net233"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5243,7 +5243,7 @@
           "pcb_smtpad_161",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5262,7 +5262,7 @@
           "pcb_smtpad_162",
           "connectivity_net222"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5281,7 +5281,7 @@
           "pcb_smtpad_163",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5300,7 +5300,7 @@
           "pcb_smtpad_164",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5319,7 +5319,7 @@
           "pcb_smtpad_164",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5338,7 +5338,7 @@
           "pcb_smtpad_164",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5357,7 +5357,7 @@
           "pcb_smtpad_164",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5376,7 +5376,7 @@
           "pcb_smtpad_165",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5395,7 +5395,7 @@
           "pcb_smtpad_165",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5414,7 +5414,7 @@
           "pcb_smtpad_165",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5433,7 +5433,7 @@
           "pcb_smtpad_165",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5452,7 +5452,7 @@
           "pcb_smtpad_166",
           "connectivity_net244"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5471,7 +5471,7 @@
           "pcb_smtpad_167",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5490,7 +5490,7 @@
           "pcb_smtpad_168",
           "connectivity_net233"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5509,7 +5509,7 @@
           "pcb_smtpad_169",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5528,7 +5528,7 @@
           "pcb_smtpad_170",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5547,7 +5547,7 @@
           "pcb_smtpad_170",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5566,7 +5566,7 @@
           "pcb_smtpad_170",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5585,7 +5585,7 @@
           "pcb_smtpad_170",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5604,7 +5604,7 @@
           "pcb_smtpad_171",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5623,7 +5623,7 @@
           "pcb_smtpad_171",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5642,7 +5642,7 @@
           "pcb_smtpad_171",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5661,7 +5661,7 @@
           "pcb_smtpad_171",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5680,7 +5680,7 @@
           "pcb_smtpad_172",
           "connectivity_net255"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5699,7 +5699,7 @@
           "pcb_smtpad_173",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5718,7 +5718,7 @@
           "pcb_smtpad_174",
           "connectivity_net244"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5737,7 +5737,7 @@
           "pcb_smtpad_175",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5756,7 +5756,7 @@
           "pcb_smtpad_176",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5775,7 +5775,7 @@
           "pcb_smtpad_176",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5794,7 +5794,7 @@
           "pcb_smtpad_176",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5813,7 +5813,7 @@
           "pcb_smtpad_176",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5832,7 +5832,7 @@
           "pcb_smtpad_177",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5851,7 +5851,7 @@
           "pcb_smtpad_177",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5870,7 +5870,7 @@
           "pcb_smtpad_177",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5889,7 +5889,7 @@
           "pcb_smtpad_177",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5908,7 +5908,7 @@
           "pcb_smtpad_178",
           "connectivity_net266"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5927,7 +5927,7 @@
           "pcb_smtpad_179",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5946,7 +5946,7 @@
           "pcb_smtpad_180",
           "connectivity_net255"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5965,7 +5965,7 @@
           "pcb_smtpad_181",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -5984,7 +5984,7 @@
           "pcb_smtpad_182",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6003,7 +6003,7 @@
           "pcb_smtpad_182",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6022,7 +6022,7 @@
           "pcb_smtpad_182",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6041,7 +6041,7 @@
           "pcb_smtpad_182",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6060,7 +6060,7 @@
           "pcb_smtpad_183",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6079,7 +6079,7 @@
           "pcb_smtpad_183",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6098,7 +6098,7 @@
           "pcb_smtpad_183",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6117,7 +6117,7 @@
           "pcb_smtpad_183",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6136,7 +6136,7 @@
           "pcb_smtpad_184",
           "connectivity_net277"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6155,7 +6155,7 @@
           "pcb_smtpad_185",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6174,7 +6174,7 @@
           "pcb_smtpad_186",
           "connectivity_net266"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6193,7 +6193,7 @@
           "pcb_smtpad_187",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6212,7 +6212,7 @@
           "pcb_smtpad_188",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6231,7 +6231,7 @@
           "pcb_smtpad_188",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6250,7 +6250,7 @@
           "pcb_smtpad_188",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6269,7 +6269,7 @@
           "pcb_smtpad_188",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6288,7 +6288,7 @@
           "pcb_smtpad_189",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6307,7 +6307,7 @@
           "pcb_smtpad_189",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6326,7 +6326,7 @@
           "pcb_smtpad_189",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6345,7 +6345,7 @@
           "pcb_smtpad_189",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6364,7 +6364,7 @@
           "pcb_smtpad_190",
           "connectivity_net288"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6383,7 +6383,7 @@
           "pcb_smtpad_191",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6402,7 +6402,7 @@
           "pcb_smtpad_192",
           "connectivity_net277"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6421,7 +6421,7 @@
           "pcb_smtpad_193",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6440,7 +6440,7 @@
           "pcb_smtpad_194",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6459,7 +6459,7 @@
           "pcb_smtpad_194",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6478,7 +6478,7 @@
           "pcb_smtpad_194",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6497,7 +6497,7 @@
           "pcb_smtpad_194",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6516,7 +6516,7 @@
           "pcb_smtpad_195",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6535,7 +6535,7 @@
           "pcb_smtpad_195",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6554,7 +6554,7 @@
           "pcb_smtpad_195",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6573,7 +6573,7 @@
           "pcb_smtpad_195",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6592,7 +6592,7 @@
           "pcb_smtpad_196",
           "connectivity_net299"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6611,7 +6611,7 @@
           "pcb_smtpad_197",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6630,7 +6630,7 @@
           "pcb_smtpad_198",
           "connectivity_net288"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6649,7 +6649,7 @@
           "pcb_smtpad_199",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6668,7 +6668,7 @@
           "pcb_smtpad_200",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6687,7 +6687,7 @@
           "pcb_smtpad_200",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6706,7 +6706,7 @@
           "pcb_smtpad_200",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6725,7 +6725,7 @@
           "pcb_smtpad_200",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6744,7 +6744,7 @@
           "pcb_smtpad_201",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6763,7 +6763,7 @@
           "pcb_smtpad_201",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6782,7 +6782,7 @@
           "pcb_smtpad_201",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6801,7 +6801,7 @@
           "pcb_smtpad_201",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6820,7 +6820,7 @@
           "pcb_smtpad_202",
           "connectivity_net310"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6839,7 +6839,7 @@
           "pcb_smtpad_203",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6858,7 +6858,7 @@
           "pcb_smtpad_204",
           "connectivity_net299"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6877,7 +6877,7 @@
           "pcb_smtpad_205",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6896,7 +6896,7 @@
           "pcb_smtpad_206",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6915,7 +6915,7 @@
           "pcb_smtpad_206",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6934,7 +6934,7 @@
           "pcb_smtpad_206",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6953,7 +6953,7 @@
           "pcb_smtpad_206",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6972,7 +6972,7 @@
           "pcb_smtpad_207",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -6991,7 +6991,7 @@
           "pcb_smtpad_207",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7010,7 +7010,7 @@
           "pcb_smtpad_207",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7029,7 +7029,7 @@
           "pcb_smtpad_207",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7048,7 +7048,7 @@
           "pcb_smtpad_208",
           "connectivity_net321"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7067,7 +7067,7 @@
           "pcb_smtpad_209",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7086,7 +7086,7 @@
           "pcb_smtpad_210",
           "connectivity_net310"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7105,7 +7105,7 @@
           "pcb_smtpad_211",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7124,7 +7124,7 @@
           "pcb_smtpad_212",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7143,7 +7143,7 @@
           "pcb_smtpad_212",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7162,7 +7162,7 @@
           "pcb_smtpad_212",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7181,7 +7181,7 @@
           "pcb_smtpad_212",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7200,7 +7200,7 @@
           "pcb_smtpad_213",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7219,7 +7219,7 @@
           "pcb_smtpad_213",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7238,7 +7238,7 @@
           "pcb_smtpad_213",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7257,7 +7257,7 @@
           "pcb_smtpad_213",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7276,7 +7276,7 @@
           "pcb_smtpad_214",
           "connectivity_net332"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7295,7 +7295,7 @@
           "pcb_smtpad_215",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7314,7 +7314,7 @@
           "pcb_smtpad_216",
           "connectivity_net321"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7333,7 +7333,7 @@
           "pcb_smtpad_217",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7352,7 +7352,7 @@
           "pcb_smtpad_218",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7371,7 +7371,7 @@
           "pcb_smtpad_218",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7390,7 +7390,7 @@
           "pcb_smtpad_218",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7409,7 +7409,7 @@
           "pcb_smtpad_218",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7428,7 +7428,7 @@
           "pcb_smtpad_219",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7447,7 +7447,7 @@
           "pcb_smtpad_219",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7466,7 +7466,7 @@
           "pcb_smtpad_219",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7485,7 +7485,7 @@
           "pcb_smtpad_219",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7504,7 +7504,7 @@
           "pcb_smtpad_220",
           "connectivity_net343"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7523,7 +7523,7 @@
           "pcb_smtpad_221",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7542,7 +7542,7 @@
           "pcb_smtpad_222",
           "connectivity_net332"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7561,7 +7561,7 @@
           "pcb_smtpad_223",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7580,7 +7580,7 @@
           "pcb_smtpad_224",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7599,7 +7599,7 @@
           "pcb_smtpad_224",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7618,7 +7618,7 @@
           "pcb_smtpad_224",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7637,7 +7637,7 @@
           "pcb_smtpad_224",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7656,7 +7656,7 @@
           "pcb_smtpad_225",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7675,7 +7675,7 @@
           "pcb_smtpad_225",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7694,7 +7694,7 @@
           "pcb_smtpad_225",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7713,7 +7713,7 @@
           "pcb_smtpad_225",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7732,7 +7732,7 @@
           "pcb_smtpad_226",
           "connectivity_net354"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7751,7 +7751,7 @@
           "pcb_smtpad_227",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7770,7 +7770,7 @@
           "pcb_smtpad_228",
           "connectivity_net343"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7789,7 +7789,7 @@
           "pcb_smtpad_229",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7808,7 +7808,7 @@
           "pcb_smtpad_230",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7827,7 +7827,7 @@
           "pcb_smtpad_230",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7846,7 +7846,7 @@
           "pcb_smtpad_230",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7865,7 +7865,7 @@
           "pcb_smtpad_230",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7884,7 +7884,7 @@
           "pcb_smtpad_231",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7903,7 +7903,7 @@
           "pcb_smtpad_231",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7922,7 +7922,7 @@
           "pcb_smtpad_231",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7941,7 +7941,7 @@
           "pcb_smtpad_231",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7960,7 +7960,7 @@
           "pcb_smtpad_232",
           "connectivity_net365"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7979,7 +7979,7 @@
           "pcb_smtpad_233",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -7998,7 +7998,7 @@
           "pcb_smtpad_234",
           "connectivity_net354"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8017,7 +8017,7 @@
           "pcb_smtpad_235",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8036,7 +8036,7 @@
           "pcb_smtpad_236",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8055,7 +8055,7 @@
           "pcb_smtpad_236",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8074,7 +8074,7 @@
           "pcb_smtpad_236",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8093,7 +8093,7 @@
           "pcb_smtpad_236",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8112,7 +8112,7 @@
           "pcb_smtpad_237",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8131,7 +8131,7 @@
           "pcb_smtpad_237",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8150,7 +8150,7 @@
           "pcb_smtpad_237",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8169,7 +8169,7 @@
           "pcb_smtpad_237",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8188,7 +8188,7 @@
           "pcb_smtpad_238",
           "connectivity_net376"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8207,7 +8207,7 @@
           "pcb_smtpad_239",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8226,7 +8226,7 @@
           "pcb_smtpad_240",
           "connectivity_net365"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8245,7 +8245,7 @@
           "pcb_smtpad_241",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8264,7 +8264,7 @@
           "pcb_smtpad_242",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8283,7 +8283,7 @@
           "pcb_smtpad_242",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8302,7 +8302,7 @@
           "pcb_smtpad_242",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8321,7 +8321,7 @@
           "pcb_smtpad_242",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8340,7 +8340,7 @@
           "pcb_smtpad_243",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8359,7 +8359,7 @@
           "pcb_smtpad_243",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8378,7 +8378,7 @@
           "pcb_smtpad_243",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8397,7 +8397,7 @@
           "pcb_smtpad_243",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8416,7 +8416,7 @@
           "pcb_smtpad_244",
           "connectivity_net387"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8435,7 +8435,7 @@
           "pcb_smtpad_245",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8454,7 +8454,7 @@
           "pcb_smtpad_246",
           "connectivity_net376"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8473,7 +8473,7 @@
           "pcb_smtpad_247",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8492,7 +8492,7 @@
           "pcb_smtpad_248",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8511,7 +8511,7 @@
           "pcb_smtpad_248",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8530,7 +8530,7 @@
           "pcb_smtpad_248",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8549,7 +8549,7 @@
           "pcb_smtpad_248",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8568,7 +8568,7 @@
           "pcb_smtpad_249",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8587,7 +8587,7 @@
           "pcb_smtpad_249",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8606,7 +8606,7 @@
           "pcb_smtpad_249",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8625,7 +8625,7 @@
           "pcb_smtpad_249",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8644,7 +8644,7 @@
           "pcb_smtpad_250",
           "connectivity_net398"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8663,7 +8663,7 @@
           "pcb_smtpad_251",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8682,7 +8682,7 @@
           "pcb_smtpad_252",
           "connectivity_net387"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8701,7 +8701,7 @@
           "pcb_smtpad_253",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8720,7 +8720,7 @@
           "pcb_smtpad_254",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8739,7 +8739,7 @@
           "pcb_smtpad_254",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8758,7 +8758,7 @@
           "pcb_smtpad_254",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8777,7 +8777,7 @@
           "pcb_smtpad_254",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8796,7 +8796,7 @@
           "pcb_smtpad_255",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8815,7 +8815,7 @@
           "pcb_smtpad_255",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8834,7 +8834,7 @@
           "pcb_smtpad_255",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8853,7 +8853,7 @@
           "pcb_smtpad_255",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8872,7 +8872,7 @@
           "pcb_smtpad_256",
           "connectivity_net409"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8891,7 +8891,7 @@
           "pcb_smtpad_257",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8910,7 +8910,7 @@
           "pcb_smtpad_258",
           "connectivity_net398"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8929,7 +8929,7 @@
           "pcb_smtpad_259",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8948,7 +8948,7 @@
           "pcb_smtpad_260",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8967,7 +8967,7 @@
           "pcb_smtpad_260",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -8986,7 +8986,7 @@
           "pcb_smtpad_260",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9005,7 +9005,7 @@
           "pcb_smtpad_260",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9024,7 +9024,7 @@
           "pcb_smtpad_261",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9043,7 +9043,7 @@
           "pcb_smtpad_261",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9062,7 +9062,7 @@
           "pcb_smtpad_261",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9081,7 +9081,7 @@
           "pcb_smtpad_261",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9100,7 +9100,7 @@
           "pcb_smtpad_262",
           "connectivity_net420"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9119,7 +9119,7 @@
           "pcb_smtpad_263",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9138,7 +9138,7 @@
           "pcb_smtpad_264",
           "connectivity_net409"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9157,7 +9157,7 @@
           "pcb_smtpad_265",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9176,7 +9176,7 @@
           "pcb_smtpad_266",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9195,7 +9195,7 @@
           "pcb_smtpad_266",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9214,7 +9214,7 @@
           "pcb_smtpad_266",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9233,7 +9233,7 @@
           "pcb_smtpad_266",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9252,7 +9252,7 @@
           "pcb_smtpad_267",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9271,7 +9271,7 @@
           "pcb_smtpad_267",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9290,7 +9290,7 @@
           "pcb_smtpad_267",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9309,7 +9309,7 @@
           "pcb_smtpad_267",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9328,7 +9328,7 @@
           "pcb_smtpad_268",
           "connectivity_net431"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9347,7 +9347,7 @@
           "pcb_smtpad_269",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9366,7 +9366,7 @@
           "pcb_smtpad_270",
           "connectivity_net420"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9385,7 +9385,7 @@
           "pcb_smtpad_271",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9404,7 +9404,7 @@
           "pcb_smtpad_272",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9423,7 +9423,7 @@
           "pcb_smtpad_272",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9442,7 +9442,7 @@
           "pcb_smtpad_272",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9461,7 +9461,7 @@
           "pcb_smtpad_272",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9480,7 +9480,7 @@
           "pcb_smtpad_273",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9499,7 +9499,7 @@
           "pcb_smtpad_273",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9518,7 +9518,7 @@
           "pcb_smtpad_273",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9537,7 +9537,7 @@
           "pcb_smtpad_273",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9556,7 +9556,7 @@
           "pcb_smtpad_274",
           "connectivity_net442"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9575,7 +9575,7 @@
           "pcb_smtpad_275",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9594,7 +9594,7 @@
           "pcb_smtpad_276",
           "connectivity_net431"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9613,7 +9613,7 @@
           "pcb_smtpad_277",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9632,7 +9632,7 @@
           "pcb_smtpad_278",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9651,7 +9651,7 @@
           "pcb_smtpad_278",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9670,7 +9670,7 @@
           "pcb_smtpad_278",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9689,7 +9689,7 @@
           "pcb_smtpad_278",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9708,7 +9708,7 @@
           "pcb_smtpad_279",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9727,7 +9727,7 @@
           "pcb_smtpad_279",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9746,7 +9746,7 @@
           "pcb_smtpad_279",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9765,7 +9765,7 @@
           "pcb_smtpad_279",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9784,7 +9784,7 @@
           "pcb_smtpad_280",
           "connectivity_net453"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9803,7 +9803,7 @@
           "pcb_smtpad_281",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9822,7 +9822,7 @@
           "pcb_smtpad_282",
           "connectivity_net442"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9841,7 +9841,7 @@
           "pcb_smtpad_283",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9860,7 +9860,7 @@
           "pcb_smtpad_284",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9879,7 +9879,7 @@
           "pcb_smtpad_284",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9898,7 +9898,7 @@
           "pcb_smtpad_284",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9917,7 +9917,7 @@
           "pcb_smtpad_284",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9936,7 +9936,7 @@
           "pcb_smtpad_285",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9955,7 +9955,7 @@
           "pcb_smtpad_285",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9974,7 +9974,7 @@
           "pcb_smtpad_285",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -9993,7 +9993,7 @@
           "pcb_smtpad_285",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10012,7 +10012,7 @@
           "pcb_smtpad_286",
           "connectivity_net464"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10031,7 +10031,7 @@
           "pcb_smtpad_287",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10050,7 +10050,7 @@
           "pcb_smtpad_288",
           "connectivity_net453"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10069,7 +10069,7 @@
           "pcb_smtpad_289",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10088,7 +10088,7 @@
           "pcb_smtpad_290",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10107,7 +10107,7 @@
           "pcb_smtpad_290",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10126,7 +10126,7 @@
           "pcb_smtpad_290",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10145,7 +10145,7 @@
           "pcb_smtpad_290",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10164,7 +10164,7 @@
           "pcb_smtpad_291",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10183,7 +10183,7 @@
           "pcb_smtpad_291",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10202,7 +10202,7 @@
           "pcb_smtpad_291",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10221,7 +10221,7 @@
           "pcb_smtpad_291",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10240,7 +10240,7 @@
           "pcb_smtpad_292",
           "connectivity_net475"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10259,7 +10259,7 @@
           "pcb_smtpad_293",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10278,7 +10278,7 @@
           "pcb_smtpad_294",
           "connectivity_net464"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10297,7 +10297,7 @@
           "pcb_smtpad_295",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10316,7 +10316,7 @@
           "pcb_smtpad_296",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10335,7 +10335,7 @@
           "pcb_smtpad_296",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10354,7 +10354,7 @@
           "pcb_smtpad_296",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10373,7 +10373,7 @@
           "pcb_smtpad_296",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10392,7 +10392,7 @@
           "pcb_smtpad_297",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10411,7 +10411,7 @@
           "pcb_smtpad_297",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10430,7 +10430,7 @@
           "pcb_smtpad_297",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10449,7 +10449,7 @@
           "pcb_smtpad_297",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10468,7 +10468,7 @@
           "pcb_smtpad_298",
           "connectivity_net486"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10487,7 +10487,7 @@
           "pcb_smtpad_299",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10506,7 +10506,7 @@
           "pcb_smtpad_300",
           "connectivity_net475"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10525,7 +10525,7 @@
           "pcb_smtpad_301",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10544,7 +10544,7 @@
           "pcb_smtpad_302",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10563,7 +10563,7 @@
           "pcb_smtpad_302",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10582,7 +10582,7 @@
           "pcb_smtpad_302",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10601,7 +10601,7 @@
           "pcb_smtpad_302",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10620,7 +10620,7 @@
           "pcb_smtpad_303",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10639,7 +10639,7 @@
           "pcb_smtpad_303",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10658,7 +10658,7 @@
           "pcb_smtpad_303",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10677,7 +10677,7 @@
           "pcb_smtpad_303",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10696,7 +10696,7 @@
           "pcb_smtpad_304",
           "connectivity_net497"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10715,7 +10715,7 @@
           "pcb_smtpad_305",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10734,7 +10734,7 @@
           "pcb_smtpad_306",
           "connectivity_net486"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10753,7 +10753,7 @@
           "pcb_smtpad_307",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10772,7 +10772,7 @@
           "pcb_smtpad_308",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10791,7 +10791,7 @@
           "pcb_smtpad_308",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10810,7 +10810,7 @@
           "pcb_smtpad_308",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10829,7 +10829,7 @@
           "pcb_smtpad_308",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10848,7 +10848,7 @@
           "pcb_smtpad_309",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10867,7 +10867,7 @@
           "pcb_smtpad_309",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10886,7 +10886,7 @@
           "pcb_smtpad_309",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10905,7 +10905,7 @@
           "pcb_smtpad_309",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10924,7 +10924,7 @@
           "pcb_smtpad_310",
           "connectivity_net508"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10943,7 +10943,7 @@
           "pcb_smtpad_311",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10962,7 +10962,7 @@
           "pcb_smtpad_312",
           "connectivity_net497"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -10981,7 +10981,7 @@
           "pcb_smtpad_313",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11000,7 +11000,7 @@
           "pcb_smtpad_314",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11019,7 +11019,7 @@
           "pcb_smtpad_314",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11038,7 +11038,7 @@
           "pcb_smtpad_314",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11057,7 +11057,7 @@
           "pcb_smtpad_314",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11076,7 +11076,7 @@
           "pcb_smtpad_315",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11095,7 +11095,7 @@
           "pcb_smtpad_315",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11114,7 +11114,7 @@
           "pcb_smtpad_315",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11133,7 +11133,7 @@
           "pcb_smtpad_315",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11152,7 +11152,7 @@
           "pcb_smtpad_316",
           "connectivity_net519"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11171,7 +11171,7 @@
           "pcb_smtpad_317",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11190,7 +11190,7 @@
           "pcb_smtpad_318",
           "connectivity_net508"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11209,7 +11209,7 @@
           "pcb_smtpad_319",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11228,7 +11228,7 @@
           "pcb_smtpad_320",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11247,7 +11247,7 @@
           "pcb_smtpad_320",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11266,7 +11266,7 @@
           "pcb_smtpad_320",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11285,7 +11285,7 @@
           "pcb_smtpad_320",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11304,7 +11304,7 @@
           "pcb_smtpad_321",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11323,7 +11323,7 @@
           "pcb_smtpad_321",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11342,7 +11342,7 @@
           "pcb_smtpad_321",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11361,7 +11361,7 @@
           "pcb_smtpad_321",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11380,7 +11380,7 @@
           "pcb_smtpad_322",
           "connectivity_net530"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11399,7 +11399,7 @@
           "pcb_smtpad_323",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11418,7 +11418,7 @@
           "pcb_smtpad_324",
           "connectivity_net519"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11437,7 +11437,7 @@
           "pcb_smtpad_325",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11456,7 +11456,7 @@
           "pcb_smtpad_326",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11475,7 +11475,7 @@
           "pcb_smtpad_326",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11494,7 +11494,7 @@
           "pcb_smtpad_326",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11513,7 +11513,7 @@
           "pcb_smtpad_326",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11532,7 +11532,7 @@
           "pcb_smtpad_327",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11551,7 +11551,7 @@
           "pcb_smtpad_327",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11570,7 +11570,7 @@
           "pcb_smtpad_327",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11589,7 +11589,7 @@
           "pcb_smtpad_327",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11608,7 +11608,7 @@
           "pcb_smtpad_328",
           "connectivity_net541"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11627,7 +11627,7 @@
           "pcb_smtpad_329",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11646,7 +11646,7 @@
           "pcb_smtpad_330",
           "connectivity_net530"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11665,7 +11665,7 @@
           "pcb_smtpad_331",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11684,7 +11684,7 @@
           "pcb_smtpad_332",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11703,7 +11703,7 @@
           "pcb_smtpad_332",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11722,7 +11722,7 @@
           "pcb_smtpad_332",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11741,7 +11741,7 @@
           "pcb_smtpad_332",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11760,7 +11760,7 @@
           "pcb_smtpad_333",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11779,7 +11779,7 @@
           "pcb_smtpad_333",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11798,7 +11798,7 @@
           "pcb_smtpad_333",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11817,7 +11817,7 @@
           "pcb_smtpad_333",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11836,7 +11836,7 @@
           "pcb_smtpad_334",
           "connectivity_net552"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11855,7 +11855,7 @@
           "pcb_smtpad_335",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11874,7 +11874,7 @@
           "pcb_smtpad_336",
           "connectivity_net541"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11893,7 +11893,7 @@
           "pcb_smtpad_337",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11912,7 +11912,7 @@
           "pcb_smtpad_338",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11931,7 +11931,7 @@
           "pcb_smtpad_338",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11950,7 +11950,7 @@
           "pcb_smtpad_338",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11969,7 +11969,7 @@
           "pcb_smtpad_338",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -11988,7 +11988,7 @@
           "pcb_smtpad_339",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12007,7 +12007,7 @@
           "pcb_smtpad_339",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12026,7 +12026,7 @@
           "pcb_smtpad_339",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12045,7 +12045,7 @@
           "pcb_smtpad_339",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12064,7 +12064,7 @@
           "pcb_smtpad_340",
           "connectivity_net563"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12083,7 +12083,7 @@
           "pcb_smtpad_341",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12102,7 +12102,7 @@
           "pcb_smtpad_342",
           "connectivity_net552"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12121,7 +12121,7 @@
           "pcb_smtpad_343",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12140,7 +12140,7 @@
           "pcb_smtpad_344",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12159,7 +12159,7 @@
           "pcb_smtpad_344",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12178,7 +12178,7 @@
           "pcb_smtpad_344",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12197,7 +12197,7 @@
           "pcb_smtpad_344",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12216,7 +12216,7 @@
           "pcb_smtpad_345",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12235,7 +12235,7 @@
           "pcb_smtpad_345",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12254,7 +12254,7 @@
           "pcb_smtpad_345",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12273,7 +12273,7 @@
           "pcb_smtpad_345",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12292,7 +12292,7 @@
           "pcb_smtpad_346",
           "connectivity_net574"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12311,7 +12311,7 @@
           "pcb_smtpad_347",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12330,7 +12330,7 @@
           "pcb_smtpad_348",
           "connectivity_net563"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12349,7 +12349,7 @@
           "pcb_smtpad_349",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12368,7 +12368,7 @@
           "pcb_smtpad_350",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12387,7 +12387,7 @@
           "pcb_smtpad_350",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12406,7 +12406,7 @@
           "pcb_smtpad_350",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12425,7 +12425,7 @@
           "pcb_smtpad_350",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12444,7 +12444,7 @@
           "pcb_smtpad_351",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12463,7 +12463,7 @@
           "pcb_smtpad_351",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12482,7 +12482,7 @@
           "pcb_smtpad_351",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12501,7 +12501,7 @@
           "pcb_smtpad_351",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12520,7 +12520,7 @@
           "pcb_smtpad_352",
           "connectivity_net585"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12539,7 +12539,7 @@
           "pcb_smtpad_353",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12558,7 +12558,7 @@
           "pcb_smtpad_354",
           "connectivity_net574"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12577,7 +12577,7 @@
           "pcb_smtpad_355",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12596,7 +12596,7 @@
           "pcb_smtpad_356",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12615,7 +12615,7 @@
           "pcb_smtpad_356",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12634,7 +12634,7 @@
           "pcb_smtpad_356",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12653,7 +12653,7 @@
           "pcb_smtpad_356",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12672,7 +12672,7 @@
           "pcb_smtpad_357",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12691,7 +12691,7 @@
           "pcb_smtpad_357",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12710,7 +12710,7 @@
           "pcb_smtpad_357",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12729,7 +12729,7 @@
           "pcb_smtpad_357",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12748,7 +12748,7 @@
           "pcb_smtpad_358",
           "connectivity_net596"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12767,7 +12767,7 @@
           "pcb_smtpad_359",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12786,7 +12786,7 @@
           "pcb_smtpad_360",
           "connectivity_net585"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12805,7 +12805,7 @@
           "pcb_smtpad_361",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12824,7 +12824,7 @@
           "pcb_smtpad_362",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12843,7 +12843,7 @@
           "pcb_smtpad_362",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12862,7 +12862,7 @@
           "pcb_smtpad_362",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12881,7 +12881,7 @@
           "pcb_smtpad_362",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12900,7 +12900,7 @@
           "pcb_smtpad_363",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12919,7 +12919,7 @@
           "pcb_smtpad_363",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12938,7 +12938,7 @@
           "pcb_smtpad_363",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12957,7 +12957,7 @@
           "pcb_smtpad_363",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12976,7 +12976,7 @@
           "pcb_smtpad_364",
           "connectivity_net607"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -12995,7 +12995,7 @@
           "pcb_smtpad_365",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13014,7 +13014,7 @@
           "pcb_smtpad_366",
           "connectivity_net596"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13033,7 +13033,7 @@
           "pcb_smtpad_367",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13052,7 +13052,7 @@
           "pcb_smtpad_368",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13071,7 +13071,7 @@
           "pcb_smtpad_368",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13090,7 +13090,7 @@
           "pcb_smtpad_368",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13109,7 +13109,7 @@
           "pcb_smtpad_368",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13128,7 +13128,7 @@
           "pcb_smtpad_369",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13147,7 +13147,7 @@
           "pcb_smtpad_369",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13166,7 +13166,7 @@
           "pcb_smtpad_369",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13185,7 +13185,7 @@
           "pcb_smtpad_369",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13204,7 +13204,7 @@
           "pcb_smtpad_370",
           "connectivity_net618"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13223,7 +13223,7 @@
           "pcb_smtpad_371",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13242,7 +13242,7 @@
           "pcb_smtpad_372",
           "connectivity_net607"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13261,7 +13261,7 @@
           "pcb_smtpad_373",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13280,7 +13280,7 @@
           "pcb_smtpad_374",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13299,7 +13299,7 @@
           "pcb_smtpad_374",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13318,7 +13318,7 @@
           "pcb_smtpad_374",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13337,7 +13337,7 @@
           "pcb_smtpad_374",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13356,7 +13356,7 @@
           "pcb_smtpad_375",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13375,7 +13375,7 @@
           "pcb_smtpad_375",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13394,7 +13394,7 @@
           "pcb_smtpad_375",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13413,7 +13413,7 @@
           "pcb_smtpad_375",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13432,7 +13432,7 @@
           "pcb_smtpad_376",
           "connectivity_net629"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13451,7 +13451,7 @@
           "pcb_smtpad_377",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13470,7 +13470,7 @@
           "pcb_smtpad_378",
           "connectivity_net618"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13489,7 +13489,7 @@
           "pcb_smtpad_379",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13508,7 +13508,7 @@
           "pcb_smtpad_380",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13527,7 +13527,7 @@
           "pcb_smtpad_380",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13546,7 +13546,7 @@
           "pcb_smtpad_380",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13565,7 +13565,7 @@
           "pcb_smtpad_380",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13584,7 +13584,7 @@
           "pcb_smtpad_381",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13603,7 +13603,7 @@
           "pcb_smtpad_381",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13622,7 +13622,7 @@
           "pcb_smtpad_381",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13641,7 +13641,7 @@
           "pcb_smtpad_381",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13660,7 +13660,7 @@
           "pcb_smtpad_382",
           "connectivity_net640"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13679,7 +13679,7 @@
           "pcb_smtpad_383",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13698,7 +13698,7 @@
           "pcb_smtpad_384",
           "connectivity_net629"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13717,7 +13717,7 @@
           "pcb_smtpad_385",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13736,7 +13736,7 @@
           "pcb_smtpad_386",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13755,7 +13755,7 @@
           "pcb_smtpad_386",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13774,7 +13774,7 @@
           "pcb_smtpad_386",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13793,7 +13793,7 @@
           "pcb_smtpad_386",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13812,7 +13812,7 @@
           "pcb_smtpad_387",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13831,7 +13831,7 @@
           "pcb_smtpad_387",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13850,7 +13850,7 @@
           "pcb_smtpad_387",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13869,7 +13869,7 @@
           "pcb_smtpad_387",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13888,7 +13888,7 @@
           "pcb_smtpad_388",
           "connectivity_net651"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13907,7 +13907,7 @@
           "pcb_smtpad_389",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13926,7 +13926,7 @@
           "pcb_smtpad_390",
           "connectivity_net640"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13945,7 +13945,7 @@
           "pcb_smtpad_391",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13964,7 +13964,7 @@
           "pcb_smtpad_392",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -13983,7 +13983,7 @@
           "pcb_smtpad_392",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14002,7 +14002,7 @@
           "pcb_smtpad_392",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14021,7 +14021,7 @@
           "pcb_smtpad_392",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14040,7 +14040,7 @@
           "pcb_smtpad_393",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14059,7 +14059,7 @@
           "pcb_smtpad_393",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14078,7 +14078,7 @@
           "pcb_smtpad_393",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14097,7 +14097,7 @@
           "pcb_smtpad_393",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14116,7 +14116,7 @@
           "pcb_smtpad_394",
           "connectivity_net662"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14135,7 +14135,7 @@
           "pcb_smtpad_395",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14154,7 +14154,7 @@
           "pcb_smtpad_396",
           "connectivity_net651"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14173,7 +14173,7 @@
           "pcb_smtpad_397",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14192,7 +14192,7 @@
           "pcb_smtpad_398",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14211,7 +14211,7 @@
           "pcb_smtpad_398",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14230,7 +14230,7 @@
           "pcb_smtpad_398",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14249,7 +14249,7 @@
           "pcb_smtpad_398",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14268,7 +14268,7 @@
           "pcb_smtpad_399",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14287,7 +14287,7 @@
           "pcb_smtpad_399",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14306,7 +14306,7 @@
           "pcb_smtpad_399",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14325,7 +14325,7 @@
           "pcb_smtpad_399",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14344,7 +14344,7 @@
           "pcb_smtpad_400",
           "connectivity_net673"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14363,7 +14363,7 @@
           "pcb_smtpad_401",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14382,7 +14382,7 @@
           "pcb_smtpad_402",
           "connectivity_net662"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14401,7 +14401,7 @@
           "pcb_smtpad_403",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14420,7 +14420,7 @@
           "pcb_smtpad_404",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14439,7 +14439,7 @@
           "pcb_smtpad_404",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14458,7 +14458,7 @@
           "pcb_smtpad_404",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14477,7 +14477,7 @@
           "pcb_smtpad_404",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14496,7 +14496,7 @@
           "pcb_smtpad_405",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14515,7 +14515,7 @@
           "pcb_smtpad_405",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14534,7 +14534,7 @@
           "pcb_smtpad_405",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14553,7 +14553,7 @@
           "pcb_smtpad_405",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14572,7 +14572,7 @@
           "pcb_smtpad_406",
           "connectivity_net684"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14591,7 +14591,7 @@
           "pcb_smtpad_407",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14610,7 +14610,7 @@
           "pcb_smtpad_408",
           "connectivity_net673"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14629,7 +14629,7 @@
           "pcb_smtpad_409",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14648,7 +14648,7 @@
           "pcb_smtpad_410",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14667,7 +14667,7 @@
           "pcb_smtpad_410",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14686,7 +14686,7 @@
           "pcb_smtpad_410",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14705,7 +14705,7 @@
           "pcb_smtpad_410",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14724,7 +14724,7 @@
           "pcb_smtpad_411",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14743,7 +14743,7 @@
           "pcb_smtpad_411",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14762,7 +14762,7 @@
           "pcb_smtpad_411",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14781,7 +14781,7 @@
           "pcb_smtpad_411",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14800,7 +14800,7 @@
           "pcb_smtpad_412",
           "connectivity_net695"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14819,7 +14819,7 @@
           "pcb_smtpad_413",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14838,7 +14838,7 @@
           "pcb_smtpad_414",
           "connectivity_net684"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14857,7 +14857,7 @@
           "pcb_smtpad_415",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14876,7 +14876,7 @@
           "pcb_smtpad_416",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14895,7 +14895,7 @@
           "pcb_smtpad_416",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14914,7 +14914,7 @@
           "pcb_smtpad_416",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14933,7 +14933,7 @@
           "pcb_smtpad_416",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14952,7 +14952,7 @@
           "pcb_smtpad_417",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14971,7 +14971,7 @@
           "pcb_smtpad_417",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -14990,7 +14990,7 @@
           "pcb_smtpad_417",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15009,7 +15009,7 @@
           "pcb_smtpad_417",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15028,7 +15028,7 @@
           "pcb_smtpad_418",
           "connectivity_net706"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15047,7 +15047,7 @@
           "pcb_smtpad_419",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15066,7 +15066,7 @@
           "pcb_smtpad_420",
           "connectivity_net695"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15085,7 +15085,7 @@
           "pcb_smtpad_421",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15104,7 +15104,7 @@
           "pcb_smtpad_422",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15123,7 +15123,7 @@
           "pcb_smtpad_422",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15142,7 +15142,7 @@
           "pcb_smtpad_422",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15161,7 +15161,7 @@
           "pcb_smtpad_422",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15180,7 +15180,7 @@
           "pcb_smtpad_423",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15199,7 +15199,7 @@
           "pcb_smtpad_423",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15218,7 +15218,7 @@
           "pcb_smtpad_423",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15237,7 +15237,7 @@
           "pcb_smtpad_423",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15256,7 +15256,7 @@
           "pcb_smtpad_424",
           "connectivity_net717"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15275,7 +15275,7 @@
           "pcb_smtpad_425",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15294,7 +15294,7 @@
           "pcb_smtpad_426",
           "connectivity_net706"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15313,7 +15313,7 @@
           "pcb_smtpad_427",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15332,7 +15332,7 @@
           "pcb_smtpad_428",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15351,7 +15351,7 @@
           "pcb_smtpad_428",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15370,7 +15370,7 @@
           "pcb_smtpad_428",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15389,7 +15389,7 @@
           "pcb_smtpad_428",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15408,7 +15408,7 @@
           "pcb_smtpad_429",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15427,7 +15427,7 @@
           "pcb_smtpad_429",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15446,7 +15446,7 @@
           "pcb_smtpad_429",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15465,7 +15465,7 @@
           "pcb_smtpad_429",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15484,7 +15484,7 @@
           "pcb_smtpad_430",
           "connectivity_net728"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15503,7 +15503,7 @@
           "pcb_smtpad_431",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15522,7 +15522,7 @@
           "pcb_smtpad_432",
           "connectivity_net717"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15541,7 +15541,7 @@
           "pcb_smtpad_433",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15560,7 +15560,7 @@
           "pcb_smtpad_434",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15579,7 +15579,7 @@
           "pcb_smtpad_434",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15598,7 +15598,7 @@
           "pcb_smtpad_434",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15617,7 +15617,7 @@
           "pcb_smtpad_434",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15636,7 +15636,7 @@
           "pcb_smtpad_435",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15655,7 +15655,7 @@
           "pcb_smtpad_435",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15674,7 +15674,7 @@
           "pcb_smtpad_435",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15693,7 +15693,7 @@
           "pcb_smtpad_435",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15712,7 +15712,7 @@
           "pcb_smtpad_436",
           "connectivity_net739"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15731,7 +15731,7 @@
           "pcb_smtpad_437",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15750,7 +15750,7 @@
           "pcb_smtpad_438",
           "connectivity_net728"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15769,7 +15769,7 @@
           "pcb_smtpad_439",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15788,7 +15788,7 @@
           "pcb_smtpad_440",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15807,7 +15807,7 @@
           "pcb_smtpad_440",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15826,7 +15826,7 @@
           "pcb_smtpad_440",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15845,7 +15845,7 @@
           "pcb_smtpad_440",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15864,7 +15864,7 @@
           "pcb_smtpad_441",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15883,7 +15883,7 @@
           "pcb_smtpad_441",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15902,7 +15902,7 @@
           "pcb_smtpad_441",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15921,7 +15921,7 @@
           "pcb_smtpad_441",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15940,7 +15940,7 @@
           "pcb_smtpad_442",
           "connectivity_net750"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15959,7 +15959,7 @@
           "pcb_smtpad_443",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15978,7 +15978,7 @@
           "pcb_smtpad_444",
           "connectivity_net739"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -15997,7 +15997,7 @@
           "pcb_smtpad_445",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16016,7 +16016,7 @@
           "pcb_smtpad_446",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16035,7 +16035,7 @@
           "pcb_smtpad_446",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16054,7 +16054,7 @@
           "pcb_smtpad_446",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16073,7 +16073,7 @@
           "pcb_smtpad_446",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16092,7 +16092,7 @@
           "pcb_smtpad_447",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16111,7 +16111,7 @@
           "pcb_smtpad_447",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16130,7 +16130,7 @@
           "pcb_smtpad_447",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16149,7 +16149,7 @@
           "pcb_smtpad_447",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16168,7 +16168,7 @@
           "pcb_smtpad_448",
           "connectivity_net761"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16187,7 +16187,7 @@
           "pcb_smtpad_449",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16206,7 +16206,7 @@
           "pcb_smtpad_450",
           "connectivity_net750"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16225,7 +16225,7 @@
           "pcb_smtpad_451",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16244,7 +16244,7 @@
           "pcb_smtpad_452",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16263,7 +16263,7 @@
           "pcb_smtpad_452",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16282,7 +16282,7 @@
           "pcb_smtpad_452",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16301,7 +16301,7 @@
           "pcb_smtpad_452",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16320,7 +16320,7 @@
           "pcb_smtpad_453",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16339,7 +16339,7 @@
           "pcb_smtpad_453",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16358,7 +16358,7 @@
           "pcb_smtpad_453",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16377,7 +16377,7 @@
           "pcb_smtpad_453",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16396,7 +16396,7 @@
           "pcb_smtpad_454",
           "connectivity_net772"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16415,7 +16415,7 @@
           "pcb_smtpad_455",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16434,7 +16434,7 @@
           "pcb_smtpad_456",
           "connectivity_net761"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16453,7 +16453,7 @@
           "pcb_smtpad_457",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16472,7 +16472,7 @@
           "pcb_smtpad_458",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16491,7 +16491,7 @@
           "pcb_smtpad_458",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16510,7 +16510,7 @@
           "pcb_smtpad_458",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16529,7 +16529,7 @@
           "pcb_smtpad_458",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16548,7 +16548,7 @@
           "pcb_smtpad_459",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16567,7 +16567,7 @@
           "pcb_smtpad_459",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16586,7 +16586,7 @@
           "pcb_smtpad_459",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16605,7 +16605,7 @@
           "pcb_smtpad_459",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16624,7 +16624,7 @@
           "pcb_smtpad_460",
           "connectivity_net783"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16643,7 +16643,7 @@
           "pcb_smtpad_461",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16662,7 +16662,7 @@
           "pcb_smtpad_462",
           "connectivity_net772"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16681,7 +16681,7 @@
           "pcb_smtpad_463",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16700,7 +16700,7 @@
           "pcb_smtpad_464",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16719,7 +16719,7 @@
           "pcb_smtpad_464",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16738,7 +16738,7 @@
           "pcb_smtpad_464",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16757,7 +16757,7 @@
           "pcb_smtpad_464",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16776,7 +16776,7 @@
           "pcb_smtpad_465",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16795,7 +16795,7 @@
           "pcb_smtpad_465",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16814,7 +16814,7 @@
           "pcb_smtpad_465",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16833,7 +16833,7 @@
           "pcb_smtpad_465",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16852,7 +16852,7 @@
           "pcb_smtpad_466",
           "connectivity_net794"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16871,7 +16871,7 @@
           "pcb_smtpad_467",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16890,7 +16890,7 @@
           "pcb_smtpad_468",
           "connectivity_net783"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16909,7 +16909,7 @@
           "pcb_smtpad_469",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16928,7 +16928,7 @@
           "pcb_smtpad_470",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16947,7 +16947,7 @@
           "pcb_smtpad_470",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16966,7 +16966,7 @@
           "pcb_smtpad_470",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -16985,7 +16985,7 @@
           "pcb_smtpad_470",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17004,7 +17004,7 @@
           "pcb_smtpad_471",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17023,7 +17023,7 @@
           "pcb_smtpad_471",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17042,7 +17042,7 @@
           "pcb_smtpad_471",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17061,7 +17061,7 @@
           "pcb_smtpad_471",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17080,7 +17080,7 @@
           "pcb_smtpad_472",
           "connectivity_net805"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17099,7 +17099,7 @@
           "pcb_smtpad_473",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17118,7 +17118,7 @@
           "pcb_smtpad_474",
           "connectivity_net794"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17137,7 +17137,7 @@
           "pcb_smtpad_475",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17156,7 +17156,7 @@
           "pcb_smtpad_476",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17175,7 +17175,7 @@
           "pcb_smtpad_476",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17194,7 +17194,7 @@
           "pcb_smtpad_476",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17213,7 +17213,7 @@
           "pcb_smtpad_476",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17232,7 +17232,7 @@
           "pcb_smtpad_477",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17251,7 +17251,7 @@
           "pcb_smtpad_477",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17270,7 +17270,7 @@
           "pcb_smtpad_477",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17289,7 +17289,7 @@
           "pcb_smtpad_477",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17308,7 +17308,7 @@
           "pcb_smtpad_478",
           "connectivity_net816"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17327,7 +17327,7 @@
           "pcb_smtpad_479",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17346,7 +17346,7 @@
           "pcb_smtpad_480",
           "connectivity_net805"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17365,7 +17365,7 @@
           "pcb_smtpad_481",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17384,7 +17384,7 @@
           "pcb_smtpad_482",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17403,7 +17403,7 @@
           "pcb_smtpad_482",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17422,7 +17422,7 @@
           "pcb_smtpad_482",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17441,7 +17441,7 @@
           "pcb_smtpad_482",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17460,7 +17460,7 @@
           "pcb_smtpad_483",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17479,7 +17479,7 @@
           "pcb_smtpad_483",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17498,7 +17498,7 @@
           "pcb_smtpad_483",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17517,7 +17517,7 @@
           "pcb_smtpad_483",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17536,7 +17536,7 @@
           "pcb_smtpad_484",
           "connectivity_net827"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17555,7 +17555,7 @@
           "pcb_smtpad_485",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17574,7 +17574,7 @@
           "pcb_smtpad_486",
           "connectivity_net816"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17593,7 +17593,7 @@
           "pcb_smtpad_487",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17612,7 +17612,7 @@
           "pcb_smtpad_488",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17631,7 +17631,7 @@
           "pcb_smtpad_488",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17650,7 +17650,7 @@
           "pcb_smtpad_488",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17669,7 +17669,7 @@
           "pcb_smtpad_488",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17688,7 +17688,7 @@
           "pcb_smtpad_489",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17707,7 +17707,7 @@
           "pcb_smtpad_489",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17726,7 +17726,7 @@
           "pcb_smtpad_489",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17745,7 +17745,7 @@
           "pcb_smtpad_489",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17764,7 +17764,7 @@
           "pcb_smtpad_490",
           "connectivity_net838"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17783,7 +17783,7 @@
           "pcb_smtpad_491",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17802,7 +17802,7 @@
           "pcb_smtpad_492",
           "connectivity_net827"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17821,7 +17821,7 @@
           "pcb_smtpad_493",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17840,7 +17840,7 @@
           "pcb_smtpad_494",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17859,7 +17859,7 @@
           "pcb_smtpad_494",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17878,7 +17878,7 @@
           "pcb_smtpad_494",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17897,7 +17897,7 @@
           "pcb_smtpad_494",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17916,7 +17916,7 @@
           "pcb_smtpad_495",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17935,7 +17935,7 @@
           "pcb_smtpad_495",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17954,7 +17954,7 @@
           "pcb_smtpad_495",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17973,7 +17973,7 @@
           "pcb_smtpad_495",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -17992,7 +17992,7 @@
           "pcb_smtpad_496",
           "connectivity_net849"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18011,7 +18011,7 @@
           "pcb_smtpad_497",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18030,7 +18030,7 @@
           "pcb_smtpad_498",
           "connectivity_net838"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18049,7 +18049,7 @@
           "pcb_smtpad_499",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18068,7 +18068,7 @@
           "pcb_smtpad_500",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18087,7 +18087,7 @@
           "pcb_smtpad_500",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18106,7 +18106,7 @@
           "pcb_smtpad_500",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18125,7 +18125,7 @@
           "pcb_smtpad_500",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18144,7 +18144,7 @@
           "pcb_smtpad_501",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18163,7 +18163,7 @@
           "pcb_smtpad_501",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18182,7 +18182,7 @@
           "pcb_smtpad_501",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18201,7 +18201,7 @@
           "pcb_smtpad_501",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18220,7 +18220,7 @@
           "pcb_smtpad_502",
           "connectivity_net860"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18239,7 +18239,7 @@
           "pcb_smtpad_503",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18258,7 +18258,7 @@
           "pcb_smtpad_504",
           "connectivity_net849"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18277,7 +18277,7 @@
           "pcb_smtpad_505",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18296,7 +18296,7 @@
           "pcb_smtpad_506",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18315,7 +18315,7 @@
           "pcb_smtpad_506",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18334,7 +18334,7 @@
           "pcb_smtpad_506",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18353,7 +18353,7 @@
           "pcb_smtpad_506",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18372,7 +18372,7 @@
           "pcb_smtpad_507",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18391,7 +18391,7 @@
           "pcb_smtpad_507",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18410,7 +18410,7 @@
           "pcb_smtpad_507",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18429,7 +18429,7 @@
           "pcb_smtpad_507",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18448,7 +18448,7 @@
           "pcb_smtpad_508",
           "connectivity_net871"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18467,7 +18467,7 @@
           "pcb_smtpad_509",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18486,7 +18486,7 @@
           "pcb_smtpad_510",
           "connectivity_net860"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18505,7 +18505,7 @@
           "pcb_smtpad_511",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18524,7 +18524,7 @@
           "pcb_smtpad_512",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18543,7 +18543,7 @@
           "pcb_smtpad_512",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18562,7 +18562,7 @@
           "pcb_smtpad_512",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18581,7 +18581,7 @@
           "pcb_smtpad_512",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18600,7 +18600,7 @@
           "pcb_smtpad_513",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18619,7 +18619,7 @@
           "pcb_smtpad_513",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18638,7 +18638,7 @@
           "pcb_smtpad_513",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18657,7 +18657,7 @@
           "pcb_smtpad_513",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18676,7 +18676,7 @@
           "pcb_smtpad_514",
           "connectivity_net882"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18695,7 +18695,7 @@
           "pcb_smtpad_515",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18714,7 +18714,7 @@
           "pcb_smtpad_516",
           "connectivity_net871"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18733,7 +18733,7 @@
           "pcb_smtpad_517",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18752,7 +18752,7 @@
           "pcb_smtpad_518",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18771,7 +18771,7 @@
           "pcb_smtpad_518",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18790,7 +18790,7 @@
           "pcb_smtpad_518",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18809,7 +18809,7 @@
           "pcb_smtpad_518",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18828,7 +18828,7 @@
           "pcb_smtpad_519",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18847,7 +18847,7 @@
           "pcb_smtpad_519",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18866,7 +18866,7 @@
           "pcb_smtpad_519",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18885,7 +18885,7 @@
           "pcb_smtpad_519",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18904,7 +18904,7 @@
           "pcb_smtpad_520",
           "connectivity_net893"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18923,7 +18923,7 @@
           "pcb_smtpad_521",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18942,7 +18942,7 @@
           "pcb_smtpad_522",
           "connectivity_net882"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18961,7 +18961,7 @@
           "pcb_smtpad_523",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18980,7 +18980,7 @@
           "pcb_smtpad_524",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -18999,7 +18999,7 @@
           "pcb_smtpad_524",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19018,7 +19018,7 @@
           "pcb_smtpad_524",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19037,7 +19037,7 @@
           "pcb_smtpad_524",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19056,7 +19056,7 @@
           "pcb_smtpad_525",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19075,7 +19075,7 @@
           "pcb_smtpad_525",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19094,7 +19094,7 @@
           "pcb_smtpad_525",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19113,7 +19113,7 @@
           "pcb_smtpad_525",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19132,7 +19132,7 @@
           "pcb_smtpad_526",
           "connectivity_net904"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19151,7 +19151,7 @@
           "pcb_smtpad_527",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19170,7 +19170,7 @@
           "pcb_smtpad_528",
           "connectivity_net893"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19189,7 +19189,7 @@
           "pcb_smtpad_529",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19208,7 +19208,7 @@
           "pcb_smtpad_530",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19227,7 +19227,7 @@
           "pcb_smtpad_530",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19246,7 +19246,7 @@
           "pcb_smtpad_530",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19265,7 +19265,7 @@
           "pcb_smtpad_530",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19284,7 +19284,7 @@
           "pcb_smtpad_531",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19303,7 +19303,7 @@
           "pcb_smtpad_531",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19322,7 +19322,7 @@
           "pcb_smtpad_531",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19341,7 +19341,7 @@
           "pcb_smtpad_531",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19360,7 +19360,7 @@
           "pcb_smtpad_532",
           "connectivity_net915"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19379,7 +19379,7 @@
           "pcb_smtpad_533",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19398,7 +19398,7 @@
           "pcb_smtpad_534",
           "connectivity_net904"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19417,7 +19417,7 @@
           "pcb_smtpad_535",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19436,7 +19436,7 @@
           "pcb_smtpad_536",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19455,7 +19455,7 @@
           "pcb_smtpad_536",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19474,7 +19474,7 @@
           "pcb_smtpad_536",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19493,7 +19493,7 @@
           "pcb_smtpad_536",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19512,7 +19512,7 @@
           "pcb_smtpad_537",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19531,7 +19531,7 @@
           "pcb_smtpad_537",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19550,7 +19550,7 @@
           "pcb_smtpad_537",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19569,7 +19569,7 @@
           "pcb_smtpad_537",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19588,7 +19588,7 @@
           "pcb_smtpad_538",
           "connectivity_net926"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19607,7 +19607,7 @@
           "pcb_smtpad_539",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19626,7 +19626,7 @@
           "pcb_smtpad_540",
           "connectivity_net915"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19645,7 +19645,7 @@
           "pcb_smtpad_541",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19664,7 +19664,7 @@
           "pcb_smtpad_542",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19683,7 +19683,7 @@
           "pcb_smtpad_542",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19702,7 +19702,7 @@
           "pcb_smtpad_542",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19721,7 +19721,7 @@
           "pcb_smtpad_542",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19740,7 +19740,7 @@
           "pcb_smtpad_543",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19759,7 +19759,7 @@
           "pcb_smtpad_543",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19778,7 +19778,7 @@
           "pcb_smtpad_543",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19797,7 +19797,7 @@
           "pcb_smtpad_543",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19816,7 +19816,7 @@
           "pcb_smtpad_544",
           "connectivity_net937"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19835,7 +19835,7 @@
           "pcb_smtpad_545",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19854,7 +19854,7 @@
           "pcb_smtpad_546",
           "connectivity_net926"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19873,7 +19873,7 @@
           "pcb_smtpad_547",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19892,7 +19892,7 @@
           "pcb_smtpad_548",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19911,7 +19911,7 @@
           "pcb_smtpad_548",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19930,7 +19930,7 @@
           "pcb_smtpad_548",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19949,7 +19949,7 @@
           "pcb_smtpad_548",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19968,7 +19968,7 @@
           "pcb_smtpad_549",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -19987,7 +19987,7 @@
           "pcb_smtpad_549",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20006,7 +20006,7 @@
           "pcb_smtpad_549",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20025,7 +20025,7 @@
           "pcb_smtpad_549",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20044,7 +20044,7 @@
           "pcb_smtpad_550",
           "connectivity_net948"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20063,7 +20063,7 @@
           "pcb_smtpad_551",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20082,7 +20082,7 @@
           "pcb_smtpad_552",
           "connectivity_net937"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20101,7 +20101,7 @@
           "pcb_smtpad_553",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20120,7 +20120,7 @@
           "pcb_smtpad_554",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20139,7 +20139,7 @@
           "pcb_smtpad_554",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20158,7 +20158,7 @@
           "pcb_smtpad_554",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20177,7 +20177,7 @@
           "pcb_smtpad_554",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20196,7 +20196,7 @@
           "pcb_smtpad_555",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20215,7 +20215,7 @@
           "pcb_smtpad_555",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20234,7 +20234,7 @@
           "pcb_smtpad_555",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20253,7 +20253,7 @@
           "pcb_smtpad_555",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20272,7 +20272,7 @@
           "pcb_smtpad_556",
           "connectivity_net959"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20291,7 +20291,7 @@
           "pcb_smtpad_557",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20310,7 +20310,7 @@
           "pcb_smtpad_558",
           "connectivity_net948"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20329,7 +20329,7 @@
           "pcb_smtpad_559",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20348,7 +20348,7 @@
           "pcb_smtpad_560",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20367,7 +20367,7 @@
           "pcb_smtpad_560",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20386,7 +20386,7 @@
           "pcb_smtpad_560",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20405,7 +20405,7 @@
           "pcb_smtpad_560",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20424,7 +20424,7 @@
           "pcb_smtpad_561",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20443,7 +20443,7 @@
           "pcb_smtpad_561",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20462,7 +20462,7 @@
           "pcb_smtpad_561",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20481,7 +20481,7 @@
           "pcb_smtpad_561",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20500,7 +20500,7 @@
           "pcb_smtpad_562",
           "connectivity_net970"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20519,7 +20519,7 @@
           "pcb_smtpad_563",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20538,7 +20538,7 @@
           "pcb_smtpad_564",
           "connectivity_net959"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20557,7 +20557,7 @@
           "pcb_smtpad_565",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20576,7 +20576,7 @@
           "pcb_smtpad_566",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20595,7 +20595,7 @@
           "pcb_smtpad_566",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20614,7 +20614,7 @@
           "pcb_smtpad_566",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20633,7 +20633,7 @@
           "pcb_smtpad_566",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20652,7 +20652,7 @@
           "pcb_smtpad_567",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20671,7 +20671,7 @@
           "pcb_smtpad_567",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20690,7 +20690,7 @@
           "pcb_smtpad_567",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20709,7 +20709,7 @@
           "pcb_smtpad_567",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20728,7 +20728,7 @@
           "pcb_smtpad_568",
           "connectivity_net981"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20747,7 +20747,7 @@
           "pcb_smtpad_569",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20766,7 +20766,7 @@
           "pcb_smtpad_570",
           "connectivity_net970"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20785,7 +20785,7 @@
           "pcb_smtpad_571",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20804,7 +20804,7 @@
           "pcb_smtpad_572",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20823,7 +20823,7 @@
           "pcb_smtpad_572",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20842,7 +20842,7 @@
           "pcb_smtpad_572",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20861,7 +20861,7 @@
           "pcb_smtpad_572",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20880,7 +20880,7 @@
           "pcb_smtpad_573",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20899,7 +20899,7 @@
           "pcb_smtpad_573",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20918,7 +20918,7 @@
           "pcb_smtpad_573",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20937,7 +20937,7 @@
           "pcb_smtpad_573",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20956,7 +20956,7 @@
           "pcb_smtpad_574",
           "connectivity_net992"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20975,7 +20975,7 @@
           "pcb_smtpad_575",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -20994,7 +20994,7 @@
           "pcb_smtpad_576",
           "connectivity_net981"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21013,7 +21013,7 @@
           "pcb_smtpad_577",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21032,7 +21032,7 @@
           "pcb_smtpad_578",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21051,7 +21051,7 @@
           "pcb_smtpad_578",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21070,7 +21070,7 @@
           "pcb_smtpad_578",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21089,7 +21089,7 @@
           "pcb_smtpad_578",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21108,7 +21108,7 @@
           "pcb_smtpad_579",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21127,7 +21127,7 @@
           "pcb_smtpad_579",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21146,7 +21146,7 @@
           "pcb_smtpad_579",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21165,7 +21165,7 @@
           "pcb_smtpad_579",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21184,7 +21184,7 @@
           "pcb_smtpad_580",
           "connectivity_net1003"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21203,7 +21203,7 @@
           "pcb_smtpad_581",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21222,7 +21222,7 @@
           "pcb_smtpad_582",
           "connectivity_net992"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21241,7 +21241,7 @@
           "pcb_smtpad_583",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21260,7 +21260,7 @@
           "pcb_smtpad_584",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21279,7 +21279,7 @@
           "pcb_smtpad_584",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21298,7 +21298,7 @@
           "pcb_smtpad_584",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21317,7 +21317,7 @@
           "pcb_smtpad_584",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21336,7 +21336,7 @@
           "pcb_smtpad_585",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21355,7 +21355,7 @@
           "pcb_smtpad_585",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21374,7 +21374,7 @@
           "pcb_smtpad_585",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21393,7 +21393,7 @@
           "pcb_smtpad_585",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21412,7 +21412,7 @@
           "pcb_smtpad_586",
           "connectivity_net1014"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21431,7 +21431,7 @@
           "pcb_smtpad_587",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21450,7 +21450,7 @@
           "pcb_smtpad_588",
           "connectivity_net1003"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21469,7 +21469,7 @@
           "pcb_smtpad_589",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21488,7 +21488,7 @@
           "pcb_smtpad_590",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21507,7 +21507,7 @@
           "pcb_smtpad_590",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21526,7 +21526,7 @@
           "pcb_smtpad_590",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21545,7 +21545,7 @@
           "pcb_smtpad_590",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21564,7 +21564,7 @@
           "pcb_smtpad_591",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21583,7 +21583,7 @@
           "pcb_smtpad_591",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21602,7 +21602,7 @@
           "pcb_smtpad_591",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21621,7 +21621,7 @@
           "pcb_smtpad_591",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21640,7 +21640,7 @@
           "pcb_smtpad_592",
           "connectivity_net1025"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21659,7 +21659,7 @@
           "pcb_smtpad_593",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21678,7 +21678,7 @@
           "pcb_smtpad_594",
           "connectivity_net1014"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21697,7 +21697,7 @@
           "pcb_smtpad_595",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21716,7 +21716,7 @@
           "pcb_smtpad_596",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21735,7 +21735,7 @@
           "pcb_smtpad_596",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21754,7 +21754,7 @@
           "pcb_smtpad_596",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21773,7 +21773,7 @@
           "pcb_smtpad_596",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21792,7 +21792,7 @@
           "pcb_smtpad_597",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21811,7 +21811,7 @@
           "pcb_smtpad_597",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21830,7 +21830,7 @@
           "pcb_smtpad_597",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21849,7 +21849,7 @@
           "pcb_smtpad_597",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21868,7 +21868,7 @@
           "pcb_smtpad_598",
           "connectivity_net1036"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21887,7 +21887,7 @@
           "pcb_smtpad_599",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21906,7 +21906,7 @@
           "pcb_smtpad_600",
           "connectivity_net1025"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21925,7 +21925,7 @@
           "pcb_smtpad_601",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21944,7 +21944,7 @@
           "pcb_smtpad_602",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21963,7 +21963,7 @@
           "pcb_smtpad_602",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -21982,7 +21982,7 @@
           "pcb_smtpad_602",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22001,7 +22001,7 @@
           "pcb_smtpad_602",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22020,7 +22020,7 @@
           "pcb_smtpad_603",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22039,7 +22039,7 @@
           "pcb_smtpad_603",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22058,7 +22058,7 @@
           "pcb_smtpad_603",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22077,7 +22077,7 @@
           "pcb_smtpad_603",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22096,7 +22096,7 @@
           "pcb_smtpad_604",
           "connectivity_net1047"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22115,7 +22115,7 @@
           "pcb_smtpad_605",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22134,7 +22134,7 @@
           "pcb_smtpad_606",
           "connectivity_net1036"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22153,7 +22153,7 @@
           "pcb_smtpad_607",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22172,7 +22172,7 @@
           "pcb_smtpad_608",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22191,7 +22191,7 @@
           "pcb_smtpad_608",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22210,7 +22210,7 @@
           "pcb_smtpad_608",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22229,7 +22229,7 @@
           "pcb_smtpad_608",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22248,7 +22248,7 @@
           "pcb_smtpad_609",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22267,7 +22267,7 @@
           "pcb_smtpad_609",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22286,7 +22286,7 @@
           "pcb_smtpad_609",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22305,7 +22305,7 @@
           "pcb_smtpad_609",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22324,7 +22324,7 @@
           "pcb_smtpad_610",
           "connectivity_net1058"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22343,7 +22343,7 @@
           "pcb_smtpad_611",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22362,7 +22362,7 @@
           "pcb_smtpad_612",
           "connectivity_net1047"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22381,7 +22381,7 @@
           "pcb_smtpad_613",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22400,7 +22400,7 @@
           "pcb_smtpad_614",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22419,7 +22419,7 @@
           "pcb_smtpad_614",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22438,7 +22438,7 @@
           "pcb_smtpad_614",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22457,7 +22457,7 @@
           "pcb_smtpad_614",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22476,7 +22476,7 @@
           "pcb_smtpad_615",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22495,7 +22495,7 @@
           "pcb_smtpad_615",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22514,7 +22514,7 @@
           "pcb_smtpad_615",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22533,7 +22533,7 @@
           "pcb_smtpad_615",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22552,7 +22552,7 @@
           "pcb_smtpad_616",
           "connectivity_net1069"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22571,7 +22571,7 @@
           "pcb_smtpad_617",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22590,7 +22590,7 @@
           "pcb_smtpad_618",
           "connectivity_net1058"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22609,7 +22609,7 @@
           "pcb_smtpad_619",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22628,7 +22628,7 @@
           "pcb_smtpad_620",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22647,7 +22647,7 @@
           "pcb_smtpad_620",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22666,7 +22666,7 @@
           "pcb_smtpad_620",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22685,7 +22685,7 @@
           "pcb_smtpad_620",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22704,7 +22704,7 @@
           "pcb_smtpad_621",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22723,7 +22723,7 @@
           "pcb_smtpad_621",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22742,7 +22742,7 @@
           "pcb_smtpad_621",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22761,7 +22761,7 @@
           "pcb_smtpad_621",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22780,7 +22780,7 @@
           "pcb_smtpad_622",
           "connectivity_net1080"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22799,7 +22799,7 @@
           "pcb_smtpad_623",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22818,7 +22818,7 @@
           "pcb_smtpad_624",
           "connectivity_net1069"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22837,7 +22837,7 @@
           "pcb_smtpad_625",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22856,7 +22856,7 @@
           "pcb_smtpad_626",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22875,7 +22875,7 @@
           "pcb_smtpad_626",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22894,7 +22894,7 @@
           "pcb_smtpad_626",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22913,7 +22913,7 @@
           "pcb_smtpad_626",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22932,7 +22932,7 @@
           "pcb_smtpad_627",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22951,7 +22951,7 @@
           "pcb_smtpad_627",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22970,7 +22970,7 @@
           "pcb_smtpad_627",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -22989,7 +22989,7 @@
           "pcb_smtpad_627",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23008,7 +23008,7 @@
           "pcb_smtpad_628",
           "connectivity_net1091"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23027,7 +23027,7 @@
           "pcb_smtpad_629",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23046,7 +23046,7 @@
           "pcb_smtpad_630",
           "connectivity_net1080"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23065,7 +23065,7 @@
           "pcb_smtpad_631",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23084,7 +23084,7 @@
           "pcb_smtpad_632",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23103,7 +23103,7 @@
           "pcb_smtpad_632",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23122,7 +23122,7 @@
           "pcb_smtpad_632",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23141,7 +23141,7 @@
           "pcb_smtpad_632",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23160,7 +23160,7 @@
           "pcb_smtpad_633",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23179,7 +23179,7 @@
           "pcb_smtpad_633",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23198,7 +23198,7 @@
           "pcb_smtpad_633",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23217,7 +23217,7 @@
           "pcb_smtpad_633",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23236,7 +23236,7 @@
           "pcb_smtpad_634",
           "connectivity_net1102"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23255,7 +23255,7 @@
           "pcb_smtpad_635",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23274,7 +23274,7 @@
           "pcb_smtpad_636",
           "connectivity_net1091"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23293,7 +23293,7 @@
           "pcb_smtpad_637",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23312,7 +23312,7 @@
           "pcb_smtpad_638",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23331,7 +23331,7 @@
           "pcb_smtpad_638",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23350,7 +23350,7 @@
           "pcb_smtpad_638",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23369,7 +23369,7 @@
           "pcb_smtpad_638",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23388,7 +23388,7 @@
           "pcb_smtpad_639",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23407,7 +23407,7 @@
           "pcb_smtpad_639",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23426,7 +23426,7 @@
           "pcb_smtpad_639",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23445,7 +23445,7 @@
           "pcb_smtpad_639",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23464,7 +23464,7 @@
           "pcb_smtpad_640",
           "connectivity_net1113"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23483,7 +23483,7 @@
           "pcb_smtpad_641",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23502,7 +23502,7 @@
           "pcb_smtpad_642",
           "connectivity_net1102"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23521,7 +23521,7 @@
           "pcb_smtpad_643",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23540,7 +23540,7 @@
           "pcb_smtpad_644",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23559,7 +23559,7 @@
           "pcb_smtpad_644",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23578,7 +23578,7 @@
           "pcb_smtpad_644",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23597,7 +23597,7 @@
           "pcb_smtpad_644",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23616,7 +23616,7 @@
           "pcb_smtpad_645",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23635,7 +23635,7 @@
           "pcb_smtpad_645",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23654,7 +23654,7 @@
           "pcb_smtpad_645",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23673,7 +23673,7 @@
           "pcb_smtpad_645",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23692,7 +23692,7 @@
           "pcb_smtpad_646",
           "connectivity_net1124"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23711,7 +23711,7 @@
           "pcb_smtpad_647",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23730,7 +23730,7 @@
           "pcb_smtpad_648",
           "connectivity_net1113"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23749,7 +23749,7 @@
           "pcb_smtpad_649",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23768,7 +23768,7 @@
           "pcb_smtpad_650",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23787,7 +23787,7 @@
           "pcb_smtpad_650",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23806,7 +23806,7 @@
           "pcb_smtpad_650",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23825,7 +23825,7 @@
           "pcb_smtpad_650",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23844,7 +23844,7 @@
           "pcb_smtpad_651",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23863,7 +23863,7 @@
           "pcb_smtpad_651",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23882,7 +23882,7 @@
           "pcb_smtpad_651",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23901,7 +23901,7 @@
           "pcb_smtpad_651",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23920,7 +23920,7 @@
           "pcb_smtpad_652",
           "connectivity_net1135"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23939,7 +23939,7 @@
           "pcb_smtpad_653",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23958,7 +23958,7 @@
           "pcb_smtpad_654",
           "connectivity_net1124"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23977,7 +23977,7 @@
           "pcb_smtpad_655",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -23996,7 +23996,7 @@
           "pcb_smtpad_656",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24015,7 +24015,7 @@
           "pcb_smtpad_656",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24034,7 +24034,7 @@
           "pcb_smtpad_656",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24053,7 +24053,7 @@
           "pcb_smtpad_656",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24072,7 +24072,7 @@
           "pcb_smtpad_657",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24091,7 +24091,7 @@
           "pcb_smtpad_657",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24110,7 +24110,7 @@
           "pcb_smtpad_657",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24129,7 +24129,7 @@
           "pcb_smtpad_657",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24148,7 +24148,7 @@
           "pcb_smtpad_658",
           "connectivity_net1146"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24167,7 +24167,7 @@
           "pcb_smtpad_659",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24186,7 +24186,7 @@
           "pcb_smtpad_660",
           "connectivity_net1135"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24205,7 +24205,7 @@
           "pcb_smtpad_661",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24224,7 +24224,7 @@
           "pcb_smtpad_662",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24243,7 +24243,7 @@
           "pcb_smtpad_662",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24262,7 +24262,7 @@
           "pcb_smtpad_662",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24281,7 +24281,7 @@
           "pcb_smtpad_662",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24300,7 +24300,7 @@
           "pcb_smtpad_663",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24319,7 +24319,7 @@
           "pcb_smtpad_663",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24338,7 +24338,7 @@
           "pcb_smtpad_663",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24357,7 +24357,7 @@
           "pcb_smtpad_663",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24376,7 +24376,7 @@
           "pcb_smtpad_664",
           "connectivity_net1157"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24395,7 +24395,7 @@
           "pcb_smtpad_665",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24414,7 +24414,7 @@
           "pcb_smtpad_666",
           "connectivity_net1146"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24433,7 +24433,7 @@
           "pcb_smtpad_667",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24452,7 +24452,7 @@
           "pcb_smtpad_668",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24471,7 +24471,7 @@
           "pcb_smtpad_668",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24490,7 +24490,7 @@
           "pcb_smtpad_668",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24509,7 +24509,7 @@
           "pcb_smtpad_668",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24528,7 +24528,7 @@
           "pcb_smtpad_669",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24547,7 +24547,7 @@
           "pcb_smtpad_669",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24566,7 +24566,7 @@
           "pcb_smtpad_669",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24585,7 +24585,7 @@
           "pcb_smtpad_669",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24604,7 +24604,7 @@
           "pcb_smtpad_670",
           "connectivity_net1168"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24623,7 +24623,7 @@
           "pcb_smtpad_671",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24642,7 +24642,7 @@
           "pcb_smtpad_672",
           "connectivity_net1157"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24661,7 +24661,7 @@
           "pcb_smtpad_673",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24680,7 +24680,7 @@
           "pcb_smtpad_674",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24699,7 +24699,7 @@
           "pcb_smtpad_674",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24718,7 +24718,7 @@
           "pcb_smtpad_674",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24737,7 +24737,7 @@
           "pcb_smtpad_674",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24756,7 +24756,7 @@
           "pcb_smtpad_675",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24775,7 +24775,7 @@
           "pcb_smtpad_675",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24794,7 +24794,7 @@
           "pcb_smtpad_675",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24813,7 +24813,7 @@
           "pcb_smtpad_675",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24832,7 +24832,7 @@
           "pcb_smtpad_676",
           "connectivity_net1179"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24851,7 +24851,7 @@
           "pcb_smtpad_677",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24870,7 +24870,7 @@
           "pcb_smtpad_678",
           "connectivity_net1168"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24889,7 +24889,7 @@
           "pcb_smtpad_679",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24908,7 +24908,7 @@
           "pcb_smtpad_680",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24927,7 +24927,7 @@
           "pcb_smtpad_680",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24946,7 +24946,7 @@
           "pcb_smtpad_680",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24965,7 +24965,7 @@
           "pcb_smtpad_680",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -24984,7 +24984,7 @@
           "pcb_smtpad_681",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25003,7 +25003,7 @@
           "pcb_smtpad_681",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25022,7 +25022,7 @@
           "pcb_smtpad_681",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25041,7 +25041,7 @@
           "pcb_smtpad_681",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25060,7 +25060,7 @@
           "pcb_smtpad_682",
           "connectivity_net1190"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25079,7 +25079,7 @@
           "pcb_smtpad_683",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25098,7 +25098,7 @@
           "pcb_smtpad_684",
           "connectivity_net1179"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25117,7 +25117,7 @@
           "pcb_smtpad_685",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25136,7 +25136,7 @@
           "pcb_smtpad_686",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25155,7 +25155,7 @@
           "pcb_smtpad_686",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25174,7 +25174,7 @@
           "pcb_smtpad_686",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25193,7 +25193,7 @@
           "pcb_smtpad_686",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25212,7 +25212,7 @@
           "pcb_smtpad_687",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25231,7 +25231,7 @@
           "pcb_smtpad_687",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25250,7 +25250,7 @@
           "pcb_smtpad_687",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25269,7 +25269,7 @@
           "pcb_smtpad_687",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25288,7 +25288,7 @@
           "pcb_smtpad_688",
           "connectivity_net1201"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25307,7 +25307,7 @@
           "pcb_smtpad_689",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25326,7 +25326,7 @@
           "pcb_smtpad_690",
           "connectivity_net1190"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25345,7 +25345,7 @@
           "pcb_smtpad_691",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25364,7 +25364,7 @@
           "pcb_smtpad_692",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25383,7 +25383,7 @@
           "pcb_smtpad_692",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25402,7 +25402,7 @@
           "pcb_smtpad_692",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25421,7 +25421,7 @@
           "pcb_smtpad_692",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25440,7 +25440,7 @@
           "pcb_smtpad_693",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25459,7 +25459,7 @@
           "pcb_smtpad_693",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25478,7 +25478,7 @@
           "pcb_smtpad_693",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25497,7 +25497,7 @@
           "pcb_smtpad_693",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25516,7 +25516,7 @@
           "pcb_smtpad_694",
           "connectivity_net1212"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25535,7 +25535,7 @@
           "pcb_smtpad_695",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25554,7 +25554,7 @@
           "pcb_smtpad_696",
           "connectivity_net1201"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25573,7 +25573,7 @@
           "pcb_smtpad_697",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25592,7 +25592,7 @@
           "pcb_smtpad_698",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25611,7 +25611,7 @@
           "pcb_smtpad_698",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25630,7 +25630,7 @@
           "pcb_smtpad_698",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25649,7 +25649,7 @@
           "pcb_smtpad_698",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25668,7 +25668,7 @@
           "pcb_smtpad_699",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25687,7 +25687,7 @@
           "pcb_smtpad_699",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25706,7 +25706,7 @@
           "pcb_smtpad_699",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25725,7 +25725,7 @@
           "pcb_smtpad_699",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25744,7 +25744,7 @@
           "pcb_smtpad_700",
           "connectivity_net1223"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25763,7 +25763,7 @@
           "pcb_smtpad_701",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25782,7 +25782,7 @@
           "pcb_smtpad_702",
           "connectivity_net1212"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25801,7 +25801,7 @@
           "pcb_smtpad_703",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25820,7 +25820,7 @@
           "pcb_smtpad_704",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25839,7 +25839,7 @@
           "pcb_smtpad_704",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25858,7 +25858,7 @@
           "pcb_smtpad_704",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25877,7 +25877,7 @@
           "pcb_smtpad_704",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25896,7 +25896,7 @@
           "pcb_smtpad_705",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25915,7 +25915,7 @@
           "pcb_smtpad_705",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25934,7 +25934,7 @@
           "pcb_smtpad_705",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25953,7 +25953,7 @@
           "pcb_smtpad_705",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25972,7 +25972,7 @@
           "pcb_smtpad_706",
           "connectivity_net1234"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -25991,7 +25991,7 @@
           "pcb_smtpad_707",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26010,7 +26010,7 @@
           "pcb_smtpad_708",
           "connectivity_net1223"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26029,7 +26029,7 @@
           "pcb_smtpad_709",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26048,7 +26048,7 @@
           "pcb_smtpad_710",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26067,7 +26067,7 @@
           "pcb_smtpad_710",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26086,7 +26086,7 @@
           "pcb_smtpad_710",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26105,7 +26105,7 @@
           "pcb_smtpad_710",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26124,7 +26124,7 @@
           "pcb_smtpad_711",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26143,7 +26143,7 @@
           "pcb_smtpad_711",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26162,7 +26162,7 @@
           "pcb_smtpad_711",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26181,7 +26181,7 @@
           "pcb_smtpad_711",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26200,7 +26200,7 @@
           "pcb_smtpad_712",
           "connectivity_net1245"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26219,7 +26219,7 @@
           "pcb_smtpad_713",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26238,7 +26238,7 @@
           "pcb_smtpad_714",
           "connectivity_net1234"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26257,7 +26257,7 @@
           "pcb_smtpad_715",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26276,7 +26276,7 @@
           "pcb_smtpad_716",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26295,7 +26295,7 @@
           "pcb_smtpad_716",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26314,7 +26314,7 @@
           "pcb_smtpad_716",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26333,7 +26333,7 @@
           "pcb_smtpad_716",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26352,7 +26352,7 @@
           "pcb_smtpad_717",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26371,7 +26371,7 @@
           "pcb_smtpad_717",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26390,7 +26390,7 @@
           "pcb_smtpad_717",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26409,7 +26409,7 @@
           "pcb_smtpad_717",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26428,7 +26428,7 @@
           "pcb_smtpad_718",
           "connectivity_net1256"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26447,7 +26447,7 @@
           "pcb_smtpad_719",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26466,7 +26466,7 @@
           "pcb_smtpad_720",
           "connectivity_net1245"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26485,7 +26485,7 @@
           "pcb_smtpad_721",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26504,7 +26504,7 @@
           "pcb_smtpad_722",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26523,7 +26523,7 @@
           "pcb_smtpad_722",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26542,7 +26542,7 @@
           "pcb_smtpad_722",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26561,7 +26561,7 @@
           "pcb_smtpad_722",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26580,7 +26580,7 @@
           "pcb_smtpad_723",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26599,7 +26599,7 @@
           "pcb_smtpad_723",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26618,7 +26618,7 @@
           "pcb_smtpad_723",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26637,7 +26637,7 @@
           "pcb_smtpad_723",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26656,7 +26656,7 @@
           "pcb_smtpad_724",
           "connectivity_net1267"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26675,7 +26675,7 @@
           "pcb_smtpad_725",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26694,7 +26694,7 @@
           "pcb_smtpad_726",
           "connectivity_net1256"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26713,7 +26713,7 @@
           "pcb_smtpad_727",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26732,7 +26732,7 @@
           "pcb_smtpad_728",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26751,7 +26751,7 @@
           "pcb_smtpad_728",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26770,7 +26770,7 @@
           "pcb_smtpad_728",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26789,7 +26789,7 @@
           "pcb_smtpad_728",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26808,7 +26808,7 @@
           "pcb_smtpad_729",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26827,7 +26827,7 @@
           "pcb_smtpad_729",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26846,7 +26846,7 @@
           "pcb_smtpad_729",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26865,7 +26865,7 @@
           "pcb_smtpad_729",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26884,7 +26884,7 @@
           "pcb_smtpad_730",
           "connectivity_net1278"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26903,7 +26903,7 @@
           "pcb_smtpad_731",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26922,7 +26922,7 @@
           "pcb_smtpad_732",
           "connectivity_net1267"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26941,7 +26941,7 @@
           "pcb_smtpad_733",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26960,7 +26960,7 @@
           "pcb_smtpad_734",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26979,7 +26979,7 @@
           "pcb_smtpad_734",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -26998,7 +26998,7 @@
           "pcb_smtpad_734",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27017,7 +27017,7 @@
           "pcb_smtpad_734",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27036,7 +27036,7 @@
           "pcb_smtpad_735",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27055,7 +27055,7 @@
           "pcb_smtpad_735",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27074,7 +27074,7 @@
           "pcb_smtpad_735",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27093,7 +27093,7 @@
           "pcb_smtpad_735",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27112,7 +27112,7 @@
           "pcb_smtpad_736",
           "connectivity_net1289"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27131,7 +27131,7 @@
           "pcb_smtpad_737",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27150,7 +27150,7 @@
           "pcb_smtpad_738",
           "connectivity_net1278"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27169,7 +27169,7 @@
           "pcb_smtpad_739",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27188,7 +27188,7 @@
           "pcb_smtpad_740",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27207,7 +27207,7 @@
           "pcb_smtpad_740",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27226,7 +27226,7 @@
           "pcb_smtpad_740",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27245,7 +27245,7 @@
           "pcb_smtpad_740",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27264,7 +27264,7 @@
           "pcb_smtpad_741",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27283,7 +27283,7 @@
           "pcb_smtpad_741",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27302,7 +27302,7 @@
           "pcb_smtpad_741",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27321,7 +27321,7 @@
           "pcb_smtpad_741",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27340,7 +27340,7 @@
           "pcb_smtpad_742",
           "connectivity_net1300"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27359,7 +27359,7 @@
           "pcb_smtpad_743",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27378,7 +27378,7 @@
           "pcb_smtpad_744",
           "connectivity_net1289"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27397,7 +27397,7 @@
           "pcb_smtpad_745",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27416,7 +27416,7 @@
           "pcb_smtpad_746",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27435,7 +27435,7 @@
           "pcb_smtpad_746",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27454,7 +27454,7 @@
           "pcb_smtpad_746",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27473,7 +27473,7 @@
           "pcb_smtpad_746",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27492,7 +27492,7 @@
           "pcb_smtpad_747",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27511,7 +27511,7 @@
           "pcb_smtpad_747",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27530,7 +27530,7 @@
           "pcb_smtpad_747",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27549,7 +27549,7 @@
           "pcb_smtpad_747",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27568,7 +27568,7 @@
           "pcb_smtpad_748",
           "connectivity_net1311"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27587,7 +27587,7 @@
           "pcb_smtpad_749",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27606,7 +27606,7 @@
           "pcb_smtpad_750",
           "connectivity_net1300"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27625,7 +27625,7 @@
           "pcb_smtpad_751",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27644,7 +27644,7 @@
           "pcb_smtpad_752",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27663,7 +27663,7 @@
           "pcb_smtpad_752",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27682,7 +27682,7 @@
           "pcb_smtpad_752",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27701,7 +27701,7 @@
           "pcb_smtpad_752",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27720,7 +27720,7 @@
           "pcb_smtpad_753",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27739,7 +27739,7 @@
           "pcb_smtpad_753",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27758,7 +27758,7 @@
           "pcb_smtpad_753",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27777,7 +27777,7 @@
           "pcb_smtpad_753",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27796,7 +27796,7 @@
           "pcb_smtpad_754",
           "connectivity_net1322"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27815,7 +27815,7 @@
           "pcb_smtpad_755",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27834,7 +27834,7 @@
           "pcb_smtpad_756",
           "connectivity_net1311"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27853,7 +27853,7 @@
           "pcb_smtpad_757",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27872,7 +27872,7 @@
           "pcb_smtpad_758",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27891,7 +27891,7 @@
           "pcb_smtpad_758",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27910,7 +27910,7 @@
           "pcb_smtpad_758",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27929,7 +27929,7 @@
           "pcb_smtpad_758",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27948,7 +27948,7 @@
           "pcb_smtpad_759",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27967,7 +27967,7 @@
           "pcb_smtpad_759",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -27986,7 +27986,7 @@
           "pcb_smtpad_759",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28005,7 +28005,7 @@
           "pcb_smtpad_759",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28024,7 +28024,7 @@
           "pcb_smtpad_760",
           "connectivity_net1333"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28043,7 +28043,7 @@
           "pcb_smtpad_761",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28062,7 +28062,7 @@
           "pcb_smtpad_762",
           "connectivity_net1322"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28081,7 +28081,7 @@
           "pcb_smtpad_763",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28100,7 +28100,7 @@
           "pcb_smtpad_764",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28119,7 +28119,7 @@
           "pcb_smtpad_764",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28138,7 +28138,7 @@
           "pcb_smtpad_764",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28157,7 +28157,7 @@
           "pcb_smtpad_764",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28176,7 +28176,7 @@
           "pcb_smtpad_765",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28195,7 +28195,7 @@
           "pcb_smtpad_765",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28214,7 +28214,7 @@
           "pcb_smtpad_765",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28233,7 +28233,7 @@
           "pcb_smtpad_765",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28252,7 +28252,7 @@
           "pcb_smtpad_766",
           "connectivity_net1344"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28271,7 +28271,7 @@
           "pcb_smtpad_767",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28290,7 +28290,7 @@
           "pcb_smtpad_768",
           "connectivity_net1333"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28309,7 +28309,7 @@
           "pcb_smtpad_769",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28328,7 +28328,7 @@
           "pcb_smtpad_770",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28347,7 +28347,7 @@
           "pcb_smtpad_770",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28366,7 +28366,7 @@
           "pcb_smtpad_770",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28385,7 +28385,7 @@
           "pcb_smtpad_770",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28404,7 +28404,7 @@
           "pcb_smtpad_771",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28423,7 +28423,7 @@
           "pcb_smtpad_771",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28442,7 +28442,7 @@
           "pcb_smtpad_771",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28461,7 +28461,7 @@
           "pcb_smtpad_771",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28480,7 +28480,7 @@
           "pcb_smtpad_772",
           "connectivity_net1355"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28499,7 +28499,7 @@
           "pcb_smtpad_773",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28518,7 +28518,7 @@
           "pcb_smtpad_774",
           "connectivity_net1344"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28537,7 +28537,7 @@
           "pcb_smtpad_775",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28556,7 +28556,7 @@
           "pcb_smtpad_776",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28575,7 +28575,7 @@
           "pcb_smtpad_776",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28594,7 +28594,7 @@
           "pcb_smtpad_776",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28613,7 +28613,7 @@
           "pcb_smtpad_776",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28632,7 +28632,7 @@
           "pcb_smtpad_777",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28651,7 +28651,7 @@
           "pcb_smtpad_777",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28670,7 +28670,7 @@
           "pcb_smtpad_777",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28689,7 +28689,7 @@
           "pcb_smtpad_777",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28708,7 +28708,7 @@
           "pcb_smtpad_778",
           "connectivity_net1366"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28727,7 +28727,7 @@
           "pcb_smtpad_779",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28746,7 +28746,7 @@
           "pcb_smtpad_780",
           "connectivity_net1355"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28765,7 +28765,7 @@
           "pcb_smtpad_781",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28784,7 +28784,7 @@
           "pcb_smtpad_782",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28803,7 +28803,7 @@
           "pcb_smtpad_782",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28822,7 +28822,7 @@
           "pcb_smtpad_782",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28841,7 +28841,7 @@
           "pcb_smtpad_782",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28860,7 +28860,7 @@
           "pcb_smtpad_783",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28879,7 +28879,7 @@
           "pcb_smtpad_783",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28898,7 +28898,7 @@
           "pcb_smtpad_783",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28917,7 +28917,7 @@
           "pcb_smtpad_783",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28936,7 +28936,7 @@
           "pcb_smtpad_784",
           "connectivity_net1377"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28955,7 +28955,7 @@
           "pcb_smtpad_785",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28974,7 +28974,7 @@
           "pcb_smtpad_786",
           "connectivity_net1366"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -28993,7 +28993,7 @@
           "pcb_smtpad_787",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29012,7 +29012,7 @@
           "pcb_smtpad_788",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29031,7 +29031,7 @@
           "pcb_smtpad_788",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29050,7 +29050,7 @@
           "pcb_smtpad_788",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29069,7 +29069,7 @@
           "pcb_smtpad_788",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29088,7 +29088,7 @@
           "pcb_smtpad_789",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29107,7 +29107,7 @@
           "pcb_smtpad_789",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29126,7 +29126,7 @@
           "pcb_smtpad_789",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29145,7 +29145,7 @@
           "pcb_smtpad_789",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29164,7 +29164,7 @@
           "pcb_smtpad_790",
           "connectivity_net1388"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29183,7 +29183,7 @@
           "pcb_smtpad_791",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29202,7 +29202,7 @@
           "pcb_smtpad_792",
           "connectivity_net1377"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29221,7 +29221,7 @@
           "pcb_smtpad_793",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29240,7 +29240,7 @@
           "pcb_smtpad_794",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29259,7 +29259,7 @@
           "pcb_smtpad_794",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29278,7 +29278,7 @@
           "pcb_smtpad_794",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29297,7 +29297,7 @@
           "pcb_smtpad_794",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29316,7 +29316,7 @@
           "pcb_smtpad_795",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29335,7 +29335,7 @@
           "pcb_smtpad_795",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29354,7 +29354,7 @@
           "pcb_smtpad_795",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29373,7 +29373,7 @@
           "pcb_smtpad_795",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29392,7 +29392,7 @@
           "pcb_smtpad_796",
           "connectivity_net1399"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29411,7 +29411,7 @@
           "pcb_smtpad_797",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29430,7 +29430,7 @@
           "pcb_smtpad_798",
           "connectivity_net1388"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29449,7 +29449,7 @@
           "pcb_smtpad_799",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29468,7 +29468,7 @@
           "pcb_smtpad_800",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29487,7 +29487,7 @@
           "pcb_smtpad_800",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29506,7 +29506,7 @@
           "pcb_smtpad_800",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29525,7 +29525,7 @@
           "pcb_smtpad_800",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29544,7 +29544,7 @@
           "pcb_smtpad_801",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29563,7 +29563,7 @@
           "pcb_smtpad_801",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29582,7 +29582,7 @@
           "pcb_smtpad_801",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29601,7 +29601,7 @@
           "pcb_smtpad_801",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29620,7 +29620,7 @@
           "pcb_smtpad_802",
           "connectivity_net1410"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29639,7 +29639,7 @@
           "pcb_smtpad_803",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29658,7 +29658,7 @@
           "pcb_smtpad_804",
           "connectivity_net1399"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29677,7 +29677,7 @@
           "pcb_smtpad_805",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29696,7 +29696,7 @@
           "pcb_smtpad_806",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29715,7 +29715,7 @@
           "pcb_smtpad_806",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29734,7 +29734,7 @@
           "pcb_smtpad_806",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29753,7 +29753,7 @@
           "pcb_smtpad_806",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29772,7 +29772,7 @@
           "pcb_smtpad_807",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29791,7 +29791,7 @@
           "pcb_smtpad_807",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29810,7 +29810,7 @@
           "pcb_smtpad_807",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29829,7 +29829,7 @@
           "pcb_smtpad_807",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29848,7 +29848,7 @@
           "pcb_smtpad_808",
           "connectivity_net1421"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29867,7 +29867,7 @@
           "pcb_smtpad_809",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29886,7 +29886,7 @@
           "pcb_smtpad_810",
           "connectivity_net1410"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29905,7 +29905,7 @@
           "pcb_smtpad_811",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29924,7 +29924,7 @@
           "pcb_smtpad_812",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29943,7 +29943,7 @@
           "pcb_smtpad_812",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29962,7 +29962,7 @@
           "pcb_smtpad_812",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -29981,7 +29981,7 @@
           "pcb_smtpad_812",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30000,7 +30000,7 @@
           "pcb_smtpad_813",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30019,7 +30019,7 @@
           "pcb_smtpad_813",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30038,7 +30038,7 @@
           "pcb_smtpad_813",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30057,7 +30057,7 @@
           "pcb_smtpad_813",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30076,7 +30076,7 @@
           "pcb_smtpad_814",
           "connectivity_net1432"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30095,7 +30095,7 @@
           "pcb_smtpad_815",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30114,7 +30114,7 @@
           "pcb_smtpad_816",
           "connectivity_net1421"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30133,7 +30133,7 @@
           "pcb_smtpad_817",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30152,7 +30152,7 @@
           "pcb_smtpad_818",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30171,7 +30171,7 @@
           "pcb_smtpad_818",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30190,7 +30190,7 @@
           "pcb_smtpad_818",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30209,7 +30209,7 @@
           "pcb_smtpad_818",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30228,7 +30228,7 @@
           "pcb_smtpad_819",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30247,7 +30247,7 @@
           "pcb_smtpad_819",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30266,7 +30266,7 @@
           "pcb_smtpad_819",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30285,7 +30285,7 @@
           "pcb_smtpad_819",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30304,7 +30304,7 @@
           "pcb_smtpad_820",
           "connectivity_net1443"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30323,7 +30323,7 @@
           "pcb_smtpad_821",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30342,7 +30342,7 @@
           "pcb_smtpad_822",
           "connectivity_net1432"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30361,7 +30361,7 @@
           "pcb_smtpad_823",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30380,7 +30380,7 @@
           "pcb_smtpad_824",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30399,7 +30399,7 @@
           "pcb_smtpad_824",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30418,7 +30418,7 @@
           "pcb_smtpad_824",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30437,7 +30437,7 @@
           "pcb_smtpad_824",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30456,7 +30456,7 @@
           "pcb_smtpad_825",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30475,7 +30475,7 @@
           "pcb_smtpad_825",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30494,7 +30494,7 @@
           "pcb_smtpad_825",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30513,7 +30513,7 @@
           "pcb_smtpad_825",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30532,7 +30532,7 @@
           "pcb_smtpad_826",
           "connectivity_net1454"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30551,7 +30551,7 @@
           "pcb_smtpad_827",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30570,7 +30570,7 @@
           "pcb_smtpad_828",
           "connectivity_net1443"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30589,7 +30589,7 @@
           "pcb_smtpad_829",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30608,7 +30608,7 @@
           "pcb_smtpad_830",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30627,7 +30627,7 @@
           "pcb_smtpad_830",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30646,7 +30646,7 @@
           "pcb_smtpad_830",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30665,7 +30665,7 @@
           "pcb_smtpad_830",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30684,7 +30684,7 @@
           "pcb_smtpad_831",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30703,7 +30703,7 @@
           "pcb_smtpad_831",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30722,7 +30722,7 @@
           "pcb_smtpad_831",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30741,7 +30741,7 @@
           "pcb_smtpad_831",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30760,7 +30760,7 @@
           "pcb_smtpad_832",
           "connectivity_net1465"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30779,7 +30779,7 @@
           "pcb_smtpad_833",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30798,7 +30798,7 @@
           "pcb_smtpad_834",
           "connectivity_net1454"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30817,7 +30817,7 @@
           "pcb_smtpad_835",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30836,7 +30836,7 @@
           "pcb_smtpad_836",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30855,7 +30855,7 @@
           "pcb_smtpad_836",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30874,7 +30874,7 @@
           "pcb_smtpad_836",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30893,7 +30893,7 @@
           "pcb_smtpad_836",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30912,7 +30912,7 @@
           "pcb_smtpad_837",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30931,7 +30931,7 @@
           "pcb_smtpad_837",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30950,7 +30950,7 @@
           "pcb_smtpad_837",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30969,7 +30969,7 @@
           "pcb_smtpad_837",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -30988,7 +30988,7 @@
           "pcb_smtpad_838",
           "connectivity_net1476"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31007,7 +31007,7 @@
           "pcb_smtpad_839",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31026,7 +31026,7 @@
           "pcb_smtpad_840",
           "connectivity_net1465"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31045,7 +31045,7 @@
           "pcb_smtpad_841",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31064,7 +31064,7 @@
           "pcb_smtpad_842",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31083,7 +31083,7 @@
           "pcb_smtpad_842",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31102,7 +31102,7 @@
           "pcb_smtpad_842",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31121,7 +31121,7 @@
           "pcb_smtpad_842",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31140,7 +31140,7 @@
           "pcb_smtpad_843",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31159,7 +31159,7 @@
           "pcb_smtpad_843",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31178,7 +31178,7 @@
           "pcb_smtpad_843",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31197,7 +31197,7 @@
           "pcb_smtpad_843",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31216,7 +31216,7 @@
           "pcb_smtpad_844",
           "connectivity_net1487"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31235,7 +31235,7 @@
           "pcb_smtpad_845",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31254,7 +31254,7 @@
           "pcb_smtpad_846",
           "connectivity_net1476"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31273,7 +31273,7 @@
           "pcb_smtpad_847",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31292,7 +31292,7 @@
           "pcb_smtpad_848",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31311,7 +31311,7 @@
           "pcb_smtpad_848",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31330,7 +31330,7 @@
           "pcb_smtpad_848",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31349,7 +31349,7 @@
           "pcb_smtpad_848",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31368,7 +31368,7 @@
           "pcb_smtpad_849",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31387,7 +31387,7 @@
           "pcb_smtpad_849",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31406,7 +31406,7 @@
           "pcb_smtpad_849",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31425,7 +31425,7 @@
           "pcb_smtpad_849",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31444,7 +31444,7 @@
           "pcb_smtpad_850",
           "connectivity_net1498"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31463,7 +31463,7 @@
           "pcb_smtpad_851",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31482,7 +31482,7 @@
           "pcb_smtpad_852",
           "connectivity_net1487"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31501,7 +31501,7 @@
           "pcb_smtpad_853",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31520,7 +31520,7 @@
           "pcb_smtpad_854",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31539,7 +31539,7 @@
           "pcb_smtpad_854",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31558,7 +31558,7 @@
           "pcb_smtpad_854",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31577,7 +31577,7 @@
           "pcb_smtpad_854",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31596,7 +31596,7 @@
           "pcb_smtpad_855",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31615,7 +31615,7 @@
           "pcb_smtpad_855",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31634,7 +31634,7 @@
           "pcb_smtpad_855",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31653,7 +31653,7 @@
           "pcb_smtpad_855",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31672,7 +31672,7 @@
           "pcb_smtpad_856",
           "connectivity_net1509"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31691,7 +31691,7 @@
           "pcb_smtpad_857",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31710,7 +31710,7 @@
           "pcb_smtpad_858",
           "connectivity_net1498"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31729,7 +31729,7 @@
           "pcb_smtpad_859",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31748,7 +31748,7 @@
           "pcb_smtpad_860",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31767,7 +31767,7 @@
           "pcb_smtpad_860",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31786,7 +31786,7 @@
           "pcb_smtpad_860",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31805,7 +31805,7 @@
           "pcb_smtpad_860",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31824,7 +31824,7 @@
           "pcb_smtpad_861",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31843,7 +31843,7 @@
           "pcb_smtpad_861",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31862,7 +31862,7 @@
           "pcb_smtpad_861",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31881,7 +31881,7 @@
           "pcb_smtpad_861",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31900,7 +31900,7 @@
           "pcb_smtpad_862",
           "connectivity_net1520"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31919,7 +31919,7 @@
           "pcb_smtpad_863",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31938,7 +31938,7 @@
           "pcb_smtpad_864",
           "connectivity_net1509"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31957,7 +31957,7 @@
           "pcb_smtpad_865",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31976,7 +31976,7 @@
           "pcb_smtpad_866",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -31995,7 +31995,7 @@
           "pcb_smtpad_866",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32014,7 +32014,7 @@
           "pcb_smtpad_866",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32033,7 +32033,7 @@
           "pcb_smtpad_866",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32052,7 +32052,7 @@
           "pcb_smtpad_867",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32071,7 +32071,7 @@
           "pcb_smtpad_867",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32090,7 +32090,7 @@
           "pcb_smtpad_867",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32109,7 +32109,7 @@
           "pcb_smtpad_867",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32128,7 +32128,7 @@
           "pcb_smtpad_868",
           "connectivity_net1531"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32147,7 +32147,7 @@
           "pcb_smtpad_869",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32166,7 +32166,7 @@
           "pcb_smtpad_870",
           "connectivity_net1520"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32185,7 +32185,7 @@
           "pcb_smtpad_871",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32204,7 +32204,7 @@
           "pcb_smtpad_872",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32223,7 +32223,7 @@
           "pcb_smtpad_872",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32242,7 +32242,7 @@
           "pcb_smtpad_872",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32261,7 +32261,7 @@
           "pcb_smtpad_872",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32280,7 +32280,7 @@
           "pcb_smtpad_873",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32299,7 +32299,7 @@
           "pcb_smtpad_873",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32318,7 +32318,7 @@
           "pcb_smtpad_873",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32337,7 +32337,7 @@
           "pcb_smtpad_873",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32356,7 +32356,7 @@
           "pcb_smtpad_874",
           "connectivity_net1542"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32375,7 +32375,7 @@
           "pcb_smtpad_875",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32394,7 +32394,7 @@
           "pcb_smtpad_876",
           "connectivity_net1531"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32413,7 +32413,7 @@
           "pcb_smtpad_877",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32432,7 +32432,7 @@
           "pcb_smtpad_878",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32451,7 +32451,7 @@
           "pcb_smtpad_878",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32470,7 +32470,7 @@
           "pcb_smtpad_878",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32489,7 +32489,7 @@
           "pcb_smtpad_878",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32508,7 +32508,7 @@
           "pcb_smtpad_879",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32527,7 +32527,7 @@
           "pcb_smtpad_879",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32546,7 +32546,7 @@
           "pcb_smtpad_879",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32565,7 +32565,7 @@
           "pcb_smtpad_879",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32584,7 +32584,7 @@
           "pcb_smtpad_880",
           "connectivity_net1553"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32603,7 +32603,7 @@
           "pcb_smtpad_881",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32622,7 +32622,7 @@
           "pcb_smtpad_882",
           "connectivity_net1542"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32641,7 +32641,7 @@
           "pcb_smtpad_883",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32660,7 +32660,7 @@
           "pcb_smtpad_884",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32679,7 +32679,7 @@
           "pcb_smtpad_884",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32698,7 +32698,7 @@
           "pcb_smtpad_884",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32717,7 +32717,7 @@
           "pcb_smtpad_884",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32736,7 +32736,7 @@
           "pcb_smtpad_885",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32755,7 +32755,7 @@
           "pcb_smtpad_885",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32774,7 +32774,7 @@
           "pcb_smtpad_885",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32793,7 +32793,7 @@
           "pcb_smtpad_885",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32812,7 +32812,7 @@
           "pcb_smtpad_886",
           "connectivity_net1564"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32831,7 +32831,7 @@
           "pcb_smtpad_887",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32850,7 +32850,7 @@
           "pcb_smtpad_888",
           "connectivity_net1553"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32869,7 +32869,7 @@
           "pcb_smtpad_889",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32888,7 +32888,7 @@
           "pcb_smtpad_890",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32907,7 +32907,7 @@
           "pcb_smtpad_890",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32926,7 +32926,7 @@
           "pcb_smtpad_890",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32945,7 +32945,7 @@
           "pcb_smtpad_890",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32964,7 +32964,7 @@
           "pcb_smtpad_891",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -32983,7 +32983,7 @@
           "pcb_smtpad_891",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33002,7 +33002,7 @@
           "pcb_smtpad_891",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33021,7 +33021,7 @@
           "pcb_smtpad_891",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33040,7 +33040,7 @@
           "pcb_smtpad_892",
           "connectivity_net1575"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33059,7 +33059,7 @@
           "pcb_smtpad_893",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33078,7 +33078,7 @@
           "pcb_smtpad_894",
           "connectivity_net1564"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33097,7 +33097,7 @@
           "pcb_smtpad_895",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33116,7 +33116,7 @@
           "pcb_smtpad_896",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33135,7 +33135,7 @@
           "pcb_smtpad_896",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33154,7 +33154,7 @@
           "pcb_smtpad_896",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33173,7 +33173,7 @@
           "pcb_smtpad_896",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33192,7 +33192,7 @@
           "pcb_smtpad_897",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33211,7 +33211,7 @@
           "pcb_smtpad_897",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33230,7 +33230,7 @@
           "pcb_smtpad_897",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33249,7 +33249,7 @@
           "pcb_smtpad_897",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33268,7 +33268,7 @@
           "pcb_smtpad_898",
           "connectivity_net1586"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33287,7 +33287,7 @@
           "pcb_smtpad_899",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33306,7 +33306,7 @@
           "pcb_smtpad_900",
           "connectivity_net1575"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33325,7 +33325,7 @@
           "pcb_smtpad_901",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33344,7 +33344,7 @@
           "pcb_smtpad_902",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33363,7 +33363,7 @@
           "pcb_smtpad_902",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33382,7 +33382,7 @@
           "pcb_smtpad_902",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33401,7 +33401,7 @@
           "pcb_smtpad_902",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33420,7 +33420,7 @@
           "pcb_smtpad_903",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33439,7 +33439,7 @@
           "pcb_smtpad_903",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33458,7 +33458,7 @@
           "pcb_smtpad_903",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33477,7 +33477,7 @@
           "pcb_smtpad_903",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33496,7 +33496,7 @@
           "pcb_smtpad_904",
           "connectivity_net1597"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33515,7 +33515,7 @@
           "pcb_smtpad_905",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33534,7 +33534,7 @@
           "pcb_smtpad_906",
           "connectivity_net1586"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33553,7 +33553,7 @@
           "pcb_smtpad_907",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33572,7 +33572,7 @@
           "pcb_smtpad_908",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33591,7 +33591,7 @@
           "pcb_smtpad_908",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33610,7 +33610,7 @@
           "pcb_smtpad_908",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33629,7 +33629,7 @@
           "pcb_smtpad_908",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33648,7 +33648,7 @@
           "pcb_smtpad_909",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33667,7 +33667,7 @@
           "pcb_smtpad_909",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33686,7 +33686,7 @@
           "pcb_smtpad_909",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33705,7 +33705,7 @@
           "pcb_smtpad_909",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33724,7 +33724,7 @@
           "pcb_smtpad_910",
           "connectivity_net1608"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33743,7 +33743,7 @@
           "pcb_smtpad_911",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33762,7 +33762,7 @@
           "pcb_smtpad_912",
           "connectivity_net1597"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33781,7 +33781,7 @@
           "pcb_smtpad_913",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33800,7 +33800,7 @@
           "pcb_smtpad_914",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33819,7 +33819,7 @@
           "pcb_smtpad_914",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33838,7 +33838,7 @@
           "pcb_smtpad_914",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33857,7 +33857,7 @@
           "pcb_smtpad_914",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33876,7 +33876,7 @@
           "pcb_smtpad_915",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33895,7 +33895,7 @@
           "pcb_smtpad_915",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33914,7 +33914,7 @@
           "pcb_smtpad_915",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33933,7 +33933,7 @@
           "pcb_smtpad_915",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33952,7 +33952,7 @@
           "pcb_smtpad_916",
           "connectivity_net1619"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33971,7 +33971,7 @@
           "pcb_smtpad_917",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -33990,7 +33990,7 @@
           "pcb_smtpad_918",
           "connectivity_net1608"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34009,7 +34009,7 @@
           "pcb_smtpad_919",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34028,7 +34028,7 @@
           "pcb_smtpad_920",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34047,7 +34047,7 @@
           "pcb_smtpad_920",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34066,7 +34066,7 @@
           "pcb_smtpad_920",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34085,7 +34085,7 @@
           "pcb_smtpad_920",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34104,7 +34104,7 @@
           "pcb_smtpad_921",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34123,7 +34123,7 @@
           "pcb_smtpad_921",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34142,7 +34142,7 @@
           "pcb_smtpad_921",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34161,7 +34161,7 @@
           "pcb_smtpad_921",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34180,7 +34180,7 @@
           "pcb_smtpad_922",
           "connectivity_net1630"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34199,7 +34199,7 @@
           "pcb_smtpad_923",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34218,7 +34218,7 @@
           "pcb_smtpad_924",
           "connectivity_net1619"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34237,7 +34237,7 @@
           "pcb_smtpad_925",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34256,7 +34256,7 @@
           "pcb_smtpad_926",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34275,7 +34275,7 @@
           "pcb_smtpad_926",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34294,7 +34294,7 @@
           "pcb_smtpad_926",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34313,7 +34313,7 @@
           "pcb_smtpad_926",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34332,7 +34332,7 @@
           "pcb_smtpad_927",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34351,7 +34351,7 @@
           "pcb_smtpad_927",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34370,7 +34370,7 @@
           "pcb_smtpad_927",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34389,7 +34389,7 @@
           "pcb_smtpad_927",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34408,7 +34408,7 @@
           "pcb_smtpad_928",
           "connectivity_net1641"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34427,7 +34427,7 @@
           "pcb_smtpad_929",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34446,7 +34446,7 @@
           "pcb_smtpad_930",
           "connectivity_net1630"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34465,7 +34465,7 @@
           "pcb_smtpad_931",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34484,7 +34484,7 @@
           "pcb_smtpad_932",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34503,7 +34503,7 @@
           "pcb_smtpad_932",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34522,7 +34522,7 @@
           "pcb_smtpad_932",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34541,7 +34541,7 @@
           "pcb_smtpad_932",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34560,7 +34560,7 @@
           "pcb_smtpad_933",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34579,7 +34579,7 @@
           "pcb_smtpad_933",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34598,7 +34598,7 @@
           "pcb_smtpad_933",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34617,7 +34617,7 @@
           "pcb_smtpad_933",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34636,7 +34636,7 @@
           "pcb_smtpad_934",
           "connectivity_net1652"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34655,7 +34655,7 @@
           "pcb_smtpad_935",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34674,7 +34674,7 @@
           "pcb_smtpad_936",
           "connectivity_net1641"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34693,7 +34693,7 @@
           "pcb_smtpad_937",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34712,7 +34712,7 @@
           "pcb_smtpad_938",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34731,7 +34731,7 @@
           "pcb_smtpad_938",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34750,7 +34750,7 @@
           "pcb_smtpad_938",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34769,7 +34769,7 @@
           "pcb_smtpad_938",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34788,7 +34788,7 @@
           "pcb_smtpad_939",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34807,7 +34807,7 @@
           "pcb_smtpad_939",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34826,7 +34826,7 @@
           "pcb_smtpad_939",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34845,7 +34845,7 @@
           "pcb_smtpad_939",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34864,7 +34864,7 @@
           "pcb_smtpad_940",
           "connectivity_net1663"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34883,7 +34883,7 @@
           "pcb_smtpad_941",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34902,7 +34902,7 @@
           "pcb_smtpad_942",
           "connectivity_net1652"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34921,7 +34921,7 @@
           "pcb_smtpad_943",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34940,7 +34940,7 @@
           "pcb_smtpad_944",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34959,7 +34959,7 @@
           "pcb_smtpad_944",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34978,7 +34978,7 @@
           "pcb_smtpad_944",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -34997,7 +34997,7 @@
           "pcb_smtpad_944",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35016,7 +35016,7 @@
           "pcb_smtpad_945",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35035,7 +35035,7 @@
           "pcb_smtpad_945",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35054,7 +35054,7 @@
           "pcb_smtpad_945",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35073,7 +35073,7 @@
           "pcb_smtpad_945",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35092,7 +35092,7 @@
           "pcb_smtpad_946",
           "connectivity_net1674"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35111,7 +35111,7 @@
           "pcb_smtpad_947",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35130,7 +35130,7 @@
           "pcb_smtpad_948",
           "connectivity_net1663"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35149,7 +35149,7 @@
           "pcb_smtpad_949",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35168,7 +35168,7 @@
           "pcb_smtpad_950",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35187,7 +35187,7 @@
           "pcb_smtpad_950",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35206,7 +35206,7 @@
           "pcb_smtpad_950",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35225,7 +35225,7 @@
           "pcb_smtpad_950",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35244,7 +35244,7 @@
           "pcb_smtpad_951",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35263,7 +35263,7 @@
           "pcb_smtpad_951",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35282,7 +35282,7 @@
           "pcb_smtpad_951",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35301,7 +35301,7 @@
           "pcb_smtpad_951",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35320,7 +35320,7 @@
           "pcb_smtpad_952",
           "connectivity_net1685"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35339,7 +35339,7 @@
           "pcb_smtpad_953",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35358,7 +35358,7 @@
           "pcb_smtpad_954",
           "connectivity_net1674"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35377,7 +35377,7 @@
           "pcb_smtpad_955",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35396,7 +35396,7 @@
           "pcb_smtpad_956",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35415,7 +35415,7 @@
           "pcb_smtpad_956",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35434,7 +35434,7 @@
           "pcb_smtpad_956",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35453,7 +35453,7 @@
           "pcb_smtpad_956",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35472,7 +35472,7 @@
           "pcb_smtpad_957",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35491,7 +35491,7 @@
           "pcb_smtpad_957",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35510,7 +35510,7 @@
           "pcb_smtpad_957",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35529,7 +35529,7 @@
           "pcb_smtpad_957",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35548,7 +35548,7 @@
           "pcb_smtpad_958",
           "connectivity_net1696"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35567,7 +35567,7 @@
           "pcb_smtpad_959",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35586,7 +35586,7 @@
           "pcb_smtpad_960",
           "connectivity_net1685"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35605,7 +35605,7 @@
           "pcb_smtpad_961",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35624,7 +35624,7 @@
           "pcb_smtpad_962",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35643,7 +35643,7 @@
           "pcb_smtpad_962",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35662,7 +35662,7 @@
           "pcb_smtpad_962",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35681,7 +35681,7 @@
           "pcb_smtpad_962",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35700,7 +35700,7 @@
           "pcb_smtpad_963",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35719,7 +35719,7 @@
           "pcb_smtpad_963",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35738,7 +35738,7 @@
           "pcb_smtpad_963",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35757,7 +35757,7 @@
           "pcb_smtpad_963",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35776,7 +35776,7 @@
           "pcb_smtpad_964",
           "connectivity_net1707"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35795,7 +35795,7 @@
           "pcb_smtpad_965",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35814,7 +35814,7 @@
           "pcb_smtpad_966",
           "connectivity_net1696"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35833,7 +35833,7 @@
           "pcb_smtpad_967",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35852,7 +35852,7 @@
           "pcb_smtpad_968",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35871,7 +35871,7 @@
           "pcb_smtpad_968",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35890,7 +35890,7 @@
           "pcb_smtpad_968",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35909,7 +35909,7 @@
           "pcb_smtpad_968",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35928,7 +35928,7 @@
           "pcb_smtpad_969",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35947,7 +35947,7 @@
           "pcb_smtpad_969",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35966,7 +35966,7 @@
           "pcb_smtpad_969",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -35985,7 +35985,7 @@
           "pcb_smtpad_969",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36004,7 +36004,7 @@
           "pcb_smtpad_970",
           "connectivity_net1718"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36023,7 +36023,7 @@
           "pcb_smtpad_971",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36042,7 +36042,7 @@
           "pcb_smtpad_972",
           "connectivity_net1707"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36061,7 +36061,7 @@
           "pcb_smtpad_973",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36080,7 +36080,7 @@
           "pcb_smtpad_974",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36099,7 +36099,7 @@
           "pcb_smtpad_974",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36118,7 +36118,7 @@
           "pcb_smtpad_974",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36137,7 +36137,7 @@
           "pcb_smtpad_974",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36156,7 +36156,7 @@
           "pcb_smtpad_975",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36175,7 +36175,7 @@
           "pcb_smtpad_975",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36194,7 +36194,7 @@
           "pcb_smtpad_975",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36213,7 +36213,7 @@
           "pcb_smtpad_975",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36232,7 +36232,7 @@
           "pcb_smtpad_976",
           "connectivity_net1729"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36251,7 +36251,7 @@
           "pcb_smtpad_977",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36270,7 +36270,7 @@
           "pcb_smtpad_978",
           "connectivity_net1718"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36289,7 +36289,7 @@
           "pcb_smtpad_979",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36308,7 +36308,7 @@
           "pcb_smtpad_980",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36327,7 +36327,7 @@
           "pcb_smtpad_980",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36346,7 +36346,7 @@
           "pcb_smtpad_980",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36365,7 +36365,7 @@
           "pcb_smtpad_980",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36384,7 +36384,7 @@
           "pcb_smtpad_981",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36403,7 +36403,7 @@
           "pcb_smtpad_981",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36422,7 +36422,7 @@
           "pcb_smtpad_981",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36441,7 +36441,7 @@
           "pcb_smtpad_981",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36460,7 +36460,7 @@
           "pcb_smtpad_982",
           "connectivity_net1740"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36479,7 +36479,7 @@
           "pcb_smtpad_983",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36498,7 +36498,7 @@
           "pcb_smtpad_984",
           "connectivity_net1729"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36517,7 +36517,7 @@
           "pcb_smtpad_985",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36536,7 +36536,7 @@
           "pcb_smtpad_986",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36555,7 +36555,7 @@
           "pcb_smtpad_986",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36574,7 +36574,7 @@
           "pcb_smtpad_986",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36593,7 +36593,7 @@
           "pcb_smtpad_986",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36612,7 +36612,7 @@
           "pcb_smtpad_987",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36631,7 +36631,7 @@
           "pcb_smtpad_987",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36650,7 +36650,7 @@
           "pcb_smtpad_987",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36669,7 +36669,7 @@
           "pcb_smtpad_987",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36688,7 +36688,7 @@
           "pcb_smtpad_988",
           "connectivity_net1751"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36707,7 +36707,7 @@
           "pcb_smtpad_989",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36726,7 +36726,7 @@
           "pcb_smtpad_990",
           "connectivity_net1740"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36745,7 +36745,7 @@
           "pcb_smtpad_991",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36764,7 +36764,7 @@
           "pcb_smtpad_992",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36783,7 +36783,7 @@
           "pcb_smtpad_992",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36802,7 +36802,7 @@
           "pcb_smtpad_992",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36821,7 +36821,7 @@
           "pcb_smtpad_992",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36840,7 +36840,7 @@
           "pcb_smtpad_993",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36859,7 +36859,7 @@
           "pcb_smtpad_993",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36878,7 +36878,7 @@
           "pcb_smtpad_993",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36897,7 +36897,7 @@
           "pcb_smtpad_993",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36916,7 +36916,7 @@
           "pcb_smtpad_994",
           "connectivity_net1762"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36935,7 +36935,7 @@
           "pcb_smtpad_995",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36954,7 +36954,7 @@
           "pcb_smtpad_996",
           "connectivity_net1751"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36973,7 +36973,7 @@
           "pcb_smtpad_997",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -36992,7 +36992,7 @@
           "pcb_smtpad_998",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37011,7 +37011,7 @@
           "pcb_smtpad_998",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37030,7 +37030,7 @@
           "pcb_smtpad_998",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37049,7 +37049,7 @@
           "pcb_smtpad_998",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37068,7 +37068,7 @@
           "pcb_smtpad_999",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37087,7 +37087,7 @@
           "pcb_smtpad_999",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37106,7 +37106,7 @@
           "pcb_smtpad_999",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37125,7 +37125,7 @@
           "pcb_smtpad_999",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37144,7 +37144,7 @@
           "pcb_smtpad_1000",
           "connectivity_net1773"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37163,7 +37163,7 @@
           "pcb_smtpad_1001",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37182,7 +37182,7 @@
           "pcb_smtpad_1002",
           "connectivity_net1762"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37201,7 +37201,7 @@
           "pcb_smtpad_1003",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37220,7 +37220,7 @@
           "pcb_smtpad_1004",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37239,7 +37239,7 @@
           "pcb_smtpad_1004",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37258,7 +37258,7 @@
           "pcb_smtpad_1004",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37277,7 +37277,7 @@
           "pcb_smtpad_1004",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37296,7 +37296,7 @@
           "pcb_smtpad_1005",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37315,7 +37315,7 @@
           "pcb_smtpad_1005",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37334,7 +37334,7 @@
           "pcb_smtpad_1005",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37353,7 +37353,7 @@
           "pcb_smtpad_1005",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37372,7 +37372,7 @@
           "pcb_smtpad_1006",
           "connectivity_net1784"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37391,7 +37391,7 @@
           "pcb_smtpad_1007",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37410,7 +37410,7 @@
           "pcb_smtpad_1008",
           "connectivity_net1773"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37429,7 +37429,7 @@
           "pcb_smtpad_1009",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37448,7 +37448,7 @@
           "pcb_smtpad_1010",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37467,7 +37467,7 @@
           "pcb_smtpad_1010",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37486,7 +37486,7 @@
           "pcb_smtpad_1010",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37505,7 +37505,7 @@
           "pcb_smtpad_1010",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37524,7 +37524,7 @@
           "pcb_smtpad_1011",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37543,7 +37543,7 @@
           "pcb_smtpad_1011",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37562,7 +37562,7 @@
           "pcb_smtpad_1011",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37581,7 +37581,7 @@
           "pcb_smtpad_1011",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37600,7 +37600,7 @@
           "pcb_smtpad_1012",
           "connectivity_net1795"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37619,7 +37619,7 @@
           "pcb_smtpad_1013",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37638,7 +37638,7 @@
           "pcb_smtpad_1014",
           "connectivity_net1784"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37657,7 +37657,7 @@
           "pcb_smtpad_1015",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37676,7 +37676,7 @@
           "pcb_smtpad_1016",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37695,7 +37695,7 @@
           "pcb_smtpad_1016",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37714,7 +37714,7 @@
           "pcb_smtpad_1016",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37733,7 +37733,7 @@
           "pcb_smtpad_1016",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37752,7 +37752,7 @@
           "pcb_smtpad_1017",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37771,7 +37771,7 @@
           "pcb_smtpad_1017",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37790,7 +37790,7 @@
           "pcb_smtpad_1017",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37809,7 +37809,7 @@
           "pcb_smtpad_1017",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37828,7 +37828,7 @@
           "pcb_smtpad_1018",
           "connectivity_net1806"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37847,7 +37847,7 @@
           "pcb_smtpad_1019",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37866,7 +37866,7 @@
           "pcb_smtpad_1020",
           "connectivity_net1795"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37885,7 +37885,7 @@
           "pcb_smtpad_1021",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37904,7 +37904,7 @@
           "pcb_smtpad_1022",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37923,7 +37923,7 @@
           "pcb_smtpad_1022",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37942,7 +37942,7 @@
           "pcb_smtpad_1022",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37961,7 +37961,7 @@
           "pcb_smtpad_1022",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37980,7 +37980,7 @@
           "pcb_smtpad_1023",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -37999,7 +37999,7 @@
           "pcb_smtpad_1023",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38018,7 +38018,7 @@
           "pcb_smtpad_1023",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38037,7 +38037,7 @@
           "pcb_smtpad_1023",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38056,7 +38056,7 @@
           "pcb_smtpad_1024",
           "connectivity_net1817"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38075,7 +38075,7 @@
           "pcb_smtpad_1025",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38094,7 +38094,7 @@
           "pcb_smtpad_1026",
           "connectivity_net1806"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38113,7 +38113,7 @@
           "pcb_smtpad_1027",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38132,7 +38132,7 @@
           "pcb_smtpad_1028",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38151,7 +38151,7 @@
           "pcb_smtpad_1028",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38170,7 +38170,7 @@
           "pcb_smtpad_1028",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38189,7 +38189,7 @@
           "pcb_smtpad_1028",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38208,7 +38208,7 @@
           "pcb_smtpad_1029",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38227,7 +38227,7 @@
           "pcb_smtpad_1029",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38246,7 +38246,7 @@
           "pcb_smtpad_1029",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38265,7 +38265,7 @@
           "pcb_smtpad_1029",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38284,7 +38284,7 @@
           "pcb_smtpad_1030",
           "connectivity_net1828"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38303,7 +38303,7 @@
           "pcb_smtpad_1031",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38322,7 +38322,7 @@
           "pcb_smtpad_1032",
           "connectivity_net1817"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38341,7 +38341,7 @@
           "pcb_smtpad_1033",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38360,7 +38360,7 @@
           "pcb_smtpad_1034",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38379,7 +38379,7 @@
           "pcb_smtpad_1034",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38398,7 +38398,7 @@
           "pcb_smtpad_1034",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38417,7 +38417,7 @@
           "pcb_smtpad_1034",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38436,7 +38436,7 @@
           "pcb_smtpad_1035",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38455,7 +38455,7 @@
           "pcb_smtpad_1035",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38474,7 +38474,7 @@
           "pcb_smtpad_1035",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38493,7 +38493,7 @@
           "pcb_smtpad_1035",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38512,7 +38512,7 @@
           "pcb_smtpad_1036",
           "connectivity_net1839"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38531,7 +38531,7 @@
           "pcb_smtpad_1037",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38550,7 +38550,7 @@
           "pcb_smtpad_1038",
           "connectivity_net1828"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38569,7 +38569,7 @@
           "pcb_smtpad_1039",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38588,7 +38588,7 @@
           "pcb_smtpad_1040",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38607,7 +38607,7 @@
           "pcb_smtpad_1040",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38626,7 +38626,7 @@
           "pcb_smtpad_1040",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38645,7 +38645,7 @@
           "pcb_smtpad_1040",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38664,7 +38664,7 @@
           "pcb_smtpad_1041",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38683,7 +38683,7 @@
           "pcb_smtpad_1041",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38702,7 +38702,7 @@
           "pcb_smtpad_1041",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38721,7 +38721,7 @@
           "pcb_smtpad_1041",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38740,7 +38740,7 @@
           "pcb_smtpad_1042",
           "connectivity_net1850"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38759,7 +38759,7 @@
           "pcb_smtpad_1043",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38778,7 +38778,7 @@
           "pcb_smtpad_1044",
           "connectivity_net1839"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38797,7 +38797,7 @@
           "pcb_smtpad_1045",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38816,7 +38816,7 @@
           "pcb_smtpad_1046",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38835,7 +38835,7 @@
           "pcb_smtpad_1046",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38854,7 +38854,7 @@
           "pcb_smtpad_1046",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38873,7 +38873,7 @@
           "pcb_smtpad_1046",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38892,7 +38892,7 @@
           "pcb_smtpad_1047",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38911,7 +38911,7 @@
           "pcb_smtpad_1047",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38930,7 +38930,7 @@
           "pcb_smtpad_1047",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38949,7 +38949,7 @@
           "pcb_smtpad_1047",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38968,7 +38968,7 @@
           "pcb_smtpad_1048",
           "connectivity_net1861"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -38987,7 +38987,7 @@
           "pcb_smtpad_1049",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39006,7 +39006,7 @@
           "pcb_smtpad_1050",
           "connectivity_net1850"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39025,7 +39025,7 @@
           "pcb_smtpad_1051",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39044,7 +39044,7 @@
           "pcb_smtpad_1052",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39063,7 +39063,7 @@
           "pcb_smtpad_1052",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39082,7 +39082,7 @@
           "pcb_smtpad_1052",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39101,7 +39101,7 @@
           "pcb_smtpad_1052",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39120,7 +39120,7 @@
           "pcb_smtpad_1053",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39139,7 +39139,7 @@
           "pcb_smtpad_1053",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39158,7 +39158,7 @@
           "pcb_smtpad_1053",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39177,7 +39177,7 @@
           "pcb_smtpad_1053",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39196,7 +39196,7 @@
           "pcb_smtpad_1054",
           "connectivity_net1872"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39215,7 +39215,7 @@
           "pcb_smtpad_1055",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39234,7 +39234,7 @@
           "pcb_smtpad_1056",
           "connectivity_net1861"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39253,7 +39253,7 @@
           "pcb_smtpad_1057",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39272,7 +39272,7 @@
           "pcb_smtpad_1058",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39291,7 +39291,7 @@
           "pcb_smtpad_1058",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39310,7 +39310,7 @@
           "pcb_smtpad_1058",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39329,7 +39329,7 @@
           "pcb_smtpad_1058",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39348,7 +39348,7 @@
           "pcb_smtpad_1059",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39367,7 +39367,7 @@
           "pcb_smtpad_1059",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39386,7 +39386,7 @@
           "pcb_smtpad_1059",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39405,7 +39405,7 @@
           "pcb_smtpad_1059",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39424,7 +39424,7 @@
           "pcb_smtpad_1060",
           "connectivity_net1883"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39443,7 +39443,7 @@
           "pcb_smtpad_1061",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39462,7 +39462,7 @@
           "pcb_smtpad_1062",
           "connectivity_net1872"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39481,7 +39481,7 @@
           "pcb_smtpad_1063",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39500,7 +39500,7 @@
           "pcb_smtpad_1064",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39519,7 +39519,7 @@
           "pcb_smtpad_1064",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39538,7 +39538,7 @@
           "pcb_smtpad_1064",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39557,7 +39557,7 @@
           "pcb_smtpad_1064",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39576,7 +39576,7 @@
           "pcb_smtpad_1065",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39595,7 +39595,7 @@
           "pcb_smtpad_1065",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39614,7 +39614,7 @@
           "pcb_smtpad_1065",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39633,7 +39633,7 @@
           "pcb_smtpad_1065",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39652,7 +39652,7 @@
           "pcb_smtpad_1066",
           "connectivity_net1894"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39671,7 +39671,7 @@
           "pcb_smtpad_1067",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39690,7 +39690,7 @@
           "pcb_smtpad_1068",
           "connectivity_net1883"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39709,7 +39709,7 @@
           "pcb_smtpad_1069",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39728,7 +39728,7 @@
           "pcb_smtpad_1070",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39747,7 +39747,7 @@
           "pcb_smtpad_1070",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39766,7 +39766,7 @@
           "pcb_smtpad_1070",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39785,7 +39785,7 @@
           "pcb_smtpad_1070",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39804,7 +39804,7 @@
           "pcb_smtpad_1071",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39823,7 +39823,7 @@
           "pcb_smtpad_1071",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39842,7 +39842,7 @@
           "pcb_smtpad_1071",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39861,7 +39861,7 @@
           "pcb_smtpad_1071",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39880,7 +39880,7 @@
           "pcb_smtpad_1072",
           "connectivity_net1905"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39899,7 +39899,7 @@
           "pcb_smtpad_1073",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39918,7 +39918,7 @@
           "pcb_smtpad_1074",
           "connectivity_net1894"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39937,7 +39937,7 @@
           "pcb_smtpad_1075",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39956,7 +39956,7 @@
           "pcb_smtpad_1076",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39975,7 +39975,7 @@
           "pcb_smtpad_1076",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -39994,7 +39994,7 @@
           "pcb_smtpad_1076",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40013,7 +40013,7 @@
           "pcb_smtpad_1076",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40032,7 +40032,7 @@
           "pcb_smtpad_1077",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40051,7 +40051,7 @@
           "pcb_smtpad_1077",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40070,7 +40070,7 @@
           "pcb_smtpad_1077",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40089,7 +40089,7 @@
           "pcb_smtpad_1077",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40108,7 +40108,7 @@
           "pcb_smtpad_1078",
           "connectivity_net1916"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40127,7 +40127,7 @@
           "pcb_smtpad_1079",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40146,7 +40146,7 @@
           "pcb_smtpad_1080",
           "connectivity_net1905"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40165,7 +40165,7 @@
           "pcb_smtpad_1081",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40184,7 +40184,7 @@
           "pcb_smtpad_1082",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40203,7 +40203,7 @@
           "pcb_smtpad_1082",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40222,7 +40222,7 @@
           "pcb_smtpad_1082",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40241,7 +40241,7 @@
           "pcb_smtpad_1082",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40260,7 +40260,7 @@
           "pcb_smtpad_1083",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40279,7 +40279,7 @@
           "pcb_smtpad_1083",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40298,7 +40298,7 @@
           "pcb_smtpad_1083",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40317,7 +40317,7 @@
           "pcb_smtpad_1083",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40336,7 +40336,7 @@
           "pcb_smtpad_1084",
           "connectivity_net1927"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40355,7 +40355,7 @@
           "pcb_smtpad_1085",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40374,7 +40374,7 @@
           "pcb_smtpad_1086",
           "connectivity_net1916"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40393,7 +40393,7 @@
           "pcb_smtpad_1087",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40412,7 +40412,7 @@
           "pcb_smtpad_1088",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40431,7 +40431,7 @@
           "pcb_smtpad_1088",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40450,7 +40450,7 @@
           "pcb_smtpad_1088",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40469,7 +40469,7 @@
           "pcb_smtpad_1088",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40488,7 +40488,7 @@
           "pcb_smtpad_1089",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40507,7 +40507,7 @@
           "pcb_smtpad_1089",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40526,7 +40526,7 @@
           "pcb_smtpad_1089",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40545,7 +40545,7 @@
           "pcb_smtpad_1089",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40564,7 +40564,7 @@
           "pcb_smtpad_1090",
           "connectivity_net1938"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40583,7 +40583,7 @@
           "pcb_smtpad_1091",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40602,7 +40602,7 @@
           "pcb_smtpad_1092",
           "connectivity_net1927"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40621,7 +40621,7 @@
           "pcb_smtpad_1093",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40640,7 +40640,7 @@
           "pcb_smtpad_1094",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40659,7 +40659,7 @@
           "pcb_smtpad_1094",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40678,7 +40678,7 @@
           "pcb_smtpad_1094",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40697,7 +40697,7 @@
           "pcb_smtpad_1094",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40716,7 +40716,7 @@
           "pcb_smtpad_1095",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40735,7 +40735,7 @@
           "pcb_smtpad_1095",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40754,7 +40754,7 @@
           "pcb_smtpad_1095",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40773,7 +40773,7 @@
           "pcb_smtpad_1095",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40792,7 +40792,7 @@
           "pcb_smtpad_1096",
           "connectivity_net1949"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40811,7 +40811,7 @@
           "pcb_smtpad_1097",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40830,7 +40830,7 @@
           "pcb_smtpad_1098",
           "connectivity_net1938"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40849,7 +40849,7 @@
           "pcb_smtpad_1099",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40868,7 +40868,7 @@
           "pcb_smtpad_1100",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40887,7 +40887,7 @@
           "pcb_smtpad_1100",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40906,7 +40906,7 @@
           "pcb_smtpad_1100",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40925,7 +40925,7 @@
           "pcb_smtpad_1100",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40944,7 +40944,7 @@
           "pcb_smtpad_1101",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40963,7 +40963,7 @@
           "pcb_smtpad_1101",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -40982,7 +40982,7 @@
           "pcb_smtpad_1101",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41001,7 +41001,7 @@
           "pcb_smtpad_1101",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41020,7 +41020,7 @@
           "pcb_smtpad_1102",
           "connectivity_net1960"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41039,7 +41039,7 @@
           "pcb_smtpad_1103",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41058,7 +41058,7 @@
           "pcb_smtpad_1104",
           "connectivity_net1949"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41077,7 +41077,7 @@
           "pcb_smtpad_1105",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41096,7 +41096,7 @@
           "pcb_smtpad_1106",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41115,7 +41115,7 @@
           "pcb_smtpad_1106",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41134,7 +41134,7 @@
           "pcb_smtpad_1106",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41153,7 +41153,7 @@
           "pcb_smtpad_1106",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41172,7 +41172,7 @@
           "pcb_smtpad_1107",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41191,7 +41191,7 @@
           "pcb_smtpad_1107",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41210,7 +41210,7 @@
           "pcb_smtpad_1107",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41229,7 +41229,7 @@
           "pcb_smtpad_1107",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41248,7 +41248,7 @@
           "pcb_smtpad_1108",
           "connectivity_net1971"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41267,7 +41267,7 @@
           "pcb_smtpad_1109",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41286,7 +41286,7 @@
           "pcb_smtpad_1110",
           "connectivity_net1960"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41305,7 +41305,7 @@
           "pcb_smtpad_1111",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41324,7 +41324,7 @@
           "pcb_smtpad_1112",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41343,7 +41343,7 @@
           "pcb_smtpad_1112",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41362,7 +41362,7 @@
           "pcb_smtpad_1112",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41381,7 +41381,7 @@
           "pcb_smtpad_1112",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41400,7 +41400,7 @@
           "pcb_smtpad_1113",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41419,7 +41419,7 @@
           "pcb_smtpad_1113",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41438,7 +41438,7 @@
           "pcb_smtpad_1113",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41457,7 +41457,7 @@
           "pcb_smtpad_1113",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41476,7 +41476,7 @@
           "pcb_smtpad_1114",
           "connectivity_net1982"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41495,7 +41495,7 @@
           "pcb_smtpad_1115",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41514,7 +41514,7 @@
           "pcb_smtpad_1116",
           "connectivity_net1971"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41533,7 +41533,7 @@
           "pcb_smtpad_1117",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41552,7 +41552,7 @@
           "pcb_smtpad_1118",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41571,7 +41571,7 @@
           "pcb_smtpad_1118",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41590,7 +41590,7 @@
           "pcb_smtpad_1118",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41609,7 +41609,7 @@
           "pcb_smtpad_1118",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41628,7 +41628,7 @@
           "pcb_smtpad_1119",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41647,7 +41647,7 @@
           "pcb_smtpad_1119",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41666,7 +41666,7 @@
           "pcb_smtpad_1119",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41685,7 +41685,7 @@
           "pcb_smtpad_1119",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41704,7 +41704,7 @@
           "pcb_smtpad_1120",
           "connectivity_net1993"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41723,7 +41723,7 @@
           "pcb_smtpad_1121",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41742,7 +41742,7 @@
           "pcb_smtpad_1122",
           "connectivity_net1982"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41761,7 +41761,7 @@
           "pcb_smtpad_1123",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41780,7 +41780,7 @@
           "pcb_smtpad_1124",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41799,7 +41799,7 @@
           "pcb_smtpad_1124",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41818,7 +41818,7 @@
           "pcb_smtpad_1124",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41837,7 +41837,7 @@
           "pcb_smtpad_1124",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41856,7 +41856,7 @@
           "pcb_smtpad_1125",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41875,7 +41875,7 @@
           "pcb_smtpad_1125",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41894,7 +41894,7 @@
           "pcb_smtpad_1125",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41913,7 +41913,7 @@
           "pcb_smtpad_1125",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41932,7 +41932,7 @@
           "pcb_smtpad_1126",
           "connectivity_net2004"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41951,7 +41951,7 @@
           "pcb_smtpad_1127",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41970,7 +41970,7 @@
           "pcb_smtpad_1128",
           "connectivity_net1993"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -41989,7 +41989,7 @@
           "pcb_smtpad_1129",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42008,7 +42008,7 @@
           "pcb_smtpad_1130",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42027,7 +42027,7 @@
           "pcb_smtpad_1130",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42046,7 +42046,7 @@
           "pcb_smtpad_1130",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42065,7 +42065,7 @@
           "pcb_smtpad_1130",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42084,7 +42084,7 @@
           "pcb_smtpad_1131",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42103,7 +42103,7 @@
           "pcb_smtpad_1131",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42122,7 +42122,7 @@
           "pcb_smtpad_1131",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42141,7 +42141,7 @@
           "pcb_smtpad_1131",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42160,7 +42160,7 @@
           "pcb_smtpad_1132",
           "connectivity_net2015"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42179,7 +42179,7 @@
           "pcb_smtpad_1133",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42198,7 +42198,7 @@
           "pcb_smtpad_1134",
           "connectivity_net2004"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42217,7 +42217,7 @@
           "pcb_smtpad_1135",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42236,7 +42236,7 @@
           "pcb_smtpad_1136",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42255,7 +42255,7 @@
           "pcb_smtpad_1136",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42274,7 +42274,7 @@
           "pcb_smtpad_1136",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42293,7 +42293,7 @@
           "pcb_smtpad_1136",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42312,7 +42312,7 @@
           "pcb_smtpad_1137",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42331,7 +42331,7 @@
           "pcb_smtpad_1137",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42350,7 +42350,7 @@
           "pcb_smtpad_1137",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42369,7 +42369,7 @@
           "pcb_smtpad_1137",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42388,7 +42388,7 @@
           "pcb_smtpad_1138",
           "connectivity_net2026"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42407,7 +42407,7 @@
           "pcb_smtpad_1139",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42426,7 +42426,7 @@
           "pcb_smtpad_1140",
           "connectivity_net2015"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42445,7 +42445,7 @@
           "pcb_smtpad_1141",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42464,7 +42464,7 @@
           "pcb_smtpad_1142",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42483,7 +42483,7 @@
           "pcb_smtpad_1142",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42502,7 +42502,7 @@
           "pcb_smtpad_1142",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42521,7 +42521,7 @@
           "pcb_smtpad_1142",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42540,7 +42540,7 @@
           "pcb_smtpad_1143",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42559,7 +42559,7 @@
           "pcb_smtpad_1143",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42578,7 +42578,7 @@
           "pcb_smtpad_1143",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42597,7 +42597,7 @@
           "pcb_smtpad_1143",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42616,7 +42616,7 @@
           "pcb_smtpad_1144",
           "connectivity_net2037"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42635,7 +42635,7 @@
           "pcb_smtpad_1145",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42654,7 +42654,7 @@
           "pcb_smtpad_1146",
           "connectivity_net2026"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42673,7 +42673,7 @@
           "pcb_smtpad_1147",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42692,7 +42692,7 @@
           "pcb_smtpad_1148",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42711,7 +42711,7 @@
           "pcb_smtpad_1148",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42730,7 +42730,7 @@
           "pcb_smtpad_1148",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42749,7 +42749,7 @@
           "pcb_smtpad_1148",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42768,7 +42768,7 @@
           "pcb_smtpad_1149",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42787,7 +42787,7 @@
           "pcb_smtpad_1149",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42806,7 +42806,7 @@
           "pcb_smtpad_1149",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42825,7 +42825,7 @@
           "pcb_smtpad_1149",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42844,7 +42844,7 @@
           "pcb_smtpad_1150",
           "connectivity_net2048"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42863,7 +42863,7 @@
           "pcb_smtpad_1151",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42882,7 +42882,7 @@
           "pcb_smtpad_1152",
           "connectivity_net2037"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42901,7 +42901,7 @@
           "pcb_smtpad_1153",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42920,7 +42920,7 @@
           "pcb_smtpad_1154",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42939,7 +42939,7 @@
           "pcb_smtpad_1154",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42958,7 +42958,7 @@
           "pcb_smtpad_1154",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42977,7 +42977,7 @@
           "pcb_smtpad_1154",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -42996,7 +42996,7 @@
           "pcb_smtpad_1155",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43015,7 +43015,7 @@
           "pcb_smtpad_1155",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43034,7 +43034,7 @@
           "pcb_smtpad_1155",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43053,7 +43053,7 @@
           "pcb_smtpad_1155",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43072,7 +43072,7 @@
           "pcb_smtpad_1156",
           "connectivity_net2059"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43091,7 +43091,7 @@
           "pcb_smtpad_1157",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43110,7 +43110,7 @@
           "pcb_smtpad_1158",
           "connectivity_net2048"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43129,7 +43129,7 @@
           "pcb_smtpad_1159",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43148,7 +43148,7 @@
           "pcb_smtpad_1160",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43167,7 +43167,7 @@
           "pcb_smtpad_1160",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43186,7 +43186,7 @@
           "pcb_smtpad_1160",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43205,7 +43205,7 @@
           "pcb_smtpad_1160",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43224,7 +43224,7 @@
           "pcb_smtpad_1161",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43243,7 +43243,7 @@
           "pcb_smtpad_1161",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43262,7 +43262,7 @@
           "pcb_smtpad_1161",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43281,7 +43281,7 @@
           "pcb_smtpad_1161",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43300,7 +43300,7 @@
           "pcb_smtpad_1162",
           "connectivity_net2070"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43319,7 +43319,7 @@
           "pcb_smtpad_1163",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43338,7 +43338,7 @@
           "pcb_smtpad_1164",
           "connectivity_net2059"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43357,7 +43357,7 @@
           "pcb_smtpad_1165",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43376,7 +43376,7 @@
           "pcb_smtpad_1166",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43395,7 +43395,7 @@
           "pcb_smtpad_1166",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43414,7 +43414,7 @@
           "pcb_smtpad_1166",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43433,7 +43433,7 @@
           "pcb_smtpad_1166",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43452,7 +43452,7 @@
           "pcb_smtpad_1167",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43471,7 +43471,7 @@
           "pcb_smtpad_1167",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43490,7 +43490,7 @@
           "pcb_smtpad_1167",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43509,7 +43509,7 @@
           "pcb_smtpad_1167",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43528,7 +43528,7 @@
           "pcb_smtpad_1168",
           "connectivity_net2081"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43547,7 +43547,7 @@
           "pcb_smtpad_1169",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43566,7 +43566,7 @@
           "pcb_smtpad_1170",
           "connectivity_net2070"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43585,7 +43585,7 @@
           "pcb_smtpad_1171",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43604,7 +43604,7 @@
           "pcb_smtpad_1172",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43623,7 +43623,7 @@
           "pcb_smtpad_1172",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43642,7 +43642,7 @@
           "pcb_smtpad_1172",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43661,7 +43661,7 @@
           "pcb_smtpad_1172",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43680,7 +43680,7 @@
           "pcb_smtpad_1173",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43699,7 +43699,7 @@
           "pcb_smtpad_1173",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43718,7 +43718,7 @@
           "pcb_smtpad_1173",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43737,7 +43737,7 @@
           "pcb_smtpad_1173",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43756,7 +43756,7 @@
           "pcb_smtpad_1174",
           "connectivity_net2092"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43775,7 +43775,7 @@
           "pcb_smtpad_1175",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43794,7 +43794,7 @@
           "pcb_smtpad_1176",
           "connectivity_net2081"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43813,7 +43813,7 @@
           "pcb_smtpad_1177",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43832,7 +43832,7 @@
           "pcb_smtpad_1178",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43851,7 +43851,7 @@
           "pcb_smtpad_1178",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43870,7 +43870,7 @@
           "pcb_smtpad_1178",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43889,7 +43889,7 @@
           "pcb_smtpad_1178",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43908,7 +43908,7 @@
           "pcb_smtpad_1179",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43927,7 +43927,7 @@
           "pcb_smtpad_1179",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43946,7 +43946,7 @@
           "pcb_smtpad_1179",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43965,7 +43965,7 @@
           "pcb_smtpad_1179",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -43984,7 +43984,7 @@
           "pcb_smtpad_1180",
           "connectivity_net2103"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44003,7 +44003,7 @@
           "pcb_smtpad_1181",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44022,7 +44022,7 @@
           "pcb_smtpad_1182",
           "connectivity_net2092"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44041,7 +44041,7 @@
           "pcb_smtpad_1183",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44060,7 +44060,7 @@
           "pcb_smtpad_1184",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44079,7 +44079,7 @@
           "pcb_smtpad_1184",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44098,7 +44098,7 @@
           "pcb_smtpad_1184",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44117,7 +44117,7 @@
           "pcb_smtpad_1184",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44136,7 +44136,7 @@
           "pcb_smtpad_1185",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44155,7 +44155,7 @@
           "pcb_smtpad_1185",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44174,7 +44174,7 @@
           "pcb_smtpad_1185",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44193,7 +44193,7 @@
           "pcb_smtpad_1185",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44212,7 +44212,7 @@
           "pcb_smtpad_1186",
           "connectivity_net2114"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44231,7 +44231,7 @@
           "pcb_smtpad_1187",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44250,7 +44250,7 @@
           "pcb_smtpad_1188",
           "connectivity_net2103"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44269,7 +44269,7 @@
           "pcb_smtpad_1189",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44288,7 +44288,7 @@
           "pcb_smtpad_1190",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44307,7 +44307,7 @@
           "pcb_smtpad_1190",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44326,7 +44326,7 @@
           "pcb_smtpad_1190",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44345,7 +44345,7 @@
           "pcb_smtpad_1190",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44364,7 +44364,7 @@
           "pcb_smtpad_1191",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44383,7 +44383,7 @@
           "pcb_smtpad_1191",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44402,7 +44402,7 @@
           "pcb_smtpad_1191",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44421,7 +44421,7 @@
           "pcb_smtpad_1191",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44440,7 +44440,7 @@
           "pcb_smtpad_1192",
           "connectivity_net2125"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44459,7 +44459,7 @@
           "pcb_smtpad_1193",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44478,7 +44478,7 @@
           "pcb_smtpad_1194",
           "connectivity_net2114"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44497,7 +44497,7 @@
           "pcb_smtpad_1195",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44516,7 +44516,7 @@
           "pcb_smtpad_1196",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44535,7 +44535,7 @@
           "pcb_smtpad_1196",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44554,7 +44554,7 @@
           "pcb_smtpad_1196",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44573,7 +44573,7 @@
           "pcb_smtpad_1196",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44592,7 +44592,7 @@
           "pcb_smtpad_1197",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44611,7 +44611,7 @@
           "pcb_smtpad_1197",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44630,7 +44630,7 @@
           "pcb_smtpad_1197",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44649,7 +44649,7 @@
           "pcb_smtpad_1197",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44668,7 +44668,7 @@
           "pcb_smtpad_1198",
           "connectivity_net2136"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44687,7 +44687,7 @@
           "pcb_smtpad_1199",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44706,7 +44706,7 @@
           "pcb_smtpad_1200",
           "connectivity_net2125"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44725,7 +44725,7 @@
           "pcb_smtpad_1201",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44744,7 +44744,7 @@
           "pcb_smtpad_1202",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44763,7 +44763,7 @@
           "pcb_smtpad_1202",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44782,7 +44782,7 @@
           "pcb_smtpad_1202",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44801,7 +44801,7 @@
           "pcb_smtpad_1202",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44820,7 +44820,7 @@
           "pcb_smtpad_1203",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44839,7 +44839,7 @@
           "pcb_smtpad_1203",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44858,7 +44858,7 @@
           "pcb_smtpad_1203",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44877,7 +44877,7 @@
           "pcb_smtpad_1203",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44896,7 +44896,7 @@
           "pcb_smtpad_1204",
           "connectivity_net2147"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44915,7 +44915,7 @@
           "pcb_smtpad_1205",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44934,7 +44934,7 @@
           "pcb_smtpad_1206",
           "connectivity_net2136"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44953,7 +44953,7 @@
           "pcb_smtpad_1207",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44972,7 +44972,7 @@
           "pcb_smtpad_1208",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -44991,7 +44991,7 @@
           "pcb_smtpad_1208",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45010,7 +45010,7 @@
           "pcb_smtpad_1208",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45029,7 +45029,7 @@
           "pcb_smtpad_1208",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45048,7 +45048,7 @@
           "pcb_smtpad_1209",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45067,7 +45067,7 @@
           "pcb_smtpad_1209",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45086,7 +45086,7 @@
           "pcb_smtpad_1209",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45105,7 +45105,7 @@
           "pcb_smtpad_1209",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45124,7 +45124,7 @@
           "pcb_smtpad_1210",
           "connectivity_net2158"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45143,7 +45143,7 @@
           "pcb_smtpad_1211",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45162,7 +45162,7 @@
           "pcb_smtpad_1212",
           "connectivity_net2147"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45181,7 +45181,7 @@
           "pcb_smtpad_1213",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45200,7 +45200,7 @@
           "pcb_smtpad_1214",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45219,7 +45219,7 @@
           "pcb_smtpad_1214",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45238,7 +45238,7 @@
           "pcb_smtpad_1214",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45257,7 +45257,7 @@
           "pcb_smtpad_1214",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45276,7 +45276,7 @@
           "pcb_smtpad_1215",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45295,7 +45295,7 @@
           "pcb_smtpad_1215",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45314,7 +45314,7 @@
           "pcb_smtpad_1215",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45333,7 +45333,7 @@
           "pcb_smtpad_1215",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45352,7 +45352,7 @@
           "pcb_smtpad_1216",
           "connectivity_net2169"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45371,7 +45371,7 @@
           "pcb_smtpad_1217",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45390,7 +45390,7 @@
           "pcb_smtpad_1218",
           "connectivity_net2158"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45409,7 +45409,7 @@
           "pcb_smtpad_1219",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45428,7 +45428,7 @@
           "pcb_smtpad_1220",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45447,7 +45447,7 @@
           "pcb_smtpad_1220",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45466,7 +45466,7 @@
           "pcb_smtpad_1220",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45485,7 +45485,7 @@
           "pcb_smtpad_1220",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45504,7 +45504,7 @@
           "pcb_smtpad_1221",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45523,7 +45523,7 @@
           "pcb_smtpad_1221",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45542,7 +45542,7 @@
           "pcb_smtpad_1221",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45561,7 +45561,7 @@
           "pcb_smtpad_1221",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45580,7 +45580,7 @@
           "pcb_smtpad_1222",
           "connectivity_net2180"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45599,7 +45599,7 @@
           "pcb_smtpad_1223",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45618,7 +45618,7 @@
           "pcb_smtpad_1224",
           "connectivity_net2169"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45637,7 +45637,7 @@
           "pcb_smtpad_1225",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45656,7 +45656,7 @@
           "pcb_smtpad_1226",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45675,7 +45675,7 @@
           "pcb_smtpad_1226",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45694,7 +45694,7 @@
           "pcb_smtpad_1226",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45713,7 +45713,7 @@
           "pcb_smtpad_1226",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45732,7 +45732,7 @@
           "pcb_smtpad_1227",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45751,7 +45751,7 @@
           "pcb_smtpad_1227",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45770,7 +45770,7 @@
           "pcb_smtpad_1227",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45789,7 +45789,7 @@
           "pcb_smtpad_1227",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45808,7 +45808,7 @@
           "pcb_smtpad_1228",
           "connectivity_net2191"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45827,7 +45827,7 @@
           "pcb_smtpad_1229",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45846,7 +45846,7 @@
           "pcb_smtpad_1230",
           "connectivity_net2180"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45865,7 +45865,7 @@
           "pcb_smtpad_1231",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45884,7 +45884,7 @@
           "pcb_smtpad_1232",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45903,7 +45903,7 @@
           "pcb_smtpad_1232",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45922,7 +45922,7 @@
           "pcb_smtpad_1232",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45941,7 +45941,7 @@
           "pcb_smtpad_1232",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45960,7 +45960,7 @@
           "pcb_smtpad_1233",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45979,7 +45979,7 @@
           "pcb_smtpad_1233",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -45998,7 +45998,7 @@
           "pcb_smtpad_1233",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46017,7 +46017,7 @@
           "pcb_smtpad_1233",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46036,7 +46036,7 @@
           "pcb_smtpad_1234",
           "connectivity_net2202"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46055,7 +46055,7 @@
           "pcb_smtpad_1235",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46074,7 +46074,7 @@
           "pcb_smtpad_1236",
           "connectivity_net2191"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46093,7 +46093,7 @@
           "pcb_smtpad_1237",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46112,7 +46112,7 @@
           "pcb_smtpad_1238",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46131,7 +46131,7 @@
           "pcb_smtpad_1238",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46150,7 +46150,7 @@
           "pcb_smtpad_1238",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46169,7 +46169,7 @@
           "pcb_smtpad_1238",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46188,7 +46188,7 @@
           "pcb_smtpad_1239",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46207,7 +46207,7 @@
           "pcb_smtpad_1239",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46226,7 +46226,7 @@
           "pcb_smtpad_1239",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46245,7 +46245,7 @@
           "pcb_smtpad_1239",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46264,7 +46264,7 @@
           "pcb_smtpad_1240",
           "connectivity_net2213"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46283,7 +46283,7 @@
           "pcb_smtpad_1241",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46302,7 +46302,7 @@
           "pcb_smtpad_1242",
           "connectivity_net2202"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46321,7 +46321,7 @@
           "pcb_smtpad_1243",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46340,7 +46340,7 @@
           "pcb_smtpad_1244",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46359,7 +46359,7 @@
           "pcb_smtpad_1244",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46378,7 +46378,7 @@
           "pcb_smtpad_1244",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46397,7 +46397,7 @@
           "pcb_smtpad_1244",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46416,7 +46416,7 @@
           "pcb_smtpad_1245",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46435,7 +46435,7 @@
           "pcb_smtpad_1245",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46454,7 +46454,7 @@
           "pcb_smtpad_1245",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46473,7 +46473,7 @@
           "pcb_smtpad_1245",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46492,7 +46492,7 @@
           "pcb_smtpad_1246",
           "connectivity_net2224"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46511,7 +46511,7 @@
           "pcb_smtpad_1247",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46530,7 +46530,7 @@
           "pcb_smtpad_1248",
           "connectivity_net2213"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46549,7 +46549,7 @@
           "pcb_smtpad_1249",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46568,7 +46568,7 @@
           "pcb_smtpad_1250",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46587,7 +46587,7 @@
           "pcb_smtpad_1250",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46606,7 +46606,7 @@
           "pcb_smtpad_1250",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46625,7 +46625,7 @@
           "pcb_smtpad_1250",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46644,7 +46644,7 @@
           "pcb_smtpad_1251",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46663,7 +46663,7 @@
           "pcb_smtpad_1251",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46682,7 +46682,7 @@
           "pcb_smtpad_1251",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46701,7 +46701,7 @@
           "pcb_smtpad_1251",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46720,7 +46720,7 @@
           "pcb_smtpad_1252",
           "connectivity_net2235"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46739,7 +46739,7 @@
           "pcb_smtpad_1253",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46758,7 +46758,7 @@
           "pcb_smtpad_1254",
           "connectivity_net2224"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46777,7 +46777,7 @@
           "pcb_smtpad_1255",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46796,7 +46796,7 @@
           "pcb_smtpad_1256",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46815,7 +46815,7 @@
           "pcb_smtpad_1256",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46834,7 +46834,7 @@
           "pcb_smtpad_1256",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46853,7 +46853,7 @@
           "pcb_smtpad_1256",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46872,7 +46872,7 @@
           "pcb_smtpad_1257",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46891,7 +46891,7 @@
           "pcb_smtpad_1257",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46910,7 +46910,7 @@
           "pcb_smtpad_1257",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46929,7 +46929,7 @@
           "pcb_smtpad_1257",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46948,7 +46948,7 @@
           "pcb_smtpad_1258",
           "connectivity_net2246"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46967,7 +46967,7 @@
           "pcb_smtpad_1259",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -46986,7 +46986,7 @@
           "pcb_smtpad_1260",
           "connectivity_net2235"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47005,7 +47005,7 @@
           "pcb_smtpad_1261",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47024,7 +47024,7 @@
           "pcb_smtpad_1262",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47043,7 +47043,7 @@
           "pcb_smtpad_1262",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47062,7 +47062,7 @@
           "pcb_smtpad_1262",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47081,7 +47081,7 @@
           "pcb_smtpad_1262",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47100,7 +47100,7 @@
           "pcb_smtpad_1263",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47119,7 +47119,7 @@
           "pcb_smtpad_1263",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47138,7 +47138,7 @@
           "pcb_smtpad_1263",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47157,7 +47157,7 @@
           "pcb_smtpad_1263",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47176,7 +47176,7 @@
           "pcb_smtpad_1264",
           "connectivity_net2257"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47195,7 +47195,7 @@
           "pcb_smtpad_1265",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47214,7 +47214,7 @@
           "pcb_smtpad_1266",
           "connectivity_net2246"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47233,7 +47233,7 @@
           "pcb_smtpad_1267",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47252,7 +47252,7 @@
           "pcb_smtpad_1268",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47271,7 +47271,7 @@
           "pcb_smtpad_1268",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47290,7 +47290,7 @@
           "pcb_smtpad_1268",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47309,7 +47309,7 @@
           "pcb_smtpad_1268",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47328,7 +47328,7 @@
           "pcb_smtpad_1269",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47347,7 +47347,7 @@
           "pcb_smtpad_1269",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47366,7 +47366,7 @@
           "pcb_smtpad_1269",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47385,7 +47385,7 @@
           "pcb_smtpad_1269",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47404,7 +47404,7 @@
           "pcb_smtpad_1270",
           "connectivity_net2268"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47423,7 +47423,7 @@
           "pcb_smtpad_1271",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47442,7 +47442,7 @@
           "pcb_smtpad_1272",
           "connectivity_net2257"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47461,7 +47461,7 @@
           "pcb_smtpad_1273",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47480,7 +47480,7 @@
           "pcb_smtpad_1274",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47499,7 +47499,7 @@
           "pcb_smtpad_1274",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47518,7 +47518,7 @@
           "pcb_smtpad_1274",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47537,7 +47537,7 @@
           "pcb_smtpad_1274",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47556,7 +47556,7 @@
           "pcb_smtpad_1275",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47575,7 +47575,7 @@
           "pcb_smtpad_1275",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47594,7 +47594,7 @@
           "pcb_smtpad_1275",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47613,7 +47613,7 @@
           "pcb_smtpad_1275",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47632,7 +47632,7 @@
           "pcb_smtpad_1276",
           "connectivity_net2279"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47651,7 +47651,7 @@
           "pcb_smtpad_1277",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47670,7 +47670,7 @@
           "pcb_smtpad_1278",
           "connectivity_net2268"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47689,7 +47689,7 @@
           "pcb_smtpad_1279",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47708,7 +47708,7 @@
           "pcb_smtpad_1280",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47727,7 +47727,7 @@
           "pcb_smtpad_1280",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47746,7 +47746,7 @@
           "pcb_smtpad_1280",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47765,7 +47765,7 @@
           "pcb_smtpad_1280",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47784,7 +47784,7 @@
           "pcb_smtpad_1281",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47803,7 +47803,7 @@
           "pcb_smtpad_1281",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47822,7 +47822,7 @@
           "pcb_smtpad_1281",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47841,7 +47841,7 @@
           "pcb_smtpad_1281",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47860,7 +47860,7 @@
           "pcb_smtpad_1282",
           "connectivity_net2290"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47879,7 +47879,7 @@
           "pcb_smtpad_1283",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47898,7 +47898,7 @@
           "pcb_smtpad_1284",
           "connectivity_net2279"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47917,7 +47917,7 @@
           "pcb_smtpad_1285",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47936,7 +47936,7 @@
           "pcb_smtpad_1286",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47955,7 +47955,7 @@
           "pcb_smtpad_1286",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47974,7 +47974,7 @@
           "pcb_smtpad_1286",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -47993,7 +47993,7 @@
           "pcb_smtpad_1286",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48012,7 +48012,7 @@
           "pcb_smtpad_1287",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48031,7 +48031,7 @@
           "pcb_smtpad_1287",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48050,7 +48050,7 @@
           "pcb_smtpad_1287",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48069,7 +48069,7 @@
           "pcb_smtpad_1287",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48088,7 +48088,7 @@
           "pcb_smtpad_1288",
           "connectivity_net2301"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48107,7 +48107,7 @@
           "pcb_smtpad_1289",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48126,7 +48126,7 @@
           "pcb_smtpad_1290",
           "connectivity_net2290"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48145,7 +48145,7 @@
           "pcb_smtpad_1291",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48164,7 +48164,7 @@
           "pcb_smtpad_1292",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48183,7 +48183,7 @@
           "pcb_smtpad_1292",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48202,7 +48202,7 @@
           "pcb_smtpad_1292",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48221,7 +48221,7 @@
           "pcb_smtpad_1292",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48240,7 +48240,7 @@
           "pcb_smtpad_1293",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48259,7 +48259,7 @@
           "pcb_smtpad_1293",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48278,7 +48278,7 @@
           "pcb_smtpad_1293",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48297,7 +48297,7 @@
           "pcb_smtpad_1293",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48316,7 +48316,7 @@
           "pcb_smtpad_1294",
           "connectivity_net2312"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48335,7 +48335,7 @@
           "pcb_smtpad_1295",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48354,7 +48354,7 @@
           "pcb_smtpad_1296",
           "connectivity_net2301"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48373,7 +48373,7 @@
           "pcb_smtpad_1297",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48392,7 +48392,7 @@
           "pcb_smtpad_1298",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48411,7 +48411,7 @@
           "pcb_smtpad_1298",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48430,7 +48430,7 @@
           "pcb_smtpad_1298",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48449,7 +48449,7 @@
           "pcb_smtpad_1298",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48468,7 +48468,7 @@
           "pcb_smtpad_1299",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48487,7 +48487,7 @@
           "pcb_smtpad_1299",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48506,7 +48506,7 @@
           "pcb_smtpad_1299",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48525,7 +48525,7 @@
           "pcb_smtpad_1299",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48544,7 +48544,7 @@
           "pcb_smtpad_1300",
           "connectivity_net2323"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48563,7 +48563,7 @@
           "pcb_smtpad_1301",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48582,7 +48582,7 @@
           "pcb_smtpad_1302",
           "connectivity_net2312"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48601,7 +48601,7 @@
           "pcb_smtpad_1303",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48620,7 +48620,7 @@
           "pcb_smtpad_1304",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48639,7 +48639,7 @@
           "pcb_smtpad_1304",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48658,7 +48658,7 @@
           "pcb_smtpad_1304",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48677,7 +48677,7 @@
           "pcb_smtpad_1304",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48696,7 +48696,7 @@
           "pcb_smtpad_1305",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48715,7 +48715,7 @@
           "pcb_smtpad_1305",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48734,7 +48734,7 @@
           "pcb_smtpad_1305",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48753,7 +48753,7 @@
           "pcb_smtpad_1305",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48772,7 +48772,7 @@
           "pcb_smtpad_1306",
           "connectivity_net2334"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48791,7 +48791,7 @@
           "pcb_smtpad_1307",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48810,7 +48810,7 @@
           "pcb_smtpad_1308",
           "connectivity_net2323"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48829,7 +48829,7 @@
           "pcb_smtpad_1309",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48848,7 +48848,7 @@
           "pcb_smtpad_1310",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48867,7 +48867,7 @@
           "pcb_smtpad_1310",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48886,7 +48886,7 @@
           "pcb_smtpad_1310",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48905,7 +48905,7 @@
           "pcb_smtpad_1310",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48924,7 +48924,7 @@
           "pcb_smtpad_1311",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48943,7 +48943,7 @@
           "pcb_smtpad_1311",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48962,7 +48962,7 @@
           "pcb_smtpad_1311",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -48981,7 +48981,7 @@
           "pcb_smtpad_1311",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49000,7 +49000,7 @@
           "pcb_smtpad_1312",
           "connectivity_net2345"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49019,7 +49019,7 @@
           "pcb_smtpad_1313",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49038,7 +49038,7 @@
           "pcb_smtpad_1314",
           "connectivity_net2334"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49057,7 +49057,7 @@
           "pcb_smtpad_1315",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49076,7 +49076,7 @@
           "pcb_smtpad_1316",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49095,7 +49095,7 @@
           "pcb_smtpad_1316",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49114,7 +49114,7 @@
           "pcb_smtpad_1316",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49133,7 +49133,7 @@
           "pcb_smtpad_1316",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49152,7 +49152,7 @@
           "pcb_smtpad_1317",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49171,7 +49171,7 @@
           "pcb_smtpad_1317",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49190,7 +49190,7 @@
           "pcb_smtpad_1317",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49209,7 +49209,7 @@
           "pcb_smtpad_1317",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49228,7 +49228,7 @@
           "pcb_smtpad_1318",
           "connectivity_net2356"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49247,7 +49247,7 @@
           "pcb_smtpad_1319",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49266,7 +49266,7 @@
           "pcb_smtpad_1320",
           "connectivity_net2345"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49285,7 +49285,7 @@
           "pcb_smtpad_1321",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49304,7 +49304,7 @@
           "pcb_smtpad_1322",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49323,7 +49323,7 @@
           "pcb_smtpad_1322",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49342,7 +49342,7 @@
           "pcb_smtpad_1322",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49361,7 +49361,7 @@
           "pcb_smtpad_1322",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49380,7 +49380,7 @@
           "pcb_smtpad_1323",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49399,7 +49399,7 @@
           "pcb_smtpad_1323",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49418,7 +49418,7 @@
           "pcb_smtpad_1323",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49437,7 +49437,7 @@
           "pcb_smtpad_1323",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49456,7 +49456,7 @@
           "pcb_smtpad_1324",
           "connectivity_net2367"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49475,7 +49475,7 @@
           "pcb_smtpad_1325",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49494,7 +49494,7 @@
           "pcb_smtpad_1326",
           "connectivity_net2356"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49513,7 +49513,7 @@
           "pcb_smtpad_1327",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49532,7 +49532,7 @@
           "pcb_smtpad_1328",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49551,7 +49551,7 @@
           "pcb_smtpad_1328",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49570,7 +49570,7 @@
           "pcb_smtpad_1328",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49589,7 +49589,7 @@
           "pcb_smtpad_1328",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49608,7 +49608,7 @@
           "pcb_smtpad_1329",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49627,7 +49627,7 @@
           "pcb_smtpad_1329",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49646,7 +49646,7 @@
           "pcb_smtpad_1329",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49665,7 +49665,7 @@
           "pcb_smtpad_1329",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49684,7 +49684,7 @@
           "pcb_smtpad_1330",
           "connectivity_net2378"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49703,7 +49703,7 @@
           "pcb_smtpad_1331",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49722,7 +49722,7 @@
           "pcb_smtpad_1332",
           "connectivity_net2367"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49741,7 +49741,7 @@
           "pcb_smtpad_1333",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49760,7 +49760,7 @@
           "pcb_smtpad_1334",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49779,7 +49779,7 @@
           "pcb_smtpad_1334",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49798,7 +49798,7 @@
           "pcb_smtpad_1334",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49817,7 +49817,7 @@
           "pcb_smtpad_1334",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49836,7 +49836,7 @@
           "pcb_smtpad_1335",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49855,7 +49855,7 @@
           "pcb_smtpad_1335",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49874,7 +49874,7 @@
           "pcb_smtpad_1335",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49893,7 +49893,7 @@
           "pcb_smtpad_1335",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49912,7 +49912,7 @@
           "pcb_smtpad_1336",
           "connectivity_net2389"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49931,7 +49931,7 @@
           "pcb_smtpad_1337",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49950,7 +49950,7 @@
           "pcb_smtpad_1338",
           "connectivity_net2378"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49969,7 +49969,7 @@
           "pcb_smtpad_1339",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -49988,7 +49988,7 @@
           "pcb_smtpad_1340",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50007,7 +50007,7 @@
           "pcb_smtpad_1340",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50026,7 +50026,7 @@
           "pcb_smtpad_1340",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50045,7 +50045,7 @@
           "pcb_smtpad_1340",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50064,7 +50064,7 @@
           "pcb_smtpad_1341",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50083,7 +50083,7 @@
           "pcb_smtpad_1341",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50102,7 +50102,7 @@
           "pcb_smtpad_1341",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50121,7 +50121,7 @@
           "pcb_smtpad_1341",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50140,7 +50140,7 @@
           "pcb_smtpad_1342",
           "connectivity_net2400"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50159,7 +50159,7 @@
           "pcb_smtpad_1343",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50178,7 +50178,7 @@
           "pcb_smtpad_1344",
           "connectivity_net2389"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50197,7 +50197,7 @@
           "pcb_smtpad_1345",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50216,7 +50216,7 @@
           "pcb_smtpad_1346",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50235,7 +50235,7 @@
           "pcb_smtpad_1346",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50254,7 +50254,7 @@
           "pcb_smtpad_1346",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50273,7 +50273,7 @@
           "pcb_smtpad_1346",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50292,7 +50292,7 @@
           "pcb_smtpad_1347",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50311,7 +50311,7 @@
           "pcb_smtpad_1347",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50330,7 +50330,7 @@
           "pcb_smtpad_1347",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50349,7 +50349,7 @@
           "pcb_smtpad_1347",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50368,7 +50368,7 @@
           "pcb_smtpad_1348",
           "connectivity_net2411"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50387,7 +50387,7 @@
           "pcb_smtpad_1349",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50406,7 +50406,7 @@
           "pcb_smtpad_1350",
           "connectivity_net2400"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50425,7 +50425,7 @@
           "pcb_smtpad_1351",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50444,7 +50444,7 @@
           "pcb_smtpad_1352",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50463,7 +50463,7 @@
           "pcb_smtpad_1352",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50482,7 +50482,7 @@
           "pcb_smtpad_1352",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50501,7 +50501,7 @@
           "pcb_smtpad_1352",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50520,7 +50520,7 @@
           "pcb_smtpad_1353",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50539,7 +50539,7 @@
           "pcb_smtpad_1353",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50558,7 +50558,7 @@
           "pcb_smtpad_1353",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50577,7 +50577,7 @@
           "pcb_smtpad_1353",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50596,7 +50596,7 @@
           "pcb_smtpad_1354",
           "connectivity_net2422"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50615,7 +50615,7 @@
           "pcb_smtpad_1355",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50634,7 +50634,7 @@
           "pcb_smtpad_1356",
           "connectivity_net2411"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50653,7 +50653,7 @@
           "pcb_smtpad_1357",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50672,7 +50672,7 @@
           "pcb_smtpad_1358",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50691,7 +50691,7 @@
           "pcb_smtpad_1358",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50710,7 +50710,7 @@
           "pcb_smtpad_1358",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50729,7 +50729,7 @@
           "pcb_smtpad_1358",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50748,7 +50748,7 @@
           "pcb_smtpad_1359",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50767,7 +50767,7 @@
           "pcb_smtpad_1359",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50786,7 +50786,7 @@
           "pcb_smtpad_1359",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50805,7 +50805,7 @@
           "pcb_smtpad_1359",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50824,7 +50824,7 @@
           "pcb_smtpad_1360",
           "connectivity_net2433"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50843,7 +50843,7 @@
           "pcb_smtpad_1361",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50862,7 +50862,7 @@
           "pcb_smtpad_1362",
           "connectivity_net2422"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50881,7 +50881,7 @@
           "pcb_smtpad_1363",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50900,7 +50900,7 @@
           "pcb_smtpad_1364",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50919,7 +50919,7 @@
           "pcb_smtpad_1364",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50938,7 +50938,7 @@
           "pcb_smtpad_1364",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50957,7 +50957,7 @@
           "pcb_smtpad_1364",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50976,7 +50976,7 @@
           "pcb_smtpad_1365",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -50995,7 +50995,7 @@
           "pcb_smtpad_1365",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51014,7 +51014,7 @@
           "pcb_smtpad_1365",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51033,7 +51033,7 @@
           "pcb_smtpad_1365",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51052,7 +51052,7 @@
           "pcb_smtpad_1366",
           "connectivity_net2444"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51071,7 +51071,7 @@
           "pcb_smtpad_1367",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51090,7 +51090,7 @@
           "pcb_smtpad_1368",
           "connectivity_net2433"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51109,7 +51109,7 @@
           "pcb_smtpad_1369",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51128,7 +51128,7 @@
           "pcb_smtpad_1370",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51147,7 +51147,7 @@
           "pcb_smtpad_1370",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51166,7 +51166,7 @@
           "pcb_smtpad_1370",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51185,7 +51185,7 @@
           "pcb_smtpad_1370",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51204,7 +51204,7 @@
           "pcb_smtpad_1371",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51223,7 +51223,7 @@
           "pcb_smtpad_1371",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51242,7 +51242,7 @@
           "pcb_smtpad_1371",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51261,7 +51261,7 @@
           "pcb_smtpad_1371",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51280,7 +51280,7 @@
           "pcb_smtpad_1372",
           "connectivity_net2455"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51299,7 +51299,7 @@
           "pcb_smtpad_1373",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51318,7 +51318,7 @@
           "pcb_smtpad_1374",
           "connectivity_net2444"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51337,7 +51337,7 @@
           "pcb_smtpad_1375",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51356,7 +51356,7 @@
           "pcb_smtpad_1376",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51375,7 +51375,7 @@
           "pcb_smtpad_1376",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51394,7 +51394,7 @@
           "pcb_smtpad_1376",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51413,7 +51413,7 @@
           "pcb_smtpad_1376",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51432,7 +51432,7 @@
           "pcb_smtpad_1377",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51451,7 +51451,7 @@
           "pcb_smtpad_1377",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51470,7 +51470,7 @@
           "pcb_smtpad_1377",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51489,7 +51489,7 @@
           "pcb_smtpad_1377",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51508,7 +51508,7 @@
           "pcb_smtpad_1378",
           "connectivity_net2466"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51527,7 +51527,7 @@
           "pcb_smtpad_1379",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51546,7 +51546,7 @@
           "pcb_smtpad_1380",
           "connectivity_net2455"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51565,7 +51565,7 @@
           "pcb_smtpad_1381",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51584,7 +51584,7 @@
           "pcb_smtpad_1382",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51603,7 +51603,7 @@
           "pcb_smtpad_1382",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51622,7 +51622,7 @@
           "pcb_smtpad_1382",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51641,7 +51641,7 @@
           "pcb_smtpad_1382",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51660,7 +51660,7 @@
           "pcb_smtpad_1383",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51679,7 +51679,7 @@
           "pcb_smtpad_1383",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51698,7 +51698,7 @@
           "pcb_smtpad_1383",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51717,7 +51717,7 @@
           "pcb_smtpad_1383",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51736,7 +51736,7 @@
           "pcb_smtpad_1384",
           "connectivity_net2477"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51755,7 +51755,7 @@
           "pcb_smtpad_1385",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51774,7 +51774,7 @@
           "pcb_smtpad_1386",
           "connectivity_net2466"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51793,7 +51793,7 @@
           "pcb_smtpad_1387",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51812,7 +51812,7 @@
           "pcb_smtpad_1388",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51831,7 +51831,7 @@
           "pcb_smtpad_1388",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51850,7 +51850,7 @@
           "pcb_smtpad_1388",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51869,7 +51869,7 @@
           "pcb_smtpad_1388",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51888,7 +51888,7 @@
           "pcb_smtpad_1389",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51907,7 +51907,7 @@
           "pcb_smtpad_1389",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51926,7 +51926,7 @@
           "pcb_smtpad_1389",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51945,7 +51945,7 @@
           "pcb_smtpad_1389",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51964,7 +51964,7 @@
           "pcb_smtpad_1390",
           "connectivity_net2488"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -51983,7 +51983,7 @@
           "pcb_smtpad_1391",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52002,7 +52002,7 @@
           "pcb_smtpad_1392",
           "connectivity_net2477"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52021,7 +52021,7 @@
           "pcb_smtpad_1393",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52040,7 +52040,7 @@
           "pcb_smtpad_1394",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52059,7 +52059,7 @@
           "pcb_smtpad_1394",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52078,7 +52078,7 @@
           "pcb_smtpad_1394",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52097,7 +52097,7 @@
           "pcb_smtpad_1394",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52116,7 +52116,7 @@
           "pcb_smtpad_1395",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52135,7 +52135,7 @@
           "pcb_smtpad_1395",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52154,7 +52154,7 @@
           "pcb_smtpad_1395",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52173,7 +52173,7 @@
           "pcb_smtpad_1395",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52192,7 +52192,7 @@
           "pcb_smtpad_1396",
           "connectivity_net2499"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52211,7 +52211,7 @@
           "pcb_smtpad_1397",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52230,7 +52230,7 @@
           "pcb_smtpad_1398",
           "connectivity_net2488"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52249,7 +52249,7 @@
           "pcb_smtpad_1399",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52268,7 +52268,7 @@
           "pcb_smtpad_1400",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52287,7 +52287,7 @@
           "pcb_smtpad_1400",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52306,7 +52306,7 @@
           "pcb_smtpad_1400",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52325,7 +52325,7 @@
           "pcb_smtpad_1400",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52344,7 +52344,7 @@
           "pcb_smtpad_1401",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52363,7 +52363,7 @@
           "pcb_smtpad_1401",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52382,7 +52382,7 @@
           "pcb_smtpad_1401",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52401,7 +52401,7 @@
           "pcb_smtpad_1401",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52420,7 +52420,7 @@
           "pcb_smtpad_1402",
           "connectivity_net2510"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52439,7 +52439,7 @@
           "pcb_smtpad_1403",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52458,7 +52458,7 @@
           "pcb_smtpad_1404",
           "connectivity_net2499"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52477,7 +52477,7 @@
           "pcb_smtpad_1405",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52496,7 +52496,7 @@
           "pcb_smtpad_1406",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52515,7 +52515,7 @@
           "pcb_smtpad_1406",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52534,7 +52534,7 @@
           "pcb_smtpad_1406",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52553,7 +52553,7 @@
           "pcb_smtpad_1406",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52572,7 +52572,7 @@
           "pcb_smtpad_1407",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52591,7 +52591,7 @@
           "pcb_smtpad_1407",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52610,7 +52610,7 @@
           "pcb_smtpad_1407",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52629,7 +52629,7 @@
           "pcb_smtpad_1407",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52648,7 +52648,7 @@
           "pcb_smtpad_1408",
           "connectivity_net2521"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52667,7 +52667,7 @@
           "pcb_smtpad_1409",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52686,7 +52686,7 @@
           "pcb_smtpad_1410",
           "connectivity_net2510"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52705,7 +52705,7 @@
           "pcb_smtpad_1411",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52724,7 +52724,7 @@
           "pcb_smtpad_1412",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52743,7 +52743,7 @@
           "pcb_smtpad_1412",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52762,7 +52762,7 @@
           "pcb_smtpad_1412",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52781,7 +52781,7 @@
           "pcb_smtpad_1412",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52800,7 +52800,7 @@
           "pcb_smtpad_1413",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52819,7 +52819,7 @@
           "pcb_smtpad_1413",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52838,7 +52838,7 @@
           "pcb_smtpad_1413",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52857,7 +52857,7 @@
           "pcb_smtpad_1413",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52876,7 +52876,7 @@
           "pcb_smtpad_1414",
           "connectivity_net2532"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52895,7 +52895,7 @@
           "pcb_smtpad_1415",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52914,7 +52914,7 @@
           "pcb_smtpad_1416",
           "connectivity_net2521"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52933,7 +52933,7 @@
           "pcb_smtpad_1417",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52952,7 +52952,7 @@
           "pcb_smtpad_1418",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52971,7 +52971,7 @@
           "pcb_smtpad_1418",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -52990,7 +52990,7 @@
           "pcb_smtpad_1418",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53009,7 +53009,7 @@
           "pcb_smtpad_1418",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53028,7 +53028,7 @@
           "pcb_smtpad_1419",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53047,7 +53047,7 @@
           "pcb_smtpad_1419",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53066,7 +53066,7 @@
           "pcb_smtpad_1419",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53085,7 +53085,7 @@
           "pcb_smtpad_1419",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53104,7 +53104,7 @@
           "pcb_smtpad_1420",
           "connectivity_net2543"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53123,7 +53123,7 @@
           "pcb_smtpad_1421",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53142,7 +53142,7 @@
           "pcb_smtpad_1422",
           "connectivity_net2532"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53161,7 +53161,7 @@
           "pcb_smtpad_1423",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53180,7 +53180,7 @@
           "pcb_smtpad_1424",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53199,7 +53199,7 @@
           "pcb_smtpad_1424",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53218,7 +53218,7 @@
           "pcb_smtpad_1424",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53237,7 +53237,7 @@
           "pcb_smtpad_1424",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53256,7 +53256,7 @@
           "pcb_smtpad_1425",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53275,7 +53275,7 @@
           "pcb_smtpad_1425",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53294,7 +53294,7 @@
           "pcb_smtpad_1425",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53313,7 +53313,7 @@
           "pcb_smtpad_1425",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53332,7 +53332,7 @@
           "pcb_smtpad_1426",
           "connectivity_net2554"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53351,7 +53351,7 @@
           "pcb_smtpad_1427",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53370,7 +53370,7 @@
           "pcb_smtpad_1428",
           "connectivity_net2543"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53389,7 +53389,7 @@
           "pcb_smtpad_1429",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53408,7 +53408,7 @@
           "pcb_smtpad_1430",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53427,7 +53427,7 @@
           "pcb_smtpad_1430",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53446,7 +53446,7 @@
           "pcb_smtpad_1430",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53465,7 +53465,7 @@
           "pcb_smtpad_1430",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53484,7 +53484,7 @@
           "pcb_smtpad_1431",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53503,7 +53503,7 @@
           "pcb_smtpad_1431",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53522,7 +53522,7 @@
           "pcb_smtpad_1431",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53541,7 +53541,7 @@
           "pcb_smtpad_1431",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53560,7 +53560,7 @@
           "pcb_smtpad_1432",
           "connectivity_net2565"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53579,7 +53579,7 @@
           "pcb_smtpad_1433",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53598,7 +53598,7 @@
           "pcb_smtpad_1434",
           "connectivity_net2554"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53617,7 +53617,7 @@
           "pcb_smtpad_1435",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53636,7 +53636,7 @@
           "pcb_smtpad_1436",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53655,7 +53655,7 @@
           "pcb_smtpad_1436",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53674,7 +53674,7 @@
           "pcb_smtpad_1436",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53693,7 +53693,7 @@
           "pcb_smtpad_1436",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53712,7 +53712,7 @@
           "pcb_smtpad_1437",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53731,7 +53731,7 @@
           "pcb_smtpad_1437",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53750,7 +53750,7 @@
           "pcb_smtpad_1437",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53769,7 +53769,7 @@
           "pcb_smtpad_1437",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53788,7 +53788,7 @@
           "pcb_smtpad_1438",
           "connectivity_net2576"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53807,7 +53807,7 @@
           "pcb_smtpad_1439",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53826,7 +53826,7 @@
           "pcb_smtpad_1440",
           "connectivity_net2565"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53845,7 +53845,7 @@
           "pcb_smtpad_1441",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53864,7 +53864,7 @@
           "pcb_smtpad_1442",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53883,7 +53883,7 @@
           "pcb_smtpad_1442",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53902,7 +53902,7 @@
           "pcb_smtpad_1442",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53921,7 +53921,7 @@
           "pcb_smtpad_1442",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53940,7 +53940,7 @@
           "pcb_smtpad_1443",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53959,7 +53959,7 @@
           "pcb_smtpad_1443",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53978,7 +53978,7 @@
           "pcb_smtpad_1443",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -53997,7 +53997,7 @@
           "pcb_smtpad_1443",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54016,7 +54016,7 @@
           "pcb_smtpad_1444",
           "connectivity_net2587"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54035,7 +54035,7 @@
           "pcb_smtpad_1445",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54054,7 +54054,7 @@
           "pcb_smtpad_1446",
           "connectivity_net2576"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54073,7 +54073,7 @@
           "pcb_smtpad_1447",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54092,7 +54092,7 @@
           "pcb_smtpad_1448",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54111,7 +54111,7 @@
           "pcb_smtpad_1448",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54130,7 +54130,7 @@
           "pcb_smtpad_1448",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54149,7 +54149,7 @@
           "pcb_smtpad_1448",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54168,7 +54168,7 @@
           "pcb_smtpad_1449",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54187,7 +54187,7 @@
           "pcb_smtpad_1449",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54206,7 +54206,7 @@
           "pcb_smtpad_1449",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54225,7 +54225,7 @@
           "pcb_smtpad_1449",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54244,7 +54244,7 @@
           "pcb_smtpad_1450",
           "connectivity_net2598"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54263,7 +54263,7 @@
           "pcb_smtpad_1451",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54282,7 +54282,7 @@
           "pcb_smtpad_1452",
           "connectivity_net2587"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54301,7 +54301,7 @@
           "pcb_smtpad_1453",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54320,7 +54320,7 @@
           "pcb_smtpad_1454",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54339,7 +54339,7 @@
           "pcb_smtpad_1454",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54358,7 +54358,7 @@
           "pcb_smtpad_1454",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54377,7 +54377,7 @@
           "pcb_smtpad_1454",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54396,7 +54396,7 @@
           "pcb_smtpad_1455",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54415,7 +54415,7 @@
           "pcb_smtpad_1455",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54434,7 +54434,7 @@
           "pcb_smtpad_1455",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54453,7 +54453,7 @@
           "pcb_smtpad_1455",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54472,7 +54472,7 @@
           "pcb_smtpad_1456",
           "connectivity_net2609"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54491,7 +54491,7 @@
           "pcb_smtpad_1457",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54510,7 +54510,7 @@
           "pcb_smtpad_1458",
           "connectivity_net2598"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54529,7 +54529,7 @@
           "pcb_smtpad_1459",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54548,7 +54548,7 @@
           "pcb_smtpad_1460",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54567,7 +54567,7 @@
           "pcb_smtpad_1460",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54586,7 +54586,7 @@
           "pcb_smtpad_1460",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54605,7 +54605,7 @@
           "pcb_smtpad_1460",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54624,7 +54624,7 @@
           "pcb_smtpad_1461",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54643,7 +54643,7 @@
           "pcb_smtpad_1461",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54662,7 +54662,7 @@
           "pcb_smtpad_1461",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54681,7 +54681,7 @@
           "pcb_smtpad_1461",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54700,7 +54700,7 @@
           "pcb_smtpad_1462",
           "connectivity_net2620"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54719,7 +54719,7 @@
           "pcb_smtpad_1463",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54738,7 +54738,7 @@
           "pcb_smtpad_1464",
           "connectivity_net2609"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54757,7 +54757,7 @@
           "pcb_smtpad_1465",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54776,7 +54776,7 @@
           "pcb_smtpad_1466",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54795,7 +54795,7 @@
           "pcb_smtpad_1466",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54814,7 +54814,7 @@
           "pcb_smtpad_1466",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54833,7 +54833,7 @@
           "pcb_smtpad_1466",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54852,7 +54852,7 @@
           "pcb_smtpad_1467",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54871,7 +54871,7 @@
           "pcb_smtpad_1467",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54890,7 +54890,7 @@
           "pcb_smtpad_1467",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54909,7 +54909,7 @@
           "pcb_smtpad_1467",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54928,7 +54928,7 @@
           "pcb_smtpad_1468",
           "connectivity_net2631"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54947,7 +54947,7 @@
           "pcb_smtpad_1469",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54966,7 +54966,7 @@
           "pcb_smtpad_1470",
           "connectivity_net2620"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -54985,7 +54985,7 @@
           "pcb_smtpad_1471",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55004,7 +55004,7 @@
           "pcb_smtpad_1472",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55023,7 +55023,7 @@
           "pcb_smtpad_1472",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55042,7 +55042,7 @@
           "pcb_smtpad_1472",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55061,7 +55061,7 @@
           "pcb_smtpad_1472",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55080,7 +55080,7 @@
           "pcb_smtpad_1473",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55099,7 +55099,7 @@
           "pcb_smtpad_1473",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55118,7 +55118,7 @@
           "pcb_smtpad_1473",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55137,7 +55137,7 @@
           "pcb_smtpad_1473",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55156,7 +55156,7 @@
           "pcb_smtpad_1474",
           "connectivity_net2642"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55175,7 +55175,7 @@
           "pcb_smtpad_1475",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55194,7 +55194,7 @@
           "pcb_smtpad_1476",
           "connectivity_net2631"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55213,7 +55213,7 @@
           "pcb_smtpad_1477",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55232,7 +55232,7 @@
           "pcb_smtpad_1478",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55251,7 +55251,7 @@
           "pcb_smtpad_1478",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55270,7 +55270,7 @@
           "pcb_smtpad_1478",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55289,7 +55289,7 @@
           "pcb_smtpad_1478",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55308,7 +55308,7 @@
           "pcb_smtpad_1479",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55327,7 +55327,7 @@
           "pcb_smtpad_1479",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55346,7 +55346,7 @@
           "pcb_smtpad_1479",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55365,7 +55365,7 @@
           "pcb_smtpad_1479",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55384,7 +55384,7 @@
           "pcb_smtpad_1480",
           "connectivity_net2653"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55403,7 +55403,7 @@
           "pcb_smtpad_1481",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55422,7 +55422,7 @@
           "pcb_smtpad_1482",
           "connectivity_net2642"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55441,7 +55441,7 @@
           "pcb_smtpad_1483",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55460,7 +55460,7 @@
           "pcb_smtpad_1484",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55479,7 +55479,7 @@
           "pcb_smtpad_1484",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55498,7 +55498,7 @@
           "pcb_smtpad_1484",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55517,7 +55517,7 @@
           "pcb_smtpad_1484",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55536,7 +55536,7 @@
           "pcb_smtpad_1485",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55555,7 +55555,7 @@
           "pcb_smtpad_1485",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55574,7 +55574,7 @@
           "pcb_smtpad_1485",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55593,7 +55593,7 @@
           "pcb_smtpad_1485",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55612,7 +55612,7 @@
           "pcb_smtpad_1486",
           "connectivity_net2664"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55631,7 +55631,7 @@
           "pcb_smtpad_1487",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55650,7 +55650,7 @@
           "pcb_smtpad_1488",
           "connectivity_net2653"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55669,7 +55669,7 @@
           "pcb_smtpad_1489",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55688,7 +55688,7 @@
           "pcb_smtpad_1490",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55707,7 +55707,7 @@
           "pcb_smtpad_1490",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55726,7 +55726,7 @@
           "pcb_smtpad_1490",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55745,7 +55745,7 @@
           "pcb_smtpad_1490",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55764,7 +55764,7 @@
           "pcb_smtpad_1491",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55783,7 +55783,7 @@
           "pcb_smtpad_1491",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55802,7 +55802,7 @@
           "pcb_smtpad_1491",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55821,7 +55821,7 @@
           "pcb_smtpad_1491",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55840,7 +55840,7 @@
           "pcb_smtpad_1492",
           "connectivity_net2675"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55859,7 +55859,7 @@
           "pcb_smtpad_1493",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55878,7 +55878,7 @@
           "pcb_smtpad_1494",
           "connectivity_net2664"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55897,7 +55897,7 @@
           "pcb_smtpad_1495",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55916,7 +55916,7 @@
           "pcb_smtpad_1496",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55935,7 +55935,7 @@
           "pcb_smtpad_1496",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55954,7 +55954,7 @@
           "pcb_smtpad_1496",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55973,7 +55973,7 @@
           "pcb_smtpad_1496",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -55992,7 +55992,7 @@
           "pcb_smtpad_1497",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56011,7 +56011,7 @@
           "pcb_smtpad_1497",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56030,7 +56030,7 @@
           "pcb_smtpad_1497",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56049,7 +56049,7 @@
           "pcb_smtpad_1497",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56068,7 +56068,7 @@
           "pcb_smtpad_1498",
           "connectivity_net2686"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56087,7 +56087,7 @@
           "pcb_smtpad_1499",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56106,7 +56106,7 @@
           "pcb_smtpad_1500",
           "connectivity_net2675"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56125,7 +56125,7 @@
           "pcb_smtpad_1501",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56144,7 +56144,7 @@
           "pcb_smtpad_1502",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56163,7 +56163,7 @@
           "pcb_smtpad_1502",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56182,7 +56182,7 @@
           "pcb_smtpad_1502",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56201,7 +56201,7 @@
           "pcb_smtpad_1502",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56220,7 +56220,7 @@
           "pcb_smtpad_1503",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56239,7 +56239,7 @@
           "pcb_smtpad_1503",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56258,7 +56258,7 @@
           "pcb_smtpad_1503",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56277,7 +56277,7 @@
           "pcb_smtpad_1503",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56296,7 +56296,7 @@
           "pcb_smtpad_1504",
           "connectivity_net2697"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56315,7 +56315,7 @@
           "pcb_smtpad_1505",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56334,7 +56334,7 @@
           "pcb_smtpad_1506",
           "connectivity_net2686"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56353,7 +56353,7 @@
           "pcb_smtpad_1507",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56372,7 +56372,7 @@
           "pcb_smtpad_1508",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56391,7 +56391,7 @@
           "pcb_smtpad_1508",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56410,7 +56410,7 @@
           "pcb_smtpad_1508",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56429,7 +56429,7 @@
           "pcb_smtpad_1508",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56448,7 +56448,7 @@
           "pcb_smtpad_1509",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56467,7 +56467,7 @@
           "pcb_smtpad_1509",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56486,7 +56486,7 @@
           "pcb_smtpad_1509",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56505,7 +56505,7 @@
           "pcb_smtpad_1509",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56524,7 +56524,7 @@
           "pcb_smtpad_1510",
           "connectivity_net2708"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56543,7 +56543,7 @@
           "pcb_smtpad_1511",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56562,7 +56562,7 @@
           "pcb_smtpad_1512",
           "connectivity_net2697"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56581,7 +56581,7 @@
           "pcb_smtpad_1513",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56600,7 +56600,7 @@
           "pcb_smtpad_1514",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56619,7 +56619,7 @@
           "pcb_smtpad_1514",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56638,7 +56638,7 @@
           "pcb_smtpad_1514",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56657,7 +56657,7 @@
           "pcb_smtpad_1514",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56676,7 +56676,7 @@
           "pcb_smtpad_1515",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56695,7 +56695,7 @@
           "pcb_smtpad_1515",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56714,7 +56714,7 @@
           "pcb_smtpad_1515",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56733,7 +56733,7 @@
           "pcb_smtpad_1515",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56752,7 +56752,7 @@
           "pcb_smtpad_1516",
           "connectivity_net2719"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56771,7 +56771,7 @@
           "pcb_smtpad_1517",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56790,7 +56790,7 @@
           "pcb_smtpad_1518",
           "connectivity_net2708"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56809,7 +56809,7 @@
           "pcb_smtpad_1519",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56828,7 +56828,7 @@
           "pcb_smtpad_1520",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56847,7 +56847,7 @@
           "pcb_smtpad_1520",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56866,7 +56866,7 @@
           "pcb_smtpad_1520",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56885,7 +56885,7 @@
           "pcb_smtpad_1520",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56904,7 +56904,7 @@
           "pcb_smtpad_1521",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56923,7 +56923,7 @@
           "pcb_smtpad_1521",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56942,7 +56942,7 @@
           "pcb_smtpad_1521",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56961,7 +56961,7 @@
           "pcb_smtpad_1521",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56980,7 +56980,7 @@
           "pcb_smtpad_1522",
           "connectivity_net2730"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -56999,7 +56999,7 @@
           "pcb_smtpad_1523",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57018,7 +57018,7 @@
           "pcb_smtpad_1524",
           "connectivity_net2719"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57037,7 +57037,7 @@
           "pcb_smtpad_1525",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57056,7 +57056,7 @@
           "pcb_smtpad_1526",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57075,7 +57075,7 @@
           "pcb_smtpad_1526",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57094,7 +57094,7 @@
           "pcb_smtpad_1526",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57113,7 +57113,7 @@
           "pcb_smtpad_1526",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57132,7 +57132,7 @@
           "pcb_smtpad_1527",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57151,7 +57151,7 @@
           "pcb_smtpad_1527",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57170,7 +57170,7 @@
           "pcb_smtpad_1527",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57189,7 +57189,7 @@
           "pcb_smtpad_1527",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57208,7 +57208,7 @@
           "pcb_smtpad_1528",
           "connectivity_net2741"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57227,7 +57227,7 @@
           "pcb_smtpad_1529",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57246,7 +57246,7 @@
           "pcb_smtpad_1530",
           "connectivity_net2730"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57265,7 +57265,7 @@
           "pcb_smtpad_1531",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57284,7 +57284,7 @@
           "pcb_smtpad_1532",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57303,7 +57303,7 @@
           "pcb_smtpad_1532",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57322,7 +57322,7 @@
           "pcb_smtpad_1532",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57341,7 +57341,7 @@
           "pcb_smtpad_1532",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57360,7 +57360,7 @@
           "pcb_smtpad_1533",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57379,7 +57379,7 @@
           "pcb_smtpad_1533",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57398,7 +57398,7 @@
           "pcb_smtpad_1533",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57417,7 +57417,7 @@
           "pcb_smtpad_1533",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57436,7 +57436,7 @@
           "pcb_smtpad_1534",
           "connectivity_net2752"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57455,7 +57455,7 @@
           "pcb_smtpad_1535",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57474,7 +57474,7 @@
           "pcb_smtpad_1536",
           "connectivity_net2741"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57493,7 +57493,7 @@
           "pcb_smtpad_1537",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57512,7 +57512,7 @@
           "pcb_smtpad_1538",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57531,7 +57531,7 @@
           "pcb_smtpad_1538",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57550,7 +57550,7 @@
           "pcb_smtpad_1538",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57569,7 +57569,7 @@
           "pcb_smtpad_1538",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57588,7 +57588,7 @@
           "pcb_smtpad_1539",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57607,7 +57607,7 @@
           "pcb_smtpad_1539",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57626,7 +57626,7 @@
           "pcb_smtpad_1539",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57645,7 +57645,7 @@
           "pcb_smtpad_1539",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57664,7 +57664,7 @@
           "pcb_smtpad_1540",
           "connectivity_net2763"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57683,7 +57683,7 @@
           "pcb_smtpad_1541",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57702,7 +57702,7 @@
           "pcb_smtpad_1542",
           "connectivity_net2752"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57721,7 +57721,7 @@
           "pcb_smtpad_1543",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57740,7 +57740,7 @@
           "pcb_smtpad_1544",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57759,7 +57759,7 @@
           "pcb_smtpad_1544",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57778,7 +57778,7 @@
           "pcb_smtpad_1544",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57797,7 +57797,7 @@
           "pcb_smtpad_1544",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57816,7 +57816,7 @@
           "pcb_smtpad_1545",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57835,7 +57835,7 @@
           "pcb_smtpad_1545",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57854,7 +57854,7 @@
           "pcb_smtpad_1545",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57873,7 +57873,7 @@
           "pcb_smtpad_1545",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57892,7 +57892,7 @@
           "pcb_smtpad_1546",
           "connectivity_net2774"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57911,7 +57911,7 @@
           "pcb_smtpad_1547",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57930,7 +57930,7 @@
           "pcb_smtpad_1548",
           "connectivity_net2763"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57949,7 +57949,7 @@
           "pcb_smtpad_1549",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57968,7 +57968,7 @@
           "pcb_smtpad_1550",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -57987,7 +57987,7 @@
           "pcb_smtpad_1550",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58006,7 +58006,7 @@
           "pcb_smtpad_1550",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58025,7 +58025,7 @@
           "pcb_smtpad_1550",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58044,7 +58044,7 @@
           "pcb_smtpad_1551",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58063,7 +58063,7 @@
           "pcb_smtpad_1551",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58082,7 +58082,7 @@
           "pcb_smtpad_1551",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58101,7 +58101,7 @@
           "pcb_smtpad_1551",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58120,7 +58120,7 @@
           "pcb_smtpad_1552",
           "connectivity_net2785"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58139,7 +58139,7 @@
           "pcb_smtpad_1553",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58158,7 +58158,7 @@
           "pcb_smtpad_1554",
           "connectivity_net2774"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58177,7 +58177,7 @@
           "pcb_smtpad_1555",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58196,7 +58196,7 @@
           "pcb_smtpad_1556",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58215,7 +58215,7 @@
           "pcb_smtpad_1556",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58234,7 +58234,7 @@
           "pcb_smtpad_1556",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58253,7 +58253,7 @@
           "pcb_smtpad_1556",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58272,7 +58272,7 @@
           "pcb_smtpad_1557",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58291,7 +58291,7 @@
           "pcb_smtpad_1557",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58310,7 +58310,7 @@
           "pcb_smtpad_1557",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58329,7 +58329,7 @@
           "pcb_smtpad_1557",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58348,7 +58348,7 @@
           "pcb_smtpad_1558",
           "connectivity_net2796"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58367,7 +58367,7 @@
           "pcb_smtpad_1559",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58386,7 +58386,7 @@
           "pcb_smtpad_1560",
           "connectivity_net2785"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58405,7 +58405,7 @@
           "pcb_smtpad_1561",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58424,7 +58424,7 @@
           "pcb_smtpad_1562",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58443,7 +58443,7 @@
           "pcb_smtpad_1562",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58462,7 +58462,7 @@
           "pcb_smtpad_1562",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58481,7 +58481,7 @@
           "pcb_smtpad_1562",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58500,7 +58500,7 @@
           "pcb_smtpad_1563",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58519,7 +58519,7 @@
           "pcb_smtpad_1563",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58538,7 +58538,7 @@
           "pcb_smtpad_1563",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58557,7 +58557,7 @@
           "pcb_smtpad_1563",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58576,7 +58576,7 @@
           "pcb_smtpad_1564",
           "connectivity_net2807"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58595,7 +58595,7 @@
           "pcb_smtpad_1565",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58614,7 +58614,7 @@
           "pcb_smtpad_1566",
           "connectivity_net2796"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58633,7 +58633,7 @@
           "pcb_smtpad_1567",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58652,7 +58652,7 @@
           "pcb_smtpad_1568",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58671,7 +58671,7 @@
           "pcb_smtpad_1568",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58690,7 +58690,7 @@
           "pcb_smtpad_1568",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58709,7 +58709,7 @@
           "pcb_smtpad_1568",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58728,7 +58728,7 @@
           "pcb_smtpad_1569",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58747,7 +58747,7 @@
           "pcb_smtpad_1569",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58766,7 +58766,7 @@
           "pcb_smtpad_1569",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58785,7 +58785,7 @@
           "pcb_smtpad_1569",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58804,7 +58804,7 @@
           "pcb_smtpad_1570",
           "connectivity_net2818"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58823,7 +58823,7 @@
           "pcb_smtpad_1571",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58842,7 +58842,7 @@
           "pcb_smtpad_1572",
           "connectivity_net2807"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58861,7 +58861,7 @@
           "pcb_smtpad_1573",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58880,7 +58880,7 @@
           "pcb_smtpad_1574",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58899,7 +58899,7 @@
           "pcb_smtpad_1574",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58918,7 +58918,7 @@
           "pcb_smtpad_1574",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58937,7 +58937,7 @@
           "pcb_smtpad_1574",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58956,7 +58956,7 @@
           "pcb_smtpad_1575",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58975,7 +58975,7 @@
           "pcb_smtpad_1575",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -58994,7 +58994,7 @@
           "pcb_smtpad_1575",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59013,7 +59013,7 @@
           "pcb_smtpad_1575",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59032,7 +59032,7 @@
           "pcb_smtpad_1576",
           "connectivity_net2829"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59051,7 +59051,7 @@
           "pcb_smtpad_1577",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59070,7 +59070,7 @@
           "pcb_smtpad_1578",
           "connectivity_net2818"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59089,7 +59089,7 @@
           "pcb_smtpad_1579",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59108,7 +59108,7 @@
           "pcb_smtpad_1580",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59127,7 +59127,7 @@
           "pcb_smtpad_1580",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59146,7 +59146,7 @@
           "pcb_smtpad_1580",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59165,7 +59165,7 @@
           "pcb_smtpad_1580",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59184,7 +59184,7 @@
           "pcb_smtpad_1581",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59203,7 +59203,7 @@
           "pcb_smtpad_1581",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59222,7 +59222,7 @@
           "pcb_smtpad_1581",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59241,7 +59241,7 @@
           "pcb_smtpad_1581",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59260,7 +59260,7 @@
           "pcb_smtpad_1582",
           "connectivity_net2840"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59279,7 +59279,7 @@
           "pcb_smtpad_1583",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59298,7 +59298,7 @@
           "pcb_smtpad_1584",
           "connectivity_net2829"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59317,7 +59317,7 @@
           "pcb_smtpad_1585",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59336,7 +59336,7 @@
           "pcb_smtpad_1586",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59355,7 +59355,7 @@
           "pcb_smtpad_1586",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59374,7 +59374,7 @@
           "pcb_smtpad_1586",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59393,7 +59393,7 @@
           "pcb_smtpad_1586",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59412,7 +59412,7 @@
           "pcb_smtpad_1587",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59431,7 +59431,7 @@
           "pcb_smtpad_1587",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59450,7 +59450,7 @@
           "pcb_smtpad_1587",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59469,7 +59469,7 @@
           "pcb_smtpad_1587",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59488,7 +59488,7 @@
           "pcb_smtpad_1588",
           "connectivity_net2851"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59507,7 +59507,7 @@
           "pcb_smtpad_1589",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59526,7 +59526,7 @@
           "pcb_smtpad_1590",
           "connectivity_net2840"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59545,7 +59545,7 @@
           "pcb_smtpad_1591",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59564,7 +59564,7 @@
           "pcb_smtpad_1592",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59583,7 +59583,7 @@
           "pcb_smtpad_1592",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59602,7 +59602,7 @@
           "pcb_smtpad_1592",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59621,7 +59621,7 @@
           "pcb_smtpad_1592",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59640,7 +59640,7 @@
           "pcb_smtpad_1593",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59659,7 +59659,7 @@
           "pcb_smtpad_1593",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59678,7 +59678,7 @@
           "pcb_smtpad_1593",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59697,7 +59697,7 @@
           "pcb_smtpad_1593",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59716,7 +59716,7 @@
           "pcb_smtpad_1594",
           "connectivity_net2862"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59735,7 +59735,7 @@
           "pcb_smtpad_1595",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59754,7 +59754,7 @@
           "pcb_smtpad_1596",
           "connectivity_net2851"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59773,7 +59773,7 @@
           "pcb_smtpad_1597",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59792,7 +59792,7 @@
           "pcb_smtpad_1598",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59811,7 +59811,7 @@
           "pcb_smtpad_1598",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59830,7 +59830,7 @@
           "pcb_smtpad_1598",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59849,7 +59849,7 @@
           "pcb_smtpad_1598",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59868,7 +59868,7 @@
           "pcb_smtpad_1599",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59887,7 +59887,7 @@
           "pcb_smtpad_1599",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59906,7 +59906,7 @@
           "pcb_smtpad_1599",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59925,7 +59925,7 @@
           "pcb_smtpad_1599",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59944,7 +59944,7 @@
           "pcb_smtpad_1600",
           "connectivity_net2873"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59963,7 +59963,7 @@
           "pcb_smtpad_1601",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -59982,7 +59982,7 @@
           "pcb_smtpad_1602",
           "connectivity_net2862"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60001,7 +60001,7 @@
           "pcb_smtpad_1603",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60020,7 +60020,7 @@
           "pcb_smtpad_1604",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60039,7 +60039,7 @@
           "pcb_smtpad_1604",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60058,7 +60058,7 @@
           "pcb_smtpad_1604",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60077,7 +60077,7 @@
           "pcb_smtpad_1604",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60096,7 +60096,7 @@
           "pcb_smtpad_1605",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60115,7 +60115,7 @@
           "pcb_smtpad_1605",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60134,7 +60134,7 @@
           "pcb_smtpad_1605",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60153,7 +60153,7 @@
           "pcb_smtpad_1605",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60172,7 +60172,7 @@
           "pcb_smtpad_1606",
           "connectivity_net2884"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60191,7 +60191,7 @@
           "pcb_smtpad_1607",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60210,7 +60210,7 @@
           "pcb_smtpad_1608",
           "connectivity_net2873"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60229,7 +60229,7 @@
           "pcb_smtpad_1609",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60248,7 +60248,7 @@
           "pcb_smtpad_1610",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60267,7 +60267,7 @@
           "pcb_smtpad_1610",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60286,7 +60286,7 @@
           "pcb_smtpad_1610",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60305,7 +60305,7 @@
           "pcb_smtpad_1610",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60324,7 +60324,7 @@
           "pcb_smtpad_1611",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60343,7 +60343,7 @@
           "pcb_smtpad_1611",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60362,7 +60362,7 @@
           "pcb_smtpad_1611",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60381,7 +60381,7 @@
           "pcb_smtpad_1611",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60400,7 +60400,7 @@
           "pcb_smtpad_1612",
           "connectivity_net2895"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60419,7 +60419,7 @@
           "pcb_smtpad_1613",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60438,7 +60438,7 @@
           "pcb_smtpad_1614",
           "connectivity_net2884"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60457,7 +60457,7 @@
           "pcb_smtpad_1615",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60476,7 +60476,7 @@
           "pcb_smtpad_1616",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60495,7 +60495,7 @@
           "pcb_smtpad_1616",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60514,7 +60514,7 @@
           "pcb_smtpad_1616",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60533,7 +60533,7 @@
           "pcb_smtpad_1616",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60552,7 +60552,7 @@
           "pcb_smtpad_1617",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60571,7 +60571,7 @@
           "pcb_smtpad_1617",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60590,7 +60590,7 @@
           "pcb_smtpad_1617",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60609,7 +60609,7 @@
           "pcb_smtpad_1617",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60628,7 +60628,7 @@
           "pcb_smtpad_1618",
           "connectivity_net2906"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60647,7 +60647,7 @@
           "pcb_smtpad_1619",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60666,7 +60666,7 @@
           "pcb_smtpad_1620",
           "connectivity_net2895"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60685,7 +60685,7 @@
           "pcb_smtpad_1621",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60704,7 +60704,7 @@
           "pcb_smtpad_1622",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60723,7 +60723,7 @@
           "pcb_smtpad_1622",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60742,7 +60742,7 @@
           "pcb_smtpad_1622",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60761,7 +60761,7 @@
           "pcb_smtpad_1622",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60780,7 +60780,7 @@
           "pcb_smtpad_1623",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60799,7 +60799,7 @@
           "pcb_smtpad_1623",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60818,7 +60818,7 @@
           "pcb_smtpad_1623",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60837,7 +60837,7 @@
           "pcb_smtpad_1623",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60856,7 +60856,7 @@
           "pcb_smtpad_1624",
           "connectivity_net2917"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60875,7 +60875,7 @@
           "pcb_smtpad_1625",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60894,7 +60894,7 @@
           "pcb_smtpad_1626",
           "connectivity_net2906"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60913,7 +60913,7 @@
           "pcb_smtpad_1627",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60932,7 +60932,7 @@
           "pcb_smtpad_1628",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60951,7 +60951,7 @@
           "pcb_smtpad_1628",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60970,7 +60970,7 @@
           "pcb_smtpad_1628",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -60989,7 +60989,7 @@
           "pcb_smtpad_1628",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61008,7 +61008,7 @@
           "pcb_smtpad_1629",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61027,7 +61027,7 @@
           "pcb_smtpad_1629",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61046,7 +61046,7 @@
           "pcb_smtpad_1629",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61065,7 +61065,7 @@
           "pcb_smtpad_1629",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61084,7 +61084,7 @@
           "pcb_smtpad_1630",
           "connectivity_net2928"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61103,7 +61103,7 @@
           "pcb_smtpad_1631",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61122,7 +61122,7 @@
           "pcb_smtpad_1632",
           "connectivity_net2917"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61141,7 +61141,7 @@
           "pcb_smtpad_1633",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61160,7 +61160,7 @@
           "pcb_smtpad_1634",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61179,7 +61179,7 @@
           "pcb_smtpad_1634",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61198,7 +61198,7 @@
           "pcb_smtpad_1634",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61217,7 +61217,7 @@
           "pcb_smtpad_1634",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61236,7 +61236,7 @@
           "pcb_smtpad_1635",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61255,7 +61255,7 @@
           "pcb_smtpad_1635",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61274,7 +61274,7 @@
           "pcb_smtpad_1635",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61293,7 +61293,7 @@
           "pcb_smtpad_1635",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61312,7 +61312,7 @@
           "pcb_smtpad_1636",
           "connectivity_net2939"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61331,7 +61331,7 @@
           "pcb_smtpad_1637",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61350,7 +61350,7 @@
           "pcb_smtpad_1638",
           "connectivity_net2928"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61369,7 +61369,7 @@
           "pcb_smtpad_1639",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61388,7 +61388,7 @@
           "pcb_smtpad_1640",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61407,7 +61407,7 @@
           "pcb_smtpad_1640",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61426,7 +61426,7 @@
           "pcb_smtpad_1640",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61445,7 +61445,7 @@
           "pcb_smtpad_1640",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61464,7 +61464,7 @@
           "pcb_smtpad_1641",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61483,7 +61483,7 @@
           "pcb_smtpad_1641",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61502,7 +61502,7 @@
           "pcb_smtpad_1641",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61521,7 +61521,7 @@
           "pcb_smtpad_1641",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61540,7 +61540,7 @@
           "pcb_smtpad_1642",
           "connectivity_net2950"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61559,7 +61559,7 @@
           "pcb_smtpad_1643",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61578,7 +61578,7 @@
           "pcb_smtpad_1644",
           "connectivity_net2939"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61597,7 +61597,7 @@
           "pcb_smtpad_1645",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61616,7 +61616,7 @@
           "pcb_smtpad_1646",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61635,7 +61635,7 @@
           "pcb_smtpad_1646",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61654,7 +61654,7 @@
           "pcb_smtpad_1646",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61673,7 +61673,7 @@
           "pcb_smtpad_1646",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61692,7 +61692,7 @@
           "pcb_smtpad_1647",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61711,7 +61711,7 @@
           "pcb_smtpad_1647",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61730,7 +61730,7 @@
           "pcb_smtpad_1647",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61749,7 +61749,7 @@
           "pcb_smtpad_1647",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61768,7 +61768,7 @@
           "pcb_smtpad_1648",
           "connectivity_net2961"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61787,7 +61787,7 @@
           "pcb_smtpad_1649",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61806,7 +61806,7 @@
           "pcb_smtpad_1650",
           "connectivity_net2950"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61825,7 +61825,7 @@
           "pcb_smtpad_1651",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61844,7 +61844,7 @@
           "pcb_smtpad_1652",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61863,7 +61863,7 @@
           "pcb_smtpad_1652",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61882,7 +61882,7 @@
           "pcb_smtpad_1652",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61901,7 +61901,7 @@
           "pcb_smtpad_1652",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61920,7 +61920,7 @@
           "pcb_smtpad_1653",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61939,7 +61939,7 @@
           "pcb_smtpad_1653",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61958,7 +61958,7 @@
           "pcb_smtpad_1653",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61977,7 +61977,7 @@
           "pcb_smtpad_1653",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -61996,7 +61996,7 @@
           "pcb_smtpad_1654",
           "connectivity_net2972"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62015,7 +62015,7 @@
           "pcb_smtpad_1655",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62034,7 +62034,7 @@
           "pcb_smtpad_1656",
           "connectivity_net2961"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62053,7 +62053,7 @@
           "pcb_smtpad_1657",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62072,7 +62072,7 @@
           "pcb_smtpad_1658",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62091,7 +62091,7 @@
           "pcb_smtpad_1658",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62110,7 +62110,7 @@
           "pcb_smtpad_1658",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62129,7 +62129,7 @@
           "pcb_smtpad_1658",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62148,7 +62148,7 @@
           "pcb_smtpad_1659",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62167,7 +62167,7 @@
           "pcb_smtpad_1659",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62186,7 +62186,7 @@
           "pcb_smtpad_1659",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62205,7 +62205,7 @@
           "pcb_smtpad_1659",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62224,7 +62224,7 @@
           "pcb_smtpad_1660",
           "connectivity_net2983"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62243,7 +62243,7 @@
           "pcb_smtpad_1661",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62262,7 +62262,7 @@
           "pcb_smtpad_1662",
           "connectivity_net2972"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62281,7 +62281,7 @@
           "pcb_smtpad_1663",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62300,7 +62300,7 @@
           "pcb_smtpad_1664",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62319,7 +62319,7 @@
           "pcb_smtpad_1664",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62338,7 +62338,7 @@
           "pcb_smtpad_1664",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62357,7 +62357,7 @@
           "pcb_smtpad_1664",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62376,7 +62376,7 @@
           "pcb_smtpad_1665",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62395,7 +62395,7 @@
           "pcb_smtpad_1665",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62414,7 +62414,7 @@
           "pcb_smtpad_1665",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62433,7 +62433,7 @@
           "pcb_smtpad_1665",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62452,7 +62452,7 @@
           "pcb_smtpad_1666",
           "connectivity_net2994"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62471,7 +62471,7 @@
           "pcb_smtpad_1667",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62490,7 +62490,7 @@
           "pcb_smtpad_1668",
           "connectivity_net2983"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62509,7 +62509,7 @@
           "pcb_smtpad_1669",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62528,7 +62528,7 @@
           "pcb_smtpad_1670",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62547,7 +62547,7 @@
           "pcb_smtpad_1670",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62566,7 +62566,7 @@
           "pcb_smtpad_1670",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62585,7 +62585,7 @@
           "pcb_smtpad_1670",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62604,7 +62604,7 @@
           "pcb_smtpad_1671",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62623,7 +62623,7 @@
           "pcb_smtpad_1671",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62642,7 +62642,7 @@
           "pcb_smtpad_1671",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62661,7 +62661,7 @@
           "pcb_smtpad_1671",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62680,7 +62680,7 @@
           "pcb_smtpad_1672",
           "connectivity_net3005"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62699,7 +62699,7 @@
           "pcb_smtpad_1673",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62718,7 +62718,7 @@
           "pcb_smtpad_1674",
           "connectivity_net2994"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62737,7 +62737,7 @@
           "pcb_smtpad_1675",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62756,7 +62756,7 @@
           "pcb_smtpad_1676",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62775,7 +62775,7 @@
           "pcb_smtpad_1676",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62794,7 +62794,7 @@
           "pcb_smtpad_1676",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62813,7 +62813,7 @@
           "pcb_smtpad_1676",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62832,7 +62832,7 @@
           "pcb_smtpad_1677",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62851,7 +62851,7 @@
           "pcb_smtpad_1677",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62870,7 +62870,7 @@
           "pcb_smtpad_1677",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62889,7 +62889,7 @@
           "pcb_smtpad_1677",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62908,7 +62908,7 @@
           "pcb_smtpad_1678",
           "connectivity_net3016"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62927,7 +62927,7 @@
           "pcb_smtpad_1679",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62946,7 +62946,7 @@
           "pcb_smtpad_1680",
           "connectivity_net3005"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62965,7 +62965,7 @@
           "pcb_smtpad_1681",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -62984,7 +62984,7 @@
           "pcb_smtpad_1682",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63003,7 +63003,7 @@
           "pcb_smtpad_1682",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63022,7 +63022,7 @@
           "pcb_smtpad_1682",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63041,7 +63041,7 @@
           "pcb_smtpad_1682",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63060,7 +63060,7 @@
           "pcb_smtpad_1683",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63079,7 +63079,7 @@
           "pcb_smtpad_1683",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63098,7 +63098,7 @@
           "pcb_smtpad_1683",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63117,7 +63117,7 @@
           "pcb_smtpad_1683",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63136,7 +63136,7 @@
           "pcb_smtpad_1684",
           "connectivity_net3027"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63155,7 +63155,7 @@
           "pcb_smtpad_1685",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63174,7 +63174,7 @@
           "pcb_smtpad_1686",
           "connectivity_net3016"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63193,7 +63193,7 @@
           "pcb_smtpad_1687",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63212,7 +63212,7 @@
           "pcb_smtpad_1688",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63231,7 +63231,7 @@
           "pcb_smtpad_1688",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63250,7 +63250,7 @@
           "pcb_smtpad_1688",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63269,7 +63269,7 @@
           "pcb_smtpad_1688",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63288,7 +63288,7 @@
           "pcb_smtpad_1689",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63307,7 +63307,7 @@
           "pcb_smtpad_1689",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63326,7 +63326,7 @@
           "pcb_smtpad_1689",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63345,7 +63345,7 @@
           "pcb_smtpad_1689",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63364,7 +63364,7 @@
           "pcb_smtpad_1690",
           "connectivity_net3038"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63383,7 +63383,7 @@
           "pcb_smtpad_1691",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63402,7 +63402,7 @@
           "pcb_smtpad_1692",
           "connectivity_net3027"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63421,7 +63421,7 @@
           "pcb_smtpad_1693",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63440,7 +63440,7 @@
           "pcb_smtpad_1694",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63459,7 +63459,7 @@
           "pcb_smtpad_1694",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63478,7 +63478,7 @@
           "pcb_smtpad_1694",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63497,7 +63497,7 @@
           "pcb_smtpad_1694",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63516,7 +63516,7 @@
           "pcb_smtpad_1695",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63535,7 +63535,7 @@
           "pcb_smtpad_1695",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63554,7 +63554,7 @@
           "pcb_smtpad_1695",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63573,7 +63573,7 @@
           "pcb_smtpad_1695",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63592,7 +63592,7 @@
           "pcb_smtpad_1696",
           "connectivity_net3049"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63611,7 +63611,7 @@
           "pcb_smtpad_1697",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63630,7 +63630,7 @@
           "pcb_smtpad_1698",
           "connectivity_net3038"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63649,7 +63649,7 @@
           "pcb_smtpad_1699",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63668,7 +63668,7 @@
           "pcb_smtpad_1700",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63687,7 +63687,7 @@
           "pcb_smtpad_1700",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63706,7 +63706,7 @@
           "pcb_smtpad_1700",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63725,7 +63725,7 @@
           "pcb_smtpad_1700",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63744,7 +63744,7 @@
           "pcb_smtpad_1701",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63763,7 +63763,7 @@
           "pcb_smtpad_1701",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63782,7 +63782,7 @@
           "pcb_smtpad_1701",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63801,7 +63801,7 @@
           "pcb_smtpad_1701",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63820,7 +63820,7 @@
           "pcb_smtpad_1702",
           "connectivity_net3060"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63839,7 +63839,7 @@
           "pcb_smtpad_1703",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63858,7 +63858,7 @@
           "pcb_smtpad_1704",
           "connectivity_net3049"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63877,7 +63877,7 @@
           "pcb_smtpad_1705",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63896,7 +63896,7 @@
           "pcb_smtpad_1706",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63915,7 +63915,7 @@
           "pcb_smtpad_1706",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63934,7 +63934,7 @@
           "pcb_smtpad_1706",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63953,7 +63953,7 @@
           "pcb_smtpad_1706",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63972,7 +63972,7 @@
           "pcb_smtpad_1707",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -63991,7 +63991,7 @@
           "pcb_smtpad_1707",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64010,7 +64010,7 @@
           "pcb_smtpad_1707",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64029,7 +64029,7 @@
           "pcb_smtpad_1707",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64048,7 +64048,7 @@
           "pcb_smtpad_1708",
           "connectivity_net3071"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64067,7 +64067,7 @@
           "pcb_smtpad_1709",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64086,7 +64086,7 @@
           "pcb_smtpad_1710",
           "connectivity_net3060"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64105,7 +64105,7 @@
           "pcb_smtpad_1711",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64124,7 +64124,7 @@
           "pcb_smtpad_1712",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64143,7 +64143,7 @@
           "pcb_smtpad_1712",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64162,7 +64162,7 @@
           "pcb_smtpad_1712",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64181,7 +64181,7 @@
           "pcb_smtpad_1712",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64200,7 +64200,7 @@
           "pcb_smtpad_1713",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64219,7 +64219,7 @@
           "pcb_smtpad_1713",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64238,7 +64238,7 @@
           "pcb_smtpad_1713",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64257,7 +64257,7 @@
           "pcb_smtpad_1713",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64276,7 +64276,7 @@
           "pcb_smtpad_1714",
           "connectivity_net3082"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64295,7 +64295,7 @@
           "pcb_smtpad_1715",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64314,7 +64314,7 @@
           "pcb_smtpad_1716",
           "connectivity_net3071"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64333,7 +64333,7 @@
           "pcb_smtpad_1717",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64352,7 +64352,7 @@
           "pcb_smtpad_1718",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64371,7 +64371,7 @@
           "pcb_smtpad_1718",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64390,7 +64390,7 @@
           "pcb_smtpad_1718",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64409,7 +64409,7 @@
           "pcb_smtpad_1718",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64428,7 +64428,7 @@
           "pcb_smtpad_1719",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64447,7 +64447,7 @@
           "pcb_smtpad_1719",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64466,7 +64466,7 @@
           "pcb_smtpad_1719",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64485,7 +64485,7 @@
           "pcb_smtpad_1719",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64504,7 +64504,7 @@
           "pcb_smtpad_1720",
           "connectivity_net3093"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64523,7 +64523,7 @@
           "pcb_smtpad_1721",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64542,7 +64542,7 @@
           "pcb_smtpad_1722",
           "connectivity_net3082"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64561,7 +64561,7 @@
           "pcb_smtpad_1723",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64580,7 +64580,7 @@
           "pcb_smtpad_1724",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64599,7 +64599,7 @@
           "pcb_smtpad_1724",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64618,7 +64618,7 @@
           "pcb_smtpad_1724",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64637,7 +64637,7 @@
           "pcb_smtpad_1724",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64656,7 +64656,7 @@
           "pcb_smtpad_1725",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64675,7 +64675,7 @@
           "pcb_smtpad_1725",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64694,7 +64694,7 @@
           "pcb_smtpad_1725",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64713,7 +64713,7 @@
           "pcb_smtpad_1725",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64732,7 +64732,7 @@
           "pcb_smtpad_1726",
           "connectivity_net3104"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64751,7 +64751,7 @@
           "pcb_smtpad_1727",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64770,7 +64770,7 @@
           "pcb_smtpad_1728",
           "connectivity_net3093"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64789,7 +64789,7 @@
           "pcb_smtpad_1729",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64808,7 +64808,7 @@
           "pcb_smtpad_1730",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64827,7 +64827,7 @@
           "pcb_smtpad_1730",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64846,7 +64846,7 @@
           "pcb_smtpad_1730",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64865,7 +64865,7 @@
           "pcb_smtpad_1730",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64884,7 +64884,7 @@
           "pcb_smtpad_1731",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64903,7 +64903,7 @@
           "pcb_smtpad_1731",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64922,7 +64922,7 @@
           "pcb_smtpad_1731",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64941,7 +64941,7 @@
           "pcb_smtpad_1731",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64960,7 +64960,7 @@
           "pcb_smtpad_1732",
           "connectivity_net3115"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64979,7 +64979,7 @@
           "pcb_smtpad_1733",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -64998,7 +64998,7 @@
           "pcb_smtpad_1734",
           "connectivity_net3104"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65017,7 +65017,7 @@
           "pcb_smtpad_1735",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65036,7 +65036,7 @@
           "pcb_smtpad_1736",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65055,7 +65055,7 @@
           "pcb_smtpad_1736",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65074,7 +65074,7 @@
           "pcb_smtpad_1736",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65093,7 +65093,7 @@
           "pcb_smtpad_1736",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65112,7 +65112,7 @@
           "pcb_smtpad_1737",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65131,7 +65131,7 @@
           "pcb_smtpad_1737",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65150,7 +65150,7 @@
           "pcb_smtpad_1737",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65169,7 +65169,7 @@
           "pcb_smtpad_1737",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65188,7 +65188,7 @@
           "pcb_smtpad_1738",
           "connectivity_net3126"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65207,7 +65207,7 @@
           "pcb_smtpad_1739",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65226,7 +65226,7 @@
           "pcb_smtpad_1740",
           "connectivity_net3115"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65245,7 +65245,7 @@
           "pcb_smtpad_1741",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65264,7 +65264,7 @@
           "pcb_smtpad_1742",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65283,7 +65283,7 @@
           "pcb_smtpad_1742",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65302,7 +65302,7 @@
           "pcb_smtpad_1742",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65321,7 +65321,7 @@
           "pcb_smtpad_1742",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65340,7 +65340,7 @@
           "pcb_smtpad_1743",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65359,7 +65359,7 @@
           "pcb_smtpad_1743",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65378,7 +65378,7 @@
           "pcb_smtpad_1743",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65397,7 +65397,7 @@
           "pcb_smtpad_1743",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65416,7 +65416,7 @@
           "pcb_smtpad_1744",
           "connectivity_net3137"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65435,7 +65435,7 @@
           "pcb_smtpad_1745",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65454,7 +65454,7 @@
           "pcb_smtpad_1746",
           "connectivity_net3126"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65473,7 +65473,7 @@
           "pcb_smtpad_1747",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65492,7 +65492,7 @@
           "pcb_smtpad_1748",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65511,7 +65511,7 @@
           "pcb_smtpad_1748",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65530,7 +65530,7 @@
           "pcb_smtpad_1748",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65549,7 +65549,7 @@
           "pcb_smtpad_1748",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65568,7 +65568,7 @@
           "pcb_smtpad_1749",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65587,7 +65587,7 @@
           "pcb_smtpad_1749",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65606,7 +65606,7 @@
           "pcb_smtpad_1749",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65625,7 +65625,7 @@
           "pcb_smtpad_1749",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65644,7 +65644,7 @@
           "pcb_smtpad_1750",
           "connectivity_net3148"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65663,7 +65663,7 @@
           "pcb_smtpad_1751",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65682,7 +65682,7 @@
           "pcb_smtpad_1752",
           "connectivity_net3137"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65701,7 +65701,7 @@
           "pcb_smtpad_1753",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65720,7 +65720,7 @@
           "pcb_smtpad_1754",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65739,7 +65739,7 @@
           "pcb_smtpad_1754",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65758,7 +65758,7 @@
           "pcb_smtpad_1754",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65777,7 +65777,7 @@
           "pcb_smtpad_1754",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65796,7 +65796,7 @@
           "pcb_smtpad_1755",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65815,7 +65815,7 @@
           "pcb_smtpad_1755",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65834,7 +65834,7 @@
           "pcb_smtpad_1755",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65853,7 +65853,7 @@
           "pcb_smtpad_1755",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65872,7 +65872,7 @@
           "pcb_smtpad_1756",
           "connectivity_net3159"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65891,7 +65891,7 @@
           "pcb_smtpad_1757",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65910,7 +65910,7 @@
           "pcb_smtpad_1758",
           "connectivity_net3148"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65929,7 +65929,7 @@
           "pcb_smtpad_1759",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65948,7 +65948,7 @@
           "pcb_smtpad_1760",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65967,7 +65967,7 @@
           "pcb_smtpad_1760",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -65986,7 +65986,7 @@
           "pcb_smtpad_1760",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66005,7 +66005,7 @@
           "pcb_smtpad_1760",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66024,7 +66024,7 @@
           "pcb_smtpad_1761",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66043,7 +66043,7 @@
           "pcb_smtpad_1761",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66062,7 +66062,7 @@
           "pcb_smtpad_1761",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66081,7 +66081,7 @@
           "pcb_smtpad_1761",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66100,7 +66100,7 @@
           "pcb_smtpad_1762",
           "connectivity_net3170"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66119,7 +66119,7 @@
           "pcb_smtpad_1763",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66138,7 +66138,7 @@
           "pcb_smtpad_1764",
           "connectivity_net3159"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66157,7 +66157,7 @@
           "pcb_smtpad_1765",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66176,7 +66176,7 @@
           "pcb_smtpad_1766",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66195,7 +66195,7 @@
           "pcb_smtpad_1766",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66214,7 +66214,7 @@
           "pcb_smtpad_1766",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66233,7 +66233,7 @@
           "pcb_smtpad_1766",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66252,7 +66252,7 @@
           "pcb_smtpad_1767",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66271,7 +66271,7 @@
           "pcb_smtpad_1767",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66290,7 +66290,7 @@
           "pcb_smtpad_1767",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66309,7 +66309,7 @@
           "pcb_smtpad_1767",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66328,7 +66328,7 @@
           "pcb_smtpad_1768",
           "connectivity_net3181"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66347,7 +66347,7 @@
           "pcb_smtpad_1769",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66366,7 +66366,7 @@
           "pcb_smtpad_1770",
           "connectivity_net3170"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66385,7 +66385,7 @@
           "pcb_smtpad_1771",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66404,7 +66404,7 @@
           "pcb_smtpad_1772",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66423,7 +66423,7 @@
           "pcb_smtpad_1772",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66442,7 +66442,7 @@
           "pcb_smtpad_1772",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66461,7 +66461,7 @@
           "pcb_smtpad_1772",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66480,7 +66480,7 @@
           "pcb_smtpad_1773",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66499,7 +66499,7 @@
           "pcb_smtpad_1773",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66518,7 +66518,7 @@
           "pcb_smtpad_1773",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66537,7 +66537,7 @@
           "pcb_smtpad_1773",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66556,7 +66556,7 @@
           "pcb_smtpad_1774",
           "connectivity_net3192"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66575,7 +66575,7 @@
           "pcb_smtpad_1775",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66594,7 +66594,7 @@
           "pcb_smtpad_1776",
           "connectivity_net3181"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66613,7 +66613,7 @@
           "pcb_smtpad_1777",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66632,7 +66632,7 @@
           "pcb_smtpad_1778",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66651,7 +66651,7 @@
           "pcb_smtpad_1778",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66670,7 +66670,7 @@
           "pcb_smtpad_1778",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66689,7 +66689,7 @@
           "pcb_smtpad_1778",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66708,7 +66708,7 @@
           "pcb_smtpad_1779",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66727,7 +66727,7 @@
           "pcb_smtpad_1779",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66746,7 +66746,7 @@
           "pcb_smtpad_1779",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66765,7 +66765,7 @@
           "pcb_smtpad_1779",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66784,7 +66784,7 @@
           "pcb_smtpad_1780",
           "connectivity_net3203"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66803,7 +66803,7 @@
           "pcb_smtpad_1781",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66822,7 +66822,7 @@
           "pcb_smtpad_1782",
           "connectivity_net3192"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66841,7 +66841,7 @@
           "pcb_smtpad_1783",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66860,7 +66860,7 @@
           "pcb_smtpad_1784",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66879,7 +66879,7 @@
           "pcb_smtpad_1784",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66898,7 +66898,7 @@
           "pcb_smtpad_1784",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66917,7 +66917,7 @@
           "pcb_smtpad_1784",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66936,7 +66936,7 @@
           "pcb_smtpad_1785",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66955,7 +66955,7 @@
           "pcb_smtpad_1785",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66974,7 +66974,7 @@
           "pcb_smtpad_1785",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -66993,7 +66993,7 @@
           "pcb_smtpad_1785",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67012,7 +67012,7 @@
           "pcb_smtpad_1786",
           "connectivity_net3214"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67031,7 +67031,7 @@
           "pcb_smtpad_1787",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67050,7 +67050,7 @@
           "pcb_smtpad_1788",
           "connectivity_net3203"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67069,7 +67069,7 @@
           "pcb_smtpad_1789",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67088,7 +67088,7 @@
           "pcb_smtpad_1790",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67107,7 +67107,7 @@
           "pcb_smtpad_1790",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67126,7 +67126,7 @@
           "pcb_smtpad_1790",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67145,7 +67145,7 @@
           "pcb_smtpad_1790",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67164,7 +67164,7 @@
           "pcb_smtpad_1791",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67183,7 +67183,7 @@
           "pcb_smtpad_1791",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67202,7 +67202,7 @@
           "pcb_smtpad_1791",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67221,7 +67221,7 @@
           "pcb_smtpad_1791",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67240,7 +67240,7 @@
           "pcb_smtpad_1792",
           "connectivity_net3225"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67259,7 +67259,7 @@
           "pcb_smtpad_1793",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67278,7 +67278,7 @@
           "pcb_smtpad_1794",
           "connectivity_net3214"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67297,7 +67297,7 @@
           "pcb_smtpad_1795",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67316,7 +67316,7 @@
           "pcb_smtpad_1796",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67335,7 +67335,7 @@
           "pcb_smtpad_1796",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67354,7 +67354,7 @@
           "pcb_smtpad_1796",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67373,7 +67373,7 @@
           "pcb_smtpad_1796",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67392,7 +67392,7 @@
           "pcb_smtpad_1797",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67411,7 +67411,7 @@
           "pcb_smtpad_1797",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67430,7 +67430,7 @@
           "pcb_smtpad_1797",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67449,7 +67449,7 @@
           "pcb_smtpad_1797",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67468,7 +67468,7 @@
           "pcb_smtpad_1798",
           "connectivity_net3236"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67487,7 +67487,7 @@
           "pcb_smtpad_1799",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67506,7 +67506,7 @@
           "pcb_smtpad_1800",
           "connectivity_net3225"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67525,7 +67525,7 @@
           "pcb_smtpad_1801",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67544,7 +67544,7 @@
           "pcb_smtpad_1802",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67563,7 +67563,7 @@
           "pcb_smtpad_1802",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67582,7 +67582,7 @@
           "pcb_smtpad_1802",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67601,7 +67601,7 @@
           "pcb_smtpad_1802",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67620,7 +67620,7 @@
           "pcb_smtpad_1803",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67639,7 +67639,7 @@
           "pcb_smtpad_1803",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67658,7 +67658,7 @@
           "pcb_smtpad_1803",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67677,7 +67677,7 @@
           "pcb_smtpad_1803",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67696,7 +67696,7 @@
           "pcb_smtpad_1804",
           "connectivity_net3247"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67715,7 +67715,7 @@
           "pcb_smtpad_1805",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67734,7 +67734,7 @@
           "pcb_smtpad_1806",
           "connectivity_net3236"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67753,7 +67753,7 @@
           "pcb_smtpad_1807",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67772,7 +67772,7 @@
           "pcb_smtpad_1808",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67791,7 +67791,7 @@
           "pcb_smtpad_1808",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67810,7 +67810,7 @@
           "pcb_smtpad_1808",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67829,7 +67829,7 @@
           "pcb_smtpad_1808",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67848,7 +67848,7 @@
           "pcb_smtpad_1809",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67867,7 +67867,7 @@
           "pcb_smtpad_1809",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67886,7 +67886,7 @@
           "pcb_smtpad_1809",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67905,7 +67905,7 @@
           "pcb_smtpad_1809",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67924,7 +67924,7 @@
           "pcb_smtpad_1810",
           "connectivity_net3258"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67943,7 +67943,7 @@
           "pcb_smtpad_1811",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67962,7 +67962,7 @@
           "pcb_smtpad_1812",
           "connectivity_net3247"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -67981,7 +67981,7 @@
           "pcb_smtpad_1813",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68000,7 +68000,7 @@
           "pcb_smtpad_1814",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68019,7 +68019,7 @@
           "pcb_smtpad_1814",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68038,7 +68038,7 @@
           "pcb_smtpad_1814",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68057,7 +68057,7 @@
           "pcb_smtpad_1814",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68076,7 +68076,7 @@
           "pcb_smtpad_1815",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68095,7 +68095,7 @@
           "pcb_smtpad_1815",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68114,7 +68114,7 @@
           "pcb_smtpad_1815",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68133,7 +68133,7 @@
           "pcb_smtpad_1815",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68152,7 +68152,7 @@
           "pcb_smtpad_1816",
           "connectivity_net3269"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68171,7 +68171,7 @@
           "pcb_smtpad_1817",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68190,7 +68190,7 @@
           "pcb_smtpad_1818",
           "connectivity_net3258"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68209,7 +68209,7 @@
           "pcb_smtpad_1819",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68228,7 +68228,7 @@
           "pcb_smtpad_1820",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68247,7 +68247,7 @@
           "pcb_smtpad_1820",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68266,7 +68266,7 @@
           "pcb_smtpad_1820",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68285,7 +68285,7 @@
           "pcb_smtpad_1820",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68304,7 +68304,7 @@
           "pcb_smtpad_1821",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68323,7 +68323,7 @@
           "pcb_smtpad_1821",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68342,7 +68342,7 @@
           "pcb_smtpad_1821",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68361,7 +68361,7 @@
           "pcb_smtpad_1821",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68380,7 +68380,7 @@
           "pcb_smtpad_1822",
           "connectivity_net3280"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68399,7 +68399,7 @@
           "pcb_smtpad_1823",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68418,7 +68418,7 @@
           "pcb_smtpad_1824",
           "connectivity_net3269"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68437,7 +68437,7 @@
           "pcb_smtpad_1825",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68456,7 +68456,7 @@
           "pcb_smtpad_1826",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68475,7 +68475,7 @@
           "pcb_smtpad_1826",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68494,7 +68494,7 @@
           "pcb_smtpad_1826",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68513,7 +68513,7 @@
           "pcb_smtpad_1826",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68532,7 +68532,7 @@
           "pcb_smtpad_1827",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68551,7 +68551,7 @@
           "pcb_smtpad_1827",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68570,7 +68570,7 @@
           "pcb_smtpad_1827",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68589,7 +68589,7 @@
           "pcb_smtpad_1827",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68608,7 +68608,7 @@
           "pcb_smtpad_1828",
           "connectivity_net3291"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68627,7 +68627,7 @@
           "pcb_smtpad_1829",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68646,7 +68646,7 @@
           "pcb_smtpad_1830",
           "connectivity_net3280"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68665,7 +68665,7 @@
           "pcb_smtpad_1831",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68684,7 +68684,7 @@
           "pcb_smtpad_1832",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68703,7 +68703,7 @@
           "pcb_smtpad_1832",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68722,7 +68722,7 @@
           "pcb_smtpad_1832",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68741,7 +68741,7 @@
           "pcb_smtpad_1832",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68760,7 +68760,7 @@
           "pcb_smtpad_1833",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68779,7 +68779,7 @@
           "pcb_smtpad_1833",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68798,7 +68798,7 @@
           "pcb_smtpad_1833",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68817,7 +68817,7 @@
           "pcb_smtpad_1833",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68836,7 +68836,7 @@
           "pcb_smtpad_1834",
           "connectivity_net3302"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68855,7 +68855,7 @@
           "pcb_smtpad_1835",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68874,7 +68874,7 @@
           "pcb_smtpad_1836",
           "connectivity_net3291"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68893,7 +68893,7 @@
           "pcb_smtpad_1837",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68912,7 +68912,7 @@
           "pcb_smtpad_1838",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68931,7 +68931,7 @@
           "pcb_smtpad_1838",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68950,7 +68950,7 @@
           "pcb_smtpad_1838",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68969,7 +68969,7 @@
           "pcb_smtpad_1838",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -68988,7 +68988,7 @@
           "pcb_smtpad_1839",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69007,7 +69007,7 @@
           "pcb_smtpad_1839",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69026,7 +69026,7 @@
           "pcb_smtpad_1839",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69045,7 +69045,7 @@
           "pcb_smtpad_1839",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69064,7 +69064,7 @@
           "pcb_smtpad_1840",
           "connectivity_net3313"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69083,7 +69083,7 @@
           "pcb_smtpad_1841",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69102,7 +69102,7 @@
           "pcb_smtpad_1842",
           "connectivity_net3302"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69121,7 +69121,7 @@
           "pcb_smtpad_1843",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69140,7 +69140,7 @@
           "pcb_smtpad_1844",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69159,7 +69159,7 @@
           "pcb_smtpad_1844",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69178,7 +69178,7 @@
           "pcb_smtpad_1844",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69197,7 +69197,7 @@
           "pcb_smtpad_1844",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69216,7 +69216,7 @@
           "pcb_smtpad_1845",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69235,7 +69235,7 @@
           "pcb_smtpad_1845",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69254,7 +69254,7 @@
           "pcb_smtpad_1845",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69273,7 +69273,7 @@
           "pcb_smtpad_1845",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69292,7 +69292,7 @@
           "pcb_smtpad_1846",
           "connectivity_net3324"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69311,7 +69311,7 @@
           "pcb_smtpad_1847",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69330,7 +69330,7 @@
           "pcb_smtpad_1848",
           "connectivity_net3313"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69349,7 +69349,7 @@
           "pcb_smtpad_1849",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69368,7 +69368,7 @@
           "pcb_smtpad_1850",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69387,7 +69387,7 @@
           "pcb_smtpad_1850",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69406,7 +69406,7 @@
           "pcb_smtpad_1850",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69425,7 +69425,7 @@
           "pcb_smtpad_1850",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69444,7 +69444,7 @@
           "pcb_smtpad_1851",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69463,7 +69463,7 @@
           "pcb_smtpad_1851",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69482,7 +69482,7 @@
           "pcb_smtpad_1851",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69501,7 +69501,7 @@
           "pcb_smtpad_1851",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69520,7 +69520,7 @@
           "pcb_smtpad_1852",
           "connectivity_net3335"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69539,7 +69539,7 @@
           "pcb_smtpad_1853",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69558,7 +69558,7 @@
           "pcb_smtpad_1854",
           "connectivity_net3324"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69577,7 +69577,7 @@
           "pcb_smtpad_1855",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69596,7 +69596,7 @@
           "pcb_smtpad_1856",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69615,7 +69615,7 @@
           "pcb_smtpad_1856",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69634,7 +69634,7 @@
           "pcb_smtpad_1856",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69653,7 +69653,7 @@
           "pcb_smtpad_1856",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69672,7 +69672,7 @@
           "pcb_smtpad_1857",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69691,7 +69691,7 @@
           "pcb_smtpad_1857",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69710,7 +69710,7 @@
           "pcb_smtpad_1857",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69729,7 +69729,7 @@
           "pcb_smtpad_1857",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69748,7 +69748,7 @@
           "pcb_smtpad_1858",
           "connectivity_net3346"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69767,7 +69767,7 @@
           "pcb_smtpad_1859",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69786,7 +69786,7 @@
           "pcb_smtpad_1860",
           "connectivity_net3335"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69805,7 +69805,7 @@
           "pcb_smtpad_1861",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69824,7 +69824,7 @@
           "pcb_smtpad_1862",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69843,7 +69843,7 @@
           "pcb_smtpad_1862",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69862,7 +69862,7 @@
           "pcb_smtpad_1862",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69881,7 +69881,7 @@
           "pcb_smtpad_1862",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69900,7 +69900,7 @@
           "pcb_smtpad_1863",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69919,7 +69919,7 @@
           "pcb_smtpad_1863",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69938,7 +69938,7 @@
           "pcb_smtpad_1863",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69957,7 +69957,7 @@
           "pcb_smtpad_1863",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69976,7 +69976,7 @@
           "pcb_smtpad_1864",
           "connectivity_net3357"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -69995,7 +69995,7 @@
           "pcb_smtpad_1865",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70014,7 +70014,7 @@
           "pcb_smtpad_1866",
           "connectivity_net3346"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70033,7 +70033,7 @@
           "pcb_smtpad_1867",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70052,7 +70052,7 @@
           "pcb_smtpad_1868",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70071,7 +70071,7 @@
           "pcb_smtpad_1868",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70090,7 +70090,7 @@
           "pcb_smtpad_1868",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70109,7 +70109,7 @@
           "pcb_smtpad_1868",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70128,7 +70128,7 @@
           "pcb_smtpad_1869",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70147,7 +70147,7 @@
           "pcb_smtpad_1869",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70166,7 +70166,7 @@
           "pcb_smtpad_1869",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70185,7 +70185,7 @@
           "pcb_smtpad_1869",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70204,7 +70204,7 @@
           "pcb_smtpad_1870",
           "connectivity_net3368"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70223,7 +70223,7 @@
           "pcb_smtpad_1871",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70242,7 +70242,7 @@
           "pcb_smtpad_1872",
           "connectivity_net3357"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70261,7 +70261,7 @@
           "pcb_smtpad_1873",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70280,7 +70280,7 @@
           "pcb_smtpad_1874",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70299,7 +70299,7 @@
           "pcb_smtpad_1874",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70318,7 +70318,7 @@
           "pcb_smtpad_1874",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70337,7 +70337,7 @@
           "pcb_smtpad_1874",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70356,7 +70356,7 @@
           "pcb_smtpad_1875",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70375,7 +70375,7 @@
           "pcb_smtpad_1875",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70394,7 +70394,7 @@
           "pcb_smtpad_1875",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70413,7 +70413,7 @@
           "pcb_smtpad_1875",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70432,7 +70432,7 @@
           "pcb_smtpad_1876",
           "connectivity_net3379"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70451,7 +70451,7 @@
           "pcb_smtpad_1877",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70470,7 +70470,7 @@
           "pcb_smtpad_1878",
           "connectivity_net3368"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70489,7 +70489,7 @@
           "pcb_smtpad_1879",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70508,7 +70508,7 @@
           "pcb_smtpad_1880",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70527,7 +70527,7 @@
           "pcb_smtpad_1880",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70546,7 +70546,7 @@
           "pcb_smtpad_1880",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70565,7 +70565,7 @@
           "pcb_smtpad_1880",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70584,7 +70584,7 @@
           "pcb_smtpad_1881",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70603,7 +70603,7 @@
           "pcb_smtpad_1881",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70622,7 +70622,7 @@
           "pcb_smtpad_1881",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70641,7 +70641,7 @@
           "pcb_smtpad_1881",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70660,7 +70660,7 @@
           "pcb_smtpad_1882",
           "connectivity_net3390"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70679,7 +70679,7 @@
           "pcb_smtpad_1883",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70698,7 +70698,7 @@
           "pcb_smtpad_1884",
           "connectivity_net3379"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70717,7 +70717,7 @@
           "pcb_smtpad_1885",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70736,7 +70736,7 @@
           "pcb_smtpad_1886",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70755,7 +70755,7 @@
           "pcb_smtpad_1886",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70774,7 +70774,7 @@
           "pcb_smtpad_1886",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70793,7 +70793,7 @@
           "pcb_smtpad_1886",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70812,7 +70812,7 @@
           "pcb_smtpad_1887",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70831,7 +70831,7 @@
           "pcb_smtpad_1887",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70850,7 +70850,7 @@
           "pcb_smtpad_1887",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70869,7 +70869,7 @@
           "pcb_smtpad_1887",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70888,7 +70888,7 @@
           "pcb_smtpad_1888",
           "connectivity_net3401"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70907,7 +70907,7 @@
           "pcb_smtpad_1889",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70926,7 +70926,7 @@
           "pcb_smtpad_1890",
           "connectivity_net3390"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70945,7 +70945,7 @@
           "pcb_smtpad_1891",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70964,7 +70964,7 @@
           "pcb_smtpad_1892",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -70983,7 +70983,7 @@
           "pcb_smtpad_1892",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71002,7 +71002,7 @@
           "pcb_smtpad_1892",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71021,7 +71021,7 @@
           "pcb_smtpad_1892",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71040,7 +71040,7 @@
           "pcb_smtpad_1893",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71059,7 +71059,7 @@
           "pcb_smtpad_1893",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71078,7 +71078,7 @@
           "pcb_smtpad_1893",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71097,7 +71097,7 @@
           "pcb_smtpad_1893",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71116,7 +71116,7 @@
           "pcb_smtpad_1894",
           "connectivity_net3412"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71135,7 +71135,7 @@
           "pcb_smtpad_1895",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71154,7 +71154,7 @@
           "pcb_smtpad_1896",
           "connectivity_net3401"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71173,7 +71173,7 @@
           "pcb_smtpad_1897",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71192,7 +71192,7 @@
           "pcb_smtpad_1898",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71211,7 +71211,7 @@
           "pcb_smtpad_1898",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71230,7 +71230,7 @@
           "pcb_smtpad_1898",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71249,7 +71249,7 @@
           "pcb_smtpad_1898",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71268,7 +71268,7 @@
           "pcb_smtpad_1899",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71287,7 +71287,7 @@
           "pcb_smtpad_1899",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71306,7 +71306,7 @@
           "pcb_smtpad_1899",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71325,7 +71325,7 @@
           "pcb_smtpad_1899",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71344,7 +71344,7 @@
           "pcb_smtpad_1900",
           "connectivity_net3423"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71363,7 +71363,7 @@
           "pcb_smtpad_1901",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71382,7 +71382,7 @@
           "pcb_smtpad_1902",
           "connectivity_net3412"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71401,7 +71401,7 @@
           "pcb_smtpad_1903",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71420,7 +71420,7 @@
           "pcb_smtpad_1904",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71439,7 +71439,7 @@
           "pcb_smtpad_1904",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71458,7 +71458,7 @@
           "pcb_smtpad_1904",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71477,7 +71477,7 @@
           "pcb_smtpad_1904",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71496,7 +71496,7 @@
           "pcb_smtpad_1905",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71515,7 +71515,7 @@
           "pcb_smtpad_1905",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71534,7 +71534,7 @@
           "pcb_smtpad_1905",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71553,7 +71553,7 @@
           "pcb_smtpad_1905",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71572,7 +71572,7 @@
           "pcb_smtpad_1906",
           "connectivity_net3434"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71591,7 +71591,7 @@
           "pcb_smtpad_1907",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71610,7 +71610,7 @@
           "pcb_smtpad_1908",
           "connectivity_net3423"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71629,7 +71629,7 @@
           "pcb_smtpad_1909",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71648,7 +71648,7 @@
           "pcb_smtpad_1910",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71667,7 +71667,7 @@
           "pcb_smtpad_1910",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71686,7 +71686,7 @@
           "pcb_smtpad_1910",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71705,7 +71705,7 @@
           "pcb_smtpad_1910",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71724,7 +71724,7 @@
           "pcb_smtpad_1911",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71743,7 +71743,7 @@
           "pcb_smtpad_1911",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71762,7 +71762,7 @@
           "pcb_smtpad_1911",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71781,7 +71781,7 @@
           "pcb_smtpad_1911",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71800,7 +71800,7 @@
           "pcb_smtpad_1912",
           "connectivity_net3445"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71819,7 +71819,7 @@
           "pcb_smtpad_1913",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71838,7 +71838,7 @@
           "pcb_smtpad_1914",
           "connectivity_net3434"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71857,7 +71857,7 @@
           "pcb_smtpad_1915",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71876,7 +71876,7 @@
           "pcb_smtpad_1916",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71895,7 +71895,7 @@
           "pcb_smtpad_1916",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71914,7 +71914,7 @@
           "pcb_smtpad_1916",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71933,7 +71933,7 @@
           "pcb_smtpad_1916",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71952,7 +71952,7 @@
           "pcb_smtpad_1917",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71971,7 +71971,7 @@
           "pcb_smtpad_1917",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -71990,7 +71990,7 @@
           "pcb_smtpad_1917",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72009,7 +72009,7 @@
           "pcb_smtpad_1917",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72028,7 +72028,7 @@
           "pcb_smtpad_1918",
           "connectivity_net3456"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72047,7 +72047,7 @@
           "pcb_smtpad_1919",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72066,7 +72066,7 @@
           "pcb_smtpad_1920",
           "connectivity_net3445"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72085,7 +72085,7 @@
           "pcb_smtpad_1921",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72104,7 +72104,7 @@
           "pcb_smtpad_1922",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72123,7 +72123,7 @@
           "pcb_smtpad_1922",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72142,7 +72142,7 @@
           "pcb_smtpad_1922",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72161,7 +72161,7 @@
           "pcb_smtpad_1922",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72180,7 +72180,7 @@
           "pcb_smtpad_1923",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72199,7 +72199,7 @@
           "pcb_smtpad_1923",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72218,7 +72218,7 @@
           "pcb_smtpad_1923",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72237,7 +72237,7 @@
           "pcb_smtpad_1923",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72256,7 +72256,7 @@
           "pcb_smtpad_1924",
           "connectivity_net3467"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72275,7 +72275,7 @@
           "pcb_smtpad_1925",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72294,7 +72294,7 @@
           "pcb_smtpad_1926",
           "connectivity_net3456"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72313,7 +72313,7 @@
           "pcb_smtpad_1927",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72332,7 +72332,7 @@
           "pcb_smtpad_1928",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72351,7 +72351,7 @@
           "pcb_smtpad_1928",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72370,7 +72370,7 @@
           "pcb_smtpad_1928",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72389,7 +72389,7 @@
           "pcb_smtpad_1928",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72408,7 +72408,7 @@
           "pcb_smtpad_1929",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72427,7 +72427,7 @@
           "pcb_smtpad_1929",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72446,7 +72446,7 @@
           "pcb_smtpad_1929",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72465,7 +72465,7 @@
           "pcb_smtpad_1929",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72484,7 +72484,7 @@
           "pcb_smtpad_1930",
           "connectivity_net3478"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72503,7 +72503,7 @@
           "pcb_smtpad_1931",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72522,7 +72522,7 @@
           "pcb_smtpad_1932",
           "connectivity_net3467"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72541,7 +72541,7 @@
           "pcb_smtpad_1933",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72560,7 +72560,7 @@
           "pcb_smtpad_1934",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72579,7 +72579,7 @@
           "pcb_smtpad_1934",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72598,7 +72598,7 @@
           "pcb_smtpad_1934",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72617,7 +72617,7 @@
           "pcb_smtpad_1934",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72636,7 +72636,7 @@
           "pcb_smtpad_1935",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72655,7 +72655,7 @@
           "pcb_smtpad_1935",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72674,7 +72674,7 @@
           "pcb_smtpad_1935",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72693,7 +72693,7 @@
           "pcb_smtpad_1935",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72712,7 +72712,7 @@
           "pcb_smtpad_1936",
           "connectivity_net3489"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72731,7 +72731,7 @@
           "pcb_smtpad_1937",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72750,7 +72750,7 @@
           "pcb_smtpad_1938",
           "connectivity_net3478"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72769,7 +72769,7 @@
           "pcb_smtpad_1939",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72788,7 +72788,7 @@
           "pcb_smtpad_1940",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72807,7 +72807,7 @@
           "pcb_smtpad_1940",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72826,7 +72826,7 @@
           "pcb_smtpad_1940",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72845,7 +72845,7 @@
           "pcb_smtpad_1940",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72864,7 +72864,7 @@
           "pcb_smtpad_1941",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72883,7 +72883,7 @@
           "pcb_smtpad_1941",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72902,7 +72902,7 @@
           "pcb_smtpad_1941",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72921,7 +72921,7 @@
           "pcb_smtpad_1941",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72940,7 +72940,7 @@
           "pcb_smtpad_1942",
           "connectivity_net3500"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72959,7 +72959,7 @@
           "pcb_smtpad_1943",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72978,7 +72978,7 @@
           "pcb_smtpad_1944",
           "connectivity_net3489"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -72997,7 +72997,7 @@
           "pcb_smtpad_1945",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73016,7 +73016,7 @@
           "pcb_smtpad_1946",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73035,7 +73035,7 @@
           "pcb_smtpad_1946",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73054,7 +73054,7 @@
           "pcb_smtpad_1946",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73073,7 +73073,7 @@
           "pcb_smtpad_1946",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73092,7 +73092,7 @@
           "pcb_smtpad_1947",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73111,7 +73111,7 @@
           "pcb_smtpad_1947",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73130,7 +73130,7 @@
           "pcb_smtpad_1947",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73149,7 +73149,7 @@
           "pcb_smtpad_1947",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73168,7 +73168,7 @@
           "pcb_smtpad_1948",
           "connectivity_net3511"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73187,7 +73187,7 @@
           "pcb_smtpad_1949",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73206,7 +73206,7 @@
           "pcb_smtpad_1950",
           "connectivity_net3500"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73225,7 +73225,7 @@
           "pcb_smtpad_1951",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73244,7 +73244,7 @@
           "pcb_smtpad_1952",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73263,7 +73263,7 @@
           "pcb_smtpad_1952",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73282,7 +73282,7 @@
           "pcb_smtpad_1952",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73301,7 +73301,7 @@
           "pcb_smtpad_1952",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73320,7 +73320,7 @@
           "pcb_smtpad_1953",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73339,7 +73339,7 @@
           "pcb_smtpad_1953",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73358,7 +73358,7 @@
           "pcb_smtpad_1953",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73377,7 +73377,7 @@
           "pcb_smtpad_1953",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73396,7 +73396,7 @@
           "pcb_smtpad_1954",
           "connectivity_net3522"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73415,7 +73415,7 @@
           "pcb_smtpad_1955",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73434,7 +73434,7 @@
           "pcb_smtpad_1956",
           "connectivity_net3511"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73453,7 +73453,7 @@
           "pcb_smtpad_1957",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73472,7 +73472,7 @@
           "pcb_smtpad_1958",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73491,7 +73491,7 @@
           "pcb_smtpad_1958",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73510,7 +73510,7 @@
           "pcb_smtpad_1958",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73529,7 +73529,7 @@
           "pcb_smtpad_1958",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73548,7 +73548,7 @@
           "pcb_smtpad_1959",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73567,7 +73567,7 @@
           "pcb_smtpad_1959",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73586,7 +73586,7 @@
           "pcb_smtpad_1959",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73605,7 +73605,7 @@
           "pcb_smtpad_1959",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73624,7 +73624,7 @@
           "pcb_smtpad_1960",
           "connectivity_net3533"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73643,7 +73643,7 @@
           "pcb_smtpad_1961",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73662,7 +73662,7 @@
           "pcb_smtpad_1962",
           "connectivity_net3522"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73681,7 +73681,7 @@
           "pcb_smtpad_1963",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73700,7 +73700,7 @@
           "pcb_smtpad_1964",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73719,7 +73719,7 @@
           "pcb_smtpad_1964",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73738,7 +73738,7 @@
           "pcb_smtpad_1964",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73757,7 +73757,7 @@
           "pcb_smtpad_1964",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73776,7 +73776,7 @@
           "pcb_smtpad_1965",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73795,7 +73795,7 @@
           "pcb_smtpad_1965",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73814,7 +73814,7 @@
           "pcb_smtpad_1965",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73833,7 +73833,7 @@
           "pcb_smtpad_1965",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73852,7 +73852,7 @@
           "pcb_smtpad_1966",
           "connectivity_net3544"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73871,7 +73871,7 @@
           "pcb_smtpad_1967",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73890,7 +73890,7 @@
           "pcb_smtpad_1968",
           "connectivity_net3533"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73909,7 +73909,7 @@
           "pcb_smtpad_1969",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73928,7 +73928,7 @@
           "pcb_smtpad_1970",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73947,7 +73947,7 @@
           "pcb_smtpad_1970",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73966,7 +73966,7 @@
           "pcb_smtpad_1970",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -73985,7 +73985,7 @@
           "pcb_smtpad_1970",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74004,7 +74004,7 @@
           "pcb_smtpad_1971",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74023,7 +74023,7 @@
           "pcb_smtpad_1971",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74042,7 +74042,7 @@
           "pcb_smtpad_1971",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74061,7 +74061,7 @@
           "pcb_smtpad_1971",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74080,7 +74080,7 @@
           "pcb_smtpad_1972",
           "connectivity_net3555"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74099,7 +74099,7 @@
           "pcb_smtpad_1973",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74118,7 +74118,7 @@
           "pcb_smtpad_1974",
           "connectivity_net3544"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74137,7 +74137,7 @@
           "pcb_smtpad_1975",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74156,7 +74156,7 @@
           "pcb_smtpad_1976",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74175,7 +74175,7 @@
           "pcb_smtpad_1976",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74194,7 +74194,7 @@
           "pcb_smtpad_1976",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74213,7 +74213,7 @@
           "pcb_smtpad_1976",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74232,7 +74232,7 @@
           "pcb_smtpad_1977",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74251,7 +74251,7 @@
           "pcb_smtpad_1977",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74270,7 +74270,7 @@
           "pcb_smtpad_1977",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74289,7 +74289,7 @@
           "pcb_smtpad_1977",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74308,7 +74308,7 @@
           "pcb_smtpad_1978",
           "connectivity_net3566"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74327,7 +74327,7 @@
           "pcb_smtpad_1979",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74346,7 +74346,7 @@
           "pcb_smtpad_1980",
           "connectivity_net3555"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74365,7 +74365,7 @@
           "pcb_smtpad_1981",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74384,7 +74384,7 @@
           "pcb_smtpad_1982",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74403,7 +74403,7 @@
           "pcb_smtpad_1982",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74422,7 +74422,7 @@
           "pcb_smtpad_1982",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74441,7 +74441,7 @@
           "pcb_smtpad_1982",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74460,7 +74460,7 @@
           "pcb_smtpad_1983",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74479,7 +74479,7 @@
           "pcb_smtpad_1983",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74498,7 +74498,7 @@
           "pcb_smtpad_1983",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74517,7 +74517,7 @@
           "pcb_smtpad_1983",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74536,7 +74536,7 @@
           "pcb_smtpad_1984",
           "connectivity_net3577"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74555,7 +74555,7 @@
           "pcb_smtpad_1985",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74574,7 +74574,7 @@
           "pcb_smtpad_1986",
           "connectivity_net3566"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74593,7 +74593,7 @@
           "pcb_smtpad_1987",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74612,7 +74612,7 @@
           "pcb_smtpad_1988",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74631,7 +74631,7 @@
           "pcb_smtpad_1988",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74650,7 +74650,7 @@
           "pcb_smtpad_1988",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74669,7 +74669,7 @@
           "pcb_smtpad_1988",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74688,7 +74688,7 @@
           "pcb_smtpad_1989",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74707,7 +74707,7 @@
           "pcb_smtpad_1989",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74726,7 +74726,7 @@
           "pcb_smtpad_1989",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74745,7 +74745,7 @@
           "pcb_smtpad_1989",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74764,7 +74764,7 @@
           "pcb_smtpad_1990",
           "connectivity_net3588"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74783,7 +74783,7 @@
           "pcb_smtpad_1991",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74802,7 +74802,7 @@
           "pcb_smtpad_1992",
           "connectivity_net3577"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74821,7 +74821,7 @@
           "pcb_smtpad_1993",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74840,7 +74840,7 @@
           "pcb_smtpad_1994",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74859,7 +74859,7 @@
           "pcb_smtpad_1994",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74878,7 +74878,7 @@
           "pcb_smtpad_1994",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74897,7 +74897,7 @@
           "pcb_smtpad_1994",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74916,7 +74916,7 @@
           "pcb_smtpad_1995",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74935,7 +74935,7 @@
           "pcb_smtpad_1995",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74954,7 +74954,7 @@
           "pcb_smtpad_1995",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74973,7 +74973,7 @@
           "pcb_smtpad_1995",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -74992,7 +74992,7 @@
           "pcb_smtpad_1996",
           "connectivity_net3599"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75011,7 +75011,7 @@
           "pcb_smtpad_1997",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75030,7 +75030,7 @@
           "pcb_smtpad_1998",
           "connectivity_net3588"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75049,7 +75049,7 @@
           "pcb_smtpad_1999",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75068,7 +75068,7 @@
           "pcb_smtpad_2000",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75087,7 +75087,7 @@
           "pcb_smtpad_2000",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75106,7 +75106,7 @@
           "pcb_smtpad_2000",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75125,7 +75125,7 @@
           "pcb_smtpad_2000",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75144,7 +75144,7 @@
           "pcb_smtpad_2001",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75163,7 +75163,7 @@
           "pcb_smtpad_2001",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75182,7 +75182,7 @@
           "pcb_smtpad_2001",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75201,7 +75201,7 @@
           "pcb_smtpad_2001",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75220,7 +75220,7 @@
           "pcb_smtpad_2002",
           "connectivity_net3610"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75239,7 +75239,7 @@
           "pcb_smtpad_2003",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75258,7 +75258,7 @@
           "pcb_smtpad_2004",
           "connectivity_net3599"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75277,7 +75277,7 @@
           "pcb_smtpad_2005",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75296,7 +75296,7 @@
           "pcb_smtpad_2006",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75315,7 +75315,7 @@
           "pcb_smtpad_2006",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75334,7 +75334,7 @@
           "pcb_smtpad_2006",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75353,7 +75353,7 @@
           "pcb_smtpad_2006",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75372,7 +75372,7 @@
           "pcb_smtpad_2007",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75391,7 +75391,7 @@
           "pcb_smtpad_2007",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75410,7 +75410,7 @@
           "pcb_smtpad_2007",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75429,7 +75429,7 @@
           "pcb_smtpad_2007",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75448,7 +75448,7 @@
           "pcb_smtpad_2008",
           "connectivity_net3621"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75467,7 +75467,7 @@
           "pcb_smtpad_2009",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75486,7 +75486,7 @@
           "pcb_smtpad_2010",
           "connectivity_net3610"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75505,7 +75505,7 @@
           "pcb_smtpad_2011",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75524,7 +75524,7 @@
           "pcb_smtpad_2012",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75543,7 +75543,7 @@
           "pcb_smtpad_2012",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75562,7 +75562,7 @@
           "pcb_smtpad_2012",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75581,7 +75581,7 @@
           "pcb_smtpad_2012",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75600,7 +75600,7 @@
           "pcb_smtpad_2013",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75619,7 +75619,7 @@
           "pcb_smtpad_2013",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75638,7 +75638,7 @@
           "pcb_smtpad_2013",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75657,7 +75657,7 @@
           "pcb_smtpad_2013",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75676,7 +75676,7 @@
           "pcb_smtpad_2014",
           "connectivity_net3632"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75695,7 +75695,7 @@
           "pcb_smtpad_2015",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75714,7 +75714,7 @@
           "pcb_smtpad_2016",
           "connectivity_net3621"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75733,7 +75733,7 @@
           "pcb_smtpad_2017",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75752,7 +75752,7 @@
           "pcb_smtpad_2018",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75771,7 +75771,7 @@
           "pcb_smtpad_2018",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75790,7 +75790,7 @@
           "pcb_smtpad_2018",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75809,7 +75809,7 @@
           "pcb_smtpad_2018",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75828,7 +75828,7 @@
           "pcb_smtpad_2019",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75847,7 +75847,7 @@
           "pcb_smtpad_2019",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75866,7 +75866,7 @@
           "pcb_smtpad_2019",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75885,7 +75885,7 @@
           "pcb_smtpad_2019",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75904,7 +75904,7 @@
           "pcb_smtpad_2020",
           "connectivity_net3643"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75923,7 +75923,7 @@
           "pcb_smtpad_2021",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75942,7 +75942,7 @@
           "pcb_smtpad_2022",
           "connectivity_net3632"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75961,7 +75961,7 @@
           "pcb_smtpad_2023",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75980,7 +75980,7 @@
           "pcb_smtpad_2024",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -75999,7 +75999,7 @@
           "pcb_smtpad_2024",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76018,7 +76018,7 @@
           "pcb_smtpad_2024",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76037,7 +76037,7 @@
           "pcb_smtpad_2024",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76056,7 +76056,7 @@
           "pcb_smtpad_2025",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76075,7 +76075,7 @@
           "pcb_smtpad_2025",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76094,7 +76094,7 @@
           "pcb_smtpad_2025",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76113,7 +76113,7 @@
           "pcb_smtpad_2025",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76132,7 +76132,7 @@
           "pcb_smtpad_2026",
           "connectivity_net3654"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76151,7 +76151,7 @@
           "pcb_smtpad_2027",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76170,7 +76170,7 @@
           "pcb_smtpad_2028",
           "connectivity_net3643"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76189,7 +76189,7 @@
           "pcb_smtpad_2029",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76208,7 +76208,7 @@
           "pcb_smtpad_2030",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76227,7 +76227,7 @@
           "pcb_smtpad_2030",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76246,7 +76246,7 @@
           "pcb_smtpad_2030",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76265,7 +76265,7 @@
           "pcb_smtpad_2030",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76284,7 +76284,7 @@
           "pcb_smtpad_2031",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76303,7 +76303,7 @@
           "pcb_smtpad_2031",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76322,7 +76322,7 @@
           "pcb_smtpad_2031",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76341,7 +76341,7 @@
           "pcb_smtpad_2031",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76360,7 +76360,7 @@
           "pcb_smtpad_2032",
           "connectivity_net3665"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76379,7 +76379,7 @@
           "pcb_smtpad_2033",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76398,7 +76398,7 @@
           "pcb_smtpad_2034",
           "connectivity_net3654"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76417,7 +76417,7 @@
           "pcb_smtpad_2035",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76436,7 +76436,7 @@
           "pcb_smtpad_2036",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76455,7 +76455,7 @@
           "pcb_smtpad_2036",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76474,7 +76474,7 @@
           "pcb_smtpad_2036",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76493,7 +76493,7 @@
           "pcb_smtpad_2036",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76512,7 +76512,7 @@
           "pcb_smtpad_2037",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76531,7 +76531,7 @@
           "pcb_smtpad_2037",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76550,7 +76550,7 @@
           "pcb_smtpad_2037",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76569,7 +76569,7 @@
           "pcb_smtpad_2037",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76588,7 +76588,7 @@
           "pcb_smtpad_2038",
           "connectivity_net3676"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76607,7 +76607,7 @@
           "pcb_smtpad_2039",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76626,7 +76626,7 @@
           "pcb_smtpad_2040",
           "connectivity_net3665"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76645,7 +76645,7 @@
           "pcb_smtpad_2041",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76664,7 +76664,7 @@
           "pcb_smtpad_2042",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76683,7 +76683,7 @@
           "pcb_smtpad_2042",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76702,7 +76702,7 @@
           "pcb_smtpad_2042",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76721,7 +76721,7 @@
           "pcb_smtpad_2042",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76740,7 +76740,7 @@
           "pcb_smtpad_2043",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76759,7 +76759,7 @@
           "pcb_smtpad_2043",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76778,7 +76778,7 @@
           "pcb_smtpad_2043",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76797,7 +76797,7 @@
           "pcb_smtpad_2043",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76816,7 +76816,7 @@
           "pcb_smtpad_2044",
           "connectivity_net3687"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76835,7 +76835,7 @@
           "pcb_smtpad_2045",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76854,7 +76854,7 @@
           "pcb_smtpad_2046",
           "connectivity_net3676"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76873,7 +76873,7 @@
           "pcb_smtpad_2047",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76892,7 +76892,7 @@
           "pcb_smtpad_2048",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76911,7 +76911,7 @@
           "pcb_smtpad_2048",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76930,7 +76930,7 @@
           "pcb_smtpad_2048",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76949,7 +76949,7 @@
           "pcb_smtpad_2048",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76968,7 +76968,7 @@
           "pcb_smtpad_2049",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -76987,7 +76987,7 @@
           "pcb_smtpad_2049",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77006,7 +77006,7 @@
           "pcb_smtpad_2049",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77025,7 +77025,7 @@
           "pcb_smtpad_2049",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77044,7 +77044,7 @@
           "pcb_smtpad_2050",
           "connectivity_net3698"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77063,7 +77063,7 @@
           "pcb_smtpad_2051",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77082,7 +77082,7 @@
           "pcb_smtpad_2052",
           "connectivity_net3687"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77101,7 +77101,7 @@
           "pcb_smtpad_2053",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77120,7 +77120,7 @@
           "pcb_smtpad_2054",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77139,7 +77139,7 @@
           "pcb_smtpad_2054",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77158,7 +77158,7 @@
           "pcb_smtpad_2054",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77177,7 +77177,7 @@
           "pcb_smtpad_2054",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77196,7 +77196,7 @@
           "pcb_smtpad_2055",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77215,7 +77215,7 @@
           "pcb_smtpad_2055",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77234,7 +77234,7 @@
           "pcb_smtpad_2055",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77253,7 +77253,7 @@
           "pcb_smtpad_2055",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77272,7 +77272,7 @@
           "pcb_smtpad_2056",
           "connectivity_net3709"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77291,7 +77291,7 @@
           "pcb_smtpad_2057",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77310,7 +77310,7 @@
           "pcb_smtpad_2058",
           "connectivity_net3698"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77329,7 +77329,7 @@
           "pcb_smtpad_2059",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77348,7 +77348,7 @@
           "pcb_smtpad_2060",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77367,7 +77367,7 @@
           "pcb_smtpad_2060",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77386,7 +77386,7 @@
           "pcb_smtpad_2060",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77405,7 +77405,7 @@
           "pcb_smtpad_2060",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77424,7 +77424,7 @@
           "pcb_smtpad_2061",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77443,7 +77443,7 @@
           "pcb_smtpad_2061",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77462,7 +77462,7 @@
           "pcb_smtpad_2061",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77481,7 +77481,7 @@
           "pcb_smtpad_2061",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77500,7 +77500,7 @@
           "pcb_smtpad_2062",
           "connectivity_net3720"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77519,7 +77519,7 @@
           "pcb_smtpad_2063",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77538,7 +77538,7 @@
           "pcb_smtpad_2064",
           "connectivity_net3709"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77557,7 +77557,7 @@
           "pcb_smtpad_2065",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77576,7 +77576,7 @@
           "pcb_smtpad_2066",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77595,7 +77595,7 @@
           "pcb_smtpad_2066",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77614,7 +77614,7 @@
           "pcb_smtpad_2066",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77633,7 +77633,7 @@
           "pcb_smtpad_2066",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77652,7 +77652,7 @@
           "pcb_smtpad_2067",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77671,7 +77671,7 @@
           "pcb_smtpad_2067",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77690,7 +77690,7 @@
           "pcb_smtpad_2067",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77709,7 +77709,7 @@
           "pcb_smtpad_2067",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77728,7 +77728,7 @@
           "pcb_smtpad_2068",
           "connectivity_net3731"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77747,7 +77747,7 @@
           "pcb_smtpad_2069",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77766,7 +77766,7 @@
           "pcb_smtpad_2070",
           "connectivity_net3720"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77785,7 +77785,7 @@
           "pcb_smtpad_2071",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77804,7 +77804,7 @@
           "pcb_smtpad_2072",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77823,7 +77823,7 @@
           "pcb_smtpad_2072",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77842,7 +77842,7 @@
           "pcb_smtpad_2072",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77861,7 +77861,7 @@
           "pcb_smtpad_2072",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77880,7 +77880,7 @@
           "pcb_smtpad_2073",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77899,7 +77899,7 @@
           "pcb_smtpad_2073",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77918,7 +77918,7 @@
           "pcb_smtpad_2073",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77937,7 +77937,7 @@
           "pcb_smtpad_2073",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77956,7 +77956,7 @@
           "pcb_smtpad_2074",
           "connectivity_net3742"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77975,7 +77975,7 @@
           "pcb_smtpad_2075",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -77994,7 +77994,7 @@
           "pcb_smtpad_2076",
           "connectivity_net3731"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78013,7 +78013,7 @@
           "pcb_smtpad_2077",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78032,7 +78032,7 @@
           "pcb_smtpad_2078",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78051,7 +78051,7 @@
           "pcb_smtpad_2078",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78070,7 +78070,7 @@
           "pcb_smtpad_2078",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78089,7 +78089,7 @@
           "pcb_smtpad_2078",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78108,7 +78108,7 @@
           "pcb_smtpad_2079",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78127,7 +78127,7 @@
           "pcb_smtpad_2079",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78146,7 +78146,7 @@
           "pcb_smtpad_2079",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78165,7 +78165,7 @@
           "pcb_smtpad_2079",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78184,7 +78184,7 @@
           "pcb_smtpad_2080",
           "connectivity_net3753"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78203,7 +78203,7 @@
           "pcb_smtpad_2081",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78222,7 +78222,7 @@
           "pcb_smtpad_2082",
           "connectivity_net3742"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78241,7 +78241,7 @@
           "pcb_smtpad_2083",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78260,7 +78260,7 @@
           "pcb_smtpad_2084",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78279,7 +78279,7 @@
           "pcb_smtpad_2084",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78298,7 +78298,7 @@
           "pcb_smtpad_2084",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78317,7 +78317,7 @@
           "pcb_smtpad_2084",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78336,7 +78336,7 @@
           "pcb_smtpad_2085",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78355,7 +78355,7 @@
           "pcb_smtpad_2085",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78374,7 +78374,7 @@
           "pcb_smtpad_2085",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78393,7 +78393,7 @@
           "pcb_smtpad_2085",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78412,7 +78412,7 @@
           "pcb_smtpad_2086",
           "connectivity_net3764"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78431,7 +78431,7 @@
           "pcb_smtpad_2087",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78450,7 +78450,7 @@
           "pcb_smtpad_2088",
           "connectivity_net3753"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78469,7 +78469,7 @@
           "pcb_smtpad_2089",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78488,7 +78488,7 @@
           "pcb_smtpad_2090",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78507,7 +78507,7 @@
           "pcb_smtpad_2090",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78526,7 +78526,7 @@
           "pcb_smtpad_2090",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78545,7 +78545,7 @@
           "pcb_smtpad_2090",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78564,7 +78564,7 @@
           "pcb_smtpad_2091",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78583,7 +78583,7 @@
           "pcb_smtpad_2091",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78602,7 +78602,7 @@
           "pcb_smtpad_2091",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78621,7 +78621,7 @@
           "pcb_smtpad_2091",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78640,7 +78640,7 @@
           "pcb_smtpad_2092",
           "connectivity_net3775"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78659,7 +78659,7 @@
           "pcb_smtpad_2093",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78678,7 +78678,7 @@
           "pcb_smtpad_2094",
           "connectivity_net3764"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78697,7 +78697,7 @@
           "pcb_smtpad_2095",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78716,7 +78716,7 @@
           "pcb_smtpad_2096",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78735,7 +78735,7 @@
           "pcb_smtpad_2096",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78754,7 +78754,7 @@
           "pcb_smtpad_2096",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78773,7 +78773,7 @@
           "pcb_smtpad_2096",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78792,7 +78792,7 @@
           "pcb_smtpad_2097",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78811,7 +78811,7 @@
           "pcb_smtpad_2097",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78830,7 +78830,7 @@
           "pcb_smtpad_2097",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78849,7 +78849,7 @@
           "pcb_smtpad_2097",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78868,7 +78868,7 @@
           "pcb_smtpad_2098",
           "connectivity_net3786"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78887,7 +78887,7 @@
           "pcb_smtpad_2099",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78906,7 +78906,7 @@
           "pcb_smtpad_2100",
           "connectivity_net3775"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78925,7 +78925,7 @@
           "pcb_smtpad_2101",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78944,7 +78944,7 @@
           "pcb_smtpad_2102",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78963,7 +78963,7 @@
           "pcb_smtpad_2102",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -78982,7 +78982,7 @@
           "pcb_smtpad_2102",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79001,7 +79001,7 @@
           "pcb_smtpad_2102",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79020,7 +79020,7 @@
           "pcb_smtpad_2103",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79039,7 +79039,7 @@
           "pcb_smtpad_2103",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79058,7 +79058,7 @@
           "pcb_smtpad_2103",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79077,7 +79077,7 @@
           "pcb_smtpad_2103",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79096,7 +79096,7 @@
           "pcb_smtpad_2104",
           "connectivity_net3797"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79115,7 +79115,7 @@
           "pcb_smtpad_2105",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79134,7 +79134,7 @@
           "pcb_smtpad_2106",
           "connectivity_net3786"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79153,7 +79153,7 @@
           "pcb_smtpad_2107",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79172,7 +79172,7 @@
           "pcb_smtpad_2108",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79191,7 +79191,7 @@
           "pcb_smtpad_2108",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79210,7 +79210,7 @@
           "pcb_smtpad_2108",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79229,7 +79229,7 @@
           "pcb_smtpad_2108",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79248,7 +79248,7 @@
           "pcb_smtpad_2109",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79267,7 +79267,7 @@
           "pcb_smtpad_2109",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79286,7 +79286,7 @@
           "pcb_smtpad_2109",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79305,7 +79305,7 @@
           "pcb_smtpad_2109",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79324,7 +79324,7 @@
           "pcb_smtpad_2110",
           "connectivity_net3808"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79343,7 +79343,7 @@
           "pcb_smtpad_2111",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79362,7 +79362,7 @@
           "pcb_smtpad_2112",
           "connectivity_net3797"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79381,7 +79381,7 @@
           "pcb_smtpad_2113",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79400,7 +79400,7 @@
           "pcb_smtpad_2114",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79419,7 +79419,7 @@
           "pcb_smtpad_2114",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79438,7 +79438,7 @@
           "pcb_smtpad_2114",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79457,7 +79457,7 @@
           "pcb_smtpad_2114",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79476,7 +79476,7 @@
           "pcb_smtpad_2115",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79495,7 +79495,7 @@
           "pcb_smtpad_2115",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79514,7 +79514,7 @@
           "pcb_smtpad_2115",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79533,7 +79533,7 @@
           "pcb_smtpad_2115",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79552,7 +79552,7 @@
           "pcb_smtpad_2116",
           "connectivity_net3819"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79571,7 +79571,7 @@
           "pcb_smtpad_2117",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79590,7 +79590,7 @@
           "pcb_smtpad_2118",
           "connectivity_net3808"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79609,7 +79609,7 @@
           "pcb_smtpad_2119",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79628,7 +79628,7 @@
           "pcb_smtpad_2120",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79647,7 +79647,7 @@
           "pcb_smtpad_2120",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79666,7 +79666,7 @@
           "pcb_smtpad_2120",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79685,7 +79685,7 @@
           "pcb_smtpad_2120",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79704,7 +79704,7 @@
           "pcb_smtpad_2121",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79723,7 +79723,7 @@
           "pcb_smtpad_2121",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79742,7 +79742,7 @@
           "pcb_smtpad_2121",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79761,7 +79761,7 @@
           "pcb_smtpad_2121",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79780,7 +79780,7 @@
           "pcb_smtpad_2122",
           "connectivity_net3830"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79799,7 +79799,7 @@
           "pcb_smtpad_2123",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79818,7 +79818,7 @@
           "pcb_smtpad_2124",
           "connectivity_net3819"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79837,7 +79837,7 @@
           "pcb_smtpad_2125",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79856,7 +79856,7 @@
           "pcb_smtpad_2126",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79875,7 +79875,7 @@
           "pcb_smtpad_2126",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79894,7 +79894,7 @@
           "pcb_smtpad_2126",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79913,7 +79913,7 @@
           "pcb_smtpad_2126",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79932,7 +79932,7 @@
           "pcb_smtpad_2127",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79951,7 +79951,7 @@
           "pcb_smtpad_2127",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79970,7 +79970,7 @@
           "pcb_smtpad_2127",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -79989,7 +79989,7 @@
           "pcb_smtpad_2127",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80008,7 +80008,7 @@
           "pcb_smtpad_2128",
           "connectivity_net3841"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80027,7 +80027,7 @@
           "pcb_smtpad_2129",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80046,7 +80046,7 @@
           "pcb_smtpad_2130",
           "connectivity_net3830"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80065,7 +80065,7 @@
           "pcb_smtpad_2131",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80084,7 +80084,7 @@
           "pcb_smtpad_2132",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80103,7 +80103,7 @@
           "pcb_smtpad_2132",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80122,7 +80122,7 @@
           "pcb_smtpad_2132",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80141,7 +80141,7 @@
           "pcb_smtpad_2132",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80160,7 +80160,7 @@
           "pcb_smtpad_2133",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80179,7 +80179,7 @@
           "pcb_smtpad_2133",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80198,7 +80198,7 @@
           "pcb_smtpad_2133",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80217,7 +80217,7 @@
           "pcb_smtpad_2133",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80236,7 +80236,7 @@
           "pcb_smtpad_2134",
           "connectivity_net3852"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80255,7 +80255,7 @@
           "pcb_smtpad_2135",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80274,7 +80274,7 @@
           "pcb_smtpad_2136",
           "connectivity_net3841"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80293,7 +80293,7 @@
           "pcb_smtpad_2137",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80312,7 +80312,7 @@
           "pcb_smtpad_2138",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80331,7 +80331,7 @@
           "pcb_smtpad_2138",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80350,7 +80350,7 @@
           "pcb_smtpad_2138",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80369,7 +80369,7 @@
           "pcb_smtpad_2138",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80388,7 +80388,7 @@
           "pcb_smtpad_2139",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80407,7 +80407,7 @@
           "pcb_smtpad_2139",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80426,7 +80426,7 @@
           "pcb_smtpad_2139",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80445,7 +80445,7 @@
           "pcb_smtpad_2139",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80464,7 +80464,7 @@
           "pcb_smtpad_2140",
           "connectivity_net3863"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80483,7 +80483,7 @@
           "pcb_smtpad_2141",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80502,7 +80502,7 @@
           "pcb_smtpad_2142",
           "connectivity_net3852"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80521,7 +80521,7 @@
           "pcb_smtpad_2143",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80540,7 +80540,7 @@
           "pcb_smtpad_2144",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80559,7 +80559,7 @@
           "pcb_smtpad_2144",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80578,7 +80578,7 @@
           "pcb_smtpad_2144",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80597,7 +80597,7 @@
           "pcb_smtpad_2144",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80616,7 +80616,7 @@
           "pcb_smtpad_2145",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80635,7 +80635,7 @@
           "pcb_smtpad_2145",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80654,7 +80654,7 @@
           "pcb_smtpad_2145",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80673,7 +80673,7 @@
           "pcb_smtpad_2145",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80692,7 +80692,7 @@
           "pcb_smtpad_2146",
           "connectivity_net3874"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80711,7 +80711,7 @@
           "pcb_smtpad_2147",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80730,7 +80730,7 @@
           "pcb_smtpad_2148",
           "connectivity_net3863"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80749,7 +80749,7 @@
           "pcb_smtpad_2149",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80768,7 +80768,7 @@
           "pcb_smtpad_2150",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80787,7 +80787,7 @@
           "pcb_smtpad_2150",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80806,7 +80806,7 @@
           "pcb_smtpad_2150",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80825,7 +80825,7 @@
           "pcb_smtpad_2150",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80844,7 +80844,7 @@
           "pcb_smtpad_2151",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80863,7 +80863,7 @@
           "pcb_smtpad_2151",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80882,7 +80882,7 @@
           "pcb_smtpad_2151",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80901,7 +80901,7 @@
           "pcb_smtpad_2151",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80920,7 +80920,7 @@
           "pcb_smtpad_2152",
           "connectivity_net3885"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80939,7 +80939,7 @@
           "pcb_smtpad_2153",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80958,7 +80958,7 @@
           "pcb_smtpad_2154",
           "connectivity_net3874"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80977,7 +80977,7 @@
           "pcb_smtpad_2155",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -80996,7 +80996,7 @@
           "pcb_smtpad_2156",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81015,7 +81015,7 @@
           "pcb_smtpad_2156",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81034,7 +81034,7 @@
           "pcb_smtpad_2156",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81053,7 +81053,7 @@
           "pcb_smtpad_2156",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81072,7 +81072,7 @@
           "pcb_smtpad_2157",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81091,7 +81091,7 @@
           "pcb_smtpad_2157",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81110,7 +81110,7 @@
           "pcb_smtpad_2157",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81129,7 +81129,7 @@
           "pcb_smtpad_2157",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81148,7 +81148,7 @@
           "pcb_smtpad_2158",
           "connectivity_net3896"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81167,7 +81167,7 @@
           "pcb_smtpad_2159",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81186,7 +81186,7 @@
           "pcb_smtpad_2160",
           "connectivity_net3885"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81205,7 +81205,7 @@
           "pcb_smtpad_2161",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81224,7 +81224,7 @@
           "pcb_smtpad_2162",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81243,7 +81243,7 @@
           "pcb_smtpad_2162",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81262,7 +81262,7 @@
           "pcb_smtpad_2162",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81281,7 +81281,7 @@
           "pcb_smtpad_2162",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81300,7 +81300,7 @@
           "pcb_smtpad_2163",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81319,7 +81319,7 @@
           "pcb_smtpad_2163",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81338,7 +81338,7 @@
           "pcb_smtpad_2163",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81357,7 +81357,7 @@
           "pcb_smtpad_2163",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81376,7 +81376,7 @@
           "pcb_smtpad_2164",
           "connectivity_net3907"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81395,7 +81395,7 @@
           "pcb_smtpad_2165",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81414,7 +81414,7 @@
           "pcb_smtpad_2166",
           "connectivity_net3896"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81433,7 +81433,7 @@
           "pcb_smtpad_2167",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81452,7 +81452,7 @@
           "pcb_smtpad_2168",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81471,7 +81471,7 @@
           "pcb_smtpad_2168",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81490,7 +81490,7 @@
           "pcb_smtpad_2168",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81509,7 +81509,7 @@
           "pcb_smtpad_2168",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81528,7 +81528,7 @@
           "pcb_smtpad_2169",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81547,7 +81547,7 @@
           "pcb_smtpad_2169",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81566,7 +81566,7 @@
           "pcb_smtpad_2169",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81585,7 +81585,7 @@
           "pcb_smtpad_2169",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81604,7 +81604,7 @@
           "pcb_smtpad_2170",
           "connectivity_net3918"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81623,7 +81623,7 @@
           "pcb_smtpad_2171",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81642,7 +81642,7 @@
           "pcb_smtpad_2172",
           "connectivity_net3907"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81661,7 +81661,7 @@
           "pcb_smtpad_2173",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81680,7 +81680,7 @@
           "pcb_smtpad_2174",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81699,7 +81699,7 @@
           "pcb_smtpad_2174",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81718,7 +81718,7 @@
           "pcb_smtpad_2174",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81737,7 +81737,7 @@
           "pcb_smtpad_2174",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81756,7 +81756,7 @@
           "pcb_smtpad_2175",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81775,7 +81775,7 @@
           "pcb_smtpad_2175",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81794,7 +81794,7 @@
           "pcb_smtpad_2175",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81813,7 +81813,7 @@
           "pcb_smtpad_2175",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81832,7 +81832,7 @@
           "pcb_smtpad_2176",
           "connectivity_net3929"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81851,7 +81851,7 @@
           "pcb_smtpad_2177",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81870,7 +81870,7 @@
           "pcb_smtpad_2178",
           "connectivity_net3918"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81889,7 +81889,7 @@
           "pcb_smtpad_2179",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81908,7 +81908,7 @@
           "pcb_smtpad_2180",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81927,7 +81927,7 @@
           "pcb_smtpad_2180",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81946,7 +81946,7 @@
           "pcb_smtpad_2180",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81965,7 +81965,7 @@
           "pcb_smtpad_2180",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -81984,7 +81984,7 @@
           "pcb_smtpad_2181",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82003,7 +82003,7 @@
           "pcb_smtpad_2181",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82022,7 +82022,7 @@
           "pcb_smtpad_2181",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82041,7 +82041,7 @@
           "pcb_smtpad_2181",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82060,7 +82060,7 @@
           "pcb_smtpad_2182",
           "connectivity_net3940"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82079,7 +82079,7 @@
           "pcb_smtpad_2183",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82098,7 +82098,7 @@
           "pcb_smtpad_2184",
           "connectivity_net3929"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82117,7 +82117,7 @@
           "pcb_smtpad_2185",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82136,7 +82136,7 @@
           "pcb_smtpad_2186",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82155,7 +82155,7 @@
           "pcb_smtpad_2186",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82174,7 +82174,7 @@
           "pcb_smtpad_2186",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82193,7 +82193,7 @@
           "pcb_smtpad_2186",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82212,7 +82212,7 @@
           "pcb_smtpad_2187",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82231,7 +82231,7 @@
           "pcb_smtpad_2187",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82250,7 +82250,7 @@
           "pcb_smtpad_2187",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82269,7 +82269,7 @@
           "pcb_smtpad_2187",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82288,7 +82288,7 @@
           "pcb_smtpad_2188",
           "connectivity_net3951"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82307,7 +82307,7 @@
           "pcb_smtpad_2189",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82326,7 +82326,7 @@
           "pcb_smtpad_2190",
           "connectivity_net3940"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82345,7 +82345,7 @@
           "pcb_smtpad_2191",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82364,7 +82364,7 @@
           "pcb_smtpad_2192",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82383,7 +82383,7 @@
           "pcb_smtpad_2192",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82402,7 +82402,7 @@
           "pcb_smtpad_2192",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82421,7 +82421,7 @@
           "pcb_smtpad_2192",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82440,7 +82440,7 @@
           "pcb_smtpad_2193",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82459,7 +82459,7 @@
           "pcb_smtpad_2193",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82478,7 +82478,7 @@
           "pcb_smtpad_2193",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82497,7 +82497,7 @@
           "pcb_smtpad_2193",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82516,7 +82516,7 @@
           "pcb_smtpad_2194",
           "connectivity_net3962"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82535,7 +82535,7 @@
           "pcb_smtpad_2195",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82554,7 +82554,7 @@
           "pcb_smtpad_2196",
           "connectivity_net3951"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82573,7 +82573,7 @@
           "pcb_smtpad_2197",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82592,7 +82592,7 @@
           "pcb_smtpad_2198",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82611,7 +82611,7 @@
           "pcb_smtpad_2198",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82630,7 +82630,7 @@
           "pcb_smtpad_2198",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82649,7 +82649,7 @@
           "pcb_smtpad_2198",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82668,7 +82668,7 @@
           "pcb_smtpad_2199",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82687,7 +82687,7 @@
           "pcb_smtpad_2199",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82706,7 +82706,7 @@
           "pcb_smtpad_2199",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82725,7 +82725,7 @@
           "pcb_smtpad_2199",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82744,7 +82744,7 @@
           "pcb_smtpad_2200",
           "connectivity_net3973"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82763,7 +82763,7 @@
           "pcb_smtpad_2201",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82782,7 +82782,7 @@
           "pcb_smtpad_2202",
           "connectivity_net3962"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82801,7 +82801,7 @@
           "pcb_smtpad_2203",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82820,7 +82820,7 @@
           "pcb_smtpad_2204",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82839,7 +82839,7 @@
           "pcb_smtpad_2204",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82858,7 +82858,7 @@
           "pcb_smtpad_2204",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82877,7 +82877,7 @@
           "pcb_smtpad_2204",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82896,7 +82896,7 @@
           "pcb_smtpad_2205",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82915,7 +82915,7 @@
           "pcb_smtpad_2205",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82934,7 +82934,7 @@
           "pcb_smtpad_2205",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82953,7 +82953,7 @@
           "pcb_smtpad_2205",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82972,7 +82972,7 @@
           "pcb_smtpad_2206",
           "connectivity_net3984"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -82991,7 +82991,7 @@
           "pcb_smtpad_2207",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83010,7 +83010,7 @@
           "pcb_smtpad_2208",
           "connectivity_net3973"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83029,7 +83029,7 @@
           "pcb_smtpad_2209",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83048,7 +83048,7 @@
           "pcb_smtpad_2210",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83067,7 +83067,7 @@
           "pcb_smtpad_2210",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83086,7 +83086,7 @@
           "pcb_smtpad_2210",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83105,7 +83105,7 @@
           "pcb_smtpad_2210",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83124,7 +83124,7 @@
           "pcb_smtpad_2211",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83143,7 +83143,7 @@
           "pcb_smtpad_2211",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83162,7 +83162,7 @@
           "pcb_smtpad_2211",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83181,7 +83181,7 @@
           "pcb_smtpad_2211",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83200,7 +83200,7 @@
           "pcb_smtpad_2212",
           "connectivity_net3995"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83219,7 +83219,7 @@
           "pcb_smtpad_2213",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83238,7 +83238,7 @@
           "pcb_smtpad_2214",
           "connectivity_net3984"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83257,7 +83257,7 @@
           "pcb_smtpad_2215",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83276,7 +83276,7 @@
           "pcb_smtpad_2216",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83295,7 +83295,7 @@
           "pcb_smtpad_2216",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83314,7 +83314,7 @@
           "pcb_smtpad_2216",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83333,7 +83333,7 @@
           "pcb_smtpad_2216",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83352,7 +83352,7 @@
           "pcb_smtpad_2217",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83371,7 +83371,7 @@
           "pcb_smtpad_2217",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83390,7 +83390,7 @@
           "pcb_smtpad_2217",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83409,7 +83409,7 @@
           "pcb_smtpad_2217",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83428,7 +83428,7 @@
           "pcb_smtpad_2218",
           "connectivity_net4006"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83447,7 +83447,7 @@
           "pcb_smtpad_2219",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83466,7 +83466,7 @@
           "pcb_smtpad_2220",
           "connectivity_net3995"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83485,7 +83485,7 @@
           "pcb_smtpad_2221",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83504,7 +83504,7 @@
           "pcb_smtpad_2222",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83523,7 +83523,7 @@
           "pcb_smtpad_2222",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83542,7 +83542,7 @@
           "pcb_smtpad_2222",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83561,7 +83561,7 @@
           "pcb_smtpad_2222",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83580,7 +83580,7 @@
           "pcb_smtpad_2223",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83599,7 +83599,7 @@
           "pcb_smtpad_2223",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83618,7 +83618,7 @@
           "pcb_smtpad_2223",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83637,7 +83637,7 @@
           "pcb_smtpad_2223",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83656,7 +83656,7 @@
           "pcb_smtpad_2224",
           "connectivity_net4017"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83675,7 +83675,7 @@
           "pcb_smtpad_2225",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83694,7 +83694,7 @@
           "pcb_smtpad_2226",
           "connectivity_net4006"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83713,7 +83713,7 @@
           "pcb_smtpad_2227",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83732,7 +83732,7 @@
           "pcb_smtpad_2228",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83751,7 +83751,7 @@
           "pcb_smtpad_2228",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83770,7 +83770,7 @@
           "pcb_smtpad_2228",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83789,7 +83789,7 @@
           "pcb_smtpad_2228",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83808,7 +83808,7 @@
           "pcb_smtpad_2229",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83827,7 +83827,7 @@
           "pcb_smtpad_2229",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83846,7 +83846,7 @@
           "pcb_smtpad_2229",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83865,7 +83865,7 @@
           "pcb_smtpad_2229",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83884,7 +83884,7 @@
           "pcb_smtpad_2230",
           "connectivity_net4028"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83903,7 +83903,7 @@
           "pcb_smtpad_2231",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83922,7 +83922,7 @@
           "pcb_smtpad_2232",
           "connectivity_net4017"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83941,7 +83941,7 @@
           "pcb_smtpad_2233",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83960,7 +83960,7 @@
           "pcb_smtpad_2234",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83979,7 +83979,7 @@
           "pcb_smtpad_2234",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -83998,7 +83998,7 @@
           "pcb_smtpad_2234",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84017,7 +84017,7 @@
           "pcb_smtpad_2234",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84036,7 +84036,7 @@
           "pcb_smtpad_2235",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84055,7 +84055,7 @@
           "pcb_smtpad_2235",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84074,7 +84074,7 @@
           "pcb_smtpad_2235",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84093,7 +84093,7 @@
           "pcb_smtpad_2235",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84112,7 +84112,7 @@
           "pcb_smtpad_2236",
           "connectivity_net4039"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84131,7 +84131,7 @@
           "pcb_smtpad_2237",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84150,7 +84150,7 @@
           "pcb_smtpad_2238",
           "connectivity_net4028"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84169,7 +84169,7 @@
           "pcb_smtpad_2239",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84188,7 +84188,7 @@
           "pcb_smtpad_2240",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84207,7 +84207,7 @@
           "pcb_smtpad_2240",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84226,7 +84226,7 @@
           "pcb_smtpad_2240",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84245,7 +84245,7 @@
           "pcb_smtpad_2240",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84264,7 +84264,7 @@
           "pcb_smtpad_2241",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84283,7 +84283,7 @@
           "pcb_smtpad_2241",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84302,7 +84302,7 @@
           "pcb_smtpad_2241",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84321,7 +84321,7 @@
           "pcb_smtpad_2241",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84340,7 +84340,7 @@
           "pcb_smtpad_2242",
           "connectivity_net4050"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84359,7 +84359,7 @@
           "pcb_smtpad_2243",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84378,7 +84378,7 @@
           "pcb_smtpad_2244",
           "connectivity_net4039"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84397,7 +84397,7 @@
           "pcb_smtpad_2245",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84416,7 +84416,7 @@
           "pcb_smtpad_2246",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84435,7 +84435,7 @@
           "pcb_smtpad_2246",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84454,7 +84454,7 @@
           "pcb_smtpad_2246",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84473,7 +84473,7 @@
           "pcb_smtpad_2246",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84492,7 +84492,7 @@
           "pcb_smtpad_2247",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84511,7 +84511,7 @@
           "pcb_smtpad_2247",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84530,7 +84530,7 @@
           "pcb_smtpad_2247",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84549,7 +84549,7 @@
           "pcb_smtpad_2247",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84568,7 +84568,7 @@
           "pcb_smtpad_2248",
           "connectivity_net4061"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84587,7 +84587,7 @@
           "pcb_smtpad_2249",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84606,7 +84606,7 @@
           "pcb_smtpad_2250",
           "connectivity_net4050"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84625,7 +84625,7 @@
           "pcb_smtpad_2251",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84644,7 +84644,7 @@
           "pcb_smtpad_2252",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84663,7 +84663,7 @@
           "pcb_smtpad_2252",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84682,7 +84682,7 @@
           "pcb_smtpad_2252",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84701,7 +84701,7 @@
           "pcb_smtpad_2252",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84720,7 +84720,7 @@
           "pcb_smtpad_2253",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84739,7 +84739,7 @@
           "pcb_smtpad_2253",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84758,7 +84758,7 @@
           "pcb_smtpad_2253",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84777,7 +84777,7 @@
           "pcb_smtpad_2253",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84796,7 +84796,7 @@
           "pcb_smtpad_2254",
           "connectivity_net4072"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84815,7 +84815,7 @@
           "pcb_smtpad_2255",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84834,7 +84834,7 @@
           "pcb_smtpad_2256",
           "connectivity_net4061"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84853,7 +84853,7 @@
           "pcb_smtpad_2257",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84872,7 +84872,7 @@
           "pcb_smtpad_2258",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84891,7 +84891,7 @@
           "pcb_smtpad_2258",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84910,7 +84910,7 @@
           "pcb_smtpad_2258",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84929,7 +84929,7 @@
           "pcb_smtpad_2258",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84948,7 +84948,7 @@
           "pcb_smtpad_2259",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84967,7 +84967,7 @@
           "pcb_smtpad_2259",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -84986,7 +84986,7 @@
           "pcb_smtpad_2259",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -85005,7 +85005,7 @@
           "pcb_smtpad_2259",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -85024,7 +85024,7 @@
           "pcb_smtpad_2260",
           "connectivity_net4083"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -85043,7 +85043,7 @@
           "pcb_smtpad_2261",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -85062,7 +85062,7 @@
           "pcb_smtpad_2262",
           "connectivity_net4072"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -85081,7 +85081,7 @@
           "pcb_smtpad_2263",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -85100,7 +85100,7 @@
           "pcb_smtpad_2264",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -85119,7 +85119,7 @@
           "pcb_smtpad_2264",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -85138,7 +85138,7 @@
           "pcb_smtpad_2264",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -85157,7 +85157,7 @@
           "pcb_smtpad_2264",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -85176,7 +85176,7 @@
           "pcb_smtpad_2265",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -85195,7 +85195,7 @@
           "pcb_smtpad_2265",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -85214,7 +85214,7 @@
           "pcb_smtpad_2265",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -85233,7 +85233,7 @@
           "pcb_smtpad_2265",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -85252,7 +85252,7 @@
           "pcb_smtpad_2266",
           "connectivity_net8704"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -85271,7 +85271,7 @@
           "pcb_smtpad_2267",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -85290,7 +85290,7 @@
           "pcb_smtpad_2268",
           "connectivity_net4083"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -85309,7 +85309,7 @@
           "pcb_smtpad_2269",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -85328,7 +85328,7 @@
           "pcb_smtpad_2270",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -85347,7 +85347,7 @@
           "pcb_smtpad_2270",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -85366,7 +85366,7 @@
           "pcb_smtpad_2270",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -85385,7 +85385,7 @@
           "pcb_smtpad_2270",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -85404,7 +85404,7 @@
           "pcb_smtpad_2271",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -85423,7 +85423,7 @@
           "pcb_smtpad_2271",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -85442,7 +85442,7 @@
           "pcb_smtpad_2271",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -85461,7 +85461,7 @@
           "pcb_smtpad_2271",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -85480,7 +85480,7 @@
           "pcb_smtpad_2272",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -85499,7 +85499,7 @@
           "pcb_smtpad_2273",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0
         ]
       },
@@ -85521,7 +85521,7 @@
           "pcb_plated_hole_0",
           "connectivity_net4109"
         ],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -85546,7 +85546,7 @@
           "pcb_plated_hole_1",
           "connectivity_net4111"
         ],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -85571,7 +85571,7 @@
           "pcb_plated_hole_2",
           "connectivity_net6"
         ],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,
@@ -85596,7 +85596,7 @@
           "pcb_plated_hole_3",
           "connectivity_net9"
         ],
-        "zLayers": [
+        "__zLayers": [
           0,
           1,
           2,

--- a/fixtures/prefab-clad/prefab-clad01.srj.json
+++ b/fixtures/prefab-clad/prefab-clad01.srj.json
@@ -3250,7 +3250,7 @@
   "connections": [
     {
       "name": "sample_connection_usb_dm_a",
-      "netConnectionName": "USB_DM_A",
+      "__netConnectionName": "USB_DM_A",
       "nominalTraceWidth": 0.35,
       "pointsToConnect": [
         {
@@ -3269,7 +3269,7 @@
     },
     {
       "name": "sample_connection_usb_dm_b",
-      "netConnectionName": "USB_DM_B",
+      "__netConnectionName": "USB_DM_B",
       "nominalTraceWidth": 0.35,
       "pointsToConnect": [
         {
@@ -3288,7 +3288,7 @@
     },
     {
       "name": "sample_connection_usb_dp_a",
-      "netConnectionName": "USB_DP_A",
+      "__netConnectionName": "USB_DP_A",
       "nominalTraceWidth": 0.35,
       "pointsToConnect": [
         {
@@ -3307,7 +3307,7 @@
     },
     {
       "name": "sample_connection_usb_dp_b",
-      "netConnectionName": "USB_DP_B",
+      "__netConnectionName": "USB_DP_B",
       "nominalTraceWidth": 0.35,
       "pointsToConnect": [
         {
@@ -3326,7 +3326,7 @@
     },
     {
       "name": "sample_connection_usb_cc1",
-      "netConnectionName": "USB_CC1",
+      "__netConnectionName": "USB_CC1",
       "nominalTraceWidth": 0.35,
       "pointsToConnect": [
         {
@@ -3345,7 +3345,7 @@
     },
     {
       "name": "sample_connection_usb_cc2",
-      "netConnectionName": "USB_CC2",
+      "__netConnectionName": "USB_CC2",
       "nominalTraceWidth": 0.35,
       "pointsToConnect": [
         {
@@ -3364,7 +3364,7 @@
     },
     {
       "name": "sample_connection_vbus",
-      "netConnectionName": "VBUS",
+      "__netConnectionName": "VBUS",
       "nominalTraceWidth": 0.35,
       "pointsToConnect": [
         {
@@ -3395,7 +3395,7 @@
     },
     {
       "name": "sample_connection_3v3",
-      "netConnectionName": "3V3",
+      "__netConnectionName": "3V3",
       "nominalTraceWidth": 0.35,
       "pointsToConnect": [
         {
@@ -3444,7 +3444,7 @@
     },
     {
       "name": "sample_connection_1v1",
-      "netConnectionName": "1V1",
+      "__netConnectionName": "1V1",
       "nominalTraceWidth": 0.35,
       "pointsToConnect": [
         {
@@ -3469,7 +3469,7 @@
     },
     {
       "name": "sample_connection_gnd_00",
-      "netConnectionName": "GND",
+      "__netConnectionName": "GND",
       "nominalTraceWidth": 0.35,
       "pointsToConnect": [
         {
@@ -3488,7 +3488,7 @@
     },
     {
       "name": "sample_connection_gnd_01",
-      "netConnectionName": "GND",
+      "__netConnectionName": "GND",
       "nominalTraceWidth": 0.35,
       "pointsToConnect": [
         {
@@ -3507,7 +3507,7 @@
     },
     {
       "name": "sample_connection_gnd_02",
-      "netConnectionName": "GND",
+      "__netConnectionName": "GND",
       "nominalTraceWidth": 0.35,
       "pointsToConnect": [
         {
@@ -3526,7 +3526,7 @@
     },
     {
       "name": "sample_connection_gnd_03",
-      "netConnectionName": "GND",
+      "__netConnectionName": "GND",
       "nominalTraceWidth": 0.35,
       "pointsToConnect": [
         {
@@ -3545,7 +3545,7 @@
     },
     {
       "name": "sample_connection_gnd_04",
-      "netConnectionName": "GND",
+      "__netConnectionName": "GND",
       "nominalTraceWidth": 0.35,
       "pointsToConnect": [
         {
@@ -3564,7 +3564,7 @@
     },
     {
       "name": "sample_connection_gnd_05",
-      "netConnectionName": "GND",
+      "__netConnectionName": "GND",
       "nominalTraceWidth": 0.35,
       "pointsToConnect": [
         {
@@ -3583,7 +3583,7 @@
     },
     {
       "name": "sample_connection_gnd_06",
-      "netConnectionName": "GND",
+      "__netConnectionName": "GND",
       "nominalTraceWidth": 0.35,
       "pointsToConnect": [
         {
@@ -3602,7 +3602,7 @@
     },
     {
       "name": "sample_connection_gnd_07",
-      "netConnectionName": "GND",
+      "__netConnectionName": "GND",
       "nominalTraceWidth": 0.35,
       "pointsToConnect": [
         {

--- a/fixtures/unassigned-obstacles/AssignableViaCapacityPathingSolver_DirectiveSubOptimal/AssignableViaCapacityPathingSolver_DirectiveSubOptimal01.json
+++ b/fixtures/unassigned-obstacles/AssignableViaCapacityPathingSolver_DirectiveSubOptimal/AssignableViaCapacityPathingSolver_DirectiveSubOptimal01.json
@@ -27,7 +27,7 @@
             "pcb_port_214"
           ],
           "netIsAssignable": false,
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -54,7 +54,7 @@
             "pcb_port_230"
           ],
           "netIsAssignable": false,
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -81,7 +81,7 @@
             "pcb_port_229"
           ],
           "netIsAssignable": false,
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -108,7 +108,7 @@
             "pcb_port_228"
           ],
           "netIsAssignable": false,
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -135,7 +135,7 @@
             "pcb_port_227"
           ],
           "netIsAssignable": false,
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -162,7 +162,7 @@
             "pcb_port_226"
           ],
           "netIsAssignable": false,
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -189,7 +189,7 @@
             "pcb_port_225"
           ],
           "netIsAssignable": false,
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -216,7 +216,7 @@
             "pcb_port_224"
           ],
           "netIsAssignable": false,
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -243,7 +243,7 @@
             "pcb_port_223"
           ],
           "netIsAssignable": false,
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -270,7 +270,7 @@
             "pcb_port_223"
           ],
           "netIsAssignable": false,
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -297,7 +297,7 @@
             "pcb_port_224"
           ],
           "netIsAssignable": false,
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -324,7 +324,7 @@
             "pcb_port_225"
           ],
           "netIsAssignable": false,
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -351,7 +351,7 @@
             "pcb_port_226"
           ],
           "netIsAssignable": false,
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -378,7 +378,7 @@
             "pcb_port_227"
           ],
           "netIsAssignable": false,
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -405,7 +405,7 @@
             "pcb_port_228"
           ],
           "netIsAssignable": false,
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -432,7 +432,7 @@
             "pcb_port_229"
           ],
           "netIsAssignable": false,
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -459,7 +459,7 @@
             "pcb_port_230"
           ],
           "netIsAssignable": false,
-          "zLayers": [
+          "__zLayers": [
             0
           ]
         },
@@ -477,7 +477,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -496,7 +496,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -515,7 +515,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -534,7 +534,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -553,7 +553,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -572,7 +572,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -591,7 +591,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -610,7 +610,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -629,7 +629,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -648,7 +648,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -667,7 +667,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -686,7 +686,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -705,7 +705,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -724,7 +724,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -743,7 +743,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -762,7 +762,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -781,7 +781,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -800,7 +800,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -819,7 +819,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -838,7 +838,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -857,7 +857,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -876,7 +876,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -895,7 +895,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -914,7 +914,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -933,7 +933,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -952,7 +952,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -971,7 +971,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -990,7 +990,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1009,7 +1009,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1028,7 +1028,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1047,7 +1047,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1066,7 +1066,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1085,7 +1085,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1104,7 +1104,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1123,7 +1123,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1142,7 +1142,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1161,7 +1161,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1180,7 +1180,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1199,7 +1199,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1218,7 +1218,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1237,7 +1237,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1256,7 +1256,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1275,7 +1275,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1294,7 +1294,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1313,7 +1313,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1332,7 +1332,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1351,7 +1351,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1370,7 +1370,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1389,7 +1389,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1408,7 +1408,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1427,7 +1427,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1446,7 +1446,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1465,7 +1465,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1484,7 +1484,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1503,7 +1503,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1522,7 +1522,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1541,7 +1541,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1560,7 +1560,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1579,7 +1579,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1598,7 +1598,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1617,7 +1617,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1636,7 +1636,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1655,7 +1655,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1674,7 +1674,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1693,7 +1693,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1712,7 +1712,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1731,7 +1731,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1750,7 +1750,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1769,7 +1769,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -1788,7 +1788,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -189145,7 +189145,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -189180,7 +189180,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -189215,7 +189215,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -189250,7 +189250,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -189285,7 +189285,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -189320,7 +189320,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -189355,7 +189355,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -189390,7 +189390,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -189425,7 +189425,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -189460,7 +189460,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -189495,7 +189495,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -189530,7 +189530,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -189565,7 +189565,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -189600,7 +189600,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -189635,7 +189635,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -189670,7 +189670,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -189705,7 +189705,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -189740,7 +189740,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -189775,7 +189775,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -189810,7 +189810,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -189845,7 +189845,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -189880,7 +189880,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -189915,7 +189915,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -189950,7 +189950,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -189985,7 +189985,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -190020,7 +190020,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -190055,7 +190055,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -190090,7 +190090,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -190125,7 +190125,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -190160,7 +190160,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -190195,7 +190195,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -190230,7 +190230,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -190265,7 +190265,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -190300,7 +190300,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -190335,7 +190335,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -190370,7 +190370,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -190405,7 +190405,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -190440,7 +190440,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -190475,7 +190475,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -190510,7 +190510,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -190545,7 +190545,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -190580,7 +190580,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -190615,7 +190615,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -190650,7 +190650,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -190685,7 +190685,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -190720,7 +190720,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -190755,7 +190755,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -190790,7 +190790,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -190825,7 +190825,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -190860,7 +190860,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -190895,7 +190895,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -190930,7 +190930,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -190965,7 +190965,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -191000,7 +191000,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -191035,7 +191035,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -191070,7 +191070,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -191105,7 +191105,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -191140,7 +191140,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -191175,7 +191175,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -191210,7 +191210,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -191245,7 +191245,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -191280,7 +191280,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -191315,7 +191315,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -191350,7 +191350,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -191385,7 +191385,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -191420,7 +191420,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -191455,7 +191455,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -191490,7 +191490,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -191525,7 +191525,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]
@@ -191560,7 +191560,7 @@
           "width": 1.5,
           "height": 1.5,
           "netIsAssignable": true,
-          "zLayers": [
+          "__zLayers": [
             1,
             0
           ]

--- a/lib/autorouter-pipelines/AssignableAutoroutingPipeline1/AssignableAutoroutingPipeline1Solver.ts
+++ b/lib/autorouter-pipelines/AssignableAutoroutingPipeline1/AssignableAutoroutingPipeline1Solver.ts
@@ -719,7 +719,7 @@ export class AssignableAutoroutingPipeline1Solver extends BaseSolver {
     const connections = this.srjWithPointPairs?.connections ?? []
 
     for (const connection of connections) {
-      const netConnectionName = connection.netConnectionName
+      const netConnectionName = connection.__netConnectionName
       const rootConnectionName = connection.__rootConnectionNames?.[0]
 
       // Find all the hdRoutes that correspond to this connection

--- a/lib/autorouter-pipelines/AssignableAutoroutingPipeline1/OffboardPathFragmentSolver.ts
+++ b/lib/autorouter-pipelines/AssignableAutoroutingPipeline1/OffboardPathFragmentSolver.ts
@@ -181,7 +181,7 @@ export class OffboardPathFragmentSolver extends BaseSolver {
         this.fragmentedConnections.push({
           name: fragment.connectionName,
           pointsToConnect,
-          netConnectionName: originalConnection.netConnectionName,
+          __netConnectionName: originalConnection.__netConnectionName,
           __rootConnectionNames: originalConnection.__rootConnectionNames,
         })
       }

--- a/lib/autorouter-pipelines/AssignableAutoroutingPipeline2/AssignableAutoroutingPipeline2.ts
+++ b/lib/autorouter-pipelines/AssignableAutoroutingPipeline2/AssignableAutoroutingPipeline2.ts
@@ -725,9 +725,9 @@ export class AssignableAutoroutingPipeline2 extends BaseSolver {
 
     for (const connection of this.netToPointPairsSolver?.newConnections ?? []) {
       const netConnectionName =
-        connection.netConnectionName ??
+        connection.__netConnectionName ??
         this.srj.connections.find((c) => c.name === connection.name)
-          ?.netConnectionName
+          ?.__netConnectionName
 
       // Find all the hdRoutes that correspond to this connection
       const hdRoutes = allHdRoutes.filter(

--- a/lib/autorouter-pipelines/AssignableAutoroutingPipeline2/PortPointOffboardPathFragmentSolver.ts
+++ b/lib/autorouter-pipelines/AssignableAutoroutingPipeline2/PortPointOffboardPathFragmentSolver.ts
@@ -170,7 +170,7 @@ export class PortPointOffboardPathFragmentSolver extends BaseSolver {
 
     // Compute available Z from obstacle layers
     const availableZ =
-      obstacle.zLayers ?? obstacle.layers.map((layer) => this.layerToZ(layer))
+      obstacle.__zLayers ?? obstacle.layers.map((layer) => this.layerToZ(layer))
 
     const portPoint: OffboardPortPoint = {
       portPointId: `offboard_pp_${index}`,

--- a/lib/autorouter-pipelines/AssignableAutoroutingPipeline2/RelateNodesToOffBoardConnectionsSolver.ts
+++ b/lib/autorouter-pipelines/AssignableAutoroutingPipeline2/RelateNodesToOffBoardConnectionsSolver.ts
@@ -75,7 +75,7 @@ export class RelateNodesToOffBoardConnectionsSolver extends BaseSolver {
     )!
     const nodesNearObstacle = this.nodeTree
       .getNodesInArea(obstacle.center.x, obstacle.center.y, 0.01, 0.01)
-      .filter((n) => n.availableZ.some((z) => obstacle.zLayers?.includes(z)))
+      .filter((n) => n.availableZ.some((z) => obstacle.__zLayers?.includes(z)))
       .filter(
         (n) =>
           Math.abs(n.center.x - obstacle.center.x) < 0.01 &&

--- a/lib/autorouter-pipelines/AssignableAutoroutingPipeline3/AssignableAutoroutingPipeline3.ts
+++ b/lib/autorouter-pipelines/AssignableAutoroutingPipeline3/AssignableAutoroutingPipeline3.ts
@@ -775,9 +775,9 @@ export class AssignableAutoroutingPipeline3 extends BaseSolver {
 
     for (const connection of this.netToPointPairsSolver?.newConnections ?? []) {
       const netConnectionName =
-        connection.netConnectionName ??
+        connection.__netConnectionName ??
         this.srj.connections.find((c) => c.name === connection.name)
-          ?.netConnectionName
+          ?.__netConnectionName
 
       // Find all the hdRoutes that correspond to this connection
       const hdRoutes = allHdRoutes.filter(

--- a/lib/autorouter-pipelines/AutoroutingPipeline1_OriginalUnravel/AutoroutingPipeline1_OriginalUnravel.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline1_OriginalUnravel/AutoroutingPipeline1_OriginalUnravel.ts
@@ -624,9 +624,9 @@ export class AutoroutingPipeline1_OriginalUnravel extends BaseSolver {
 
     for (const connection of this.netToPointPairsSolver?.newConnections ?? []) {
       const netConnectionName =
-        connection.netConnectionName ??
+        connection.__netConnectionName ??
         this.srj.connections.find((c) => c.name === connection.name)
-          ?.netConnectionName
+          ?.__netConnectionName
 
       // Find all the hdRoutes that correspond to this connection
       const hdRoutes = allHdRoutes.filter(

--- a/lib/autorouter-pipelines/AutoroutingPipeline2_PortPointPathing/AutoroutingPipelineSolver2_PortPointPathing.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline2_PortPointPathing/AutoroutingPipelineSolver2_PortPointPathing.ts
@@ -673,9 +673,9 @@ export class AutoroutingPipelineSolver2_PortPointPathing extends BaseSolver {
 
     for (const connection of this.netToPointPairsSolver?.newConnections ?? []) {
       const netConnectionName =
-        connection.netConnectionName ??
+        connection.__netConnectionName ??
         this.srj.connections.find((c) => c.name === connection.name)
-          ?.netConnectionName
+          ?.__netConnectionName
 
       // Find all the hdRoutes that correspond to this connection
       const hdRoutes = allHdRoutes.filter(

--- a/lib/autorouter-pipelines/AutoroutingPipeline3_HgPortPointPathing/AutoroutingPipelineSolver3_HgPortPointPathing.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline3_HgPortPointPathing/AutoroutingPipelineSolver3_HgPortPointPathing.ts
@@ -601,9 +601,9 @@ export class AutoroutingPipelineSolver3_HgPortPointPathing extends BaseSolver {
 
     for (const connection of this.netToPointPairsSolver?.newConnections ?? []) {
       const netConnectionName =
-        connection.netConnectionName ??
+        connection.__netConnectionName ??
         this.srj.connections.find((c) => c.name === connection.name)
-          ?.netConnectionName
+          ?.__netConnectionName
 
       const hdRoutes = allHdRoutes.filter(
         (r) => r.connectionName === connection.name,

--- a/lib/autorouter-pipelines/AutoroutingPipeline4_TinyHypergraph/AutoroutingPipelineSolver4_TinyHypergraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline4_TinyHypergraph/AutoroutingPipelineSolver4_TinyHypergraph.ts
@@ -727,9 +727,9 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
 
     for (const connection of this.netToPointPairsSolver?.newConnections ?? []) {
       const netConnectionName =
-        connection.netConnectionName ??
+        connection.__netConnectionName ??
         this.originalSrj.connections.find((c) => c.name === connection.name)
-          ?.netConnectionName
+          ?.__netConnectionName
 
       const hdRoutes = allHdRoutes.filter(
         (r) => r.connectionName === connection.name,

--- a/lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/AutoroutingPipelineSolver6_PolyHypergraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/AutoroutingPipelineSolver6_PolyHypergraph.ts
@@ -601,9 +601,9 @@ export class AutoroutingPipelineSolver6_PolyHypergraph extends BaseSolver {
 
     for (const connection of this.netToPointPairsSolver?.newConnections ?? []) {
       const netConnectionName =
-        connection.netConnectionName ??
+        connection.__netConnectionName ??
         this.originalSrj.connections.find((c) => c.name === connection.name)
-          ?.netConnectionName
+          ?.__netConnectionName
 
       const hdRoutes = allHdRoutes.filter(
         (route) => route.connectionName === connection.name,

--- a/lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/srjToPolyHyperGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/srjToPolyHyperGraph.ts
@@ -16,7 +16,7 @@ import type {
 
 type AnyObstacle = Omit<Obstacle, "type"> & {
   type: string
-  zLayers?: number[]
+  __zLayers?: number[]
   isCopperPour?: boolean
 }
 
@@ -84,7 +84,7 @@ export const getPolyGraphRectsFromSrj = (srj: SimpleRouteJson): Rect[] =>
       height: obstacle.height,
       ccwRotation: getRotationRadians(obstacle),
       layers: obstacle.layers,
-      zLayers: obstacle.zLayers,
+      zLayers: obstacle.__zLayers,
       isCopperPour: obstacle.isCopperPour,
     }))
 
@@ -94,7 +94,7 @@ export const getPolyGraphPolygonsFromSrj = (srj: SimpleRouteJson): Polygon[] =>
     .map((obstacle) => ({
       points: getOvalPoints(obstacle),
       layers: obstacle.layers,
-      zLayers: obstacle.zLayers,
+      zLayers: obstacle.__zLayers,
       isCopperPour: obstacle.isCopperPour,
     }))
 
@@ -125,7 +125,7 @@ export const getConnectedObstacleRegionsFromSrj = (
         polygon: {
           points: getOvalPoints(obstacle),
           layers: obstacle.layers,
-          zLayers: obstacle.zLayers,
+          zLayers: obstacle.__zLayers,
           isCopperPour: obstacle.isCopperPour,
         },
         clearance,

--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -979,9 +979,9 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
 
     for (const connection of this.netToPointPairsSolver?.newConnections ?? []) {
       const netConnectionName =
-        connection.netConnectionName ??
+        connection.__netConnectionName ??
         this.originalSrj.connections.find((c) => c.name === connection.name)
-          ?.netConnectionName
+          ?.__netConnectionName
 
       const hdRoutes = allHdRoutes.filter(
         (r) => r.connectionName === connection.name,

--- a/lib/autorouter-pipelines/AutoroutingPipeline8/AutoroutingPipelineSolver8.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline8/AutoroutingPipelineSolver8.ts
@@ -862,9 +862,9 @@ export class AutoroutingPipelineSolver8 extends BaseSolver {
 
     for (const connection of this.netToPointPairsSolver?.newConnections ?? []) {
       const netConnectionName =
-        connection.netConnectionName ??
+        connection.__netConnectionName ??
         this.originalSrj.connections.find((c) => c.name === connection.name)
-          ?.netConnectionName
+          ?.__netConnectionName
 
       const hdRoutes = allHdRoutes.filter(
         (r) => r.connectionName === connection.name,

--- a/lib/solvers/BgaTopologyGeneratorSolver/ExpandUnconnectedEdgesToMesh.ts
+++ b/lib/solvers/BgaTopologyGeneratorSolver/ExpandUnconnectedEdgesToMesh.ts
@@ -66,7 +66,7 @@ export class ExpandUnconnectedEdgesToMesh extends BaseSolver {
 
   private getObstacleAvailableZ(obstacle: Obstacle): number[] {
     return (
-      obstacle.zLayers ??
+      obstacle.__zLayers ??
       obstacle.layers.map((layerName) =>
         mapLayerNameToZ(layerName, this.inputProblem.layerCount),
       )

--- a/lib/solvers/BgaTopologyGeneratorSolver/GapFill.ts
+++ b/lib/solvers/BgaTopologyGeneratorSolver/GapFill.ts
@@ -116,7 +116,7 @@ export class GapFill extends BasePipelineSolver<GapFillInput> {
 
   private getObstacleLayer(edgeWithObstacle: EdgeSegmentWithObstacle): string {
     const availableZ =
-      edgeWithObstacle.obstacle.zLayers ??
+      edgeWithObstacle.obstacle.__zLayers ??
       edgeWithObstacle.obstacle.layers.map((layerName) =>
         mapLayerNameToZ(layerName, this.inputProblem.layerCount),
       )
@@ -128,7 +128,7 @@ export class GapFill extends BasePipelineSolver<GapFillInput> {
     return this.inputProblem.unmarkedComponentObstacles.map(
       (obstacle): Rect => {
         const availableZ =
-          obstacle.zLayers ??
+          obstacle.__zLayers ??
           obstacle.layers.map((layerName) =>
             mapLayerNameToZ(layerName, this.inputProblem.layerCount),
           )

--- a/lib/solvers/BgaTopologyGeneratorSolver/bgpTopologyGeneratorShared.ts
+++ b/lib/solvers/BgaTopologyGeneratorSolver/bgpTopologyGeneratorShared.ts
@@ -62,8 +62,8 @@ export function getObstacleAvailableZ(
   obstacle: Obstacle,
   layerCount: number,
 ): number[] {
-  return obstacle.zLayers && obstacle.zLayers.length > 0
-    ? getUniqueValidZLayers(obstacle.zLayers, layerCount)
+  return obstacle.__zLayers && obstacle.__zLayers.length > 0
+    ? getUniqueValidZLayers(obstacle.__zLayers, layerCount)
     : getUniqueValidZLayersFromLayerNames(obstacle.layers, layerCount)
 }
 

--- a/lib/solvers/CapacityMeshSolver/CapacityMeshNodeSolver1.ts
+++ b/lib/solvers/CapacityMeshSolver/CapacityMeshNodeSolver1.ts
@@ -107,7 +107,7 @@ export class CapacityMeshNodeSolver extends BaseSolver {
     for (const [index, obstacle] of this.srj.obstacles.entries()) {
       this.obstacleZLayersByObstacle.set(
         obstacle,
-        normalizedObstacles[index].zLayers,
+        normalizedObstacles[index].__zLayers,
       )
     }
     this.obstacleTree = new ObstacleSpatialHashIndex(

--- a/lib/solvers/CapacityNodeTargetMerger/CapacityNodeTargetMerger.ts
+++ b/lib/solvers/CapacityNodeTargetMerger/CapacityNodeTargetMerger.ts
@@ -56,7 +56,7 @@ export class CapacityNodeTargetMerger extends BaseSolver {
 
       const implicitlyConnected =
         doRectsOverlap(n, obstacle) &&
-        obstacle.zLayers?.includes(n.availableZ?.[0])
+        obstacle.__zLayers?.includes(n.availableZ?.[0])
 
       return implicitlyConnected
     })

--- a/lib/solvers/CapacityNodeTargetMerger/CapacityNodeTargetMerger2.ts
+++ b/lib/solvers/CapacityNodeTargetMerger/CapacityNodeTargetMerger2.ts
@@ -345,7 +345,7 @@ export class CapacityNodeTargetMerger2 extends BaseSolver {
       // Otherwise check for overlap with node
       return (
         doRectsOverlap(node, obstacle) &&
-        obstacle.zLayers?.some((z) => node.availableZ.includes(z))
+        obstacle.__zLayers?.some((z) => node.availableZ.includes(z))
       )
     })
 

--- a/lib/solvers/ComponentTopologyGeneratorSolver/ComponentTopologyGeneratorSolver.ts
+++ b/lib/solvers/ComponentTopologyGeneratorSolver/ComponentTopologyGeneratorSolver.ts
@@ -44,7 +44,7 @@ export function createReplacementObstacleForComponent({
     componentId: detectedComponent.componentId,
     type: "rect",
     layers,
-    zLayers,
+    __zLayers: zLayers,
     center: {
       x: (bounds.minX + bounds.maxX) / 2,
       y: (bounds.minY + bounds.maxY) / 2,

--- a/lib/solvers/EscapeViaLocationSolver/EscapeViaLocationSolver.ts
+++ b/lib/solvers/EscapeViaLocationSolver/EscapeViaLocationSolver.ts
@@ -128,7 +128,7 @@ export class EscapeViaLocationSolver extends BaseSolver {
       [
         connection.name,
         ...(connection.__rootConnectionNames ?? []),
-        connection.netConnectionName,
+        connection.__netConnectionName,
       ].filter((id): id is string => Boolean(id)),
     )
   }
@@ -141,8 +141,8 @@ export class EscapeViaLocationSolver extends BaseSolver {
   }
 
   private getObstacleZs(obstacle: Obstacle): number[] {
-    if (obstacle.zLayers && obstacle.zLayers.length > 0) {
-      return obstacle.zLayers
+    if (obstacle.__zLayers && obstacle.__zLayers.length > 0) {
+      return obstacle.__zLayers
     }
     return obstacle.layers.map((layer) =>
       mapLayerNameToZ(layer, this.ogSrj.layerCount),
@@ -154,7 +154,7 @@ export class EscapeViaLocationSolver extends BaseSolver {
     targetLayer: string,
   ): {
     layers: string[]
-    zLayers: number[]
+    __zLayers: number[]
   } {
     const sourceZ = mapLayerNameToZ(sourceLayer, this.ogSrj.layerCount)
     const targetZ = mapLayerNameToZ(targetLayer, this.ogSrj.layerCount)
@@ -166,7 +166,7 @@ export class EscapeViaLocationSolver extends BaseSolver {
     )
 
     return {
-      zLayers,
+      __zLayers: zLayers,
       layers: zLayers.map((z) => mapZToLayerName(z, this.ogSrj.layerCount)),
     }
   }
@@ -176,7 +176,7 @@ export class EscapeViaLocationSolver extends BaseSolver {
     connectionNetIds: Set<string>
   }): Obstacle {
     const { escapeVia, connectionNetIds } = params
-    const { layers, zLayers } = this.getViaSpanLayers(
+    const { layers, __zLayers } = this.getViaSpanLayers(
       escapeVia.sourceLayer,
       escapeVia.targetLayer,
     )
@@ -185,7 +185,7 @@ export class EscapeViaLocationSolver extends BaseSolver {
       obstacleId: `escape-via-obstacle:${escapeVia.pointId}`,
       type: "rect",
       layers,
-      zLayers,
+      __zLayers,
       center: {
         x: escapeVia.x,
         y: escapeVia.y,

--- a/lib/solvers/HighDensityRepairSolver/Pipeline4HighDensityRepairSolver.ts
+++ b/lib/solvers/HighDensityRepairSolver/Pipeline4HighDensityRepairSolver.ts
@@ -69,7 +69,7 @@ const isPointInsideObstacle = (
 }
 
 const isMultilayerObstacle = (obstacle: Obstacle) =>
-  (obstacle.zLayers?.length ?? obstacle.layers?.length ?? 0) > 1
+  (obstacle.__zLayers?.length ?? obstacle.layers?.length ?? 0) > 1
 
 const isObstacleConnectedToRoute = (
   obstacle: Obstacle,

--- a/lib/solvers/HighDensitySolver/SingleTransitionThroughObstacleIntraNodeSolver.ts
+++ b/lib/solvers/HighDensitySolver/SingleTransitionThroughObstacleIntraNodeSolver.ts
@@ -16,7 +16,7 @@ type Route = {
   connectionName: string
   rootConnectionName?: string
 }
-type LayeredObstacle = Obstacle & { zLayers: number[] }
+type LayeredObstacle = Obstacle & { __zLayers: number[] }
 
 const CONTAINS_POINT_TOLERANCE = 1e-6
 
@@ -198,10 +198,13 @@ export class SingleTransitionThroughObstacleIntraNodeSolver extends BaseSolver {
 
     return (
       this.obstacles.find((obstacle) => {
-        if (obstacle.zLayers.length < 2) {
+        if (obstacle.__zLayers.length < 2) {
           return false
         }
-        if (!obstacle.zLayers.includes(zA) || !obstacle.zLayers.includes(zB)) {
+        if (
+          !obstacle.__zLayers.includes(zA) ||
+          !obstacle.__zLayers.includes(zB)
+        ) {
           return false
         }
         if (
@@ -240,7 +243,7 @@ export class SingleTransitionThroughObstacleIntraNodeSolver extends BaseSolver {
         height: obstacle.height,
         fill: "rgba(128, 0, 128, 0.2)",
         stroke: "rgba(128, 0, 128, 0.6)",
-        label: `through obstacle candidate\nz: ${obstacle.zLayers.join(",")}`,
+        label: `through obstacle candidate\nz: ${obstacle.__zLayers.join(",")}`,
       })
     }
 

--- a/lib/solvers/NetToPointPairsSolver/NetToPointPairsSolver.ts
+++ b/lib/solvers/NetToPointPairsSolver/NetToPointPairsSolver.ts
@@ -185,7 +185,7 @@ export class NetToPointPairsSolver extends BaseSolver {
         __rootConnectionNames: connection.__rootConnectionNames ?? [
           connection.name,
         ],
-        netConnectionName: connection.netConnectionName,
+        __netConnectionName: connection.__netConnectionName,
       })
     }
   }

--- a/lib/solvers/NetToPointPairsSolver/mergeConnections.ts
+++ b/lib/solvers/NetToPointPairsSolver/mergeConnections.ts
@@ -121,8 +121,8 @@ export function mergeConnections(
       }
 
       // Collect netConnectionNames (deduplicate)
-      if (simpleRouteConnection.netConnectionName) {
-        mergedNetConnectionNames.add(simpleRouteConnection.netConnectionName)
+      if (simpleRouteConnection.__netConnectionName) {
+        mergedNetConnectionNames.add(simpleRouteConnection.__netConnectionName)
       }
 
       // Take the nominalTraceWidth from the first connection for now
@@ -147,7 +147,7 @@ export function mergeConnections(
         mergedExternallyConnectedPointIds.length > 0
           ? mergedExternallyConnectedPointIds
           : undefined,
-      netConnectionName:
+      __netConnectionName:
         mergedNetConnectionNames.size > 0
           ? Array.from(mergedNetConnectionNames).join("__") // Combine unique net connection names
           : undefined,

--- a/lib/solvers/NetToPointPairsSolver2_OffBoardConnection/NetToPointPairsSolver2_OffBoardConnection.ts
+++ b/lib/solvers/NetToPointPairsSolver2_OffBoardConnection/NetToPointPairsSolver2_OffBoardConnection.ts
@@ -176,7 +176,7 @@ export class NetToPointPairsSolver2_OffBoardConnection extends NetToPointPairsSo
         __rootConnectionNames: currentConnection.__rootConnectionNames ?? [
           currentConnection.name,
         ],
-        netConnectionName: currentConnection.netConnectionName,
+        __netConnectionName: currentConnection.__netConnectionName,
       })
     }
   }

--- a/lib/solvers/SameNetViaMergerSolver/SameNetViaMergerSolver.ts
+++ b/lib/solvers/SameNetViaMergerSolver/SameNetViaMergerSolver.ts
@@ -134,12 +134,12 @@ const canMoveViaTo = (
     )
 
     for (const obstacle of obstacles) {
-      if (!obstacle.zLayers) {
+      if (!obstacle.__zLayers) {
         throw new Error(
           `SameNetViaMergerSolver found obstacle without zLayers near via at (${viaToRemove.x}, ${viaToRemove.y})`,
         )
       }
-      if (!obstacle.zLayers.includes(z)) continue
+      if (!obstacle.__zLayers.includes(z)) continue
       if (obstacleIsSameNet(context.connMap, obstacle, viaToRemove)) continue
       if (segmentToBoxMinDistance(start, end, obstacle) < searchMargin) {
         return false
@@ -467,7 +467,7 @@ export class SameNetViaMergerSolver extends BaseSolver {
 
     // Visualize obstacles
     for (const obstacle of this.input.obstacles) {
-      if (!obstacle.zLayers) {
+      if (!obstacle.__zLayers) {
         throw new Error(
           `SameNetViaMergerSolver found obstacle without zLayers while visualizing`,
         )
@@ -475,8 +475,8 @@ export class SameNetViaMergerSolver extends BaseSolver {
 
       let fillColor = "rgba(128, 128, 128, 0.2)" // Default faded gray
       const strokeColor = "rgba(128, 128, 128, 0.5)"
-      const isOnLayer0 = obstacle.zLayers.includes(0)
-      const isOnLayer1 = obstacle.zLayers.includes(1)
+      const isOnLayer0 = obstacle.__zLayers.includes(0)
+      const isOnLayer1 = obstacle.__zLayers.includes(1)
 
       if (isOnLayer0 && isOnLayer1) {
         fillColor = "rgba(128, 0, 128, 0.2)" // Faded purple for both layers
@@ -491,7 +491,7 @@ export class SameNetViaMergerSolver extends BaseSolver {
         width: obstacle.width,
         height: obstacle.height,
         fill: fillColor,
-        label: `Obstacle (Z: ${obstacle.zLayers?.join(", ")})`,
+        label: `Obstacle (Z: ${obstacle.__zLayers?.join(", ")})`,
       })
     }
 

--- a/lib/solvers/SimplifiedPathSolver/SingleSimplifiedPathSolver5_Deg45.ts
+++ b/lib/solvers/SimplifiedPathSolver/SingleSimplifiedPathSolver5_Deg45.ts
@@ -381,7 +381,7 @@ export class SingleSimplifiedPathSolver5 extends SingleSimplifiedPathSolver {
   isValidPathSegment(start: Point, end: Point): boolean {
     // Check if the segment intersects with any obstacle
     for (const obstacle of this.filteredObstacles) {
-      if (!obstacle.zLayers?.includes(start.z)) {
+      if (!obstacle.__zLayers?.includes(start.z)) {
         continue
       }
 

--- a/lib/solvers/TraceKeepoutSolver/TraceKeepoutSolver.ts
+++ b/lib/solvers/TraceKeepoutSolver/TraceKeepoutSolver.ts
@@ -156,7 +156,7 @@ export class TraceKeepoutSolver extends BaseSolver {
     )) {
       const obstacles = this.obstacleSHI
         .searchArea(endpoint.x, endpoint.y, 0.01, 0.01)
-        .filter((o) => o.zLayers?.includes(endpoint.z))
+        .filter((o) => o.__zLayers?.includes(endpoint.z))
       if (obstacles.length === 0) continue
       const obstacle = obstacles[0]!
 
@@ -189,7 +189,7 @@ export class TraceKeepoutSolver extends BaseSolver {
       for (const pad of jumper.pads) {
         obstacles.push({
           ...pad,
-          zLayers: [0], // Jumper pads are on layer 0 (top)
+          __zLayers: [0], // Jumper pads are on layer 0 (top)
         })
       }
     }
@@ -576,12 +576,12 @@ export class TraceKeepoutSolver extends BaseSolver {
     // Check for obstacles within the keepout radius
     const nearbyObstacles = this.obstacleSHI
       .searchArea(position.x, position.y, searchRadius, searchRadius)
-      .filter((e) => e.zLayers?.includes(position.z))
+      .filter((e) => e.__zLayers?.includes(position.z))
 
     // Filter to non-connected obstacles on the same layer and convert to segments
     for (const obstacle of nearbyObstacles) {
       // Check if obstacle is on the same layer
-      if (obstacle.zLayers && !obstacle.zLayers.includes(position.z)) {
+      if (obstacle.__zLayers && !obstacle.__zLayers.includes(position.z)) {
         continue
       }
 
@@ -990,8 +990,8 @@ export class TraceKeepoutSolver extends BaseSolver {
     // Visualize obstacles
     for (const obstacle of this.input.obstacles) {
       let fillColor = "rgba(128, 128, 128, 0.2)"
-      const isOnLayer0 = obstacle.zLayers?.includes(0)
-      const isOnLayer1 = obstacle.zLayers?.includes(1)
+      const isOnLayer0 = obstacle.__zLayers?.includes(0)
+      const isOnLayer1 = obstacle.__zLayers?.includes(1)
 
       if (isOnLayer0 && isOnLayer1) {
         fillColor = "rgba(128, 0, 128, 0.2)"
@@ -1006,7 +1006,7 @@ export class TraceKeepoutSolver extends BaseSolver {
         width: obstacle.width,
         height: obstacle.height,
         fill: fillColor,
-        label: `Obstacle (Z: ${obstacle.zLayers?.join(", ")})`,
+        label: `Obstacle (Z: ${obstacle.__zLayers?.join(", ")})`,
       })
     }
 

--- a/lib/solvers/TraceSimplificationSolver/TraceSimplificationSolver.ts
+++ b/lib/solvers/TraceSimplificationSolver/TraceSimplificationSolver.ts
@@ -23,7 +23,7 @@ const pointInsideObstacle = (
     obstacle.height / 2 + VIA_INSIDE_OBSTACLE_TOLERANCE
 
 const isMultilayerObstacle = (obstacle: Obstacle) =>
-  (obstacle.zLayers?.length ?? obstacle.layers?.length ?? 0) > 1
+  (obstacle.__zLayers?.length ?? obstacle.layers?.length ?? 0) > 1
 
 /**
  * TraceSimplificationSolver consolidates trace optimization by iteratively applying
@@ -298,8 +298,8 @@ export class TraceSimplificationSolver extends BaseSolver {
     // Visualize obstacles
     for (const obstacle of this.simplificationConfig.obstacles) {
       let fillColor = "rgba(128, 128, 128, 0.2)"
-      const isOnLayer0 = obstacle.zLayers?.includes(0)
-      const isOnLayer1 = obstacle.zLayers?.includes(1)
+      const isOnLayer0 = obstacle.__zLayers?.includes(0)
+      const isOnLayer1 = obstacle.__zLayers?.includes(1)
 
       if (isOnLayer0 && isOnLayer1) {
         fillColor = "rgba(128, 0, 128, 0.2)"
@@ -314,7 +314,7 @@ export class TraceSimplificationSolver extends BaseSolver {
         width: obstacle.width,
         height: obstacle.height,
         fill: fillColor,
-        label: `Obstacle (Z: ${obstacle.zLayers?.join(", ")})`,
+        label: `Obstacle (Z: ${obstacle.__zLayers?.join(", ")})`,
       })
     }
 

--- a/lib/solvers/TraceWidthSolver/TraceWidthSolver.ts
+++ b/lib/solvers/TraceWidthSolver/TraceWidthSolver.ts
@@ -362,7 +362,7 @@ export class TraceWidthSolver extends BaseSolver {
       )
 
       for (const obstacle of nearbyObstacles) {
-        if (obstacle.zLayers && !obstacle.zLayers.includes(position.z)) {
+        if (obstacle.__zLayers && !obstacle.__zLayers.includes(position.z)) {
           continue
         }
 
@@ -461,7 +461,7 @@ export class TraceWidthSolver extends BaseSolver {
   }
 
   private isObstacleOnPointLayer(obstacle: Obstacle, point: Point3D): boolean {
-    return !obstacle.zLayers || obstacle.zLayers.includes(point.z)
+    return !obstacle.__zLayers || obstacle.__zLayers.includes(point.z)
   }
 
   private getAdjacentNonCoincidentRoutePoint(
@@ -833,8 +833,8 @@ export class TraceWidthSolver extends BaseSolver {
     // Draw all obstacles (faded, with colliding ones highlighted)
     for (const obstacle of this.obstacles) {
       const isColliding = collidingObstacleIds.has(obstacle.obstacleId)
-      const isOnLayer0 = obstacle.zLayers?.includes(0)
-      const isOnLayer1 = obstacle.zLayers?.includes(1)
+      const isOnLayer0 = obstacle.__zLayers?.includes(0)
+      const isOnLayer1 = obstacle.__zLayers?.includes(1)
 
       let fillColor: string
       if (isColliding) {
@@ -857,7 +857,7 @@ export class TraceWidthSolver extends BaseSolver {
         stroke: isColliding ? "red" : undefined,
         label: isColliding
           ? `COLLIDING: ${obstacle.obstacleId ?? "obstacle"}`
-          : `${obstacle.obstacleId ?? "obstacle"} (Z: ${obstacle.zLayers?.join(", ")})`,
+          : `${obstacle.obstacleId ?? "obstacle"} (Z: ${obstacle.__zLayers?.join(", ")})`,
       })
     }
 

--- a/lib/solvers/UselessViaRemovalSolver/UselessViaRemovalSolver.ts
+++ b/lib/solvers/UselessViaRemovalSolver/UselessViaRemovalSolver.ts
@@ -100,8 +100,8 @@ export class UselessViaRemovalSolver extends BaseSolver {
     for (const obstacle of this.input.obstacles) {
       let fillColor = "rgba(128, 128, 128, 0.2)" // Default faded gray
       const strokeColor = "rgba(128, 128, 128, 0.5)"
-      const isOnLayer0 = obstacle.zLayers?.includes(0)
-      const isOnLayer1 = obstacle.zLayers?.includes(1)
+      const isOnLayer0 = obstacle.__zLayers?.includes(0)
+      const isOnLayer1 = obstacle.__zLayers?.includes(1)
 
       if (isOnLayer0 && isOnLayer1) {
         fillColor = "rgba(128, 0, 128, 0.2)" // Faded purple for both layers
@@ -116,7 +116,7 @@ export class UselessViaRemovalSolver extends BaseSolver {
         width: obstacle.width,
         height: obstacle.height,
         fill: fillColor,
-        label: `Obstacle (Z: ${obstacle.zLayers?.join(", ")})`,
+        label: `Obstacle (Z: ${obstacle.__zLayers?.join(", ")})`,
       })
     }
 

--- a/lib/solvers/UselessViaRemovalSolver/can-endpoint-connect-on-layer.ts
+++ b/lib/solvers/UselessViaRemovalSolver/can-endpoint-connect-on-layer.ts
@@ -41,7 +41,7 @@ export const canEndpointConnectOnLayer = ({
 
   if (connectedObstacles.length > 0) {
     return connectedObstacles.some((obstacle) =>
-      obstacle.zLayers?.includes(targetZ),
+      obstacle.__zLayers?.includes(targetZ),
     )
   }
 

--- a/lib/solvers/UselessViaRemovalSolver/can-section-move-to-layer.ts
+++ b/lib/solvers/UselessViaRemovalSolver/can-section-move-to-layer.ts
@@ -83,7 +83,7 @@ export const canSectionMoveToLayer = ({
       )
       if (obstacleIsSameNet) continue
 
-      if (obstacle.zLayers?.includes(targetZ)) {
+      if (obstacle.__zLayers?.includes(targetZ)) {
         const isAtObstacle =
           (Math.abs(A.x - obstacle.center.x) < 0.01 &&
             Math.abs(A.y - obstacle.center.y) < 0.01) ||

--- a/lib/testing/utils/convertToCircuitJson.ts
+++ b/lib/testing/utils/convertToCircuitJson.ts
@@ -231,7 +231,7 @@ function createSourceTraces(
 
     // Look for original connection name (might be MST-suffixed by NetToPointPairsSolver)
     const netConnectionName =
-      connection.netConnectionName ||
+      connection.__netConnectionName ||
       connection.__rootConnectionNames?.[0] ||
       connection.name
 
@@ -671,7 +671,7 @@ export function convertToCircuitJson(
   srjWithPointPairs.connections.forEach((conn) => {
     connectionMap.set(
       conn.name,
-      conn.netConnectionName || conn.__rootConnectionNames?.[0] || conn.name,
+      conn.__netConnectionName || conn.__rootConnectionNames?.[0] || conn.name,
     )
   })
 

--- a/lib/types/srj-types.ts
+++ b/lib/types/srj-types.ts
@@ -78,7 +78,7 @@ export interface Obstacle {
   componentId?: string
   type: "rect"
   layers: string[]
-  zLayers?: number[]
+  __zLayers?: number[]
   center: { x: number; y: number }
   width: number
   height: number
@@ -94,7 +94,7 @@ export interface SimpleRouteConnection {
   name: string
   __rootConnectionNames?: string[]
   isOffBoard?: boolean
-  netConnectionName?: string
+  __netConnectionName?: string
   nominalTraceWidth?: number
   pointsToConnect: Array<ConnectionPoint>
 

--- a/lib/utils/convertHdRouteToSimplifiedRoute.ts
+++ b/lib/utils/convertHdRouteToSimplifiedRoute.ts
@@ -52,7 +52,7 @@ const pointInsideObstacle = (
 ) => pointToBoxDistance(point, obstacle) <= SAME_NET_OBSTACLE_TOLERANCE
 
 const isMultilayerObstacle = (obstacle: Obstacle) =>
-  (obstacle.zLayers?.length ?? obstacle.layers?.length ?? 0) > 1
+  (obstacle.__zLayers?.length ?? obstacle.layers?.length ?? 0) > 1
 
 const isThroughObstacleSegment = (
   hdRoute: HdRouteWithOptionalJumpers,

--- a/lib/utils/create-srj-with-board-valid-obstacle-layers.ts
+++ b/lib/utils/create-srj-with-board-valid-obstacle-layers.ts
@@ -10,7 +10,7 @@ function getObstacleZLayersOnBoard(
   layerCount: number,
 ): number[] {
   const explicitZLayers = getUniqueValidZLayers(
-    obstacle.zLayers ?? [],
+    obstacle.__zLayers ?? [],
     layerCount,
   )
   if (explicitZLayers.length > 0) return explicitZLayers
@@ -35,7 +35,7 @@ function createObstacleWithBoardValidLayers(
   return {
     ...obstacle,
     layers: zLayers.map((z) => mapZToLayerName(z, layerCount)),
-    zLayers,
+    __zLayers: zLayers,
   }
 }
 

--- a/lib/utils/createObjectsWithZLayers.ts
+++ b/lib/utils/createObjectsWithZLayers.ts
@@ -4,12 +4,12 @@ import {
 } from "lib/utils/mapLayerNameToZ"
 
 type LayerMappedObject = {
-  zLayers?: number[]
+  __zLayers?: number[]
   layers?: string[]
 }
 
 /**
- * Produces a derived object array where every item has a valid `zLayers` array.
+ * Produces a derived object array where every item has a valid `__zLayers` array.
  *
  * This centralizes layer normalization for inputs that may only provide
  * string-based `layers`, so downstream solvers can safely use z-layer logic
@@ -18,12 +18,12 @@ type LayerMappedObject = {
 export const createObjectsWithZLayers = <T extends LayerMappedObject>(
   objects: ReadonlyArray<T>,
   layerCount: number = 2,
-): Array<T & { zLayers: number[] }> => {
+): Array<T & { __zLayers: number[] }> => {
   const allZLayers = Array.from({ length: layerCount }, (_, i) => i)
 
   return objects.map((object) => {
     const candidateZLayers =
-      object.zLayers ??
+      object.__zLayers ??
       (object.layers
         ? getUniqueValidZLayersFromLayerNames(object.layers, layerCount)
         : undefined) ??
@@ -31,6 +31,6 @@ export const createObjectsWithZLayers = <T extends LayerMappedObject>(
 
     const zLayers = getUniqueValidZLayers(candidateZLayers, layerCount)
 
-    return { ...object, zLayers: zLayers.length > 0 ? zLayers : allZLayers }
+    return { ...object, __zLayers: zLayers.length > 0 ? zLayers : allZLayers }
   })
 }

--- a/lib/utils/formatObstacleLabel.ts
+++ b/lib/utils/formatObstacleLabel.ts
@@ -75,7 +75,7 @@ export const createObstacleLabelFormatter = (srj: SimpleRouteJson) => {
       )
       addRootConnectionMapping(
         rootConnectionIndex,
-        connection.netConnectionName,
+        connection.__netConnectionName,
         rootConnectionName,
       )
 

--- a/lib/utils/getConnectivityMapFromSimpleRouteJson.ts
+++ b/lib/utils/getConnectivityMapFromSimpleRouteJson.ts
@@ -12,8 +12,10 @@ export const getConnectivityMapFromSimpleRouteJson = (srj: SimpleRouteJson) => {
       connMap.addConnections([[connection.name, rootConnectionName]])
     }
     // Also link the connection name to its overall netConnectionName if available
-    if (connection.netConnectionName) {
-      connMap.addConnections([[connection.name, connection.netConnectionName]])
+    if (connection.__netConnectionName) {
+      connMap.addConnections([
+        [connection.name, connection.__netConnectionName],
+      ])
     }
 
     for (const point of connection.pointsToConnect) {

--- a/lib/utils/getGraphicsObjectLayer.ts
+++ b/lib/utils/getGraphicsObjectLayer.ts
@@ -20,8 +20,8 @@ export const getGraphicsLayerForObstacle = (
   layerCount: number,
 ) => {
   const zLayers =
-    obstacle.zLayers && obstacle.zLayers.length > 0
-      ? getUniqueValidZLayers(obstacle.zLayers, layerCount)
+    obstacle.__zLayers && obstacle.__zLayers.length > 0
+      ? getUniqueValidZLayers(obstacle.__zLayers, layerCount)
       : getUniqueValidZLayersFromLayerNames(obstacle.layers, layerCount)
 
   return `z${zLayers.join(",")}`

--- a/tests/bugs/__snapshots__/bugreport10-71239a.test.ts.snap
+++ b/tests/bugs/__snapshots__/bugreport10-71239a.test.ts.snap
@@ -57157,7 +57157,7 @@ segment.availableZ: 0"
       "step": 0,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -57182,7 +57182,7 @@ segment.availableZ: 0"
       "step": 0,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -57207,7 +57207,7 @@ segment.availableZ: 0"
       "step": 0,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -57232,7 +57232,7 @@ segment.availableZ: 0"
       "step": 0,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -57257,7 +57257,7 @@ segment.availableZ: 0"
       "step": 0,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -57282,7 +57282,7 @@ segment.availableZ: 0"
       "step": 0,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -57307,7 +57307,7 @@ segment.availableZ: 0"
       "step": 0,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -57338,7 +57338,7 @@ segment.availableZ: 0"
       "step": 0,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -57363,7 +57363,7 @@ segment.availableZ: 0"
       "step": 0,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -57388,7 +57388,7 @@ segment.availableZ: 0"
       "step": 0,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -57413,7 +57413,7 @@ segment.availableZ: 0"
       "step": 0,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -57438,7 +57438,7 @@ segment.availableZ: 0"
       "step": 0,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -57463,7 +57463,7 @@ segment.availableZ: 0"
       "step": 0,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -57488,7 +57488,7 @@ segment.availableZ: 0"
       "step": 0,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -57519,7 +57519,7 @@ segment.availableZ: 0"
       "step": 0,
       "type": "rect",
       "width": 0.64,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -57544,7 +57544,7 @@ segment.availableZ: 0"
       "step": 0,
       "type": "rect",
       "width": 0.64,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -57572,7 +57572,7 @@ segment.availableZ: 0"
       "step": 0,
       "type": "oval",
       "width": 1.6,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -57603,7 +57603,7 @@ segment.availableZ: 0"
       "step": 0,
       "type": "oval",
       "width": 1.6,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -57634,7 +57634,7 @@ segment.availableZ: 0"
       "step": 0,
       "type": "oval",
       "width": 1.6,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -57665,7 +57665,7 @@ segment.availableZ: 0"
       "step": 0,
       "type": "oval",
       "width": 1.6,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -57696,7 +57696,7 @@ segment.availableZ: 0"
       "step": 0,
       "type": "oval",
       "width": 1.3,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -57727,7 +57727,7 @@ segment.availableZ: 0"
       "step": 0,
       "type": "oval",
       "width": 1.3,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -57758,7 +57758,7 @@ segment.availableZ: 0"
       "step": 0,
       "type": "oval",
       "width": 1.3,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -57789,7 +57789,7 @@ segment.availableZ: 0"
       "step": 0,
       "type": "oval",
       "width": 1.3,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -57820,7 +57820,7 @@ segment.availableZ: 0"
       "step": 0,
       "type": "oval",
       "width": 1.3,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -57851,7 +57851,7 @@ segment.availableZ: 0"
       "step": 0,
       "type": "oval",
       "width": 1.3,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -57882,7 +57882,7 @@ segment.availableZ: 0"
       "step": 0,
       "type": "oval",
       "width": 1.3,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -57913,7 +57913,7 @@ segment.availableZ: 0"
       "step": 0,
       "type": "oval",
       "width": 1.3,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -57944,7 +57944,7 @@ segment.availableZ: 0"
       "step": 0,
       "type": "oval",
       "width": 1.3,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -57975,7 +57975,7 @@ segment.availableZ: 0"
       "step": 0,
       "type": "oval",
       "width": 1.3,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -167447,7 +167447,7 @@ Pf: 0.134"
       "step": 12,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -167472,7 +167472,7 @@ Pf: 0.134"
       "step": 12,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -167497,7 +167497,7 @@ Pf: 0.134"
       "step": 12,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -167522,7 +167522,7 @@ Pf: 0.134"
       "step": 12,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -167547,7 +167547,7 @@ Pf: 0.134"
       "step": 12,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -167572,7 +167572,7 @@ Pf: 0.134"
       "step": 12,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -167597,7 +167597,7 @@ Pf: 0.134"
       "step": 12,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -167628,7 +167628,7 @@ Pf: 0.134"
       "step": 12,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -167653,7 +167653,7 @@ Pf: 0.134"
       "step": 12,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -167678,7 +167678,7 @@ Pf: 0.134"
       "step": 12,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -167703,7 +167703,7 @@ Pf: 0.134"
       "step": 12,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -167728,7 +167728,7 @@ Pf: 0.134"
       "step": 12,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -167753,7 +167753,7 @@ Pf: 0.134"
       "step": 12,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -167778,7 +167778,7 @@ Pf: 0.134"
       "step": 12,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -167809,7 +167809,7 @@ Pf: 0.134"
       "step": 12,
       "type": "rect",
       "width": 0.64,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -167834,7 +167834,7 @@ Pf: 0.134"
       "step": 12,
       "type": "rect",
       "width": 0.64,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -167862,7 +167862,7 @@ Pf: 0.134"
       "step": 12,
       "type": "oval",
       "width": 1.6,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -167893,7 +167893,7 @@ Pf: 0.134"
       "step": 12,
       "type": "oval",
       "width": 1.6,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -167924,7 +167924,7 @@ Pf: 0.134"
       "step": 12,
       "type": "oval",
       "width": 1.6,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -167955,7 +167955,7 @@ Pf: 0.134"
       "step": 12,
       "type": "oval",
       "width": 1.6,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -167986,7 +167986,7 @@ Pf: 0.134"
       "step": 12,
       "type": "oval",
       "width": 1.3,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -168017,7 +168017,7 @@ Pf: 0.134"
       "step": 12,
       "type": "oval",
       "width": 1.3,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -168048,7 +168048,7 @@ Pf: 0.134"
       "step": 12,
       "type": "oval",
       "width": 1.3,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -168079,7 +168079,7 @@ Pf: 0.134"
       "step": 12,
       "type": "oval",
       "width": 1.3,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -168110,7 +168110,7 @@ Pf: 0.134"
       "step": 12,
       "type": "oval",
       "width": 1.3,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -168141,7 +168141,7 @@ Pf: 0.134"
       "step": 12,
       "type": "oval",
       "width": 1.3,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -168172,7 +168172,7 @@ Pf: 0.134"
       "step": 12,
       "type": "oval",
       "width": 1.3,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -168203,7 +168203,7 @@ Pf: 0.134"
       "step": 12,
       "type": "oval",
       "width": 1.3,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -168234,7 +168234,7 @@ Pf: 0.134"
       "step": 12,
       "type": "oval",
       "width": 1.3,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -168265,7 +168265,7 @@ Pf: 0.134"
       "step": 12,
       "type": "oval",
       "width": 1.3,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -169553,7 +169553,7 @@ Pf: 0.134"
       "step": 18,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -169578,7 +169578,7 @@ Pf: 0.134"
       "step": 18,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -169603,7 +169603,7 @@ Pf: 0.134"
       "step": 18,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -169628,7 +169628,7 @@ Pf: 0.134"
       "step": 18,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -169653,7 +169653,7 @@ Pf: 0.134"
       "step": 18,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -169678,7 +169678,7 @@ Pf: 0.134"
       "step": 18,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -169703,7 +169703,7 @@ Pf: 0.134"
       "step": 18,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -169734,7 +169734,7 @@ Pf: 0.134"
       "step": 18,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -169759,7 +169759,7 @@ Pf: 0.134"
       "step": 18,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -169784,7 +169784,7 @@ Pf: 0.134"
       "step": 18,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -169809,7 +169809,7 @@ Pf: 0.134"
       "step": 18,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -169834,7 +169834,7 @@ Pf: 0.134"
       "step": 18,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -169859,7 +169859,7 @@ Pf: 0.134"
       "step": 18,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -169884,7 +169884,7 @@ Pf: 0.134"
       "step": 18,
       "type": "rect",
       "width": 2.0379944,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -169915,7 +169915,7 @@ Pf: 0.134"
       "step": 18,
       "type": "rect",
       "width": 0.64,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -169940,7 +169940,7 @@ Pf: 0.134"
       "step": 18,
       "type": "rect",
       "width": 0.64,
-      "zLayers": [
+      "__zLayers": [
         0,
       ],
     },
@@ -169968,7 +169968,7 @@ Pf: 0.134"
       "step": 18,
       "type": "oval",
       "width": 1.6,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -169999,7 +169999,7 @@ Pf: 0.134"
       "step": 18,
       "type": "oval",
       "width": 1.6,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -170030,7 +170030,7 @@ Pf: 0.134"
       "step": 18,
       "type": "oval",
       "width": 1.6,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -170061,7 +170061,7 @@ Pf: 0.134"
       "step": 18,
       "type": "oval",
       "width": 1.6,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -170092,7 +170092,7 @@ Pf: 0.134"
       "step": 18,
       "type": "oval",
       "width": 1.3,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -170123,7 +170123,7 @@ Pf: 0.134"
       "step": 18,
       "type": "oval",
       "width": 1.3,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -170154,7 +170154,7 @@ Pf: 0.134"
       "step": 18,
       "type": "oval",
       "width": 1.3,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -170185,7 +170185,7 @@ Pf: 0.134"
       "step": 18,
       "type": "oval",
       "width": 1.3,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -170216,7 +170216,7 @@ Pf: 0.134"
       "step": 18,
       "type": "oval",
       "width": 1.3,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -170247,7 +170247,7 @@ Pf: 0.134"
       "step": 18,
       "type": "oval",
       "width": 1.3,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -170278,7 +170278,7 @@ Pf: 0.134"
       "step": 18,
       "type": "oval",
       "width": 1.3,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -170309,7 +170309,7 @@ Pf: 0.134"
       "step": 18,
       "type": "oval",
       "width": 1.3,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -170340,7 +170340,7 @@ Pf: 0.134"
       "step": 18,
       "type": "oval",
       "width": 1.3,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,
@@ -170371,7 +170371,7 @@ Pf: 0.134"
       "step": 18,
       "type": "oval",
       "width": 1.3,
-      "zLayers": [
+      "__zLayers": [
         0,
         1,
         2,

--- a/tests/bugs/bugreport22-singlelayer.test.ts
+++ b/tests/bugs/bugreport22-singlelayer.test.ts
@@ -14,7 +14,7 @@ test("bugreport22 - singlelayer (subset)", () => {
   // Filter obstacle zLayers to only include layer 0 for single layer boards
   const filteredObstacles = srj.obstacles.map((obstacle) => ({
     ...obstacle,
-    zLayers: obstacle.zLayers?.filter((z) => z === 0) ?? [0],
+    __zLayers: obstacle.__zLayers?.filter((z) => z === 0) ?? [0],
   }))
   // Use only a small subset of connections to make the test faster
   const connectionSubset = srj.connections.slice(0, 8)

--- a/tests/bugs/expansion_degrees_bug/expansion_degrees_bug_bugreport1.json
+++ b/tests/bugs/expansion_degrees_bug/expansion_degrees_bug_bugreport1.json
@@ -50,7 +50,7 @@
             "pcb_smtpad_17",
             "pcb_port_24"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -82,7 +82,7 @@
             "pcb_plated_hole_5",
             "pcb_port_19"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -104,7 +104,7 @@
             "pcb_plated_hole_1",
             "pcb_port_15"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -126,7 +126,7 @@
             "pcb_smtpad_18",
             "pcb_port_23"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -150,7 +150,7 @@
             "pcb_plated_hole_2",
             "pcb_port_16"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -174,7 +174,7 @@
             "pcb_plated_hole_3",
             "pcb_port_17"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -192,7 +192,7 @@
             "pcb_smtpad_6",
             "pcb_port_6"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -236,7 +236,7 @@
             "pcb_smtpad_17",
             "pcb_port_24"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -254,7 +254,7 @@
             "pcb_smtpad_8",
             "pcb_port_8"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -272,7 +272,7 @@
             "pcb_smtpad_9",
             "pcb_port_9"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -304,7 +304,7 @@
             "pcb_plated_hole_5",
             "pcb_port_19"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -326,7 +326,7 @@
             "pcb_smtpad_19",
             "pcb_port_25"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -344,7 +344,7 @@
             "pcb_smtpad_12",
             "pcb_port_12"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -362,7 +362,7 @@
             "pcb_smtpad_13",
             "pcb_port_13"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -406,7 +406,7 @@
             "pcb_smtpad_17",
             "pcb_port_24"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -450,7 +450,7 @@
             "pcb_smtpad_17",
             "pcb_port_24"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -494,7 +494,7 @@
             "pcb_smtpad_17",
             "pcb_port_24"
           ],
-          "zLayers": [1]
+          "__zLayers": [1]
         },
         {
           "type": "rect",
@@ -538,7 +538,7 @@
             "pcb_smtpad_17",
             "pcb_port_24"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -560,7 +560,7 @@
             "pcb_smtpad_18",
             "pcb_port_23"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -582,7 +582,7 @@
             "pcb_smtpad_19",
             "pcb_port_25"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -614,7 +614,7 @@
             "pcb_plated_hole_5",
             "pcb_port_19"
           ],
-          "zLayers": [0, 1]
+          "__zLayers": [0, 1]
         },
         {
           "type": "oval",
@@ -636,7 +636,7 @@
             "pcb_plated_hole_1",
             "pcb_port_15"
           ],
-          "zLayers": [0, 1]
+          "__zLayers": [0, 1]
         },
         {
           "type": "oval",
@@ -660,7 +660,7 @@
             "pcb_plated_hole_2",
             "pcb_port_16"
           ],
-          "zLayers": [0, 1]
+          "__zLayers": [0, 1]
         },
         {
           "type": "oval",
@@ -684,7 +684,7 @@
             "pcb_plated_hole_3",
             "pcb_port_17"
           ],
-          "zLayers": [0, 1]
+          "__zLayers": [0, 1]
         },
         {
           "type": "oval",
@@ -728,7 +728,7 @@
             "pcb_smtpad_17",
             "pcb_port_24"
           ],
-          "zLayers": [0, 1]
+          "__zLayers": [0, 1]
         },
         {
           "type": "oval",
@@ -760,7 +760,7 @@
             "pcb_plated_hole_5",
             "pcb_port_19"
           ],
-          "zLayers": [0, 1]
+          "__zLayers": [0, 1]
         },
         {
           "type": "rect",
@@ -772,7 +772,7 @@
           "height": 3.302,
           "layers": ["top", "inner1", "inner2", "bottom"],
           "connectedTo": [],
-          "zLayers": [0, 1]
+          "__zLayers": [0, 1]
         },
         {
           "type": "rect",
@@ -784,7 +784,7 @@
           "height": 3.302,
           "layers": ["top", "inner1", "inner2", "bottom"],
           "connectedTo": [],
-          "zLayers": [0, 1]
+          "__zLayers": [0, 1]
         }
       ],
       "layerCount": 2,

--- a/tests/bugs/expansion_degrees_bug/expansion_degrees_bug_bugreport16.json
+++ b/tests/bugs/expansion_degrees_bug/expansion_degrees_bug_bugreport16.json
@@ -38,7 +38,7 @@
             "pcb_smtpad_9",
             "pcb_port_13"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -74,7 +74,7 @@
             "pcb_smtpad_8",
             "pcb_port_12"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -98,7 +98,7 @@
             "pcb_smtpad_10",
             "pcb_port_14"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -116,7 +116,7 @@
             "pcb_smtpad_3",
             "pcb_port_7"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -144,7 +144,7 @@
             "pcb_smtpad_5",
             "pcb_port_9"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -172,7 +172,7 @@
             "pcb_smtpad_5",
             "pcb_port_9"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -208,7 +208,7 @@
             "pcb_smtpad_8",
             "pcb_port_12"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -240,7 +240,7 @@
             "pcb_smtpad_9",
             "pcb_port_13"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -276,7 +276,7 @@
             "pcb_smtpad_8",
             "pcb_port_12"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -308,7 +308,7 @@
             "pcb_smtpad_9",
             "pcb_port_13"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -332,7 +332,7 @@
             "pcb_smtpad_10",
             "pcb_port_14"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "oval",
@@ -368,7 +368,7 @@
             "pcb_smtpad_8",
             "pcb_port_12"
           ],
-          "zLayers": [0, 1]
+          "__zLayers": [0, 1]
         },
         {
           "type": "oval",
@@ -400,7 +400,7 @@
             "pcb_smtpad_9",
             "pcb_port_13"
           ],
-          "zLayers": [0, 1]
+          "__zLayers": [0, 1]
         },
         {
           "type": "oval",
@@ -428,7 +428,7 @@
             "pcb_smtpad_5",
             "pcb_port_9"
           ],
-          "zLayers": [0, 1]
+          "__zLayers": [0, 1]
         },
         {
           "type": "oval",
@@ -464,7 +464,7 @@
             "pcb_smtpad_8",
             "pcb_port_12"
           ],
-          "zLayers": [0, 1]
+          "__zLayers": [0, 1]
         }
       ],
       "layerCount": 2,

--- a/tests/bugs/expansion_degrees_bug/expansion_degrees_bug_bugreport19.json
+++ b/tests/bugs/expansion_degrees_bug/expansion_degrees_bug_bugreport19.json
@@ -34,7 +34,7 @@
             "pcb_smtpad_15",
             "pcb_port_15"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -64,7 +64,7 @@
             "pcb_smtpad_12",
             "pcb_port_12"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -86,7 +86,7 @@
             "pcb_smtpad_16",
             "pcb_port_16"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -114,7 +114,7 @@
             "pcb_smtpad_8",
             "pcb_port_8"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -136,7 +136,7 @@
             "pcb_smtpad_14",
             "pcb_port_14"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -166,7 +166,7 @@
             "pcb_smtpad_12",
             "pcb_port_12"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -192,7 +192,7 @@
             "pcb_smtpad_10",
             "pcb_port_10"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -220,7 +220,7 @@
             "pcb_smtpad_8",
             "pcb_port_8"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -248,7 +248,7 @@
             "pcb_smtpad_8",
             "pcb_port_8"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -274,7 +274,7 @@
             "pcb_smtpad_10",
             "pcb_port_10"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -300,7 +300,7 @@
             "pcb_smtpad_10",
             "pcb_port_10"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -330,7 +330,7 @@
             "pcb_smtpad_12",
             "pcb_port_12"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -360,7 +360,7 @@
             "pcb_smtpad_12",
             "pcb_port_12"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -388,7 +388,7 @@
             "pcb_smtpad_15",
             "pcb_port_15"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -410,7 +410,7 @@
             "pcb_smtpad_14",
             "pcb_port_14"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -438,7 +438,7 @@
             "pcb_smtpad_15",
             "pcb_port_15"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -460,7 +460,7 @@
             "pcb_smtpad_16",
             "pcb_port_16"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         },
         {
           "type": "rect",
@@ -478,7 +478,7 @@
             "pcb_smtpad_17",
             "pcb_port_17"
           ],
-          "zLayers": [0]
+          "__zLayers": [0]
         }
       ],
       "connections": [

--- a/tests/bugs/polygon-outline02.test.ts
+++ b/tests/bugs/polygon-outline02.test.ts
@@ -27,7 +27,7 @@ const simpleRouteJson: SimpleRouteJson = {
         "pcb_smtpad_0",
         "pcb_port_0",
       ],
-      zLayers: [0],
+      __zLayers: [0],
     },
     {
       type: "rect",
@@ -49,7 +49,7 @@ const simpleRouteJson: SimpleRouteJson = {
         "pcb_smtpad_3",
         "pcb_port_3",
       ],
-      zLayers: [0],
+      __zLayers: [0],
     },
     {
       type: "rect",
@@ -67,7 +67,7 @@ const simpleRouteJson: SimpleRouteJson = {
         "pcb_smtpad_2",
         "pcb_port_2",
       ],
-      zLayers: [0],
+      __zLayers: [0],
     },
     {
       type: "rect",
@@ -89,7 +89,7 @@ const simpleRouteJson: SimpleRouteJson = {
         "pcb_smtpad_3",
         "pcb_port_3",
       ],
-      zLayers: [0],
+      __zLayers: [0],
     },
   ],
   connections: [

--- a/tests/bugs/simplification-trace-overlap-repro.test.ts
+++ b/tests/bugs/simplification-trace-overlap-repro.test.ts
@@ -22,7 +22,7 @@ const convertHdRoutesToPcbTraces = (
 ): SimplifiedPcbTraces =>
   srjWithPointPairs.connections.flatMap((connection) => {
     const netConnectionName =
-      connection.netConnectionName ??
+      connection.__netConnectionName ??
       connection.__rootConnectionNames?.[0] ??
       connection.name
 

--- a/tests/component-detection-bga-only.test.ts
+++ b/tests/component-detection-bga-only.test.ts
@@ -243,7 +243,7 @@ test("component detection only creates regions for BGA-like components", () => {
     "inner2",
     "bottom",
   ])
-  expect(replacementObstacle?.zLayers).toEqual([0, 1, 2, 3])
+  expect(replacementObstacle?.__zLayers).toEqual([0, 1, 2, 3])
 })
 
 test("component detection accepts larger BGA-like components", () => {

--- a/tests/features/pipeline7-dataset-srj18-sample001-two-layer-topology.test.ts
+++ b/tests/features/pipeline7-dataset-srj18-sample001-two-layer-topology.test.ts
@@ -24,7 +24,7 @@ test("pipeline7 dataset-srj18 sample001 keeps topology within its two board laye
     solver.originalSrj.obstacles.every(
       (obstacle) =>
         obstacle.layers.every((layer) => ["top", "bottom"].includes(layer)) &&
-        obstacle.zLayers?.every((z) => z === 0 || z === 1),
+        obstacle.__zLayers?.every((z) => z === 0 || z === 1),
     ),
   ).toBe(true)
 })

--- a/tests/features/pour-via-escape/pour-via-escape01-escape-vias.test.ts
+++ b/tests/features/pour-via-escape/pour-via-escape01-escape-vias.test.ts
@@ -118,7 +118,7 @@ test("pour-via-escape01 adds escape via points for copper pour nets", () => {
       },
       (_, index) => Math.min(sourceZ, targetZ) + index,
     )
-    expect(escapeViaObstacle?.zLayers).toEqual(expectedZLayers)
+    expect(escapeViaObstacle?.__zLayers).toEqual(expectedZLayers)
   }
 })
 

--- a/tests/features/topology/merged-topology/bga-inner-targets.test.ts
+++ b/tests/features/topology/merged-topology/bga-inner-targets.test.ts
@@ -33,7 +33,7 @@ function createObstacle({
     componentId,
     type: "rect",
     layers: ["top"],
-    zLayers: [0],
+    __zLayers: [0],
     center: { x, y },
     width,
     height,

--- a/tests/features/topology/merged-topology/qfp-inner-targets.test.ts
+++ b/tests/features/topology/merged-topology/qfp-inner-targets.test.ts
@@ -33,7 +33,7 @@ function createObstacle({
     componentId,
     type: "rect",
     layers: ["top"],
-    zLayers: [0],
+    __zLayers: [0],
     center: { x, y },
     width,
     height,

--- a/tests/features/topology/merged-topology/qfp-thermalpad-inner-targets.test.ts
+++ b/tests/features/topology/merged-topology/qfp-thermalpad-inner-targets.test.ts
@@ -33,7 +33,7 @@ function createObstacle({
     componentId,
     type: "rect",
     layers: ["top"],
-    zLayers: [0],
+    __zLayers: [0],
     center: { x, y },
     width,
     height,

--- a/tests/features/topology/merged-topology/soic-vertical-inner-targets.test.ts
+++ b/tests/features/topology/merged-topology/soic-vertical-inner-targets.test.ts
@@ -33,7 +33,7 @@ function createObstacle({
     componentId,
     type: "rect",
     layers: ["top"],
-    zLayers: [0],
+    __zLayers: [0],
     center: { x, y },
     width,
     height,

--- a/tests/repro/assets/usb-c-power-adapter.srj.json
+++ b/tests/repro/assets/usb-c-power-adapter.srj.json
@@ -6144,7 +6144,7 @@
   "connections": [
     {
       "name": "source_trace_0",
-      "netConnectionName": "source_net_26",
+      "__netConnectionName": "source_net_26",
       "pointsToConnect": [
         {
           "x": -10.119114999999994,
@@ -6166,7 +6166,7 @@
     },
     {
       "name": "source_trace_1",
-      "netConnectionName": "source_net_26",
+      "__netConnectionName": "source_net_26",
       "pointsToConnect": [
         {
           "x": -10.119114999999994,
@@ -6188,7 +6188,7 @@
     },
     {
       "name": "source_trace_2",
-      "netConnectionName": "source_net_26",
+      "__netConnectionName": "source_net_26",
       "pointsToConnect": [
         {
           "x": -1.3831149999999894,
@@ -6210,7 +6210,7 @@
     },
     {
       "name": "source_trace_3",
-      "netConnectionName": "source_net_26",
+      "__netConnectionName": "source_net_26",
       "pointsToConnect": [
         {
           "x": -1.3831149999999894,
@@ -6232,7 +6232,7 @@
     },
     {
       "name": "source_trace_4",
-      "netConnectionName": "source_net_26",
+      "__netConnectionName": "source_net_26",
       "pointsToConnect": [
         {
           "x": -3.5691149999999823,
@@ -6254,7 +6254,7 @@
     },
     {
       "name": "source_trace_5",
-      "netConnectionName": "source_net_26",
+      "__netConnectionName": "source_net_26",
       "pointsToConnect": [
         {
           "x": 10.106885000000005,
@@ -6276,7 +6276,7 @@
     },
     {
       "name": "source_trace_6",
-      "netConnectionName": "source_net_26",
+      "__netConnectionName": "source_net_26",
       "pointsToConnect": [
         {
           "x": 5.711885000000009,
@@ -6298,7 +6298,7 @@
     },
     {
       "name": "source_trace_7",
-      "netConnectionName": "source_net_26",
+      "__netConnectionName": "source_net_26",
       "pointsToConnect": [
         {
           "x": 5.711885000000009,
@@ -6320,7 +6320,7 @@
     },
     {
       "name": "source_trace_8",
-      "netConnectionName": "source_net_26",
+      "__netConnectionName": "source_net_26",
       "pointsToConnect": [
         {
           "x": 3.9308850000000177,
@@ -6342,7 +6342,7 @@
     },
     {
       "name": "source_trace_9",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 5.330885000000009,
@@ -6367,7 +6367,7 @@
     },
     {
       "name": "source_trace_10",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -0.22011499999999273,
@@ -6395,7 +6395,7 @@
     },
     {
       "name": "source_trace_11",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -0.22011499999999273,
@@ -6423,7 +6423,7 @@
     },
     {
       "name": "source_trace_12",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -0.22011499999999273,
@@ -6451,7 +6451,7 @@
     },
     {
       "name": "source_trace_13",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -2.989114999999984,
@@ -6476,7 +6476,7 @@
     },
     {
       "name": "source_trace_14",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -2.989114999999984,
@@ -6501,7 +6501,7 @@
     },
     {
       "name": "source_trace_15",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -2.989114999999984,
@@ -6526,7 +6526,7 @@
     },
     {
       "name": "source_trace_16",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -8.806114999999991,
@@ -6548,7 +6548,7 @@
     },
     {
       "name": "source_trace_17",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -8.806114999999991,
@@ -6570,7 +6570,7 @@
     },
     {
       "name": "source_trace_18",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -4.931114999999991,
@@ -6595,7 +6595,7 @@
     },
     {
       "name": "source_trace_19",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -2.5891149999999783,
@@ -6617,7 +6617,7 @@
     },
     {
       "name": "source_trace_20",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -2.5891149999999783,
@@ -6639,7 +6639,7 @@
     },
     {
       "name": "source_trace_21",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -2.5891149999999783,
@@ -6661,7 +6661,7 @@
     },
     {
       "name": "source_trace_22",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 7.050885000000008,
@@ -6686,7 +6686,7 @@
     },
     {
       "name": "source_trace_23",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 3.3808850000000064,
@@ -6708,7 +6708,7 @@
     },
     {
       "name": "source_trace_24",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 3.710885000000019,
@@ -6730,7 +6730,7 @@
     },
     {
       "name": "source_trace_25",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 4.530885000000012,
@@ -6755,7 +6755,7 @@
     },
     {
       "name": "source_trace_26",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -2.989114999999984,
@@ -6780,7 +6780,7 @@
     },
     {
       "name": "source_trace_27",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -2.5891149999999783,
@@ -6802,7 +6802,7 @@
     },
     {
       "name": "source_trace_28",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -2.5891149999999783,
@@ -6824,7 +6824,7 @@
     },
     {
       "name": "source_trace_29",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -2.5891149999999783,
@@ -6846,7 +6846,7 @@
     },
     {
       "name": "source_trace_30",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -5.569114999999982,
@@ -6868,7 +6868,7 @@
     },
     {
       "name": "source_trace_31",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -5.569114999999982,
@@ -6890,7 +6890,7 @@
     },
     {
       "name": "source_trace_32",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -0.22011499999999273,
@@ -6918,7 +6918,7 @@
     },
     {
       "name": "source_trace_33",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -0.22011499999999273,
@@ -6946,7 +6946,7 @@
     },
     {
       "name": "source_trace_34",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 3.830885000000009,
@@ -6968,7 +6968,7 @@
     },
     {
       "name": "source_trace_35",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 3.3808850000000064,
@@ -6990,7 +6990,7 @@
     },
     {
       "name": "source_trace_36",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 4.630885000000006,
@@ -7012,7 +7012,7 @@
     },
     {
       "name": "source_trace_37",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 5.155885000000012,
@@ -7034,7 +7034,7 @@
     },
     {
       "name": "source_trace_38",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 8.010885000000016,
@@ -7059,7 +7059,7 @@
     },
     {
       "name": "source_trace_39",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 1.9797080000000165,
@@ -7084,7 +7084,7 @@
     },
     {
       "name": "source_trace_40",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -8.806114999999991,
@@ -7109,7 +7109,7 @@
     },
     {
       "name": "source_trace_41",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -2.5891149999999783,
@@ -7131,7 +7131,7 @@
     },
     {
       "name": "source_trace_42",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -8.118114999999989,
@@ -7156,7 +7156,7 @@
     },
     {
       "name": "source_trace_43",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -8.119114999999994,
@@ -7181,7 +7181,7 @@
     },
     {
       "name": "source_trace_44",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 9.930885000000018,
@@ -7203,7 +7203,7 @@
     },
     {
       "name": "source_trace_45",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 8.58088500000001,
@@ -7225,7 +7225,7 @@
     },
     {
       "name": "source_trace_46",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 7.300885000000008,
@@ -7250,7 +7250,7 @@
     },
     {
       "name": "source_trace_47",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 7.300885000000008,
@@ -7275,7 +7275,7 @@
     },
     {
       "name": "source_trace_48",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 8.010885000000016,
@@ -7300,7 +7300,7 @@
     },
     {
       "name": "source_trace_49",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 8.010885000000016,
@@ -7325,7 +7325,7 @@
     },
     {
       "name": "source_trace_50",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -0.969114999999988,
@@ -7347,7 +7347,7 @@
     },
     {
       "name": "source_trace_51",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 8.010885000000016,
@@ -7372,7 +7372,7 @@
     },
     {
       "name": "source_trace_52",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -6.043114999999986,
@@ -7397,7 +7397,7 @@
     },
     {
       "name": "source_trace_53",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 3.3808850000000064,
@@ -7419,7 +7419,7 @@
     },
     {
       "name": "source_trace_54",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -6.544114999999977,
@@ -7441,7 +7441,7 @@
     },
     {
       "name": "source_trace_55",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -6.544114999999977,
@@ -7463,7 +7463,7 @@
     },
     {
       "name": "source_trace_56",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -6.544114999999977,
@@ -7485,7 +7485,7 @@
     },
     {
       "name": "source_trace_57",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -6.544114999999977,
@@ -7507,7 +7507,7 @@
     },
     {
       "name": "source_trace_58",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 0.10588500000000067,
@@ -7529,7 +7529,7 @@
     },
     {
       "name": "source_trace_59",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 0.10588500000000067,
@@ -7551,7 +7551,7 @@
     },
     {
       "name": "source_trace_60",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 0.10588500000000067,
@@ -7573,7 +7573,7 @@
     },
     {
       "name": "source_trace_61",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 7.330885000000009,
@@ -7595,7 +7595,7 @@
     },
     {
       "name": "source_trace_62",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 7.330885000000009,
@@ -7617,7 +7617,7 @@
     },
     {
       "name": "source_trace_63",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -7.742114999999984,
@@ -7642,7 +7642,7 @@
     },
     {
       "name": "source_trace_64",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 9.58688500000001,
@@ -7667,7 +7667,7 @@
     },
     {
       "name": "source_trace_65",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 9.58688500000001,
@@ -7692,7 +7692,7 @@
     },
     {
       "name": "source_trace_66",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -8.569114999999982,
@@ -7714,7 +7714,7 @@
     },
     {
       "name": "source_trace_67",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -8.569114999999982,
@@ -7736,7 +7736,7 @@
     },
     {
       "name": "source_trace_68",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -8.569114999999982,
@@ -7758,7 +7758,7 @@
     },
     {
       "name": "source_trace_69",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -9.544114999999977,
@@ -7780,7 +7780,7 @@
     },
     {
       "name": "source_trace_70",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -9.544114999999977,
@@ -7802,7 +7802,7 @@
     },
     {
       "name": "source_trace_71",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -9.544114999999977,
@@ -7824,7 +7824,7 @@
     },
     {
       "name": "source_trace_72",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -9.544114999999977,
@@ -7846,7 +7846,7 @@
     },
     {
       "name": "source_trace_73",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -9.544114999999977,
@@ -7868,7 +7868,7 @@
     },
     {
       "name": "source_trace_74",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -8.493114999999989,
@@ -7890,7 +7890,7 @@
     },
     {
       "name": "source_trace_75",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -8.493114999999989,
@@ -7912,7 +7912,7 @@
     },
     {
       "name": "source_trace_76",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 9.58688500000001,
@@ -7937,7 +7937,7 @@
     },
     {
       "name": "source_trace_77",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -7.418114999999986,
@@ -7959,7 +7959,7 @@
     },
     {
       "name": "source_trace_78",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 0.10588500000000067,
@@ -7981,7 +7981,7 @@
     },
     {
       "name": "source_trace_79",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 3.9308850000000177,
@@ -8003,7 +8003,7 @@
     },
     {
       "name": "source_trace_80",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 3.6808850000000177,
@@ -8025,7 +8025,7 @@
     },
     {
       "name": "source_trace_81",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 9.58688500000001,
@@ -8050,7 +8050,7 @@
     },
     {
       "name": "source_trace_82",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -8.569114999999982,
@@ -8072,7 +8072,7 @@
     },
     {
       "name": "source_trace_83",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 3.9308850000000177,
@@ -8094,7 +8094,7 @@
     },
     {
       "name": "source_trace_84",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -8.569114999999982,
@@ -8116,7 +8116,7 @@
     },
     {
       "name": "source_trace_85",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -8.569114999999982,
@@ -8138,7 +8138,7 @@
     },
     {
       "name": "source_trace_86",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -5.569114999999982,
@@ -8160,7 +8160,7 @@
     },
     {
       "name": "source_trace_87",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -0.1381149999999849,
@@ -8182,7 +8182,7 @@
     },
     {
       "name": "source_trace_88",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 9.130885000000006,
@@ -8204,7 +8204,7 @@
     },
     {
       "name": "source_trace_89",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 3.9308850000000177,
@@ -8226,7 +8226,7 @@
     },
     {
       "name": "source_trace_90",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 1.9797080000000165,
@@ -8251,7 +8251,7 @@
     },
     {
       "name": "source_trace_91",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 1.9797080000000165,
@@ -8276,7 +8276,7 @@
     },
     {
       "name": "source_trace_92",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 9.58688500000001,
@@ -8301,7 +8301,7 @@
     },
     {
       "name": "source_trace_93",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -3.8931149999999946,
@@ -8326,7 +8326,7 @@
     },
     {
       "name": "source_trace_94",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -6.544114999999977,
@@ -8348,7 +8348,7 @@
     },
     {
       "name": "source_trace_95",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -6.544114999999977,
@@ -8370,7 +8370,7 @@
     },
     {
       "name": "source_trace_96",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 0.10588500000000067,
@@ -8392,7 +8392,7 @@
     },
     {
       "name": "source_trace_97",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": 0.10588500000000067,
@@ -8414,7 +8414,7 @@
     },
     {
       "name": "source_trace_98",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -0.22011499999999273,
@@ -8439,7 +8439,7 @@
     },
     {
       "name": "source_trace_99",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -9.544114999999977,
@@ -8461,7 +8461,7 @@
     },
     {
       "name": "source_trace_100",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -9.91911499999999,
@@ -8486,7 +8486,7 @@
     },
     {
       "name": "source_trace_101",
-      "netConnectionName": "source_net_0",
+      "__netConnectionName": "source_net_0",
       "pointsToConnect": [
         {
           "x": -5.069114999999982,
@@ -8511,7 +8511,7 @@
     },
     {
       "name": "source_trace_102",
-      "netConnectionName": "source_net_4",
+      "__netConnectionName": "source_net_4",
       "pointsToConnect": [
         {
           "x": -10.019114999999985,
@@ -8533,7 +8533,7 @@
     },
     {
       "name": "source_trace_103",
-      "netConnectionName": "source_net_13",
+      "__netConnectionName": "source_net_13",
       "pointsToConnect": [
         {
           "x": 8.260885000000016,
@@ -8555,7 +8555,7 @@
     },
     {
       "name": "source_trace_104",
-      "netConnectionName": "source_net_6",
+      "__netConnectionName": "source_net_6",
       "pointsToConnect": [
         {
           "x": 8.010885000000016,
@@ -8577,7 +8577,7 @@
     },
     {
       "name": "source_trace_105",
-      "netConnectionName": "source_net_6",
+      "__netConnectionName": "source_net_6",
       "pointsToConnect": [
         {
           "x": 8.010885000000016,
@@ -8599,7 +8599,7 @@
     },
     {
       "name": "source_trace_106",
-      "netConnectionName": "source_net_6",
+      "__netConnectionName": "source_net_6",
       "pointsToConnect": [
         {
           "x": 8.010885000000016,
@@ -8621,7 +8621,7 @@
     },
     {
       "name": "source_trace_107",
-      "netConnectionName": "source_net_6",
+      "__netConnectionName": "source_net_6",
       "pointsToConnect": [
         {
           "x": 8.010885000000016,
@@ -8643,7 +8643,7 @@
     },
     {
       "name": "source_trace_108",
-      "netConnectionName": "source_net_6",
+      "__netConnectionName": "source_net_6",
       "pointsToConnect": [
         {
           "x": 8.010885000000016,
@@ -8665,7 +8665,7 @@
     },
     {
       "name": "source_trace_109",
-      "netConnectionName": "source_net_6",
+      "__netConnectionName": "source_net_6",
       "pointsToConnect": [
         {
           "x": -0.6181149999999889,
@@ -8687,7 +8687,7 @@
     },
     {
       "name": "source_trace_110",
-      "netConnectionName": "source_net_6",
+      "__netConnectionName": "source_net_6",
       "pointsToConnect": [
         {
           "x": -0.6181149999999889,
@@ -8709,7 +8709,7 @@
     },
     {
       "name": "source_trace_111",
-      "netConnectionName": "source_net_6",
+      "__netConnectionName": "source_net_6",
       "pointsToConnect": [
         {
           "x": 5.630885000000006,
@@ -8731,7 +8731,7 @@
     },
     {
       "name": "source_trace_112",
-      "netConnectionName": "source_net_6",
+      "__netConnectionName": "source_net_6",
       "pointsToConnect": [
         {
           "x": -8.569114999999982,
@@ -8753,7 +8753,7 @@
     },
     {
       "name": "source_trace_113",
-      "netConnectionName": "source_net_6",
+      "__netConnectionName": "source_net_6",
       "pointsToConnect": [
         {
           "x": -8.569114999999982,
@@ -8775,7 +8775,7 @@
     },
     {
       "name": "source_trace_114",
-      "netConnectionName": "source_net_6",
+      "__netConnectionName": "source_net_6",
       "pointsToConnect": [
         {
           "x": -8.569114999999982,
@@ -8797,7 +8797,7 @@
     },
     {
       "name": "source_trace_115",
-      "netConnectionName": "source_net_6",
+      "__netConnectionName": "source_net_6",
       "pointsToConnect": [
         {
           "x": -8.569114999999982,
@@ -8819,7 +8819,7 @@
     },
     {
       "name": "source_trace_116",
-      "netConnectionName": "source_net_6",
+      "__netConnectionName": "source_net_6",
       "pointsToConnect": [
         {
           "x": -8.569114999999982,
@@ -8841,7 +8841,7 @@
     },
     {
       "name": "source_trace_117",
-      "netConnectionName": "source_net_6",
+      "__netConnectionName": "source_net_6",
       "pointsToConnect": [
         {
           "x": -8.569114999999982,
@@ -8863,7 +8863,7 @@
     },
     {
       "name": "source_trace_118",
-      "netConnectionName": "source_net_6",
+      "__netConnectionName": "source_net_6",
       "pointsToConnect": [
         {
           "x": -7.417114999999981,
@@ -8885,7 +8885,7 @@
     },
     {
       "name": "source_trace_119",
-      "netConnectionName": "source_net_6",
+      "__netConnectionName": "source_net_6",
       "pointsToConnect": [
         {
           "x": -4.118114999999989,
@@ -8907,7 +8907,7 @@
     },
     {
       "name": "source_trace_120",
-      "netConnectionName": "source_net_6",
+      "__netConnectionName": "source_net_6",
       "pointsToConnect": [
         {
           "x": -0.6181149999999889,
@@ -8929,7 +8929,7 @@
     },
     {
       "name": "source_trace_121",
-      "netConnectionName": "source_net_6",
+      "__netConnectionName": "source_net_6",
       "pointsToConnect": [
         {
           "x": -4.118114999999989,
@@ -8951,7 +8951,7 @@
     },
     {
       "name": "source_trace_122",
-      "netConnectionName": "source_net_21",
+      "__netConnectionName": "source_net_21",
       "pointsToConnect": [
         {
           "x": -1.3181149999999917,
@@ -8973,7 +8973,7 @@
     },
     {
       "name": "source_trace_123",
-      "netConnectionName": "source_net_21",
+      "__netConnectionName": "source_net_21",
       "pointsToConnect": [
         {
           "x": -1.6191149999999794,
@@ -8995,7 +8995,7 @@
     },
     {
       "name": "source_trace_124",
-      "netConnectionName": "source_net_21",
+      "__netConnectionName": "source_net_21",
       "pointsToConnect": [
         {
           "x": -5.963114999999988,
@@ -9017,7 +9017,7 @@
     },
     {
       "name": "source_trace_125",
-      "netConnectionName": "source_net_21",
+      "__netConnectionName": "source_net_21",
       "pointsToConnect": [
         {
           "x": -5.963114999999988,
@@ -9039,7 +9039,7 @@
     },
     {
       "name": "source_trace_126",
-      "netConnectionName": "source_net_21",
+      "__netConnectionName": "source_net_21",
       "pointsToConnect": [
         {
           "x": -5.963114999999988,
@@ -9061,7 +9061,7 @@
     },
     {
       "name": "source_trace_127",
-      "netConnectionName": "source_net_21",
+      "__netConnectionName": "source_net_21",
       "pointsToConnect": [
         {
           "x": -1.6191149999999794,
@@ -9083,7 +9083,7 @@
     },
     {
       "name": "source_trace_128",
-      "netConnectionName": "source_net_21",
+      "__netConnectionName": "source_net_21",
       "pointsToConnect": [
         {
           "x": -4.931114999999991,
@@ -9105,7 +9105,7 @@
     },
     {
       "name": "source_trace_129",
-      "netConnectionName": "source_net_21",
+      "__netConnectionName": "source_net_21",
       "pointsToConnect": [
         {
           "x": -3.5491149999999863,
@@ -9127,7 +9127,7 @@
     },
     {
       "name": "source_trace_130",
-      "netConnectionName": "source_net_21",
+      "__netConnectionName": "source_net_21",
       "pointsToConnect": [
         {
           "x": -3.5491149999999863,
@@ -9149,7 +9149,7 @@
     },
     {
       "name": "source_trace_131",
-      "netConnectionName": "source_net_21",
+      "__netConnectionName": "source_net_21",
       "pointsToConnect": [
         {
           "x": -1.6191149999999794,
@@ -9171,7 +9171,7 @@
     },
     {
       "name": "source_trace_132",
-      "netConnectionName": "source_net_21",
+      "__netConnectionName": "source_net_21",
       "pointsToConnect": [
         {
           "x": -1.6191149999999794,
@@ -9193,7 +9193,7 @@
     },
     {
       "name": "source_trace_133",
-      "netConnectionName": "source_net_21",
+      "__netConnectionName": "source_net_21",
       "pointsToConnect": [
         {
           "x": -1.6191149999999794,
@@ -9215,7 +9215,7 @@
     },
     {
       "name": "source_trace_134",
-      "netConnectionName": "source_net_21",
+      "__netConnectionName": "source_net_21",
       "pointsToConnect": [
         {
           "x": -1.6191149999999794,
@@ -9237,7 +9237,7 @@
     },
     {
       "name": "source_trace_135",
-      "netConnectionName": "source_net_21",
+      "__netConnectionName": "source_net_21",
       "pointsToConnect": [
         {
           "x": -1.6191149999999794,
@@ -9259,7 +9259,7 @@
     },
     {
       "name": "source_trace_136",
-      "netConnectionName": "source_net_21",
+      "__netConnectionName": "source_net_21",
       "pointsToConnect": [
         {
           "x": -2.1421149999999898,
@@ -9281,7 +9281,7 @@
     },
     {
       "name": "source_trace_137",
-      "netConnectionName": "source_net_23",
+      "__netConnectionName": "source_net_23",
       "pointsToConnect": [
         {
           "x": -4.65711499999999,
@@ -9303,7 +9303,7 @@
     },
     {
       "name": "source_trace_138",
-      "netConnectionName": "source_net_7",
+      "__netConnectionName": "source_net_7",
       "pointsToConnect": [
         {
           "x": 8.510885000000016,
@@ -9325,7 +9325,7 @@
     },
     {
       "name": "source_trace_139",
-      "netConnectionName": "source_net_7",
+      "__netConnectionName": "source_net_7",
       "pointsToConnect": [
         {
           "x": 8.510885000000016,
@@ -9347,7 +9347,7 @@
     },
     {
       "name": "source_trace_140",
-      "netConnectionName": "source_net_67",
+      "__netConnectionName": "source_net_67",
       "pointsToConnect": [
         {
           "x": -5.922114999999991,
@@ -9369,7 +9369,7 @@
     },
     {
       "name": "source_trace_141",
-      "netConnectionName": "source_net_67",
+      "__netConnectionName": "source_net_67",
       "pointsToConnect": [
         {
           "x": -5.922114999999991,
@@ -9391,7 +9391,7 @@
     },
     {
       "name": "source_trace_142",
-      "netConnectionName": "source_net_17",
+      "__netConnectionName": "source_net_17",
       "pointsToConnect": [
         {
           "x": 7.050885000000008,
@@ -9413,7 +9413,7 @@
     },
     {
       "name": "source_trace_143",
-      "netConnectionName": "source_net_17",
+      "__netConnectionName": "source_net_17",
       "pointsToConnect": [
         {
           "x": 7.050885000000008,
@@ -9435,7 +9435,7 @@
     },
     {
       "name": "source_trace_144",
-      "netConnectionName": "source_net_17",
+      "__netConnectionName": "source_net_17",
       "pointsToConnect": [
         {
           "x": 7.050885000000008,
@@ -9457,7 +9457,7 @@
     },
     {
       "name": "source_trace_145",
-      "netConnectionName": "source_net_27",
+      "__netConnectionName": "source_net_27",
       "pointsToConnect": [
         {
           "x": 2.750885000000011,
@@ -9479,7 +9479,7 @@
     },
     {
       "name": "source_trace_146",
-      "netConnectionName": "source_net_12",
+      "__netConnectionName": "source_net_12",
       "pointsToConnect": [
         {
           "x": 3.330885000000009,
@@ -9501,7 +9501,7 @@
     },
     {
       "name": "source_trace_147",
-      "netConnectionName": "source_net_12",
+      "__netConnectionName": "source_net_12",
       "pointsToConnect": [
         {
           "x": 4.330885000000009,
@@ -9523,7 +9523,7 @@
     },
     {
       "name": "source_trace_148",
-      "netConnectionName": "source_net_12",
+      "__netConnectionName": "source_net_12",
       "pointsToConnect": [
         {
           "x": 3.330885000000009,
@@ -9545,7 +9545,7 @@
     },
     {
       "name": "source_trace_149",
-      "netConnectionName": "source_net_10",
+      "__netConnectionName": "source_net_10",
       "pointsToConnect": [
         {
           "x": 4.380885000000006,
@@ -9567,7 +9567,7 @@
     },
     {
       "name": "source_trace_150",
-      "netConnectionName": "source_net_24",
+      "__netConnectionName": "source_net_24",
       "pointsToConnect": [
         {
           "x": -3.5491149999999863,
@@ -9589,7 +9589,7 @@
     },
     {
       "name": "source_trace_151",
-      "netConnectionName": "source_net_3",
+      "__netConnectionName": "source_net_3",
       "pointsToConnect": [
         {
           "x": -3.5491149999999863,
@@ -9611,7 +9611,7 @@
     },
     {
       "name": "source_trace_152",
-      "netConnectionName": "source_net_28",
+      "__netConnectionName": "source_net_28",
       "pointsToConnect": [
         {
           "x": 1.3298850000000186,
@@ -9633,7 +9633,7 @@
     },
     {
       "name": "source_trace_153",
-      "netConnectionName": "source_net_50",
+      "__netConnectionName": "source_net_50",
       "pointsToConnect": [
         {
           "x": 2.3838850000000065,
@@ -9655,7 +9655,7 @@
     },
     {
       "name": "source_trace_154",
-      "netConnectionName": "source_net_9",
+      "__netConnectionName": "source_net_9",
       "pointsToConnect": [
         {
           "x": 5.155885000000012,
@@ -9677,7 +9677,7 @@
     },
     {
       "name": "source_trace_155",
-      "netConnectionName": "source_net_9",
+      "__netConnectionName": "source_net_9",
       "pointsToConnect": [
         {
           "x": 5.630885000000006,
@@ -9699,7 +9699,7 @@
     },
     {
       "name": "source_trace_156",
-      "netConnectionName": "source_net_8",
+      "__netConnectionName": "source_net_8",
       "pointsToConnect": [
         {
           "x": 7.550885000000008,
@@ -9721,7 +9721,7 @@
     },
     {
       "name": "source_trace_157",
-      "netConnectionName": "source_net_8",
+      "__netConnectionName": "source_net_8",
       "pointsToConnect": [
         {
           "x": 7.550885000000008,
@@ -9743,7 +9743,7 @@
     },
     {
       "name": "source_trace_158",
-      "netConnectionName": "source_net_55",
+      "__netConnectionName": "source_net_55",
       "pointsToConnect": [
         {
           "x": -7.813114999999982,
@@ -9765,7 +9765,7 @@
     },
     {
       "name": "source_trace_159",
-      "netConnectionName": "source_net_69",
+      "__netConnectionName": "source_net_69",
       "pointsToConnect": [
         {
           "x": -6.0181149999999946,
@@ -9787,7 +9787,7 @@
     },
     {
       "name": "source_trace_160",
-      "netConnectionName": "source_net_57",
+      "__netConnectionName": "source_net_57",
       "pointsToConnect": [
         {
           "x": -5.922114999999991,
@@ -9809,7 +9809,7 @@
     },
     {
       "name": "source_trace_161",
-      "netConnectionName": "source_net_15",
+      "__netConnectionName": "source_net_15",
       "pointsToConnect": [
         {
           "x": 6.577021000000016,
@@ -9831,7 +9831,7 @@
     },
     {
       "name": "source_trace_162",
-      "netConnectionName": "source_net_15",
+      "__netConnectionName": "source_net_15",
       "pointsToConnect": [
         {
           "x": 6.577021000000016,
@@ -9853,7 +9853,7 @@
     },
     {
       "name": "source_trace_163",
-      "netConnectionName": "source_net_15",
+      "__netConnectionName": "source_net_15",
       "pointsToConnect": [
         {
           "x": 6.577021000000016,
@@ -9875,7 +9875,7 @@
     },
     {
       "name": "source_trace_164",
-      "netConnectionName": "source_net_15",
+      "__netConnectionName": "source_net_15",
       "pointsToConnect": [
         {
           "x": 3.9308850000000177,
@@ -9897,7 +9897,7 @@
     },
     {
       "name": "source_trace_165",
-      "netConnectionName": "source_net_15",
+      "__netConnectionName": "source_net_15",
       "pointsToConnect": [
         {
           "x": -4.843114999999983,
@@ -9919,7 +9919,7 @@
     },
     {
       "name": "source_trace_166",
-      "netConnectionName": "source_net_15",
+      "__netConnectionName": "source_net_15",
       "pointsToConnect": [
         {
           "x": -4.843114999999983,
@@ -9941,7 +9941,7 @@
     },
     {
       "name": "source_trace_167",
-      "netConnectionName": "source_net_15",
+      "__netConnectionName": "source_net_15",
       "pointsToConnect": [
         {
           "x": 6.577021000000016,
@@ -9963,7 +9963,7 @@
     },
     {
       "name": "source_trace_168",
-      "netConnectionName": "source_net_54",
+      "__netConnectionName": "source_net_54",
       "pointsToConnect": [
         {
           "x": -8.969114999999988,
@@ -9988,7 +9988,7 @@
     },
     {
       "name": "source_trace_169",
-      "netConnectionName": "source_net_30",
+      "__netConnectionName": "source_net_30",
       "pointsToConnect": [
         {
           "x": -4.931114999999991,
@@ -10010,7 +10010,7 @@
     },
     {
       "name": "source_trace_170",
-      "netConnectionName": "source_net_39",
+      "__netConnectionName": "source_net_39",
       "pointsToConnect": [
         {
           "x": 7.230885000000015,
@@ -10032,7 +10032,7 @@
     },
     {
       "name": "source_trace_171",
-      "netConnectionName": "source_net_39",
+      "__netConnectionName": "source_net_39",
       "pointsToConnect": [
         {
           "x": -7.617114999999998,
@@ -10054,7 +10054,7 @@
     },
     {
       "name": "source_trace_172",
-      "netConnectionName": "source_net_34",
+      "__netConnectionName": "source_net_34",
       "pointsToConnect": [
         {
           "x": -6.119114999999994,
@@ -10076,7 +10076,7 @@
     },
     {
       "name": "source_trace_173",
-      "netConnectionName": "source_net_34",
+      "__netConnectionName": "source_net_34",
       "pointsToConnect": [
         {
           "x": -7.596114999999983,
@@ -10098,7 +10098,7 @@
     },
     {
       "name": "source_trace_174",
-      "netConnectionName": "source_net_34",
+      "__netConnectionName": "source_net_34",
       "pointsToConnect": [
         {
           "x": -5.619114999999994,
@@ -10120,7 +10120,7 @@
     },
     {
       "name": "source_trace_175",
-      "netConnectionName": "source_net_34",
+      "__netConnectionName": "source_net_34",
       "pointsToConnect": [
         {
           "x": -5.790114999999986,
@@ -10142,7 +10142,7 @@
     },
     {
       "name": "source_trace_176",
-      "netConnectionName": "source_net_34",
+      "__netConnectionName": "source_net_34",
       "pointsToConnect": [
         {
           "x": -7.596114999999983,
@@ -10164,7 +10164,7 @@
     },
     {
       "name": "source_trace_177",
-      "netConnectionName": "source_net_36",
+      "__netConnectionName": "source_net_36",
       "pointsToConnect": [
         {
           "x": -7.617114999999998,
@@ -10186,7 +10186,7 @@
     },
     {
       "name": "source_trace_178",
-      "netConnectionName": "source_net_36",
+      "__netConnectionName": "source_net_36",
       "pointsToConnect": [
         {
           "x": -7.117114999999998,
@@ -10208,7 +10208,7 @@
     },
     {
       "name": "source_trace_179",
-      "netConnectionName": "source_net_36",
+      "__netConnectionName": "source_net_36",
       "pointsToConnect": [
         {
           "x": -4.596114999999983,
@@ -10230,7 +10230,7 @@
     },
     {
       "name": "source_trace_180",
-      "netConnectionName": "source_net_36",
+      "__netConnectionName": "source_net_36",
       "pointsToConnect": [
         {
           "x": -2.7911149999999907,
@@ -10252,7 +10252,7 @@
     },
     {
       "name": "source_trace_181",
-      "netConnectionName": "source_net_36",
+      "__netConnectionName": "source_net_36",
       "pointsToConnect": [
         {
           "x": -4.596114999999983,
@@ -10274,7 +10274,7 @@
     },
     {
       "name": "source_trace_182",
-      "netConnectionName": "source_net_19",
+      "__netConnectionName": "source_net_19",
       "pointsToConnect": [
         {
           "x": -5.069114999999982,
@@ -10296,7 +10296,7 @@
     },
     {
       "name": "source_trace_183",
-      "netConnectionName": "source_net_19",
+      "__netConnectionName": "source_net_19",
       "pointsToConnect": [
         {
           "x": -5.071114999999978,
@@ -10318,7 +10318,7 @@
     },
     {
       "name": "source_trace_184",
-      "netConnectionName": "source_net_19",
+      "__netConnectionName": "source_net_19",
       "pointsToConnect": [
         {
           "x": -5.071114999999978,
@@ -10340,7 +10340,7 @@
     },
     {
       "name": "source_trace_185",
-      "netConnectionName": "source_net_19",
+      "__netConnectionName": "source_net_19",
       "pointsToConnect": [
         {
           "x": -5.071114999999978,
@@ -10362,7 +10362,7 @@
     },
     {
       "name": "source_trace_186",
-      "netConnectionName": "source_net_19",
+      "__netConnectionName": "source_net_19",
       "pointsToConnect": [
         {
           "x": -5.069114999999982,
@@ -10384,7 +10384,7 @@
     },
     {
       "name": "source_trace_187",
-      "netConnectionName": "source_net_19",
+      "__netConnectionName": "source_net_19",
       "pointsToConnect": [
         {
           "x": -10.119114999999994,
@@ -10406,7 +10406,7 @@
     },
     {
       "name": "source_trace_188",
-      "netConnectionName": "source_net_19",
+      "__netConnectionName": "source_net_19",
       "pointsToConnect": [
         {
           "x": -8.806114999999991,
@@ -10428,7 +10428,7 @@
     },
     {
       "name": "source_trace_189",
-      "netConnectionName": "source_net_19",
+      "__netConnectionName": "source_net_19",
       "pointsToConnect": [
         {
           "x": -8.806114999999991,
@@ -10450,7 +10450,7 @@
     },
     {
       "name": "source_trace_190",
-      "netConnectionName": "source_net_18",
+      "__netConnectionName": "source_net_18",
       "pointsToConnect": [
         {
           "x": -6.069114999999982,
@@ -10472,7 +10472,7 @@
     },
     {
       "name": "source_trace_191",
-      "netConnectionName": "source_net_18",
+      "__netConnectionName": "source_net_18",
       "pointsToConnect": [
         {
           "x": -6.069114999999982,
@@ -10494,7 +10494,7 @@
     },
     {
       "name": "source_trace_192",
-      "netConnectionName": "source_net_18",
+      "__netConnectionName": "source_net_18",
       "pointsToConnect": [
         {
           "x": -6.069114999999982,
@@ -10516,7 +10516,7 @@
     },
     {
       "name": "source_trace_193",
-      "netConnectionName": "source_net_18",
+      "__netConnectionName": "source_net_18",
       "pointsToConnect": [
         {
           "x": -9.119114999999994,
@@ -10538,7 +10538,7 @@
     },
     {
       "name": "source_trace_194",
-      "netConnectionName": "source_net_18",
+      "__netConnectionName": "source_net_18",
       "pointsToConnect": [
         {
           "x": -6.069114999999982,
@@ -10560,7 +10560,7 @@
     },
     {
       "name": "source_trace_195",
-      "netConnectionName": "source_net_18",
+      "__netConnectionName": "source_net_18",
       "pointsToConnect": [
         {
           "x": -6.069114999999982,
@@ -10582,7 +10582,7 @@
     },
     {
       "name": "source_trace_196",
-      "netConnectionName": "source_net_18",
+      "__netConnectionName": "source_net_18",
       "pointsToConnect": [
         {
           "x": -8.806114999999991,
@@ -10604,7 +10604,7 @@
     },
     {
       "name": "source_trace_197",
-      "netConnectionName": "source_net_18",
+      "__netConnectionName": "source_net_18",
       "pointsToConnect": [
         {
           "x": -8.806114999999991,
@@ -10626,7 +10626,7 @@
     },
     {
       "name": "source_trace_198",
-      "netConnectionName": "source_net_18",
+      "__netConnectionName": "source_net_18",
       "pointsToConnect": [
         {
           "x": -6.069114999999982,
@@ -10648,7 +10648,7 @@
     },
     {
       "name": "source_trace_199",
-      "netConnectionName": "source_net_18",
+      "__netConnectionName": "source_net_18",
       "pointsToConnect": [
         {
           "x": -6.069114999999982,
@@ -10670,7 +10670,7 @@
     },
     {
       "name": "source_trace_200",
-      "netConnectionName": "source_net_68",
+      "__netConnectionName": "source_net_68",
       "pointsToConnect": [
         {
           "x": -3.894114999999985,
@@ -10692,7 +10692,7 @@
     },
     {
       "name": "source_trace_201",
-      "netConnectionName": "source_net_58",
+      "__netConnectionName": "source_net_58",
       "pointsToConnect": [
         {
           "x": -4.843114999999983,
@@ -10714,7 +10714,7 @@
     },
     {
       "name": "source_trace_202",
-      "netConnectionName": "source_net_58",
+      "__netConnectionName": "source_net_58",
       "pointsToConnect": [
         {
           "x": -4.843114999999983,
@@ -10736,7 +10736,7 @@
     },
     {
       "name": "source_trace_203",
-      "netConnectionName": "source_net_38",
+      "__netConnectionName": "source_net_38",
       "pointsToConnect": [
         {
           "x": -10.019114999999985,
@@ -10758,7 +10758,7 @@
     },
     {
       "name": "source_trace_204",
-      "netConnectionName": "source_net_38",
+      "__netConnectionName": "source_net_38",
       "pointsToConnect": [
         {
           "x": -8.806114999999991,
@@ -10780,7 +10780,7 @@
     },
     {
       "name": "source_trace_205",
-      "netConnectionName": "source_net_38",
+      "__netConnectionName": "source_net_38",
       "pointsToConnect": [
         {
           "x": -8.806114999999991,
@@ -10802,7 +10802,7 @@
     },
     {
       "name": "source_trace_206",
-      "netConnectionName": "source_net_37",
+      "__netConnectionName": "source_net_37",
       "pointsToConnect": [
         {
           "x": -8.118114999999989,
@@ -10824,7 +10824,7 @@
     },
     {
       "name": "source_trace_207",
-      "netConnectionName": "source_net_37",
+      "__netConnectionName": "source_net_37",
       "pointsToConnect": [
         {
           "x": -8.118114999999989,
@@ -10846,7 +10846,7 @@
     },
     {
       "name": "source_trace_208",
-      "netConnectionName": "source_net_37",
+      "__netConnectionName": "source_net_37",
       "pointsToConnect": [
         {
           "x": -8.118114999999989,
@@ -10868,7 +10868,7 @@
     },
     {
       "name": "source_trace_209",
-      "netConnectionName": "source_net_37",
+      "__netConnectionName": "source_net_37",
       "pointsToConnect": [
         {
           "x": -8.118114999999989,
@@ -10890,7 +10890,7 @@
     },
     {
       "name": "source_trace_210",
-      "netConnectionName": "source_net_11",
+      "__netConnectionName": "source_net_11",
       "pointsToConnect": [
         {
           "x": 5.330885000000009,
@@ -10912,7 +10912,7 @@
     },
     {
       "name": "source_trace_211",
-      "netConnectionName": "source_net_2",
+      "__netConnectionName": "source_net_2",
       "pointsToConnect": [
         {
           "x": 7.050885000000008,
@@ -10934,7 +10934,7 @@
     },
     {
       "name": "source_trace_212",
-      "netConnectionName": "source_net_2",
+      "__netConnectionName": "source_net_2",
       "pointsToConnect": [
         {
           "x": 7.050885000000008,
@@ -10956,7 +10956,7 @@
     },
     {
       "name": "source_trace_213",
-      "netConnectionName": "source_net_2",
+      "__netConnectionName": "source_net_2",
       "pointsToConnect": [
         {
           "x": 7.050885000000008,
@@ -10978,7 +10978,7 @@
     },
     {
       "name": "source_trace_214",
-      "netConnectionName": "source_net_49",
+      "__netConnectionName": "source_net_49",
       "pointsToConnect": [
         {
           "x": 3.033885000000012,
@@ -11000,7 +11000,7 @@
     },
     {
       "name": "source_trace_215",
-      "netConnectionName": "source_net_44",
+      "__netConnectionName": "source_net_44",
       "pointsToConnect": [
         {
           "x": 5.155885000000012,
@@ -11022,7 +11022,7 @@
     },
     {
       "name": "source_trace_216",
-      "netConnectionName": "source_net_66",
+      "__netConnectionName": "source_net_66",
       "pointsToConnect": [
         {
           "x": -4.118114999999989,
@@ -11044,7 +11044,7 @@
     },
     {
       "name": "source_trace_217",
-      "netConnectionName": "source_net_66",
+      "__netConnectionName": "source_net_66",
       "pointsToConnect": [
         {
           "x": -5.068114999999992,
@@ -11066,7 +11066,7 @@
     },
     {
       "name": "source_trace_218",
-      "netConnectionName": "source_net_16",
+      "__netConnectionName": "source_net_16",
       "pointsToConnect": [
         {
           "x": 4.330885000000009,
@@ -11088,7 +11088,7 @@
     },
     {
       "name": "source_trace_219",
-      "netConnectionName": "source_net_29",
+      "__netConnectionName": "source_net_29",
       "pointsToConnect": [
         {
           "x": 1.3818850000000111,
@@ -11110,7 +11110,7 @@
     },
     {
       "name": "source_trace_220",
-      "netConnectionName": "source_net_29",
+      "__netConnectionName": "source_net_29",
       "pointsToConnect": [
         {
           "x": 0.8818850000000111,
@@ -11132,7 +11132,7 @@
     },
     {
       "name": "source_trace_221",
-      "netConnectionName": "source_net_53",
+      "__netConnectionName": "source_net_53",
       "pointsToConnect": [
         {
           "x": 7.300885000000008,
@@ -11154,7 +11154,7 @@
     },
     {
       "name": "source_trace_222",
-      "netConnectionName": "source_net_31",
+      "__netConnectionName": "source_net_31",
       "pointsToConnect": [
         {
           "x": 5.155885000000012,
@@ -11176,7 +11176,7 @@
     },
     {
       "name": "source_trace_223",
-      "netConnectionName": "source_net_31",
+      "__netConnectionName": "source_net_31",
       "pointsToConnect": [
         {
           "x": 7.050885000000008,
@@ -11198,7 +11198,7 @@
     },
     {
       "name": "source_trace_224",
-      "netConnectionName": "source_net_42",
+      "__netConnectionName": "source_net_42",
       "pointsToConnect": [
         {
           "x": 0.3068850000000083,
@@ -11220,7 +11220,7 @@
     },
     {
       "name": "source_trace_225",
-      "netConnectionName": "source_net_22",
+      "__netConnectionName": "source_net_22",
       "pointsToConnect": [
         {
           "x": -6.619114999999994,
@@ -11242,7 +11242,7 @@
     },
     {
       "name": "source_trace_226",
-      "netConnectionName": "source_net_43",
+      "__netConnectionName": "source_net_43",
       "pointsToConnect": [
         {
           "x": -4.931114999999991,
@@ -11264,7 +11264,7 @@
     },
     {
       "name": "source_trace_227",
-      "netConnectionName": "source_net_1",
+      "__netConnectionName": "source_net_1",
       "pointsToConnect": [
         {
           "x": -9.763114999999985,
@@ -11286,7 +11286,7 @@
     },
     {
       "name": "source_trace_228",
-      "netConnectionName": "source_net_1",
+      "__netConnectionName": "source_net_1",
       "pointsToConnect": [
         {
           "x": -8.806114999999991,
@@ -11308,7 +11308,7 @@
     },
     {
       "name": "source_trace_229",
-      "netConnectionName": "source_net_41",
+      "__netConnectionName": "source_net_41",
       "pointsToConnect": [
         {
           "x": -6.119114999999994,
@@ -11330,7 +11330,7 @@
     },
     {
       "name": "source_trace_230",
-      "netConnectionName": "source_net_40",
+      "__netConnectionName": "source_net_40",
       "pointsToConnect": [
         {
           "x": -7.117114999999998,
@@ -11352,7 +11352,7 @@
     },
     {
       "name": "source_trace_231",
-      "netConnectionName": "source_net_47",
+      "__netConnectionName": "source_net_47",
       "pointsToConnect": [
         {
           "x": -4.571114999999978,
@@ -11374,7 +11374,7 @@
     },
     {
       "name": "source_trace_232",
-      "netConnectionName": "source_net_47",
+      "__netConnectionName": "source_net_47",
       "pointsToConnect": [
         {
           "x": -4.571114999999978,
@@ -11396,7 +11396,7 @@
     },
     {
       "name": "source_trace_233",
-      "netConnectionName": "source_net_47",
+      "__netConnectionName": "source_net_47",
       "pointsToConnect": [
         {
           "x": -4.571114999999978,
@@ -11418,7 +11418,7 @@
     },
     {
       "name": "source_trace_234",
-      "netConnectionName": "source_net_47",
+      "__netConnectionName": "source_net_47",
       "pointsToConnect": [
         {
           "x": -4.571114999999978,
@@ -11440,7 +11440,7 @@
     },
     {
       "name": "source_trace_235",
-      "netConnectionName": "source_net_47",
+      "__netConnectionName": "source_net_47",
       "pointsToConnect": [
         {
           "x": -3.949114999999992,
@@ -11462,7 +11462,7 @@
     },
     {
       "name": "source_trace_236",
-      "netConnectionName": "source_net_47",
+      "__netConnectionName": "source_net_47",
       "pointsToConnect": [
         {
           "x": -3.949114999999992,
@@ -11484,7 +11484,7 @@
     },
     {
       "name": "source_trace_237",
-      "netConnectionName": "source_net_20",
+      "__netConnectionName": "source_net_20",
       "pointsToConnect": [
         {
           "x": 0.48188500000001966,
@@ -11506,7 +11506,7 @@
     },
     {
       "name": "source_trace_238",
-      "netConnectionName": "source_net_20",
+      "__netConnectionName": "source_net_20",
       "pointsToConnect": [
         {
           "x": 0.48188500000001966,
@@ -11528,7 +11528,7 @@
     },
     {
       "name": "source_trace_239",
-      "netConnectionName": "source_net_20",
+      "__netConnectionName": "source_net_20",
       "pointsToConnect": [
         {
           "x": 0.48188500000001966,
@@ -11550,7 +11550,7 @@
     },
     {
       "name": "source_trace_240",
-      "netConnectionName": "source_net_20",
+      "__netConnectionName": "source_net_20",
       "pointsToConnect": [
         {
           "x": -0.21311499999998773,
@@ -11572,7 +11572,7 @@
     },
     {
       "name": "source_trace_241",
-      "netConnectionName": "source_net_33",
+      "__netConnectionName": "source_net_33",
       "pointsToConnect": [
         {
           "x": 5.3568850000000054,
@@ -11594,7 +11594,7 @@
     },
     {
       "name": "source_trace_242",
-      "netConnectionName": "source_net_5",
+      "__netConnectionName": "source_net_5",
       "pointsToConnect": [
         {
           "x": -0.6181149999999889,
@@ -11616,7 +11616,7 @@
     },
     {
       "name": "source_trace_243",
-      "netConnectionName": "source_net_14",
+      "__netConnectionName": "source_net_14",
       "pointsToConnect": [
         {
           "x": 5.880885000000006,
@@ -11638,7 +11638,7 @@
     },
     {
       "name": "source_trace_244",
-      "netConnectionName": "source_net_45",
+      "__netConnectionName": "source_net_45",
       "pointsToConnect": [
         {
           "x": 7.230885000000015,
@@ -11660,7 +11660,7 @@
     },
     {
       "name": "source_trace_245",
-      "netConnectionName": "source_net_32",
+      "__netConnectionName": "source_net_32",
       "pointsToConnect": [
         {
           "x": 8.58088500000001,
@@ -11682,7 +11682,7 @@
     },
     {
       "name": "source_trace_246",
-      "netConnectionName": "source_net_25",
+      "__netConnectionName": "source_net_25",
       "pointsToConnect": [
         {
           "x": 10.106885000000005,

--- a/tests/solvers/useless-via-removal-endpoint-layer-proof.test.ts
+++ b/tests/solvers/useless-via-removal-endpoint-layer-proof.test.ts
@@ -40,7 +40,7 @@ test("removes the first-section via when a connected endpoint obstacle supports 
   const multilayerEndpointObstacle: Obstacle = {
     type: "rect",
     layers: ["top", "bottom"],
-    zLayers: [0, 1],
+    __zLayers: [0, 1],
     center: { x: 0, y: 0 },
     width: 0.4,
     height: 0.4,

--- a/tests/solvers/useless-via-removal-synthetic-route-endpoint-connmap.test.ts
+++ b/tests/solvers/useless-via-removal-synthetic-route-endpoint-connmap.test.ts
@@ -22,7 +22,7 @@ test("uses connMap to prove endpoint layer support for synthetic route ids", () 
   const endpointObstacle: Obstacle = {
     type: "rect",
     layers: ["top", "bottom"],
-    zLayers: [0, 1],
+    __zLayers: [0, 1],
     center: { x: -6.175, y: -4 },
     width: 0.8,
     height: 0.95,

--- a/tests/utils/createObjectsWithZLayers.test.ts
+++ b/tests/utils/createObjectsWithZLayers.test.ts
@@ -27,5 +27,5 @@ test("preserves obstacle ccwRotationDegrees while normalizing zLayers", () => {
   )
 
   expect(normalizedObstacle.ccwRotationDegrees).toBe(45)
-  expect(normalizedObstacle.zLayers).toEqual([0])
+  expect(normalizedObstacle.__zLayers).toEqual([0])
 })

--- a/tests/utils/layer-count-normalization.test.ts
+++ b/tests/utils/layer-count-normalization.test.ts
@@ -22,7 +22,7 @@ test("normalizes obstacle layers to the board layer count", (): void => {
   ])
   expect(getObstacleAvailableZ(obstacle, 2)).toEqual([0, 1])
   expect(getGraphicsLayerForObstacle(obstacle, 2)).toBe("z0,1")
-  expect(createObjectsWithZLayers([obstacle], 2)[0]!.zLayers).toEqual([0, 1])
+  expect(createObjectsWithZLayers([obstacle], 2)[0]!.__zLayers).toEqual([0, 1])
 
   const srj: SimpleRouteJson = {
     layerCount: 2,
@@ -35,5 +35,5 @@ test("normalizes obstacle layers to the board layer count", (): void => {
     createSrjWithBoardValidObstacleLayers(srj).obstacles[0]!
 
   expect(outputObstacle.layers).toEqual(["top", "bottom"])
-  expect(outputObstacle.zLayers).toEqual([0, 1])
+  expect(outputObstacle.__zLayers).toEqual([0, 1])
 })


### PR DESCRIPTION
## Summary
- rename internal obstacle z-layer metadata to __zLayers
- rename internal net metadata to __netConnectionName
- update routing code, fixtures, and snapshots to use the prefixed fields

## Validation
- bunx tsc --noEmit
- bun run format:check

No full test suite run, per request.