### PR TITLE
fix: drop degenerate global mesh nodes before topology merging

### DIFF
--- a/lib/solvers/TopologyPlanningSolver/get-global-mesh-nodes-for-topology-merging.ts
+++ b/lib/solvers/TopologyPlanningSolver/get-global-mesh-nodes-for-topology-merging.ts
@@ -1,12 +1,23 @@
 import type { CapacityMeshNode } from "lib/types"
 import type { SerializedTopologyComponentInput } from "./MultiGraphTopologyPlannerSolver"
-import { GEOMETRY_EPSILON } from "./capacity-node-geometry"
+import {
+  GEOMETRY_EPSILON,
+  getCapacityMeshNodeBounds,
+  isValidCapacityBounds,
+} from "./capacity-node-geometry"
 
 /**
  * Retains the global topology as an input to common refinement. RectDiff marks
  * synthetic component replacement regions as obstacles and targets; those
  * flags describe the temporary global solve, not physical copper keepouts, so
  * they are cleared before the component-local topology groups are overlaid.
+ *
+ * Degenerate (zero-area or non-finite) nodes are dropped. The RectDiff global
+ * solve only filters exactly-zero rect sizes, so near-zero sliver nodes (e.g.
+ * from float-dust obstacle dimensions) can reach this stage. Such a node
+ * carries no routing capacity — it cannot contain a port point and topology
+ * merging samples node interiors, so it would never contribute a region — and
+ * letting it through crashes TopologyMergingSolver input validation.
  */
 export function getGlobalMeshNodesForTopologyMerging({
   meshNodes,
@@ -15,9 +26,13 @@ export function getGlobalMeshNodesForTopologyMerging({
   meshNodes: CapacityMeshNode[]
   components: SerializedTopologyComponentInput[]
 }): CapacityMeshNode[] {
-  if (components.length === 0) return meshNodes
+  const routableMeshNodes = meshNodes.filter((node) =>
+    isValidCapacityBounds(getCapacityMeshNodeBounds(node)),
+  )
 
-  return meshNodes.map((node) => {
+  if (components.length === 0) return routableMeshNodes
+
+  return routableMeshNodes.map((node) => {
     const isSyntheticComponentRegion = components.some((component) =>
       isReplacementRegionNode({ node, component }),
     )

--- a/tests/features/topology/merged-topology/degenerate-global-mesh-node.test.ts
+++ b/tests/features/topology/merged-topology/degenerate-global-mesh-node.test.ts
@@ -1,0 +1,111 @@
+import { expect, test } from "bun:test"
+import {
+  getCapacityMeshNodeBounds,
+  isValidCapacityBounds,
+} from "lib/solvers/TopologyPlanningSolver/capacity-node-geometry"
+import type { Obstacle, SimpleRouteJson } from "lib/types"
+import {
+  createTopologyMergingSolverFromPlanning,
+  createTopologyPlanningSolverForMerging,
+} from "../../../fixtures/topology-merging-test-utils"
+
+function createObstacle({
+  id,
+  x,
+  y,
+  width,
+  height,
+  connectedTo = [],
+}: {
+  id: string
+  x: number
+  y: number
+  width: number
+  height: number
+  connectedTo?: string[]
+}): Obstacle {
+  return {
+    obstacleId: id,
+    type: "rect",
+    layers: ["top"],
+    zLayers: [0],
+    center: { x, y },
+    width,
+    height,
+    connectedTo,
+  }
+}
+
+/**
+ * Reproduces https://github.com/tscircuit/tscircuit-autorouter/issues/1614:
+ * a near-zero-width obstacle makes the RectDiff global solve emit a degenerate
+ * (zero-area) mesh node, which used to crash TopologyMergingSolver input
+ * validation with 'node "cmn_N" in group "global" has invalid bounds'.
+ */
+test("topology planning drops degenerate global mesh nodes before merging", (): void => {
+  const inputSrj: SimpleRouteJson = {
+    layerCount: 2,
+    minTraceWidth: 0.15,
+    minViaPadDiameter: 0.35,
+    defaultObstacleMargin: 0.15,
+    bounds: { minX: -5, maxX: 5, minY: -5, maxY: 5 },
+    obstacles: [
+      createObstacle({
+        id: "pad_a",
+        x: -3,
+        y: 0,
+        width: 0.6,
+        height: 0.6,
+        connectedTo: ["pad_a_port"],
+      }),
+      createObstacle({
+        id: "pad_b",
+        x: 3,
+        y: 0,
+        width: 0.6,
+        height: 0.6,
+        connectedTo: ["pad_b_port"],
+      }),
+      // Near-zero-width sliver as it can arrive from upstream circuit-json
+      // float dust. RectDiff only filters exactly-zero rect sizes, so this
+      // becomes a zero-area "cmn_*" node in the global mesh.
+      createObstacle({
+        id: "degenerate_keepout",
+        x: 0,
+        y: 4,
+        width: 5e-10,
+        height: 1,
+      }),
+    ],
+    connections: [
+      {
+        name: "net1",
+        pointsToConnect: [
+          { pointId: "pad_a_port", x: -3, y: 0, layer: "top" },
+          { pointId: "pad_b_port", x: 3, y: 0, layer: "top" },
+        ],
+      },
+    ],
+  }
+
+  const topologyPlanningSolver =
+    createTopologyPlanningSolverForMerging(inputSrj)
+  topologyPlanningSolver.solve()
+  const topologyOutput = topologyPlanningSolver.getOutput()
+
+  expect(
+    topologyOutput.globalMeshNodes.every((node) =>
+      isValidCapacityBounds(getCapacityMeshNodeBounds(node)),
+    ),
+  ).toBe(true)
+
+  const topologyMergingSolver = createTopologyMergingSolverFromPlanning({
+    inputSrj,
+    topologyPlanningSolver,
+  })
+  topologyMergingSolver.solve()
+
+  expect(topologyMergingSolver.solved).toBe(true)
+  expect(topologyMergingSolver.failed).toBe(false)
+  expect(topologyMergingSolver.getOutput().length).toBeGreaterThan(0)
+})


### PR DESCRIPTION
Closes #1614

## Root cause

The RectDiff global solve (`rectsToMeshNodes`) only filters rects with **exactly** zero width/height (`w <= 0 || h <= 0`). A rect with a near-zero-but-positive dimension — e.g. an obstacle whose width is float dust like `5e-10` — survives and becomes a `cmn_*` node in the global mesh. `MultiGraphTopologyPlannerSolver.getOutput()` forwarded those nodes unchanged, so `TopologyMergingSolver` input validation then threw `node "cmn_N" in group "global" has invalid bounds`, aborting the whole autorouting pipeline.

## Fix (explicit policy, per the issue)

The topology-planning stage now never emits a degenerate global node: `getGlobalMeshNodesForTopologyMerging` drops nodes that fail `isValidCapacityBounds` (the same predicate the merging solver validates with). This is a deliberate policy decision, not a swallowed error: a zero-area node carries no routing capacity — it cannot contain a port point, and topology merging samples node interiors (zero-width slabs are skipped), so it can never contribute a region or serve as source geometry for any output node. Non-degenerate nodes are untouched, and the merging solver's validation still throws loudly for any other invalid input.

## Test

`tests/features/topology/merged-topology/degenerate-global-mesh-node.test.ts` builds an SRJ with a near-zero-width (`5e-10`) obstacle, runs the real `ComponentDetectionSolver → MultiGraphTopologyPlannerSolver → TopologyMergingSolver` chain, and asserts the planner emits only valid global bounds and merging solves. It fails on `main` with the exact error from the issue and passes with this fix.

Full `bun test` run: 371 pass / 55 skip / 17 fail — the 17 failures are pre-existing SVG snapshot diffs on `main` in this environment (verified by re-running the same files on the pristine base commit; identical failures). `tsc --noEmit` is clean.

---
This PR was prepared with assistance from an AI coding agent; the reproduction, root-cause analysis, fix, and tests were verified locally.