### PR TITLE
Expand high-density routing portfolio dynamically

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -540,7 +540,6 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
           obstacles: cms.srj.obstacles,
           layerCount: cms.srj.layerCount,
           useGrowShrinkHighDensityIntraNodeSolver: true,
-          growShrinkMaxInnerIterationsPerGrowthAttempt: 8_000,
           growShrinkFallbackToInvalidGeometryOnFailure: true,
         },
       ]

--- a/lib/solvers/HyperHighDensitySolver/HyperSingleIntraNodeSolver.ts
+++ b/lib/solvers/HyperHighDensitySolver/HyperSingleIntraNodeSolver.ts
@@ -22,6 +22,11 @@ import {
 } from "../HyperParameterSupervisorSolver"
 import { repairDisconnectedSameRootPortPoints } from "./repairDisconnectedSameRootPortPoints"
 
+// Match the existing six-ordering portfolio used by the other intra-node
+// solver. The first ordering remains in the normal portfolio; the remaining
+// orderings are introduced only after that portfolio is exhausted.
+const A01_SHUFFLE_SEEDS = Array.from({ length: 6 }, (_, seed) => seed)
+
 export class HyperSingleIntraNodeSolver extends HyperParameterSupervisorSolver<
   | IntraNodeRouteSolver
   | TwoCrossingRoutesHighDensitySolver
@@ -40,6 +45,30 @@ export class HyperSingleIntraNodeSolver extends HyperParameterSupervisorSolver<
   nodeWithPortPoints: NodeWithPortPoints
   connMap?: ConnectivityMap
   effort: number
+  adaptiveSearchExpanded = false
+
+  private getSolvedSegmentCount(solver: IntraNodeRouteSolver): number | null {
+    const solvedConnectionsMap = (solver as any).solvedConnectionsMap
+    if (!(solvedConnectionsMap instanceof Map)) return null
+
+    let solvedSegmentCount = 0
+    for (const routes of solvedConnectionsMap.values()) {
+      if (Array.isArray(routes)) solvedSegmentCount += routes.length
+    }
+    return solvedSegmentCount
+  }
+
+  private getNodeSegmentCount(): number {
+    return Math.max(
+      1,
+      this.nodeWithPortPoints.portPointsInPairs?.length ??
+        new Set(
+          this.nodeWithPortPoints.portPoints.map(
+            (portPoint) => portPoint.connectionName,
+          ),
+        ).size,
+    )
+  }
 
   constructor(
     opts: ConstructorParameters<typeof CachedIntraNodeRouteSolver>[0] & {
@@ -212,6 +241,7 @@ export class HyperSingleIntraNodeSolver extends HyperParameterSupervisorSolver<
         possibleValues: [
           {
             HIGH_DENSITY_A01: true,
+            SHUFFLE_SEED: A01_SHUFFLE_SEEDS[0],
           },
         ],
       },
@@ -224,6 +254,88 @@ export class HyperSingleIntraNodeSolver extends HyperParameterSupervisorSolver<
         ],
       },
     ]
+  }
+
+  /**
+   * Some external solvers expose an idempotent setup phase that calculates
+   * their natural iteration budget from the problem. Running setup here does
+   * not advance the solver or give it preference in the portfolio.
+   */
+  private initializeCandidateBudget(solver: unknown) {
+    const setup = (solver as any).setup
+    if (typeof setup === "function") setup.call(solver)
+  }
+
+  private refreshDynamicIterationLimit() {
+    const remainingSupervisorIterations = (this.supervisedSolvers ?? []).reduce(
+      (total, { solver }) => {
+        if (solver.solved || solver.failed) return total
+        const remainingCandidateIterations = Math.max(
+          0,
+          solver.MAX_ITERATIONS - solver.iterations + 1,
+        )
+        return (
+          total + Math.ceil(remainingCandidateIterations / this.MIN_SUBSTEPS)
+        )
+      },
+      0,
+    )
+
+    // Keep one supervisor step available to observe that the current
+    // portfolio is exhausted and expand it before BaseSolver can fail.
+    this.MAX_ITERATIONS = Math.max(
+      this.iterations + 1,
+      this.iterations + remainingSupervisorIterations,
+    )
+    this.stats.dynamicSupervisorIterationLimit = this.MAX_ITERATIONS
+  }
+
+  override initializeSolvers() {
+    super.initializeSolvers()
+    for (const { solver } of this.supervisedSolvers ?? []) {
+      this.initializeCandidateBudget(solver)
+    }
+    this.refreshDynamicIterationLimit()
+  }
+
+  private addSupervisedCandidate(hyperParameters: Record<string, any>) {
+    const solver = this.generateSolver(hyperParameters)
+    this.initializeCandidateBudget(solver)
+    const g = this.computeG(solver)
+    this.supervisedSolvers!.push({
+      hyperParameters,
+      solver,
+      h: 0,
+      g,
+      f: g,
+    })
+  }
+
+  private expandAdaptiveSearch() {
+    if (this.adaptiveSearchExpanded) return
+
+    this.adaptiveSearchExpanded = true
+    for (const shuffleSeed of A01_SHUFFLE_SEEDS.slice(1)) {
+      this.addSupervisedCandidate({
+        HIGH_DENSITY_A01: true,
+        SHUFFLE_SEED: shuffleSeed,
+      })
+    }
+    this.refreshDynamicIterationLimit()
+    this.stats.adaptiveSearchExpanded = true
+  }
+
+  override _step() {
+    if (!this.supervisedSolvers) this.initializeSolvers()
+
+    if (
+      !this.adaptiveSearchExpanded &&
+      !this.getSupervisedSolverWithBestFitness()
+    ) {
+      this.expandAdaptiveSearch()
+    }
+
+    super._step()
   }
 
   computeG(solver: IntraNodeRouteSolver) {
@@ -247,6 +359,12 @@ export class HyperSingleIntraNodeSolver extends HyperParameterSupervisorSolver<
   }
 
   computeH(solver: IntraNodeRouteSolver) {
+    if (this.adaptiveSearchExpanded) {
+      const solvedSegmentCount = this.getSolvedSegmentCount(solver)
+      if (solvedSegmentCount !== null) {
+        return Math.max(0, 1 - solvedSegmentCount / this.getNodeSegmentCount())
+      }
+    }
     return 1 - (solver.progress || 0)
   }
 

--- a/lib/solvers/HyperHighDensitySolver/HyperSingleIntraNodeSolver.ts
+++ b/lib/solvers/HyperHighDensitySolver/HyperSingleIntraNodeSolver.ts
@@ -24,8 +24,9 @@ import { repairDisconnectedSameRootPortPoints } from "./repairDisconnectedSameRo
 
 // Match the existing six-ordering portfolio used by the other intra-node
 // solver. The first ordering remains in the normal portfolio; the remaining
-// orderings are introduced only after that portfolio is exhausted.
-const A01_SHUFFLE_SEEDS = Array.from({ length: 6 }, (_, seed) => seed)
+// orderings are introduced only after that portfolio spends its dynamically
+// derived exploration budget or exhausts all of its candidates.
+const ORDERING_SHUFFLE_SEEDS = Array.from({ length: 6 }, (_, seed) => seed)
 
 export class HyperSingleIntraNodeSolver extends HyperParameterSupervisorSolver<
   | IntraNodeRouteSolver
@@ -47,7 +48,7 @@ export class HyperSingleIntraNodeSolver extends HyperParameterSupervisorSolver<
   effort: number
   adaptiveSearchExpanded = false
 
-  private getSolvedSegmentCount(solver: IntraNodeRouteSolver): number | null {
+  private getSolvedSegmentCount(solver: unknown): number | null {
     const solvedConnectionsMap = (solver as any).solvedConnectionsMap
     if (!(solvedConnectionsMap instanceof Map)) return null
 
@@ -67,6 +68,34 @@ export class HyperSingleIntraNodeSolver extends HyperParameterSupervisorSolver<
             (portPoint) => portPoint.connectionName,
           ),
         ).size,
+    )
+  }
+
+  private getCandidateProgress(solver: { progress: number }): number {
+    const solvedSegmentCount = this.getSolvedSegmentCount(solver)
+    if (solvedSegmentCount !== null) {
+      return Math.min(1, solvedSegmentCount / this.getNodeSegmentCount())
+    }
+    return Math.max(0, Math.min(1, solver.progress || 0))
+  }
+
+  private getTotalCandidateWork(): number {
+    return (this.supervisedSolvers ?? []).reduce(
+      (total, { solver }) => total + solver.iterations,
+      0,
+    )
+  }
+
+  private getDynamicExpansionWorkBudget(): number {
+    // Give the initial portfolio as much aggregate work as its most expensive
+    // candidate could consume alone. This scales with the candidate's own
+    // problem- and effort-derived budget without waiting for every candidate
+    // to fail or introducing a wall-clock iteration constant.
+    return Math.max(
+      1,
+      ...(this.supervisedSolvers ?? []).map(
+        ({ solver }) => solver.MAX_ITERATIONS,
+      ),
     )
   }
 
@@ -137,26 +166,9 @@ export class HyperSingleIntraNodeSolver extends HyperParameterSupervisorSolver<
       },
       {
         name: "orderings6",
-        possibleValues: [
-          {
-            SHUFFLE_SEED: 0,
-          },
-          {
-            SHUFFLE_SEED: 1,
-          },
-          {
-            SHUFFLE_SEED: 2,
-          },
-          {
-            SHUFFLE_SEED: 3,
-          },
-          {
-            SHUFFLE_SEED: 4,
-          },
-          {
-            SHUFFLE_SEED: 5,
-          },
-        ],
+        possibleValues: ORDERING_SHUFFLE_SEEDS.map((shuffleSeed) => ({
+          SHUFFLE_SEED: shuffleSeed,
+        })),
       },
       {
         name: "cellSizeFactor",
@@ -241,7 +253,7 @@ export class HyperSingleIntraNodeSolver extends HyperParameterSupervisorSolver<
         possibleValues: [
           {
             HIGH_DENSITY_A01: true,
-            SHUFFLE_SEED: A01_SHUFFLE_SEEDS[0],
+            SHUFFLE_SEED: ORDERING_SHUFFLE_SEEDS[0],
           },
         ],
       },
@@ -295,6 +307,7 @@ export class HyperSingleIntraNodeSolver extends HyperParameterSupervisorSolver<
     for (const { solver } of this.supervisedSolvers ?? []) {
       this.initializeCandidateBudget(solver)
     }
+    this.stats.dynamicExpansionWorkBudget = this.getDynamicExpansionWorkBudget()
     this.refreshDynamicIterationLimit()
   }
 
@@ -315,7 +328,7 @@ export class HyperSingleIntraNodeSolver extends HyperParameterSupervisorSolver<
     if (this.adaptiveSearchExpanded) return
 
     this.adaptiveSearchExpanded = true
-    for (const shuffleSeed of A01_SHUFFLE_SEEDS.slice(1)) {
+    for (const shuffleSeed of ORDERING_SHUFFLE_SEEDS.slice(1)) {
       this.addSupervisedCandidate({
         HIGH_DENSITY_A01: true,
         SHUFFLE_SEED: shuffleSeed,
@@ -323,6 +336,22 @@ export class HyperSingleIntraNodeSolver extends HyperParameterSupervisorSolver<
     }
     this.refreshDynamicIterationLimit()
     this.stats.adaptiveSearchExpanded = true
+    this.stats.adaptiveSearchExpandedAtIteration = this.iterations
+    this.stats.candidateWorkAtExpansion = this.getTotalCandidateWork()
+    this.stats.bestProgressAtExpansion = Math.max(
+      0,
+      ...(this.supervisedSolvers ?? []).map(({ solver }) =>
+        this.getCandidateProgress(solver),
+      ),
+    )
+  }
+
+  private shouldExpandPortfolio(): boolean {
+    if (this.adaptiveSearchExpanded) return false
+
+    const expansionWorkBudget = this.getDynamicExpansionWorkBudget()
+    this.stats.dynamicExpansionWorkBudget = expansionWorkBudget
+    return this.getTotalCandidateWork() >= expansionWorkBudget
   }
 
   override _step() {
@@ -336,6 +365,10 @@ export class HyperSingleIntraNodeSolver extends HyperParameterSupervisorSolver<
     }
 
     super._step()
+
+    if (!this.solved && !this.failed && this.shouldExpandPortfolio()) {
+      this.expandAdaptiveSearch()
+    }
   }
 
   computeG(solver: IntraNodeRouteSolver) {
@@ -360,10 +393,7 @@ export class HyperSingleIntraNodeSolver extends HyperParameterSupervisorSolver<
 
   computeH(solver: IntraNodeRouteSolver) {
     if (this.adaptiveSearchExpanded) {
-      const solvedSegmentCount = this.getSolvedSegmentCount(solver)
-      if (solvedSegmentCount !== null) {
-        return Math.max(0, 1 - solvedSegmentCount / this.getNodeSegmentCount())
-      }
+      return 1 - this.getCandidateProgress(solver)
     }
     return 1 - (solver.progress || 0)
   }

--- a/tests/features/high-density-srj18-sample002-large-node.test.ts
+++ b/tests/features/high-density-srj18-sample002-large-node.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "bun:test"
+import { HyperSingleIntraNodeSolver } from "lib/solvers/HyperHighDensitySolver/HyperSingleIntraNodeSolver"
+import type { NodeWithPortPoints } from "lib/types/high-density-types"
+import sample002LargeNode from "../fixtures/srj18-sample002-large-node.json"
+
+const solverParams = {
+  nodeWithPortPoints: sample002LargeNode as NodeWithPortPoints,
+  viaDiameter: 0.3,
+  traceWidth: 0.1,
+  obstacleMargin: 0.15,
+  obstacles: [],
+  layerCount: 2,
+  effort: 1,
+}
+
+test("the supervisor derives its limit without advancing candidates", () => {
+  const solver = new HyperSingleIntraNodeSolver(solverParams)
+  solver.initializeSolvers()
+
+  const getA01Solvers = () =>
+    solver.supervisedSolvers!.filter(
+      ({ solver }) => solver.getSolverName() === "HighDensitySolverA01",
+    )
+
+  expect(getA01Solvers()).toHaveLength(1)
+  expect(getA01Solvers()[0].solver.iterations).toBe(0)
+  expect(solver.adaptiveSearchExpanded).toBe(false)
+  expect(solver.MAX_ITERATIONS).toBe(
+    solver.stats.dynamicSupervisorIterationLimit,
+  )
+  expect(solver.MAX_ITERATIONS).toBeGreaterThan(1)
+})
+
+test("the portfolio expands only after every initial candidate is exhausted", () => {
+  const solver = new HyperSingleIntraNodeSolver(solverParams)
+  solver.initializeSolvers()
+  for (const { solver: candidate } of solver.supervisedSolvers!) {
+    candidate.failed = true
+  }
+
+  solver._step()
+
+  const a01Solvers = solver.supervisedSolvers!.filter(
+    ({ solver }) => solver.getSolverName() === "HighDensitySolverA01",
+  )
+  expect(solver.adaptiveSearchExpanded).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(
+    a01Solvers.map(({ solver }) => (solver as any).hyperParameters.shuffleSeed),
+  ).toEqual([0, 1, 2, 3, 4, 5])
+  expect(solver.MAX_ITERATIONS).toBe(
+    solver.stats.dynamicSupervisorIterationLimit,
+  )
+})
+
+test("an early solution does not expand the portfolio", () => {
+  const solver = new HyperSingleIntraNodeSolver(solverParams)
+  solver.initializeSolvers()
+  const initialSolverCount = solver.supervisedSolvers!.length
+  const immediateWinner = solver.supervisedSolvers!.find(
+    ({ solver }) => solver.getSolverName() === "HighDensitySolverA01",
+  )!
+  immediateWinner.solver.solved = true
+  ;(immediateWinner.solver as any).getOutput = () => []
+
+  solver.step()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.adaptiveSearchExpanded).toBe(false)
+  expect(solver.supervisedSolvers).toHaveLength(initialSolverCount)
+})

--- a/tests/features/high-density-srj18-sample002-large-node.test.ts
+++ b/tests/features/high-density-srj18-sample002-large-node.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test"
+import { GrowShrinkHighDensityIntraNodeSolver } from "lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver"
 import { HyperSingleIntraNodeSolver } from "lib/solvers/HyperHighDensitySolver/HyperSingleIntraNodeSolver"
 import type { NodeWithPortPoints } from "lib/types/high-density-types"
 import sample002LargeNode from "../fixtures/srj18-sample002-large-node.json"
@@ -31,14 +32,14 @@ test("the supervisor derives its limit without advancing candidates", () => {
   expect(solver.MAX_ITERATIONS).toBeGreaterThan(1)
 })
 
-test("the portfolio expands only after every initial candidate is exhausted", () => {
+test("the portfolio expands when every initial candidate is exhausted", () => {
   const solver = new HyperSingleIntraNodeSolver(solverParams)
   solver.initializeSolvers()
   for (const { solver: candidate } of solver.supervisedSolvers!) {
     candidate.failed = true
   }
 
-  solver._step()
+  solver.step()
 
   const a01Solvers = solver.supervisedSolvers!.filter(
     ({ solver }) => solver.getSolverName() === "HighDensitySolverA01",
@@ -51,6 +52,33 @@ test("the portfolio expands only after every initial candidate is exhausted", ()
   expect(solver.MAX_ITERATIONS).toBe(
     solver.stats.dynamicSupervisorIterationLimit,
   )
+})
+
+test("the portfolio expands after a dynamically sized exploration budget", () => {
+  const solver = new HyperSingleIntraNodeSolver(solverParams)
+  solver.initializeSolvers()
+  const activeCandidate = solver.supervisedSolvers!.find(
+    ({ solver }) => solver.getSolverName() === "HighDensitySolverA01",
+  )!.solver
+  for (const { solver: candidate } of solver.supervisedSolvers!) {
+    if (candidate !== activeCandidate) candidate.failed = true
+  }
+  activeCandidate.iterations = solver.stats.dynamicExpansionWorkBudget
+  ;(activeCandidate as any).step = () => {
+    activeCandidate.iterations++
+  }
+
+  expect(solver.stats.dynamicExpansionWorkBudget).toBe(
+    Math.max(
+      ...solver.supervisedSolvers!.map(({ solver }) => solver.MAX_ITERATIONS),
+    ),
+  )
+
+  solver.step()
+
+  expect(solver.adaptiveSearchExpanded).toBe(true)
+  expect(solver.stats.adaptiveSearchExpandedAtIteration).toBe(1)
+  expect(solver.stats.dynamicExpansionWorkBudget).toBeGreaterThan(0)
 })
 
 test("an early solution does not expand the portfolio", () => {
@@ -69,3 +97,24 @@ test("an early solution does not expand the portfolio", () => {
   expect(solver.adaptiveSearchExpanded).toBe(false)
   expect(solver.supervisedSolvers).toHaveLength(initialSolverCount)
 })
+
+test("the srj18 sample002 large node is solved at its physical size", () => {
+  const solver = new GrowShrinkHighDensityIntraNodeSolver({
+    ...solverParams,
+    maxGrowthAttempts: 3,
+    fallbackToInvalidGeometryOnFailure: false,
+  })
+
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(solver.growthAttempts).toBe(0)
+  expect(solver.scaleFactor).toBe(1)
+  expect(solver.winningSolver!.adaptiveSearchExpanded).toBe(true)
+  expect(solver.stats.invalidGeometryFallback).not.toBe(true)
+  expect(solver.winningSolver!.iterations).toBeLessThanOrEqual(
+    solver.winningSolver!.MAX_ITERATIONS,
+  )
+  expect(solver.solvedRoutes).toHaveLength(19)
+}, 60_000)

--- a/tests/features/never-fail-growth-high-density/pipeline7-integration.test.ts
+++ b/tests/features/never-fail-growth-high-density/pipeline7-integration.test.ts
@@ -34,7 +34,7 @@ test("Pipeline7 high-density stage opts into GrowShrinkHighDensityIntraNodeSolve
   ).toBe(true)
   expect(
     (highDensityParams as any).growShrinkMaxInnerIterationsPerGrowthAttempt,
-  ).toBe(8_000)
+  ).toBeUndefined()
 })
 
 test("Pipeline7 caps expensive post-processing stages for benchmark completion", () => {

--- a/tests/fixtures/srj18-sample002-large-node.json
+++ b/tests/fixtures/srj18-sample002-large-node.json
@@ -1,0 +1,739 @@
+{
+  "capacityMeshNodeId": "cmn_1__sub_0_0",
+  "center": {
+    "x": -15.548699999999998,
+    "y": 9.000799999999998
+  },
+  "width": 11.7214,
+  "height": 9.527999999999999,
+  "portPoints": [
+    {
+      "portPointId": "ce3816_pp1_z0::0",
+      "x": -9.875499999999999,
+      "y": 4.236799999999999,
+      "z": 0,
+      "connectionName": "source_trace_10__source_net_10_mst16",
+      "rootConnectionName": "source_trace_10",
+      "nextPortPointId": "ce3819_pp0_z0::0"
+    },
+    {
+      "portPointId": "ce3819_pp0_z0::0",
+      "x": -9.687999999999999,
+      "y": 9.7599,
+      "z": 0,
+      "connectionName": "source_trace_10__source_net_10_mst16",
+      "rootConnectionName": "source_trace_10",
+      "prevPortPointId": "ce3816_pp1_z0::0"
+    },
+    {
+      "portPointId": "ce3725_pp2_z0::0",
+      "x": -21.409399999999998,
+      "y": 13.588766666666665,
+      "z": 0,
+      "connectionName": "source_trace_28__source_net_28_mst2",
+      "rootConnectionName": "source_trace_28",
+      "nextPortPointId": "ce3817_pp0_z1::1"
+    },
+    {
+      "portPointId": "ce3817_pp0_z1::1",
+      "x": -9.687999999999999,
+      "y": 4.934199999999999,
+      "z": 1,
+      "connectionName": "source_trace_28__source_net_28_mst2",
+      "rootConnectionName": "source_trace_28",
+      "prevPortPointId": "ce3725_pp2_z0::0"
+    },
+    {
+      "portPointId": "ce3823_pp0_z0::0",
+      "x": -9.687999999999999,
+      "y": 11.8849,
+      "z": 0,
+      "connectionName": "source_trace_130__source_net_130_mst1",
+      "rootConnectionName": "source_trace_130",
+      "nextPortPointId": "ce3821_pp2_z0::0"
+    },
+    {
+      "portPointId": "ce3821_pp2_z0::0",
+      "x": -9.687999999999999,
+      "y": 10.759899999999998,
+      "z": 0,
+      "connectionName": "source_trace_130__source_net_130_mst1",
+      "rootConnectionName": "source_trace_130",
+      "prevPortPointId": "ce3823_pp0_z0::0"
+    },
+    {
+      "portPointId": "ce3719_pp1_z0::0",
+      "x": -20.453775,
+      "y": 4.236799999999999,
+      "z": 0,
+      "connectionName": "source_trace_53__source_net_53_mst0",
+      "rootConnectionName": "source_trace_53",
+      "nextPortPointId": "ce3818_pp2_z0::0"
+    },
+    {
+      "portPointId": "ce3818_pp2_z0::0",
+      "x": -9.687999999999999,
+      "y": 8.5872,
+      "z": 0,
+      "connectionName": "source_trace_53__source_net_53_mst0",
+      "rootConnectionName": "source_trace_53",
+      "prevPortPointId": "ce3719_pp1_z0::0"
+    },
+    {
+      "portPointId": "ce3719_pp6_z0::0",
+      "x": -18.542524999999998,
+      "y": 4.236799999999999,
+      "z": 0,
+      "connectionName": "source_trace_52__source_net_52_mst0",
+      "rootConnectionName": "source_trace_52",
+      "nextPortPointId": "ce3818_pp1_z1::1"
+    },
+    {
+      "portPointId": "ce3818_pp1_z1::1",
+      "x": -9.687999999999999,
+      "y": 6.6168000000000005,
+      "z": 1,
+      "connectionName": "source_trace_52__source_net_52_mst0",
+      "rootConnectionName": "source_trace_52",
+      "prevPortPointId": "ce3719_pp6_z0::0"
+    },
+    {
+      "portPointId": "ce3686_pp4_z1::1",
+      "x": -21.409399999999998,
+      "y": 8.145299999999999,
+      "z": 1,
+      "connectionName": "source_trace_40__source_net_40_mst1",
+      "rootConnectionName": "source_trace_40",
+      "nextPortPointId": "ce3725_pp0_z0::0"
+    },
+    {
+      "portPointId": "ce3725_pp0_z0::0",
+      "x": -21.409399999999998,
+      "y": 12.884633333333333,
+      "z": 0,
+      "connectionName": "source_trace_40__source_net_40_mst1",
+      "rootConnectionName": "source_trace_40",
+      "prevPortPointId": "ce3686_pp4_z1::1"
+    },
+    {
+      "portPointId": "ce3820_pp0_z1::1",
+      "x": -9.687999999999999,
+      "y": 9.7599,
+      "z": 1,
+      "connectionName": "source_trace_51__source_net_51",
+      "rootConnectionName": "source_trace_51",
+      "nextPortPointId": "ce3817_pp4_z0::0"
+    },
+    {
+      "portPointId": "ce3817_pp4_z0::0",
+      "x": -9.687999999999999,
+      "y": 5.3991333333333325,
+      "z": 0,
+      "connectionName": "source_trace_51__source_net_51",
+      "rootConnectionName": "source_trace_51",
+      "prevPortPointId": "ce3820_pp0_z1::1"
+    },
+    {
+      "portPointId": "ce3818_pp2_z1::1",
+      "x": -9.687999999999999,
+      "y": 8.5872,
+      "z": 1,
+      "connectionName": "source_trace_50__source_net_50",
+      "rootConnectionName": "source_trace_50",
+      "nextPortPointId": "ce3817_pp3_z0::0"
+    },
+    {
+      "portPointId": "ce3817_pp3_z0::0",
+      "x": -9.687999999999999,
+      "y": 4.934199999999999,
+      "z": 0,
+      "connectionName": "source_trace_50__source_net_50",
+      "rootConnectionName": "source_trace_50",
+      "prevPortPointId": "ce3818_pp2_z1::1"
+    },
+    {
+      "portPointId": "ce3810_pp15_z0::0",
+      "x": -11.153175,
+      "y": 13.764799999999997,
+      "z": 0,
+      "connectionName": "source_trace_48__source_net_48",
+      "rootConnectionName": "source_trace_48",
+      "nextPortPointId": "ce3818_pp1_z0::0"
+    },
+    {
+      "portPointId": "ce3818_pp1_z0::0",
+      "x": -9.687999999999999,
+      "y": 6.6168000000000005,
+      "z": 0,
+      "connectionName": "source_trace_48__source_net_48",
+      "rootConnectionName": "source_trace_48",
+      "prevPortPointId": "ce3810_pp15_z0::0"
+    },
+    {
+      "portPointId": "ce3824_pp2_z1::1",
+      "x": -9.687999999999999,
+      "y": 13.168599999999998,
+      "z": 1,
+      "connectionName": "source_trace_47__source_net_47",
+      "rootConnectionName": "source_trace_47",
+      "nextPortPointId": "ce3813_pp5_z1::1"
+    },
+    {
+      "portPointId": "ce3813_pp5_z1::1",
+      "x": -11.628212499999998,
+      "y": 4.236799999999999,
+      "z": 1,
+      "connectionName": "source_trace_47__source_net_47",
+      "rootConnectionName": "source_trace_47",
+      "prevPortPointId": "ce3824_pp2_z1::1"
+    },
+    {
+      "portPointId": "ce3822_pp0_z1::1",
+      "x": -9.687999999999999,
+      "y": 11.884899999999998,
+      "z": 1,
+      "connectionName": "source_trace_46__source_net_46",
+      "rootConnectionName": "source_trace_46",
+      "nextPortPointId": "ce3813_pp7_z1::1"
+    },
+    {
+      "portPointId": "ce3813_pp7_z1::1",
+      "x": -10.4597375,
+      "y": 4.236799999999999,
+      "z": 1,
+      "connectionName": "source_trace_46__source_net_46",
+      "rootConnectionName": "source_trace_46",
+      "prevPortPointId": "ce3822_pp0_z1::1"
+    },
+    {
+      "portPointId": "ce3725_pp1_z0::0",
+      "x": -21.409399999999998,
+      "y": 13.236699999999999,
+      "z": 0,
+      "connectionName": "source_trace_41__source_net_41",
+      "rootConnectionName": "source_trace_41",
+      "nextPortPointId": "ce3821_pp3_z0::0"
+    },
+    {
+      "portPointId": "ce3821_pp3_z0::0",
+      "x": -9.687999999999999,
+      "y": 11.384899999999998,
+      "z": 0,
+      "connectionName": "source_trace_41__source_net_41",
+      "rootConnectionName": "source_trace_41",
+      "prevPortPointId": "ce3725_pp1_z0::0"
+    },
+    {
+      "portPointId": "ce3824_pp0_z0::0",
+      "x": -9.687999999999999,
+      "y": 13.168599999999998,
+      "z": 0,
+      "connectionName": "source_trace_35__source_net_35",
+      "rootConnectionName": "source_trace_35",
+      "nextPortPointId": "ce3817_pp0_z0::0"
+    },
+    {
+      "portPointId": "ce3817_pp0_z0::0",
+      "x": -9.687999999999999,
+      "y": 4.469266666666665,
+      "z": 0,
+      "connectionName": "source_trace_35__source_net_35",
+      "rootConnectionName": "source_trace_35",
+      "prevPortPointId": "ce3824_pp0_z0::0"
+    },
+    {
+      "portPointId": "ce3810_pp12_z0::0",
+      "x": -14.083524999999998,
+      "y": 13.764799999999997,
+      "z": 0,
+      "connectionName": "source_trace_34__source_net_34",
+      "rootConnectionName": "source_trace_34",
+      "nextPortPointId": "ce3812_pp4_z0::0"
+    },
+    {
+      "portPointId": "ce3812_pp4_z0::0",
+      "x": -14.041274999999999,
+      "y": 4.236799999999999,
+      "z": 0,
+      "connectionName": "source_trace_34__source_net_34",
+      "rootConnectionName": "source_trace_34",
+      "prevPortPointId": "ce3810_pp12_z0::0"
+    },
+    {
+      "portPointId": "ce3810_pp12_z1::1",
+      "x": -15.548699999999998,
+      "y": 13.764799999999997,
+      "z": 1,
+      "connectionName": "source_trace_33__source_net_33",
+      "rootConnectionName": "source_trace_33",
+      "nextPortPointId": "ce3813_pp8_z1::1"
+    },
+    {
+      "portPointId": "ce3813_pp8_z1::1",
+      "x": -9.875499999999999,
+      "y": 4.236799999999999,
+      "z": 1,
+      "connectionName": "source_trace_33__source_net_33",
+      "rootConnectionName": "source_trace_33",
+      "prevPortPointId": "ce3810_pp12_z1::1"
+    },
+    {
+      "portPointId": "ce3810_pp10_z0::0",
+      "x": -17.013875,
+      "y": 13.764799999999997,
+      "z": 0,
+      "connectionName": "source_trace_32__source_net_32",
+      "rootConnectionName": "source_trace_32",
+      "nextPortPointId": "ce3815_pp0_z0::0"
+    },
+    {
+      "portPointId": "ce3815_pp0_z0::0",
+      "x": -10.7294,
+      "y": 4.236799999999999,
+      "z": 0,
+      "connectionName": "source_trace_32__source_net_32",
+      "rootConnectionName": "source_trace_32",
+      "prevPortPointId": "ce3810_pp10_z0::0"
+    },
+    {
+      "portPointId": "ce3810_pp7_z0::0",
+      "x": -19.944225,
+      "y": 13.764799999999997,
+      "z": 0,
+      "connectionName": "source_trace_31__source_net_31",
+      "rootConnectionName": "source_trace_31",
+      "nextPortPointId": "ce3812_pp5_z0::0"
+    },
+    {
+      "portPointId": "ce3812_pp5_z0::0",
+      "x": -12.650025,
+      "y": 4.236799999999999,
+      "z": 0,
+      "connectionName": "source_trace_31__source_net_31",
+      "rootConnectionName": "source_trace_31",
+      "prevPortPointId": "ce3810_pp7_z0::0"
+    },
+    {
+      "portPointId": "ce3813_pp6_z1::1",
+      "x": -11.043975,
+      "y": 4.236799999999999,
+      "z": 1,
+      "connectionName": "source_trace_26__source_net_26",
+      "rootConnectionName": "source_trace_26",
+      "nextPortPointId": "ce3820_pp1_z1::1"
+    },
+    {
+      "portPointId": "ce3820_pp1_z1::1",
+      "x": -9.687999999999999,
+      "y": 10.0099,
+      "z": 1,
+      "connectionName": "source_trace_26__source_net_26",
+      "rootConnectionName": "source_trace_26",
+      "prevPortPointId": "ce3813_pp6_z1::1"
+    },
+    {
+      "portPointId": "ce3813_pp4_z1::1",
+      "x": -12.212449999999999,
+      "y": 4.236799999999999,
+      "z": 1,
+      "connectionName": "source_trace_24__source_net_24",
+      "rootConnectionName": "source_trace_24",
+      "nextPortPointId": "ce3821_pp2_z1::1"
+    },
+    {
+      "portPointId": "ce3821_pp2_z1::1",
+      "x": -9.687999999999999,
+      "y": 11.072399999999998,
+      "z": 1,
+      "connectionName": "source_trace_24__source_net_24",
+      "rootConnectionName": "source_trace_24",
+      "prevPortPointId": "ce3813_pp4_z1::1"
+    }
+  ],
+  "portPointsInPairs": [
+    [
+      {
+        "portPointId": "ce3816_pp1_z0::0",
+        "x": -9.875499999999999,
+        "y": 4.236799999999999,
+        "z": 0,
+        "connectionName": "source_trace_10__source_net_10_mst16",
+        "rootConnectionName": "source_trace_10",
+        "nextPortPointId": "ce3819_pp0_z0::0"
+      },
+      {
+        "portPointId": "ce3819_pp0_z0::0",
+        "x": -9.687999999999999,
+        "y": 9.7599,
+        "z": 0,
+        "connectionName": "source_trace_10__source_net_10_mst16",
+        "rootConnectionName": "source_trace_10",
+        "prevPortPointId": "ce3816_pp1_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce3725_pp2_z0::0",
+        "x": -21.409399999999998,
+        "y": 13.588766666666665,
+        "z": 0,
+        "connectionName": "source_trace_28__source_net_28_mst2",
+        "rootConnectionName": "source_trace_28",
+        "nextPortPointId": "ce3817_pp0_z1::1"
+      },
+      {
+        "portPointId": "ce3817_pp0_z1::1",
+        "x": -9.687999999999999,
+        "y": 4.934199999999999,
+        "z": 1,
+        "connectionName": "source_trace_28__source_net_28_mst2",
+        "rootConnectionName": "source_trace_28",
+        "prevPortPointId": "ce3725_pp2_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce3823_pp0_z0::0",
+        "x": -9.687999999999999,
+        "y": 11.8849,
+        "z": 0,
+        "connectionName": "source_trace_130__source_net_130_mst1",
+        "rootConnectionName": "source_trace_130",
+        "nextPortPointId": "ce3821_pp2_z0::0"
+      },
+      {
+        "portPointId": "ce3821_pp2_z0::0",
+        "x": -9.687999999999999,
+        "y": 10.759899999999998,
+        "z": 0,
+        "connectionName": "source_trace_130__source_net_130_mst1",
+        "rootConnectionName": "source_trace_130",
+        "prevPortPointId": "ce3823_pp0_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce3719_pp1_z0::0",
+        "x": -20.453775,
+        "y": 4.236799999999999,
+        "z": 0,
+        "connectionName": "source_trace_53__source_net_53_mst0",
+        "rootConnectionName": "source_trace_53",
+        "nextPortPointId": "ce3818_pp2_z0::0"
+      },
+      {
+        "portPointId": "ce3818_pp2_z0::0",
+        "x": -9.687999999999999,
+        "y": 8.5872,
+        "z": 0,
+        "connectionName": "source_trace_53__source_net_53_mst0",
+        "rootConnectionName": "source_trace_53",
+        "prevPortPointId": "ce3719_pp1_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce3719_pp6_z0::0",
+        "x": -18.542524999999998,
+        "y": 4.236799999999999,
+        "z": 0,
+        "connectionName": "source_trace_52__source_net_52_mst0",
+        "rootConnectionName": "source_trace_52",
+        "nextPortPointId": "ce3818_pp1_z1::1"
+      },
+      {
+        "portPointId": "ce3818_pp1_z1::1",
+        "x": -9.687999999999999,
+        "y": 6.6168000000000005,
+        "z": 1,
+        "connectionName": "source_trace_52__source_net_52_mst0",
+        "rootConnectionName": "source_trace_52",
+        "prevPortPointId": "ce3719_pp6_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce3686_pp4_z1::1",
+        "x": -21.409399999999998,
+        "y": 8.145299999999999,
+        "z": 1,
+        "connectionName": "source_trace_40__source_net_40_mst1",
+        "rootConnectionName": "source_trace_40",
+        "nextPortPointId": "ce3725_pp0_z0::0"
+      },
+      {
+        "portPointId": "ce3725_pp0_z0::0",
+        "x": -21.409399999999998,
+        "y": 12.884633333333333,
+        "z": 0,
+        "connectionName": "source_trace_40__source_net_40_mst1",
+        "rootConnectionName": "source_trace_40",
+        "prevPortPointId": "ce3686_pp4_z1::1"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce3820_pp0_z1::1",
+        "x": -9.687999999999999,
+        "y": 9.7599,
+        "z": 1,
+        "connectionName": "source_trace_51__source_net_51",
+        "rootConnectionName": "source_trace_51",
+        "nextPortPointId": "ce3817_pp4_z0::0"
+      },
+      {
+        "portPointId": "ce3817_pp4_z0::0",
+        "x": -9.687999999999999,
+        "y": 5.3991333333333325,
+        "z": 0,
+        "connectionName": "source_trace_51__source_net_51",
+        "rootConnectionName": "source_trace_51",
+        "prevPortPointId": "ce3820_pp0_z1::1"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce3818_pp2_z1::1",
+        "x": -9.687999999999999,
+        "y": 8.5872,
+        "z": 1,
+        "connectionName": "source_trace_50__source_net_50",
+        "rootConnectionName": "source_trace_50",
+        "nextPortPointId": "ce3817_pp3_z0::0"
+      },
+      {
+        "portPointId": "ce3817_pp3_z0::0",
+        "x": -9.687999999999999,
+        "y": 4.934199999999999,
+        "z": 0,
+        "connectionName": "source_trace_50__source_net_50",
+        "rootConnectionName": "source_trace_50",
+        "prevPortPointId": "ce3818_pp2_z1::1"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce3810_pp15_z0::0",
+        "x": -11.153175,
+        "y": 13.764799999999997,
+        "z": 0,
+        "connectionName": "source_trace_48__source_net_48",
+        "rootConnectionName": "source_trace_48",
+        "nextPortPointId": "ce3818_pp1_z0::0"
+      },
+      {
+        "portPointId": "ce3818_pp1_z0::0",
+        "x": -9.687999999999999,
+        "y": 6.6168000000000005,
+        "z": 0,
+        "connectionName": "source_trace_48__source_net_48",
+        "rootConnectionName": "source_trace_48",
+        "prevPortPointId": "ce3810_pp15_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce3824_pp2_z1::1",
+        "x": -9.687999999999999,
+        "y": 13.168599999999998,
+        "z": 1,
+        "connectionName": "source_trace_47__source_net_47",
+        "rootConnectionName": "source_trace_47",
+        "nextPortPointId": "ce3813_pp5_z1::1"
+      },
+      {
+        "portPointId": "ce3813_pp5_z1::1",
+        "x": -11.628212499999998,
+        "y": 4.236799999999999,
+        "z": 1,
+        "connectionName": "source_trace_47__source_net_47",
+        "rootConnectionName": "source_trace_47",
+        "prevPortPointId": "ce3824_pp2_z1::1"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce3822_pp0_z1::1",
+        "x": -9.687999999999999,
+        "y": 11.884899999999998,
+        "z": 1,
+        "connectionName": "source_trace_46__source_net_46",
+        "rootConnectionName": "source_trace_46",
+        "nextPortPointId": "ce3813_pp7_z1::1"
+      },
+      {
+        "portPointId": "ce3813_pp7_z1::1",
+        "x": -10.4597375,
+        "y": 4.236799999999999,
+        "z": 1,
+        "connectionName": "source_trace_46__source_net_46",
+        "rootConnectionName": "source_trace_46",
+        "prevPortPointId": "ce3822_pp0_z1::1"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce3725_pp1_z0::0",
+        "x": -21.409399999999998,
+        "y": 13.236699999999999,
+        "z": 0,
+        "connectionName": "source_trace_41__source_net_41",
+        "rootConnectionName": "source_trace_41",
+        "nextPortPointId": "ce3821_pp3_z0::0"
+      },
+      {
+        "portPointId": "ce3821_pp3_z0::0",
+        "x": -9.687999999999999,
+        "y": 11.384899999999998,
+        "z": 0,
+        "connectionName": "source_trace_41__source_net_41",
+        "rootConnectionName": "source_trace_41",
+        "prevPortPointId": "ce3725_pp1_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce3824_pp0_z0::0",
+        "x": -9.687999999999999,
+        "y": 13.168599999999998,
+        "z": 0,
+        "connectionName": "source_trace_35__source_net_35",
+        "rootConnectionName": "source_trace_35",
+        "nextPortPointId": "ce3817_pp0_z0::0"
+      },
+      {
+        "portPointId": "ce3817_pp0_z0::0",
+        "x": -9.687999999999999,
+        "y": 4.469266666666665,
+        "z": 0,
+        "connectionName": "source_trace_35__source_net_35",
+        "rootConnectionName": "source_trace_35",
+        "prevPortPointId": "ce3824_pp0_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce3810_pp12_z0::0",
+        "x": -14.083524999999998,
+        "y": 13.764799999999997,
+        "z": 0,
+        "connectionName": "source_trace_34__source_net_34",
+        "rootConnectionName": "source_trace_34",
+        "nextPortPointId": "ce3812_pp4_z0::0"
+      },
+      {
+        "portPointId": "ce3812_pp4_z0::0",
+        "x": -14.041274999999999,
+        "y": 4.236799999999999,
+        "z": 0,
+        "connectionName": "source_trace_34__source_net_34",
+        "rootConnectionName": "source_trace_34",
+        "prevPortPointId": "ce3810_pp12_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce3810_pp12_z1::1",
+        "x": -15.548699999999998,
+        "y": 13.764799999999997,
+        "z": 1,
+        "connectionName": "source_trace_33__source_net_33",
+        "rootConnectionName": "source_trace_33",
+        "nextPortPointId": "ce3813_pp8_z1::1"
+      },
+      {
+        "portPointId": "ce3813_pp8_z1::1",
+        "x": -9.875499999999999,
+        "y": 4.236799999999999,
+        "z": 1,
+        "connectionName": "source_trace_33__source_net_33",
+        "rootConnectionName": "source_trace_33",
+        "prevPortPointId": "ce3810_pp12_z1::1"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce3810_pp10_z0::0",
+        "x": -17.013875,
+        "y": 13.764799999999997,
+        "z": 0,
+        "connectionName": "source_trace_32__source_net_32",
+        "rootConnectionName": "source_trace_32",
+        "nextPortPointId": "ce3815_pp0_z0::0"
+      },
+      {
+        "portPointId": "ce3815_pp0_z0::0",
+        "x": -10.7294,
+        "y": 4.236799999999999,
+        "z": 0,
+        "connectionName": "source_trace_32__source_net_32",
+        "rootConnectionName": "source_trace_32",
+        "prevPortPointId": "ce3810_pp10_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce3810_pp7_z0::0",
+        "x": -19.944225,
+        "y": 13.764799999999997,
+        "z": 0,
+        "connectionName": "source_trace_31__source_net_31",
+        "rootConnectionName": "source_trace_31",
+        "nextPortPointId": "ce3812_pp5_z0::0"
+      },
+      {
+        "portPointId": "ce3812_pp5_z0::0",
+        "x": -12.650025,
+        "y": 4.236799999999999,
+        "z": 0,
+        "connectionName": "source_trace_31__source_net_31",
+        "rootConnectionName": "source_trace_31",
+        "prevPortPointId": "ce3810_pp7_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce3813_pp6_z1::1",
+        "x": -11.043975,
+        "y": 4.236799999999999,
+        "z": 1,
+        "connectionName": "source_trace_26__source_net_26",
+        "rootConnectionName": "source_trace_26",
+        "nextPortPointId": "ce3820_pp1_z1::1"
+      },
+      {
+        "portPointId": "ce3820_pp1_z1::1",
+        "x": -9.687999999999999,
+        "y": 10.0099,
+        "z": 1,
+        "connectionName": "source_trace_26__source_net_26",
+        "rootConnectionName": "source_trace_26",
+        "prevPortPointId": "ce3813_pp6_z1::1"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce3813_pp4_z1::1",
+        "x": -12.212449999999999,
+        "y": 4.236799999999999,
+        "z": 1,
+        "connectionName": "source_trace_24__source_net_24",
+        "rootConnectionName": "source_trace_24",
+        "nextPortPointId": "ce3821_pp2_z1::1"
+      },
+      {
+        "portPointId": "ce3821_pp2_z1::1",
+        "x": -9.687999999999999,
+        "y": 11.072399999999998,
+        "z": 1,
+        "connectionName": "source_trace_24__source_net_24",
+        "rootConnectionName": "source_trace_24",
+        "prevPortPointId": "ce3813_pp4_z1::1"
+      }
+    ]
+  ],
+  "availableZ": [
+    0,
+    1
+  ]
+}


### PR DESCRIPTION

<img width="468" height="482" alt="image" src="https://github.com/user-attachments/assets/de3ce7e2-47ce-4b36-9165-971dee66c246" />

<img width="474" height="392" alt="image" src="https://github.com/user-attachments/assets/57671213-a09a-4b4d-8cbf-4a8cc00ba83a" />


## What changed

- remove Pipeline 7's fixed 8,000-round inner high-density cap
- initialize candidates through their idempotent setup lifecycle so their problem- and effort-derived limits are known without advancing them
- derive the supervisor limit from every live candidate's remaining work
- preserve the existing ordering portfolio as the initial search
- expand into the remaining deterministic ordering variants only after the initial portfolio consumes an aggregate exploration budget equal to its most expensive candidate's natural budget, or exhausts
- leave candidate selection to the existing fitness scheduler
- add a focused regression fixture and tests for the large sample 2 node

## Why

The sample 2 node is routable at its original physical size. The fixed outer cap stopped the portfolio before a viable ordering completed; grow/shrink later returned invalid direct connections, producing long intersecting traces.

An eager six-ordering portfolio removed those malformed traces, but changed winners on easy boards and regressed sample 5 from a DRC pass to a failure. This staged policy keeps the original portfolio behavior first, scales additional search breadth from the candidates' own budgets instead of a fixed iteration count, and never directly selects or forces a solver.

## Validation

Dataset 18, effort 1x:

| Sample | Completion | Relaxed DRC | High-density stage |
| --- | --- | --- | ---: |
| 1 | pass | fail, 2 errors (matches baseline) | 9.2s |
| 2 | pass | fail, 72 errors | 105.5s |
| 5 | pass | pass, 0 errors (matches baseline) | 10.8s |
| 6 | pass | fail, 506 errors | 257.1s |

- sample 2's butchered cross-board traces are visually removed
- the captured hard node solves at its original size with 19 routes, without resize or invalid fallback output
- 23 focused tests pass
- production TypeScript and declaration build passes
- formatting, lint, and diff checks pass
