### PR TITLE
Fix benchmark snapshot background zoom

### DIFF
--- a/scripts/benchmark/index.ts
+++ b/scripts/benchmark/index.ts
@@ -109,9 +109,7 @@ export const sanitizeBenchmarkSnapshotSvg = (imageSvg: string): string => {
     : -1
   const rootBackgroundMatch =
     svgContentsStart >= 0
-      ? sanitizedSvg
-          .slice(svgContentsStart)
-          .match(/^(\s*)(<rect\b[^>]*\/?>)/i)
+      ? sanitizedSvg.slice(svgContentsStart).match(/^(\s*)(<rect\b[^>]*\/?>)/i)
       : null
 
   if (
@@ -124,10 +122,7 @@ export const sanitizeBenchmarkSnapshotSvg = (imageSvg: string): string => {
     const [x, y, width, height] = viewBoxValues
     const normalizedBackground = rootBackgroundMatch[2]
       .replace(/\s+(?:x|y)=["'][^"']*["']/gi, "")
-      .replace(
-        /\bwidth=["']100%["']/i,
-        `x="${x}" y="${y}" width="${width}"`,
-      )
+      .replace(/\bwidth=["']100%["']/i, `x="${x}" y="${y}" width="${width}"`)
       .replace(/\bheight=["']100%["']/i, `height="${height}"`)
     const backgroundStart = svgContentsStart + rootBackgroundMatch[1].length
     sanitizedSvg =

--- a/scripts/benchmark/index.ts
+++ b/scripts/benchmark/index.ts
@@ -120,14 +120,14 @@ export const sanitizeBenchmarkSnapshotSvg = (imageSvg: string): string => {
     /\bheight=["']100%["']/i.test(rootBackgroundMatch[2])
   ) {
     const [x, y, width, height] = viewBoxValues
-    const normalizedBackground = rootBackgroundMatch[2]
+    const backgroundRectWithViewBoxBounds = rootBackgroundMatch[2]
       .replace(/\s+(?:x|y)=["'][^"']*["']/gi, "")
       .replace(/\bwidth=["']100%["']/i, `x="${x}" y="${y}" width="${width}"`)
       .replace(/\bheight=["']100%["']/i, `height="${height}"`)
     const backgroundStart = svgContentsStart + rootBackgroundMatch[1].length
     sanitizedSvg =
       sanitizedSvg.slice(0, backgroundStart) +
-      normalizedBackground +
+      backgroundRectWithViewBoxBounds +
       sanitizedSvg.slice(backgroundStart + rootBackgroundMatch[2].length)
   }
   sanitizedSvg = sanitizedSvg.replace(

--- a/scripts/benchmark/index.ts
+++ b/scripts/benchmark/index.ts
@@ -96,6 +96,45 @@ const escapeHtml = (value: unknown): string =>
 
 export const sanitizeBenchmarkSnapshotSvg = (imageSvg: string): string => {
   let sanitizedSvg = imageSvg.replace(/<script\b[\s\S]*?<\/script>/gi, "")
+  // Keep the generated root background in the same user-space coordinates as
+  // the circuit so changing the root viewBox pans and zooms them together.
+  const openingSvgTag = sanitizedSvg.match(/<svg\b[^>]*>/i)?.[0]
+  const viewBoxValues = openingSvgTag
+    ?.match(/\bviewBox=["']([^"']+)["']/i)?.[1]
+    ?.trim()
+    .split(/[\s,]+/)
+    .map(Number)
+  const svgContentsStart = openingSvgTag
+    ? sanitizedSvg.indexOf(openingSvgTag) + openingSvgTag.length
+    : -1
+  const rootBackgroundMatch =
+    svgContentsStart >= 0
+      ? sanitizedSvg
+          .slice(svgContentsStart)
+          .match(/^(\s*)(<rect\b[^>]*\/?>)/i)
+      : null
+
+  if (
+    viewBoxValues?.length === 4 &&
+    viewBoxValues.every(Number.isFinite) &&
+    rootBackgroundMatch &&
+    /\bwidth=["']100%["']/i.test(rootBackgroundMatch[2]) &&
+    /\bheight=["']100%["']/i.test(rootBackgroundMatch[2])
+  ) {
+    const [x, y, width, height] = viewBoxValues
+    const normalizedBackground = rootBackgroundMatch[2]
+      .replace(/\s+(?:x|y)=["'][^"']*["']/gi, "")
+      .replace(
+        /\bwidth=["']100%["']/i,
+        `x="${x}" y="${y}" width="${width}"`,
+      )
+      .replace(/\bheight=["']100%["']/i, `height="${height}"`)
+    const backgroundStart = svgContentsStart + rootBackgroundMatch[1].length
+    sanitizedSvg =
+      sanitizedSvg.slice(0, backgroundStart) +
+      normalizedBackground +
+      sanitizedSvg.slice(backgroundStart + rootBackgroundMatch[2].length)
+  }
   sanitizedSvg = sanitizedSvg.replace(
     /<g\b[^>]*\bid=["']crosshair["'][\s\S]*?<\/g>/gi,
     "",

--- a/tests/benchmark-snapshots-html.test.ts
+++ b/tests/benchmark-snapshots-html.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path"
 import { expect, test } from "bun:test"
 import { createBenchmarkSnapshotWriter } from "../scripts/benchmark/index"
 
-test("benchmark snapshot HTML shows routing counts and keeps SVG viewing crisp", async () => {
+test("benchmark snapshot HTML shows counts and keeps the SVG background aligned", async () => {
   const directory = await mkdtemp(join(tmpdir(), "benchmark-snapshots-"))
   const htmlPath = join(directory, "benchmark-snapshots.html")
 
@@ -22,7 +22,7 @@ test("benchmark snapshot HTML shows routing counts and keeps SVG viewing crisp",
       relaxedDrcPassed: false,
       drcErrorCount: 2,
       imageSvg:
-        '<svg width="640" height="640" viewBox="0 0 640 640"><g><circle data-type="point" data-label="source_trace_0 (top)" cx="10" cy="10" r="3" /></g><g><polyline data-type="line" points="0,0 10,10" /></g></svg>',
+        '<svg width="640" height="640" viewBox="-10 -20 640 320"><rect width="100%" height="100%" fill="white"/><g><circle data-type="point" data-label="source_trace_0 (top)" cx="10" cy="10" r="3" /></g><g><polyline data-type="line" points="0,0 10,10" /></g></svg>',
     })
     await writer.finish()
 
@@ -31,6 +31,10 @@ test("benchmark snapshot HTML shows routing counts and keeps SVG viewing crisp",
     expect(html).toContain("<dt>DRC Issue Count</dt><dd>2</dd>")
     expect(html).toContain('<polyline data-type="line"')
     expect(html).not.toContain('data-type="point"')
+    expect(html).toContain(
+      '<rect x="-10" y="-20" width="640" height="320" fill="white"/>',
+    )
+    expect(html).not.toContain('<rect width="100%" height="100%"')
     expect(html).toContain("state.svg.setAttribute(")
     expect(html).toContain('"viewBox"')
     expect(html).toContain(".snapshot-viewer.is-full-size")


### PR DESCRIPTION
## Summary

- normalize the generated SVG root background to the original `viewBox` coordinates
- keep the background aligned with circuit geometry during vector `viewBox` zoom and pan
- add regression coverage for non-zero, non-square `viewBox` bounds

## Root cause

PR #1631 changed snapshot zooming from a CSS transform to updates of the root SVG `viewBox` so zoomed circuits stay sharp. The generated background was still a percentage-sized root rectangle (`width="100%" height="100%"`), whose bounds resolve against the viewport rather than the circuit's original coordinate space. After zooming or panning, the circuit moved with the `viewBox` while the background could clip or remain at the old boundary.

This change converts that generated background rectangle to the original numeric `viewBox` bounds before embedding the SVG. It then behaves like the rest of the scene while preserving vector rendering.

## Validation

- `bun test tests/benchmark-snapshots-html.test.ts --timeout 9999999`
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`
