### PR TITLE
[41.6% reduction in DRC] Deduplicate autorouter DRC reports

### DIFF
--- a/lib/testing/getDrcErrors.ts
+++ b/lib/testing/getDrcErrors.ts
@@ -5,6 +5,7 @@ import {
   checkSameNetViaSpacing,
   checkTracesAreContiguous,
   checkViaTraceClearance,
+  dedupePcbDrcErrors,
 } from "@tscircuit/checks"
 import type {
   AnyCircuitElement,
@@ -98,13 +99,13 @@ export const getDrcErrors = (
     }),
   ]
 
-  const errors: DrcError[] = [
+  const errors = dedupePcbDrcErrors<DrcError>([
     ...traceErrors,
     ...checkTracesAreContiguous(circuitJson),
     ...viaTraceErrors,
     ...padTraceErrors,
     ...viaErrors,
-  ]
+  ])
 
   const vias = circuitJson.filter(
     (

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@tsci/0hmX.multi-component-dataset-srj01": "git+https://github.com/tscircuit/multi-component-dataset-srj01.git#abf9d17c966d466b56ac21b735c6bb6f4518919d",
     "@tsci/tscircuit.dataset-srj12-bus-routing": "git+https://github.com/tscircuit/dataset-srj12-bus-routing.git#ba82f86a7d1288566b7144eb8661ad2549c5f328",
     "@tscircuit/autorouting-dataset-01": "git+https://github.com/tscircuit/autorouting-dataset-01.git#52c45500b04d0380aa2a1be9b4c6f32d9b138553",
-    "@tscircuit/checks": "^0.0.143",
+    "@tscircuit/checks": "^0.0.144",
     "@tscircuit/circuit-json-util": "^0.0.94",
     "@tscircuit/core": "0.0.337",
     "@tscircuit/curvy-trace-solver": "^0.0.10",

--- a/tests/bugs/bugreport-b5b3b9d8-drc-count.test.ts
+++ b/tests/bugs/bugreport-b5b3b9d8-drc-count.test.ts
@@ -46,5 +46,10 @@ test("bugreport-b5b3b9d8 pipeline7 records current total DRC errors", () => {
     return acc
   }, {})
 
-  expect(errors).toHaveLength(9)
+  expect(errors).toHaveLength(6)
+  expect(errorCountByType).toEqual({
+    pcb_trace_error: 3,
+    pcb_via_trace_clearance_error: 1,
+    pcb_pad_trace_clearance_error: 2,
+  })
 })

--- a/tests/drc-deduplication.test.ts
+++ b/tests/drc-deduplication.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { getDrcErrors } from "lib/testing/getDrcErrors"
+
+test("getDrcErrors emits typed pad/via clearance errors without generic duplicates", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pad1",
+      shape: "rect",
+      x: 0,
+      y: 0.2,
+      width: 0.2,
+      height: 0.2,
+      layer: "top",
+    },
+    {
+      type: "pcb_via",
+      pcb_via_id: "via1",
+      x: 0.5,
+      y: 0.2,
+      hole_diameter: 0.2,
+      outer_diameter: 0.4,
+      layers: ["top", "bottom"],
+    },
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "trace1",
+      route: [
+        { route_type: "wire", x: -1, y: 0, width: 0.1, layer: "top" },
+        { route_type: "wire", x: 1, y: 0, width: 0.1, layer: "top" },
+      ],
+    },
+  ]
+
+  const { errors } = getDrcErrors(circuitJson, { traceClearance: 0.1 })
+
+  expect(
+    errors.filter((error) => error.type === "pcb_pad_trace_clearance_error"),
+  ).toHaveLength(1)
+  expect(
+    errors.filter((error) => error.type === "pcb_via_trace_clearance_error"),
+  ).toHaveLength(1)
+  expect(
+    errors.filter(
+      (error) =>
+        error.type === "pcb_trace_error" &&
+        (error.pcb_trace_error_id === "overlap_trace1_pad1" ||
+          error.pcb_trace_error_id === "overlap_trace1_via1"),
+    ),
+  ).toHaveLength(0)
+})


### PR DESCRIPTION
## Summary

- bump `@tscircuit/checks` to `^0.0.144`
- apply the shared `dedupePcbDrcErrors` helper to autorouter's assembled DRC result
- add a regression covering generic and typed pad/via reports for the same physical pairs

Depends on the merged checks fix: https://github.com/tscircuit/checks/pull/171

## Root cause

Autorouter's `getDrcErrors` calls the generic trace-overlap checker and the typed pad-trace/via-trace clearance checkers directly. It then concatenated all results, bypassing the aggregate APIs in `@tscircuit/checks` where equivalent generic records are deduplicated.

The shared helper retains the typed clearance record, including its actual and minimum clearance values, and removes only a generic `pcb_trace_error` with the same trace/object pair. Trace-trace and unmatched errors are unchanged.

## Impact

The Dataset 18 analysis found 898 duplicate records across the 14 failing samples. With the released `@tscircuit/checks@0.0.144` package and this integration, sample 3 reports 65 records for 65 physical issues, with its 13 duplicate records and 24 rotated-pad continuity false positives eliminated.

## Validation

- `bun test --timeout 9999999 tests/drc-deduplication.test.ts tests/drc-via-spacing.test.ts tests/utils/convertToCircuitJson-obstacle-connectivity-source-net-ids.test.ts` — 5 passed, 0 failed
- `bunx tsc --noEmit`
- `bun run build`
- Dataset 18 sample 3 using published `@tscircuit/checks@0.0.144`: 65 raw reports, 65 physical issues, 0 continuity false positives, 0 duplicate records
