### PR TITLE
Improve benchmark result comparison layout

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -478,23 +478,6 @@ jobs:
                 ),
               ]
             }
-            const renderCombinedSummary = (reports) => {
-              const rows = reports.flatMap((report) =>
-                Array.isArray(report?.summary)
-                  ? report.summary.map((row) => ({ report, row }))
-                  : [],
-              )
-              if (rows.length === 0) {
-                return []
-              }
-              return [
-                '| Dataset | Scenarios | Solver | Completed % | Relaxed DRC Pass % | Timed Out | P50 Time | P95 Time | Avg Via |',
-                '| --- | ---: | --- | --- | --- | --- | --- | --- | --- |',
-                ...rows.map(({ report, row }) =>
-                  `| ${escapeHtml(report.datasetName ?? '')} | ${escapeHtml(report.scenarioCount ?? '')} | ${escapeHtml(formatSolverDisplayName(row.solverName, report.effortLabel))} | ${escapeHtml(row.completedRateLabel)} | ${escapeHtml(row.relaxedDrcRateLabel)} | ${escapeHtml(row.timedOutLabel)} | ${escapeHtml(formatTime(row.p50TimeMs))} | ${escapeHtml(formatTime(row.p95TimeMs))} | ${escapeHtml(formatAverage(row.avgVia))} |`,
-                ),
-              ]
-            }
             const getOutcomeScore = (test) => {
               if (!test?.didSolve) return 0
               if (test.relaxedDrcPassed) return 2
@@ -589,16 +572,21 @@ jobs:
             }
             const renderReport = (report, fallbackText, options = {}) => {
               if (!report) {
+                if (options.omitSummary) return []
                 return ['```', truncate(fallbackText, maxLength), '```']
               }
               return [
                 ...(options.omitSummary ? [] : renderSummary(report)),
-                '',
-                '<details>',
-                '<summary>Details</summary>',
-                '',
-                ...renderTests(report, options),
-                '</details>',
+                ...(options.omitDetails
+                  ? []
+                  : [
+                      '',
+                      '<details>',
+                      `<summary>${options.detailsLabel ?? 'Details'}</summary>`,
+                      '',
+                      ...renderTests(report, options),
+                      '</details>',
+                    ]),
               ]
             }
             const getBenchmarkReports = (report) => {
@@ -611,27 +599,12 @@ jobs:
               if (!datasetName) return null
               return getBenchmarkReports(mainReport).find((report) => report?.datasetName === datasetName) ?? null
             }
-            const renderReportCollection = (report, fallbackText, options = {}) => {
-              const reports = getBenchmarkReports(report)
-              if (reports.length === 0) {
-                return renderReport(null, fallbackText, options)
+            const renderPreviousMainSummary = (report, datasetName) => {
+              if (report) {
+                return renderReport(report, '', { omitDetails: true })
               }
-              if (reports.length === 1 && !options.forceCombinedSummary) {
-                return renderReport(reports[0], fallbackText, options)
-              }
-              return [
-                ...renderCombinedSummary(reports),
-                '',
-                ...reports.flatMap((datasetReport, index) => [
-                  ...(index === 0 ? [] : ['']),
-                  `### ${escapeHtml(datasetReport.datasetName ?? `Dataset ${index + 1}`)}`,
-                  '',
-                  ...renderReport(datasetReport, fallbackText, {
-                    ...options,
-                    omitSummary: true,
-                  }),
-                ]),
-              ]
+              const datasetLabel = datasetName ? ` for \`${escapeHtml(datasetName)}\`` : ''
+              return [`_No previous main run is available${datasetLabel}._`]
             }
             const readJson = (path) => {
               if (!fs.existsSync(path)) return null
@@ -646,11 +619,11 @@ jobs:
             const readText = (path) => fs.existsSync(path) ? fs.readFileSync(path, 'utf8').trim() : null
 
             const prText = readText('benchmark-result-pr.txt') ?? readText('benchmark-result.txt')
-            const mainText = readText('benchmark-result-main.txt') ?? '(not available)'
             const prReport = readJson('benchmark-result-pr.json') ?? readJson('benchmark-result.json')
             const mainReport = readJson('benchmark-result-main.json')
             const viaCellReport = readJson('benchmark-via-cells.json')
-            const mainDatasetReport = getMainReportForDataset(mainReport, prReport?.datasetName)
+            const benchmarkDatasetName = prReport?.datasetName ?? process.env.BENCHMARK_DATASET
+            const mainDatasetReport = getMainReportForDataset(mainReport, benchmarkDatasetName)
             const mainIndex = buildMainIndex(mainDatasetReport)
             const viaCellIndex = buildViaCellIndex(viaCellReport)
             const runUrl = `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`
@@ -666,18 +639,23 @@ jobs:
                     '',
                   ]
                 : []),
-              '<details>',
-              '<summary>Main Branch Results</summary>',
+              '### Previous main run',
               '',
-              ...renderReportCollection(mainReport, mainText, {
-                forceCombinedSummary: true,
-              }),
-              '</details>',
+              ...renderPreviousMainSummary(mainDatasetReport, benchmarkDatasetName),
               '',
-              '<details open>',
-              '<summary>PR Results</summary>',
+              '### PR run',
               '',
               ...renderReport(prReport, prText ?? '(benchmark results were not produced)', {
+                omitDetails: true,
+              }),
+              '',
+              ...renderReport(mainDatasetReport, '', {
+                detailsLabel: 'Previous main run details',
+                omitSummary: true,
+              }),
+              '',
+              ...renderReport(prReport, prText ?? '(benchmark results were not produced)', {
+                detailsLabel: 'PR run details',
                 includeDelta: true,
                 mainIndex,
                 viaCellIndex,
@@ -689,7 +667,6 @@ jobs:
                     'Profile solver comparison is still running.',
                   ]
                 : []),
-              '</details>',
               '',
               `Workflow: [View run](${runUrl})`,
               `Artifact: ${runUrl}`,
@@ -989,23 +966,6 @@ jobs:
                 ),
               ]
             }
-            const renderCombinedSummary = (reports) => {
-              const rows = reports.flatMap((report) =>
-                Array.isArray(report?.summary)
-                  ? report.summary.map((row) => ({ report, row }))
-                  : [],
-              )
-              if (rows.length === 0) {
-                return []
-              }
-              return [
-                '| Dataset | Scenarios | Solver | Completed % | Relaxed DRC Pass % | Timed Out | P50 Time | P95 Time | Avg Via |',
-                '| --- | ---: | --- | --- | --- | --- | --- | --- | --- |',
-                ...rows.map(({ report, row }) =>
-                  `| ${escapeHtml(report.datasetName ?? '')} | ${escapeHtml(report.scenarioCount ?? '')} | ${escapeHtml(formatSolverDisplayName(row.solverName, report.effortLabel))} | ${escapeHtml(row.completedRateLabel)} | ${escapeHtml(row.relaxedDrcRateLabel)} | ${escapeHtml(row.timedOutLabel)} | ${escapeHtml(formatTime(row.p50TimeMs))} | ${escapeHtml(formatTime(row.p95TimeMs))} | ${escapeHtml(formatAverage(row.avgVia))} |`,
-                ),
-              ]
-            }
             const getOutcomeScore = (test) => {
               if (!test?.didSolve) return 0
               if (test.relaxedDrcPassed) return 2
@@ -1100,17 +1060,22 @@ jobs:
             }
             const renderReport = (report, fallbackText, options = {}) => {
               if (!report) {
+                if (options.omitSummary) return []
                 return ['```', truncate(fallbackText, maxLength), '```']
               }
 
               return [
                 ...(options.omitSummary ? [] : renderSummary(report)),
-                '',
-                '<details>',
-                '<summary>Details</summary>',
-                '',
-                ...renderTests(report, options),
-                '</details>',
+                ...(options.omitDetails
+                  ? []
+                  : [
+                      '',
+                      '<details>',
+                      `<summary>${options.detailsLabel ?? 'Details'}</summary>`,
+                      '',
+                      ...renderTests(report, options),
+                      '</details>',
+                    ]),
               ]
             }
             const getBenchmarkReports = (report) => {
@@ -1123,27 +1088,12 @@ jobs:
               if (!datasetName) return null
               return getBenchmarkReports(mainReport).find((report) => report?.datasetName === datasetName) ?? null
             }
-            const renderReportCollection = (report, fallbackText, options = {}) => {
-              const reports = getBenchmarkReports(report)
-              if (reports.length === 0) {
-                return renderReport(null, fallbackText, options)
+            const renderPreviousMainSummary = (report, datasetName) => {
+              if (report) {
+                return renderReport(report, '', { omitDetails: true })
               }
-              if (reports.length === 1 && !options.forceCombinedSummary) {
-                return renderReport(reports[0], fallbackText, options)
-              }
-              return [
-                ...renderCombinedSummary(reports),
-                '',
-                ...reports.flatMap((datasetReport, index) => [
-                  ...(index === 0 ? [] : ['']),
-                  `### ${escapeHtml(datasetReport.datasetName ?? `Dataset ${index + 1}`)}`,
-                  '',
-                  ...renderReport(datasetReport, fallbackText, {
-                    ...options,
-                    omitSummary: true,
-                  }),
-                ]),
-              ]
+              const datasetLabel = datasetName ? ` for \`${escapeHtml(datasetName)}\`` : ''
+              return [`_No previous main run is available${datasetLabel}._`]
             }
             const readJson = (path) => {
               if (!fs.existsSync(path)) return null
@@ -1246,17 +1196,16 @@ jobs:
                 }),
               ]
             }
-            const renderProfileSolversDetails = (lines) => [
+            const renderProfileSolversDetails = (label, lines) => [
               '',
               '<details>',
-              '<summary>Profile Solvers</summary>',
+              `<summary>${label}</summary>`,
               '',
               ...lines,
               '</details>',
             ]
 
             const prText = readText('benchmark-result-pr.txt') ?? readText('benchmark-result.txt')
-            const mainText = readText('benchmark-result-main.txt') ?? '(not available)'
             const prProfileSolversText = readText('profile-solvers-pr.txt')
             const mainProfileSolversText = readText('profile-solvers-main.txt')
             const prProfileSolversReport = readJson('profile-solvers-pr.json')
@@ -1264,7 +1213,8 @@ jobs:
             const prReport = readJson('benchmark-result-pr.json') ?? readJson('benchmark-result.json')
             const mainReport = readJson('benchmark-result-main.json')
             const viaCellReport = readJson('benchmark-via-cells.json')
-            const mainDatasetReport = getMainReportForDataset(mainReport, prReport?.datasetName)
+            const benchmarkDatasetName = prReport?.datasetName ?? process.env.BENCHMARK_DATASET
+            const mainDatasetReport = getMainReportForDataset(mainReport, benchmarkDatasetName)
             const mainIndex = buildMainIndex(mainDatasetReport)
             const viaCellIndex = buildViaCellIndex(viaCellReport)
             const runUrl = `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`
@@ -1298,23 +1248,29 @@ jobs:
                     '',
                   ]
                 : []),
-              '<details>',
-              '<summary>Main Branch Results</summary>',
+              '### Previous main run',
               '',
-              ...renderReportCollection(mainReport, mainText, {
-                forceCombinedSummary: true,
+              ...renderPreviousMainSummary(mainDatasetReport, benchmarkDatasetName),
+              '',
+              '### PR run',
+              '',
+              ...renderReport(prReport, prText ?? '(benchmark results were not produced)', {
+                omitDetails: true,
+              }),
+              '',
+              ...renderReport(mainDatasetReport, '', {
+                detailsLabel: 'Previous main run details',
+                omitSummary: true,
               }),
               ...(hasProfileSolvers
                 ? renderProfileSolversDetails(
+                    'Previous main profile details',
                     renderMainProfileSolvers(mainProfileSolversReport),
                   )
                 : []),
-              '</details>',
-              '',
-              '<details open>',
-              '<summary>PR Results</summary>',
               '',
               ...renderReport(prReport, prText ?? '(benchmark results were not produced)', {
+                detailsLabel: 'PR run details',
                 includeDelta: true,
                 mainIndex,
                 viaCellIndex,
@@ -1322,13 +1278,13 @@ jobs:
               }),
               ...(hasProfileSolvers
                 ? renderProfileSolversDetails(
+                    'PR profile comparison',
                     renderProfileComparison(
                       mainProfileSolversReport,
                       prProfileSolversReport,
                     ),
                   )
                 : []),
-              '</details>',
               '',
               `Workflow: [View run](${runUrl})`,
               `Artifact: ${runUrl}`,

--- a/tests/pr-benchmark-command.test.ts
+++ b/tests/pr-benchmark-command.test.ts
@@ -61,4 +61,14 @@ test("PR benchmark commands preserve arguments and fan-out behavior", () => {
     "benchmark_args_json: JSON.stringify(command.benchmarkArgs)",
   )
   expect(benchmarkWorkflow).toContain("benchmark_args_json:")
+  expect(benchmarkWorkflow).not.toContain(
+    "<summary>Main Branch Results</summary>",
+  )
+  expect(benchmarkWorkflow.match(/'### Previous main run'/g)).toHaveLength(2)
+  expect(benchmarkWorkflow.match(/'### PR run'/g)).toHaveLength(2)
+  expect(
+    benchmarkWorkflow.match(/No previous main run is available/g),
+  ).toHaveLength(2)
+  expect(benchmarkWorkflow).toContain("'Previous main profile details'")
+  expect(benchmarkWorkflow).toContain("'PR profile comparison'")
 })


### PR DESCRIPTION
## Summary

- show the matching previous main-run summary directly above the PR summary
- keep per-sample benchmark results collapsed below the comparison tables
- show a concise unavailable message when a dataset has no stored main baseline
- distinguish previous-main and PR profile sections

## Validation

- bun test tests/pr-benchmark-command.test.ts --timeout 9999999
- benchmark workflow YAML parsed successfully
- git diff --check
- independent review-agent pass: no remaining findings