### PR TITLE
Remove extra PR benchmark summary

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -643,12 +643,6 @@ jobs:
               '',
               ...renderPreviousMainSummary(mainDatasetReport, benchmarkDatasetName),
               '',
-              '### PR run',
-              '',
-              ...renderReport(prReport, prText ?? '(benchmark results were not produced)', {
-                omitDetails: true,
-              }),
-              '',
               ...renderReport(mainDatasetReport, '', {
                 detailsLabel: 'Previous main run details',
                 omitSummary: true,
@@ -1251,12 +1245,6 @@ jobs:
               '### Previous main run',
               '',
               ...renderPreviousMainSummary(mainDatasetReport, benchmarkDatasetName),
-              '',
-              '### PR run',
-              '',
-              ...renderReport(prReport, prText ?? '(benchmark results were not produced)', {
-                omitDetails: true,
-              }),
               '',
               ...renderReport(mainDatasetReport, '', {
                 detailsLabel: 'Previous main run details',

--- a/tests/pr-benchmark-command.test.ts
+++ b/tests/pr-benchmark-command.test.ts
@@ -61,14 +61,4 @@ test("PR benchmark commands preserve arguments and fan-out behavior", () => {
     "benchmark_args_json: JSON.stringify(command.benchmarkArgs)",
   )
   expect(benchmarkWorkflow).toContain("benchmark_args_json:")
-  expect(benchmarkWorkflow).not.toContain(
-    "<summary>Main Branch Results</summary>",
-  )
-  expect(benchmarkWorkflow.match(/'### Previous main run'/g)).toHaveLength(2)
-  expect(benchmarkWorkflow.match(/'### PR run'/g)).toHaveLength(2)
-  expect(
-    benchmarkWorkflow.match(/No previous main run is available/g),
-  ).toHaveLength(2)
-  expect(benchmarkWorkflow).toContain("'Previous main profile details'")
-  expect(benchmarkWorkflow).toContain("'PR profile comparison'")
 })


### PR DESCRIPTION
Removes the duplicate PR-run benchmark summary blocks and the layout-specific test assertions added alongside them.