### PR TITLE
Fix Pipeline 7 debugger stage count

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -42,7 +42,6 @@ import {
   getGraphicsLayerForConnectionPoint,
   getGraphicsLayerForObstacle,
 } from "lib/utils/getGraphicsObjectLayer"
-import { getPresuppliedTraceVisualization } from "lib/utils/getPresuppliedTraceVisualization"
 import { calculateOptimalCapacityDepth } from "lib/utils/getTunedTotalCapacity1"
 import { getViaDimensions } from "lib/utils/getViaDimensions"
 import {
@@ -89,6 +88,35 @@ type PipelineStep<T extends new (...args: any[]) => BaseSolver> = {
     instance: AutoroutingPipelineSolver7_MultiGraph,
   ) => ConstructorParameters<T>
   onSolved?: (instance: AutoroutingPipelineSolver7_MultiGraph) => void
+}
+
+type PipelineVisualization = {
+  solverName: string
+  graphics: GraphicsObject | undefined
+}
+
+function assignSolverStep(
+  graphics: GraphicsObject,
+  solverStep: number,
+): GraphicsObject {
+  const assign = (objects?: Array<{ step?: number }>) =>
+    objects?.map((object) => ({
+      ...object,
+      graphicsStep: object.step,
+      step: solverStep,
+    }))
+
+  return {
+    ...graphics,
+    lines: assign(graphics.lines),
+    points: assign(graphics.points),
+    circles: assign(graphics.circles),
+    rects: assign(graphics.rects),
+    polygons: assign(graphics.polygons),
+    infiniteLines: assign(graphics.infiniteLines),
+    arrows: assign(graphics.arrows),
+    texts: assign(graphics.texts),
+  } as GraphicsObject
 }
 
 /**
@@ -785,21 +813,13 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
     const escapeViaLocationViz = this.escapeViaLocationSolver?.visualize()
     const netToPPSolver = this.netToPointPairsSolver?.visualize()
     const componentDetectionViz = this.componentDetectionSolver?.visualize()
-    const componentTopologyGeneratorViz =
-      this.componentTopologyGeneratorSolver?.visualize()
-    const globalTopologyGeneratorViz =
-      this.globalTopologyGeneratorSolver?.visualize()
+    const topologyPlanningViz = this.topologyPlanningSolver?.visualize()
     const topologyMergingViz = this.topologyMergingSolver?.visualize()
     const nodeSubdivisionViz = this.nodeDimensionSubdivisionSolver?.visualize()
-    const nodeTargetMergerViz = this.nodeTargetMerger?.visualize()
-    const singleLayerNodeMergerViz = this.singleLayerNodeMerger?.visualize()
-    const strawSolverViz = this.strawSolver?.visualize()
     const edgeViz = this.edgeSolver?.visualize()
-    const deadEndViz = this.deadEndSolver?.visualize()
     const availableSegmentPointViz =
       this.availableSegmentPointSolver?.visualize()
     const portPointPathingViz = this.portPointPathingSolver?.visualize()
-    const multiSectionOptViz = this.multiSectionPortPointOptimizer?.visualize()
     const uniformPortDistributionViz =
       this.uniformPortDistributionSolver?.visualize()
     const highDensityViz = this.highDensityRouteSolver?.visualize()
@@ -812,7 +832,6 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
     const traceWidthViz = this.traceWidthSolver?.visualize()
     const necessaryCrampedPortPointSolverViz =
       this.necessaryCrampedPortPointSolver?.visualize()
-    const highDensityRouteSolverViz = this.highDensityRouteSolver?.visualize()
     const srjToVisualize = this.originalSrj
     const problemOutline = srjToVisualize.outline
     const problemLines: Line[] = []
@@ -890,63 +909,108 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
       ],
       lines: problemLines,
     } as GraphicsObject
-    const visualizationOptions = {
-      traceColorMode: this.visualizationTraceColorMode,
-    } as const
-    const routeViz = getPresuppliedTraceVisualization({
-      srj: srjToVisualize,
-      visualizationOptions,
-    })
-    const problemViz = combineVisualizations(problemBaseViz, routeViz)
     const processedProblemViz =
       this.preprocessSimpleRouteJsonSolver?.visualize()
     const globalDrcForceImproveViz =
       this.globalDrcForceImproveSolver?.visualize()
     const exactGeometryDrcForceImproveViz =
       this.exactGeometryDrcForceImproveSolver?.visualize()
-    const visualizations = [
-      problemViz,
-      processedProblemViz,
-      componentDetectionViz,
-      componentTopologyGeneratorViz,
-      escapeViaLocationViz,
-      netToPPSolver,
-      globalTopologyGeneratorViz,
-      topologyMergingViz,
-      nodeSubdivisionViz,
-      nodeTargetMergerViz,
-      singleLayerNodeMergerViz,
-      strawSolverViz,
-      edgeViz,
-      deadEndViz,
-      availableSegmentPointViz,
-      necessaryCrampedPortPointSolverViz,
-      portPointPathingViz,
-      multiSectionOptViz,
-      uniformPortDistributionViz,
-      highDensityViz
-        ? combineVisualizations(problemBaseViz, highDensityViz)
-        : null,
-      highDensityForceImproveViz,
-      highDensityRepairViz,
-      highDensityStitchViz,
-      traceSimplificationViz,
-      lengthMatchingViz,
-      traceWidthViz,
-      globalDrcForceImproveViz,
-      exactGeometryDrcForceImproveViz,
-      this.solved
-        ? combineVisualizations(
-            problemBaseViz,
-            getPresuppliedTraceVisualization({
-              srj: this.originalSrj,
-              visualizationOptions,
-            }),
-            this.visualizeFinalOutput(),
-          )
-        : null,
-    ].filter(Boolean) as GraphicsObject[]
-    const graphics = combineVisualizations(...visualizations)
+    const visualizations: PipelineVisualization[] = [
+      {
+        solverName: "preprocessSimpleRouteJsonSolver",
+        graphics: processedProblemViz,
+      },
+      {
+        solverName: "componentDetectionSolver",
+        graphics: componentDetectionViz,
+      },
+      { solverName: "escapeViaLocationSolver", graphics: escapeViaLocationViz },
+      { solverName: "netToPointPairsSolver", graphics: netToPPSolver },
+      { solverName: "topologyPlanningSolver", graphics: topologyPlanningViz },
+      { solverName: "topologyMergingSolver", graphics: topologyMergingViz },
+      {
+        solverName: "nodeDimensionSubdivisionSolver",
+        graphics: nodeSubdivisionViz,
+      },
+      { solverName: "edgeSolver", graphics: edgeViz },
+      {
+        solverName: "availableSegmentPointSolver",
+        graphics: availableSegmentPointViz,
+      },
+      {
+        solverName: "necessaryCrampedPortPointSolver",
+        graphics: necessaryCrampedPortPointSolverViz,
+      },
+      {
+        solverName: "portPointPathingSolver",
+        graphics: portPointPathingViz,
+      },
+      {
+        solverName: "uniformPortDistributionSolver",
+        graphics: uniformPortDistributionViz,
+      },
+      {
+        solverName: "highDensityRouteSolver",
+        graphics: highDensityViz
+          ? combineVisualizations(problemBaseViz, highDensityViz)
+          : undefined,
+      },
+      {
+        solverName: "highDensityForceImproveSolver",
+        graphics: highDensityForceImproveViz,
+      },
+      { solverName: "highDensityRepairSolver", graphics: highDensityRepairViz },
+      { solverName: "highDensityStitchSolver", graphics: highDensityStitchViz },
+      {
+        solverName: "traceSimplificationSolver",
+        graphics: traceSimplificationViz,
+      },
+      { solverName: "lengthMatchingSolver", graphics: lengthMatchingViz },
+      { solverName: "traceWidthSolver", graphics: traceWidthViz },
+      {
+        solverName: "globalDrcForceImproveSolver",
+        graphics: globalDrcForceImproveViz,
+      },
+      {
+        solverName: "exactGeometryDrcForceImproveSolver",
+        graphics: combineVisualizations(
+          exactGeometryDrcForceImproveViz ?? {},
+          this.visualizeFinalOutput(),
+        ),
+      },
+    ]
+    const pipelineStepNumbers = new Map(
+      this.pipelineDef.map((pipelineStep, index) => [
+        pipelineStep.solverName,
+        index + 1,
+      ]),
+    )
+    const graphics = combineVisualizations(
+      ...visualizations.flatMap(({ solverName, graphics }) => {
+        if (!graphics) return []
+
+        const stepNumber = pipelineStepNumbers.get(solverName)
+        if (stepNumber === undefined) {
+          throw new Error(`Missing Pipeline 7 stage number for ${solverName}`)
+        }
+
+        return [assignSolverStep(graphics, stepNumber)]
+      }),
+    )
+    // NOTE: The graphics viewer discovers available steps from rendered
+    // objects. Empty stage markers preserve a selectable step for solvers
+    // whose visualization intentionally contains no geometry.
+    graphics.texts = [
+      ...(graphics.texts ?? []),
+      ...this.pipelineDef.map((pipelineStep, index) => ({
+        x: this.srj.bounds.minX,
+        y: this.srj.bounds.minY,
+        text: "",
+        fontSize: 0,
+        step: index + 1,
+        label: pipelineStep.solverName,
+      })),
+    ]
     return this.visualizationTraceColorMode === "net"
       ? applyNetColorsToGraphicsObject(graphics, this.colorMap)
       : graphics

--- a/lib/testing/AutoroutingPipelineDebugger.tsx
+++ b/lib/testing/AutoroutingPipelineDebugger.tsx
@@ -150,6 +150,35 @@ type AsyncPipelineDebuggerSolver = PipelineDebuggerSolver & {
   solveAsync?: () => Promise<void>
 }
 
+type GraphicsStepMode = "solver" | "graphics"
+
+const selectGraphicsStepMode = (
+  graphics: GraphicsObject,
+  stepMode: GraphicsStepMode,
+): GraphicsObject => {
+  if (stepMode === "solver") return graphics
+
+  const useGraphicsStep = (objects?: Array<{ step?: number }>) =>
+    objects?.map((object) => ({
+      ...object,
+      step: (object as { graphicsStep?: number }).graphicsStep ?? object.step,
+    }))
+
+  return {
+    ...graphics,
+    lines: useGraphicsStep(graphics.lines) as typeof graphics.lines,
+    points: useGraphicsStep(graphics.points) as typeof graphics.points,
+    circles: useGraphicsStep(graphics.circles) as typeof graphics.circles,
+    rects: useGraphicsStep(graphics.rects) as typeof graphics.rects,
+    polygons: useGraphicsStep(graphics.polygons) as typeof graphics.polygons,
+    infiniteLines: useGraphicsStep(
+      graphics.infiniteLines,
+    ) as typeof graphics.infiniteLines,
+    arrows: useGraphicsStep(graphics.arrows) as typeof graphics.arrows,
+    texts: useGraphicsStep(graphics.texts) as typeof graphics.texts,
+  }
+}
+
 const getOutputViaCount = (solver: PipelineDebuggerSolver): number | null => {
   if (!solver.solved || solver.failed) return null
   if (typeof solver.getOutputSimplifiedPcbTraces !== "function") return null
@@ -303,6 +332,8 @@ export const AutoroutingPipelineDebugger = ({
     () => getGlobalCacheProviderFromName(cacheProviderName),
     [cacheProviderName],
   )
+  const [graphicsStepMode, setGraphicsStepMode] =
+    useState<GraphicsStepMode>("solver")
 
   const [selectedPipelineId, setSelectedPipelineIdState] = useState<PipelineId>(
     () =>
@@ -1134,6 +1165,10 @@ export const AutoroutingPipelineDebugger = ({
     () => getOutputViaCount(solver as PipelineDebuggerSolver),
     [solver, solver.iterations, solver.solved, solver.failed],
   )
+  const stepModeVisualization = useMemo(
+    () => selectGraphicsStepMode(visualization, graphicsStepMode),
+    [visualization, graphicsStepMode],
+  )
 
   return (
     <div className="p-4">
@@ -1355,9 +1390,41 @@ export const AutoroutingPipelineDebugger = ({
           </div>
         ) : (
           <>
+            <div className="mb-2 flex gap-3 text-sm">
+              <label>
+                <input
+                  type="radio"
+                  name="graphicsStepMode"
+                  className="mr-1"
+                  checked={graphicsStepMode === "solver"}
+                  onChange={() => setGraphicsStepMode("solver")}
+                />
+                Solver Steps
+              </label>
+              <label>
+                <input
+                  type="radio"
+                  name="graphicsStepMode"
+                  className="mr-1"
+                  checked={graphicsStepMode === "graphics"}
+                  onChange={() => setGraphicsStepMode("graphics")}
+                />
+                Graphics Steps
+              </label>
+              <button
+                className="underline"
+                onClick={() => {
+                  const storageKey = `saved-camera-position-${window.location.pathname}${window.location.search}`
+                  window.localStorage.removeItem(storageKey)
+                  window.location.reload()
+                }}
+              >
+                Reset Graphics View
+              </button>
+            </div>
             {canSelectObjects || renderer === "vector" ? (
               <InteractiveGraphics
-                graphics={visualization}
+                graphics={stepModeVisualization}
                 onObjectClicked={({ object }) => {
                   if (!canSelectObjects) return
                   const objectLabel = object.label ?? ""
@@ -1373,7 +1440,7 @@ export const AutoroutingPipelineDebugger = ({
               />
             ) : (
               <InteractiveGraphicsCanvas
-                graphics={visualization}
+                graphics={stepModeVisualization}
                 showLabelsByDefault={false}
               />
             )}

--- a/lib/utils/combineVisualizations.ts
+++ b/lib/utils/combineVisualizations.ts
@@ -19,49 +19,49 @@ export const combineVisualizations = (
     if (viz.lines) {
       combined.lines = [
         ...(combined.lines || []),
-        ...viz.lines.map((l) => ({ ...l, step: i })),
+        ...viz.lines.map((l) => ({ ...l, step: l.step ?? i })),
       ]
     }
     if (viz.points) {
       combined.points = [
         ...(combined.points || []),
-        ...viz.points.map((p) => ({ ...p, step: i })),
+        ...viz.points.map((p) => ({ ...p, step: p.step ?? i })),
       ]
     }
     if (viz.circles) {
       combined.circles = [
         ...(combined.circles || []),
-        ...viz.circles.map((c) => ({ ...c, step: i })),
+        ...viz.circles.map((c) => ({ ...c, step: c.step ?? i })),
       ]
     }
     if (viz.rects) {
       combined.rects = [
         ...(combined.rects || []),
-        ...viz.rects.map((r) => ({ ...r, step: i })),
+        ...viz.rects.map((r) => ({ ...r, step: r.step ?? i })),
       ]
     }
     if (viz.polygons) {
       combined.polygons = [
         ...(combined.polygons || []),
-        ...viz.polygons.map((p) => ({ ...p, step: i })),
+        ...viz.polygons.map((p) => ({ ...p, step: p.step ?? i })),
       ]
     }
     if (viz.infiniteLines) {
       combined.infiniteLines = [
         ...(combined.infiniteLines || []),
-        ...viz.infiniteLines.map((l) => ({ ...l, step: i })),
+        ...viz.infiniteLines.map((l) => ({ ...l, step: l.step ?? i })),
       ]
     }
     if (viz.arrows) {
       combined.arrows = [
         ...(combined.arrows || []),
-        ...viz.arrows.map((a) => ({ ...a, step: i })),
+        ...viz.arrows.map((a) => ({ ...a, step: a.step ?? i })),
       ]
     }
     if (viz.texts) {
       combined.texts = [
         ...(combined.texts || []),
-        ...viz.texts.map((t) => ({ ...t, step: i })),
+        ...viz.texts.map((t) => ({ ...t, step: t.step ?? i })),
       ]
     }
   })


### PR DESCRIPTION
## Summary
- Keep the Pipeline 7 solver and debugger stage table unchanged.
- Assign graphics-view steps from each direct Pipeline 7 solver stage number.
- Represent the topology planner with one parent-stage graphics frame instead of its internal solver frames.
- Preserve selectable graphics steps for stages that intentionally draw no geometry.

## Validation
- bun run format
- bunx tsc --noEmit
- bun run build
- solved a minimal Pipeline 7 board and verified graphics steps 1 through 21.