### PR TITLE
Use bounded sparse tiny-hypergraph storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "recharts": "^2.15.1",
     "tailwind-merge": "^3.2.0",
     "terser": "^5.43.1",
-    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#8a3426577f74d606f149b8c5814f31100974dcd2",
+    "tiny-hypergraph": "git+https://github.com/anassarkiz/tiny-hypergraph.git#9871076223854666ce10e93d061f7cd9254c0ba5",
     "tiny-hypergraph-poly": "git+https://github.com/tscircuit/tiny-hypergraph.git#7b93b4c",
     "tsup": "^8.3.6",
     "typescript": "^5.9.3",


### PR DESCRIPTION
## Summary

- temporarily pin `tiny-hypergraph` to the fresh performance commit from tscircuit/tiny-hypergraph#130
- keep the autorouter integration unchanged; Pipeline 7 already enables sparse candidate storage

## Why

The tiny-hypergraph change replaces two stale-entry-retaining Maps with one bounded generation-aware typed table. Representative SRJ18 Pipeline 7 tiny phases improved by 19.0% in aggregate without changing solve outcomes, iteration limits, or output hashes.

## Validation

- installed the exact fork commit from this package.json pin
- focused Pipeline 7 SRJ18 sample006 test passes in 21.08s
- `bun run build`
- linked full autorouter suite: 398 pass, 55 skip; seven visual snapshot mismatches reproduce with identical percentages against the previous package.json-pinned tiny commit
- tiny-hypergraph: 98 tests pass, typecheck/build pass, and the direct SRJ18 benchmark exactly matches main outcomes and costs

## Before marking ready

- merge tscircuit/tiny-hypergraph#130
- replace this temporary fork URL with the merged `tscircuit/tiny-hypergraph` commit hash
- rerun validation and the Blacksmith SRJ18 Pipeline 7 benchmark
