### PR TITLE
Widen DifferentialPair.lengthTolerance and document Pipeline 7 length matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ An MIT-licensed full-pipeline PCB autorouter for node.js and TypeScript projects
 
 Want to understand how the autorouter works? Read this [blog post](https://blog.autorouting.com/p/hypergraph-autorouting)
 
+For Pipeline 7 differential-pair routing, see
+[`docs/length-matching-pipeline7.md`](docs/length-matching-pipeline7.md).
+
 ## How to file a bug report
 
 1. You should have [created a bug report via the tscircuit errors tab](https://docs.tscircuit.com/contributing/report-autorouter-bugs)

--- a/docs/length-matching-pipeline7.md
+++ b/docs/length-matching-pipeline7.md
@@ -1,0 +1,24 @@
+# Pipeline 7 length matching
+
+Pipeline 7 owns the integration boundary; the standalone algorithm lives in
+`@tscircuit/length-matching-solver`.
+
+The stage order is:
+
+1. `highDensityStitchSolver` produces routed point samples.
+2. `traceSimplificationSolver` removes redundant route samples and preserves
+   route geometry.
+3. `lengthMatchingSolver` receives `simplifiedHdRoutes` and emits matched
+   routes.
+4. `traceWidthSolver` consumes `matchedHdRoutes`.
+
+The integration is defined in
+`lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts`
+around the `lengthMatchingSolver` pipeline step. Differential-pair input is
+typed by `lib/types/srj-types.ts` and uses a numeric `lengthTolerance` in mm.
+
+For solver internals, use the standalone package’s
+`lib/length-matching/README.md` and `straight-route-spans.ts` code map. A
+debug JSON exported as `{ input, options }` must be unwrapped to `.input` before
+passing it to `scripts/run-sample.ts`; the runner accepts SimpleRouteJson, not
+the outer API request envelope.

--- a/lib/types/srj-types.ts
+++ b/lib/types/srj-types.ts
@@ -69,7 +69,7 @@ export interface SimpleRouteJson {
 
 export interface DifferentialPair {
   connectionNames: [string, string]
-  lengthTolerance: 0.1
+  lengthTolerance: number
 }
 
 export interface Obstacle {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@tscircuit/hypergraph": "^0.0.71",
     "@tscircuit/jumper-topology-generator": "^0.0.4",
     "@tscircuit/krt-wasm": "^0.1.0",
-    "@tscircuit/length-matching-solver": "git+https://github.com/tscircuit/length-matching-solver.git#28275c7",
+    "@tscircuit/length-matching-solver": "git+https://github.com/tscircuit/length-matching-solver.git#9edb3af",
     "@tscircuit/math-utils": "^0.0.36",
     "@tscircuit/rectdiff": "git+https://github.com/tscircuit/rectdiff.git#a26f062441ed6baa679655fe10374b01017dcf98",
     "@tscircuit/solver-utils": "^0.0.16",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@tscircuit/hypergraph": "^0.0.71",
     "@tscircuit/jumper-topology-generator": "^0.0.4",
     "@tscircuit/krt-wasm": "^0.1.0",
-    "@tscircuit/length-matching-solver": "git+https://github.com/tscircuit/length-matching-solver.git#9edb3af",
+    "@tscircuit/length-matching-solver": "git+https://github.com/tscircuit/length-matching-solver.git#e40c996",
     "@tscircuit/math-utils": "^0.0.36",
     "@tscircuit/rectdiff": "git+https://github.com/tscircuit/rectdiff.git#a26f062441ed6baa679655fe10374b01017dcf98",
     "@tscircuit/solver-utils": "^0.0.16",


### PR DESCRIPTION
## Summary
- Widen `DifferentialPair.lengthTolerance` from the fixed `0.1` literal type to `number`, matching the standalone `@tscircuit/length-matching-solver` type and letting callers configure per-pair tolerance (already validated as non-negative/finite at that package's boundary).
- Pin `@tscircuit/length-matching-solver` to [tscircuit/length-matching-solver#20](https://github.com/tscircuit/length-matching-solver/pull/20) (tunable straight-route-span meandering).
- Add `docs/length-matching-pipeline7.md` mapping the Pipeline 7 length-matching stage order and the debug-JSON envelope unwrap needed for `scripts/run-sample.ts`, linked from the README.

## Test plan
- [ ] `bun test` after the length-matching-solver dependency PR merges and the pin is re-verified
