### PR TITLE
Preserve Pipeline 7 terminal port identities

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -471,6 +471,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
             connections,
             layerCount: cms.srj.layerCount,
             effort: cms.effort,
+            preserveTerminalPcbPortIds: true,
             minViaPadDiameter: cms.viaDiameter,
             flags: {
               FORCE_CENTER_FIRST: true,
@@ -546,6 +547,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
           obstacles: cms.srj.obstacles,
           layerCount: cms.srj.layerCount,
           useGrowShrinkHighDensityIntraNodeSolver: true,
+          preserveTerminalPcbPortIds: true,
           growShrinkFallbackToInvalidGeometryOnFailure: true,
         },
       ]
@@ -592,6 +594,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
           colorMap: cms.colorMap,
           layerCount: cms.srj.layerCount,
           defaultViaDiameter: cms.viaDiameter,
+          preserveTerminalPcbPortIds: true,
         },
       ],
     ),
@@ -645,6 +648,11 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
           hdRoutes: lockHdRouteTerminals(
             cms.traceWidthSolver!.getHdRoutesWithWidths(),
             cms.netToPointPairsSolver?.newConnections ?? [],
+            new Map(
+              (cms.highDensityStitchSolver?.mergedHdRoutes ?? []).map(
+                (route) => [route.connectionName, route],
+              ),
+            ),
           ),
           connMap: cms.connMap,
           effort: cms.effort,

--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/lock-hd-route-terminals.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/lock-hd-route-terminals.ts
@@ -10,64 +10,91 @@ import type { HighDensityRoute } from "lib/types/high-density-types"
 export const lockHdRouteTerminals = (
   hdRoutes: ReadonlyArray<HighDensityRoute>,
   connections: ReadonlyArray<SimpleRouteConnection>,
+  terminalIdentityByConnectionName: ReadonlyMap<
+    string,
+    Pick<HighDensityRoute, "startPcbPortId" | "endPcbPortId">
+  > = new Map(hdRoutes.map((route) => [route.connectionName, route])),
 ): HighDensityRoute[] => {
   const connectionByName = new Map(
     connections.map((connection) => [connection.name, connection]),
   )
 
   return hdRoutes.map((hdRoute) => {
-    if (hdRoute.route.length === 0) return hdRoute
+    if (hdRoute.route.length === 0) {
+      throw new Error(
+        `Cannot lock PCB terminals for empty route "${hdRoute.connectionName}"`,
+      )
+    }
 
     const connection = connectionByName.get(hdRoute.connectionName)
-    if (!connection || connection.pointsToConnect.length !== 2) return hdRoute
-
-    const firstRoutePoint = hdRoute.route[0]!
-    const lastRoutePoint = hdRoute.route[hdRoute.route.length - 1]!
-    const [firstConnectionPoint, secondConnectionPoint] =
-      connection.pointsToConnect
-    const directDistance =
-      Math.hypot(
-        firstRoutePoint.x - firstConnectionPoint!.x,
-        firstRoutePoint.y - firstConnectionPoint!.y,
-      ) +
-      Math.hypot(
-        lastRoutePoint.x - secondConnectionPoint!.x,
-        lastRoutePoint.y - secondConnectionPoint!.y,
+    if (!connection) {
+      throw new Error(
+        `Cannot lock PCB terminals: connection "${hdRoute.connectionName}" was not found`,
       )
-    const reversedDistance =
-      Math.hypot(
-        firstRoutePoint.x - secondConnectionPoint!.x,
-        firstRoutePoint.y - secondConnectionPoint!.y,
-      ) +
-      Math.hypot(
-        lastRoutePoint.x - firstConnectionPoint!.x,
-        lastRoutePoint.y - firstConnectionPoint!.y,
+    }
+    if (connection.pointsToConnect.length !== 2) {
+      throw new Error(
+        `Cannot lock PCB terminals for "${hdRoute.connectionName}": expected 2 connection points, found ${connection.pointsToConnect.length}`,
       )
-    const [startTerminal, endTerminal] =
-      directDistance <= reversedDistance
-        ? [firstConnectionPoint!, secondConnectionPoint!]
-        : [secondConnectionPoint!, firstConnectionPoint!]
+    }
 
-    const startPcbPortId = startTerminal.pcb_port_id
-    const endPcbPortId = endTerminal.pcb_port_id
+    const terminalIdentity =
+      terminalIdentityByConnectionName.get(hdRoute.connectionName) ?? hdRoute
+    const terminalByPcbPortId = new Map<
+      string,
+      (typeof connection.pointsToConnect)[number]
+    >()
+    for (const terminal of connection.pointsToConnect) {
+      if (!terminal.pcb_port_id) continue
+      if (terminalByPcbPortId.has(terminal.pcb_port_id)) {
+        throw new Error(
+          `Cannot lock duplicate PCB terminal "${terminal.pcb_port_id}" for "${hdRoute.connectionName}"`,
+        )
+      }
+      terminalByPcbPortId.set(terminal.pcb_port_id, terminal)
+    }
+    if (terminalByPcbPortId.size === 0) return hdRoute
 
-    if (!startPcbPortId && !endPcbPortId) return hdRoute
+    const routeEndpointPcbPortIds = [
+      terminalIdentity.startPcbPortId,
+      terminalIdentity.endPcbPortId,
+    ].filter((pcbPortId): pcbPortId is string => pcbPortId !== undefined)
+    if (routeEndpointPcbPortIds.length === 0) return hdRoute
+
+    const uniqueRouteEndpointPcbPortIds = new Set(routeEndpointPcbPortIds)
+    if (
+      uniqueRouteEndpointPcbPortIds.size !== routeEndpointPcbPortIds.length ||
+      routeEndpointPcbPortIds.some(
+        (pcbPortId) => !terminalByPcbPortId.has(pcbPortId),
+      )
+    ) {
+      throw new Error(
+        `Cannot lock PCB terminals for "${hdRoute.connectionName}": route endpoint IDs do not match connection terminal IDs`,
+      )
+    }
+
+    const startTerminal = terminalIdentity.startPcbPortId
+      ? terminalByPcbPortId.get(terminalIdentity.startPcbPortId)
+      : undefined
+    const endTerminal = terminalIdentity.endPcbPortId
+      ? terminalByPcbPortId.get(terminalIdentity.endPcbPortId)
+      : undefined
 
     const route = hdRoute.route.map((point, pointIndex) => {
-      if (pointIndex === 0 && startPcbPortId) {
+      if (pointIndex === 0 && startTerminal) {
         return {
           ...point,
           x: startTerminal.x,
           y: startTerminal.y,
-          pcb_port_id: startPcbPortId,
+          pcb_port_id: startTerminal.pcb_port_id,
         }
       }
-      if (pointIndex === hdRoute.route.length - 1 && endPcbPortId) {
+      if (pointIndex === hdRoute.route.length - 1 && endTerminal) {
         return {
           ...point,
           x: endTerminal.x,
           y: endTerminal.y,
-          pcb_port_id: endPcbPortId,
+          pcb_port_id: endTerminal.pcb_port_id,
         }
       }
       return point

--- a/lib/solvers/HighDensityRepairSolver/Pipeline4HighDensityRepairSolver.ts
+++ b/lib/solvers/HighDensityRepairSolver/Pipeline4HighDensityRepairSolver.ts
@@ -142,6 +142,12 @@ const fromRepairRoute = (
   connectionName: route.connectionName ?? fallbackRoute.connectionName,
   rootConnectionName:
     route.rootConnectionName ?? fallbackRoute.rootConnectionName,
+  ...(fallbackRoute.startPcbPortId
+    ? { startPcbPortId: fallbackRoute.startPcbPortId }
+    : {}),
+  ...(fallbackRoute.endPcbPortId
+    ? { endPcbPortId: fallbackRoute.endPcbPortId }
+    : {}),
   regionId: route.capacityMeshNodeId ?? fallbackRoute.regionId,
   traceThickness: route.traceThickness ?? fallbackRoute.traceThickness,
   viaDiameter: route.viaDiameter ?? fallbackRoute.viaDiameter,

--- a/lib/solvers/HighDensitySolver/HighDensitySolver.ts
+++ b/lib/solvers/HighDensitySolver/HighDensitySolver.ts
@@ -58,6 +58,7 @@ export class HighDensitySolver extends BaseSolver {
   obstacles: Obstacle[]
   layerCount: number
   useGrowShrinkHighDensityIntraNodeSolver: boolean
+  preserveTerminalPcbPortIds: boolean
   growShrinkMaxInnerIterationsPerGrowthAttempt?: number
   growShrinkFallbackToInvalidGeometryOnFailure: boolean
 
@@ -90,6 +91,7 @@ export class HighDensitySolver extends BaseSolver {
     obstacles,
     layerCount,
     useGrowShrinkHighDensityIntraNodeSolver,
+    preserveTerminalPcbPortIds,
     growShrinkMaxInnerIterationsPerGrowthAttempt,
     growShrinkFallbackToInvalidGeometryOnFailure,
   }: {
@@ -103,6 +105,7 @@ export class HighDensitySolver extends BaseSolver {
     obstacles?: Obstacle[]
     layerCount?: number
     useGrowShrinkHighDensityIntraNodeSolver?: boolean
+    preserveTerminalPcbPortIds?: boolean
     growShrinkMaxInnerIterationsPerGrowthAttempt?: number
     growShrinkFallbackToInvalidGeometryOnFailure?: boolean
     nodePfById?:
@@ -123,6 +126,7 @@ export class HighDensitySolver extends BaseSolver {
     this.layerCount = layerCount ?? 2
     this.useGrowShrinkHighDensityIntraNodeSolver =
       useGrowShrinkHighDensityIntraNodeSolver ?? false
+    this.preserveTerminalPcbPortIds = preserveTerminalPcbPortIds ?? false
     this.growShrinkMaxInnerIterationsPerGrowthAttempt =
       growShrinkMaxInnerIterationsPerGrowthAttempt
     this.growShrinkFallbackToInvalidGeometryOnFailure =
@@ -271,6 +275,65 @@ export class HighDensitySolver extends BaseSolver {
       (this.stats.highDensityResizeCount ?? 0) + solver.growthAttempts
   }
 
+  private getSolvedRoutesWithTerminalPcbPortIds(
+    solver: HighDensityIntraNodeSolver,
+  ): HighDensityIntraNodeRoute[] {
+    const terminalPortPoints = solver.nodeWithPortPoints.portPoints.filter(
+      (portPoint) => portPoint.pcb_port_id !== undefined,
+    )
+    if (terminalPortPoints.length === 0) return solver.solvedRoutes
+
+    const matchedTerminalCounts = new Map<string, number>()
+    const getTerminalPcbPortId = (
+      route: HighDensityIntraNodeRoute,
+      point: HighDensityIntraNodeRoute["route"][number],
+    ) => {
+      const matchingTerminals = terminalPortPoints.filter(
+        (terminal) =>
+          terminal.connectionName === route.connectionName &&
+          terminal.x === point.x &&
+          terminal.y === point.y &&
+          terminal.z === point.z,
+      )
+      if (matchingTerminals.length > 1) {
+        throw new Error(
+          `HighDensitySolver found multiple PCB terminals at an endpoint of "${route.connectionName}"`,
+        )
+      }
+      const terminal = matchingTerminals[0]
+      if (!terminal?.pcb_port_id) return undefined
+
+      const terminalKey = `${terminal.connectionName}\u0000${terminal.pcb_port_id}`
+      matchedTerminalCounts.set(
+        terminalKey,
+        (matchedTerminalCounts.get(terminalKey) ?? 0) + 1,
+      )
+      return terminal.pcb_port_id
+    }
+    const routes = solver.solvedRoutes.map((route) => ({
+      ...route,
+      startPcbPortId: route.route[0]
+        ? getTerminalPcbPortId(route, route.route[0])
+        : undefined,
+      endPcbPortId:
+        route.route.length > 1
+          ? getTerminalPcbPortId(route, route.route[route.route.length - 1]!)
+          : undefined,
+    }))
+
+    for (const terminal of terminalPortPoints) {
+      const terminalKey = `${terminal.connectionName}\u0000${terminal.pcb_port_id}`
+      const matchCount = matchedTerminalCounts.get(terminalKey) ?? 0
+      if (matchCount > 1) {
+        throw new Error(
+          `HighDensitySolver found PCB terminal "${terminal.pcb_port_id}" on multiple endpoints of "${terminal.connectionName}"`,
+        )
+      }
+    }
+
+    return routes
+  }
+
   /**
    * Each iteration, pop an unsolved node and attempt to find the routes inside
    * of it.
@@ -280,7 +343,11 @@ export class HighDensitySolver extends BaseSolver {
     if (this.activeSubSolver) {
       this.activeSubSolver.step()
       if (this.activeSubSolver.solved) {
-        this.routes.push(...this.activeSubSolver.solvedRoutes)
+        this.routes.push(
+          ...(this.preserveTerminalPcbPortIds
+            ? this.getSolvedRoutesWithTerminalPcbPortIds(this.activeSubSolver)
+            : this.activeSubSolver.solvedRoutes),
+        )
         this.recordNodeSolveMetadata(this.activeSubSolver, "solved")
         this.recordSolvedNodeStats(
           this.activeSubSolver,

--- a/lib/solvers/HighDensitySolver/HighDensitySolver.ts
+++ b/lib/solvers/HighDensitySolver/HighDensitySolver.ts
@@ -283,7 +283,6 @@ export class HighDensitySolver extends BaseSolver {
     )
     if (terminalPortPoints.length === 0) return solver.solvedRoutes
 
-    const matchedTerminalCounts = new Map<string, number>()
     const getTerminalPcbPortId = (
       route: HighDensityIntraNodeRoute,
       point: HighDensityIntraNodeRoute["route"][number],
@@ -302,15 +301,9 @@ export class HighDensitySolver extends BaseSolver {
       }
       const terminal = matchingTerminals[0]
       if (!terminal?.pcb_port_id) return undefined
-
-      const terminalKey = `${terminal.connectionName}\u0000${terminal.pcb_port_id}`
-      matchedTerminalCounts.set(
-        terminalKey,
-        (matchedTerminalCounts.get(terminalKey) ?? 0) + 1,
-      )
       return terminal.pcb_port_id
     }
-    const routes = solver.solvedRoutes.map((route) => ({
+    return solver.solvedRoutes.map((route) => ({
       ...route,
       startPcbPortId: route.route[0]
         ? getTerminalPcbPortId(route, route.route[0])
@@ -320,18 +313,6 @@ export class HighDensitySolver extends BaseSolver {
           ? getTerminalPcbPortId(route, route.route[route.route.length - 1]!)
           : undefined,
     }))
-
-    for (const terminal of terminalPortPoints) {
-      const terminalKey = `${terminal.connectionName}\u0000${terminal.pcb_port_id}`
-      const matchCount = matchedTerminalCounts.get(terminalKey) ?? 0
-      if (matchCount > 1) {
-        throw new Error(
-          `HighDensitySolver found PCB terminal "${terminal.pcb_port_id}" on multiple endpoints of "${terminal.connectionName}"`,
-        )
-      }
-    }
-
-    return routes
   }
 
   /**

--- a/lib/solvers/PortPointPathingSolver/hgportpointpathingsolver/types.ts
+++ b/lib/solvers/PortPointPathingSolver/hgportpointpathingsolver/types.ts
@@ -89,6 +89,7 @@ export interface HgPortPointPathingSolverParams {
   inputSolvedRoutes?: SolvedRoutesHg[]
   layerCount: number
   effort: number
+  preserveTerminalPcbPortIds?: boolean
   minViaPadDiameter?: number
   flags: {
     FORCE_CENTER_FIRST: boolean

--- a/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
+++ b/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
@@ -71,6 +71,7 @@ type TinyPortMetadata = {
   x?: number
   y?: number
   z?: number
+  pcb_port_id?: string
   prevPortPointId?: string
   nextPortPointId?: string
   distToCentermostPortOnZ?: number
@@ -417,6 +418,9 @@ const buildSerializedTinyGraph = (
         z: startZ,
         distToCentermostPortOnZ: 0,
         _tinyTerminal: true,
+        ...(params.preserveTerminalPcbPortIds && startPoint?.pcb_port_id
+          ? { pcb_port_id: startPoint.pcb_port_id }
+          : {}),
       },
     })
 
@@ -431,6 +435,9 @@ const buildSerializedTinyGraph = (
         z: endZ,
         distToCentermostPortOnZ: 0,
         _tinyTerminal: true,
+        ...(params.preserveTerminalPcbPortIds && endPoint?.pcb_port_id
+          ? { pcb_port_id: endPoint.pcb_port_id }
+          : {}),
       },
     })
 
@@ -990,6 +997,10 @@ export class TinyHypergraphPortPointPathingSolver extends BaseSolver {
       z: solvedTinySolver.topology.portZ[portId],
       connectionName,
       rootConnectionName,
+      ...(this.params.preserveTerminalPcbPortIds &&
+      typeof portMetadata?.pcb_port_id === "string"
+        ? { pcb_port_id: portMetadata.pcb_port_id }
+        : {}),
       prevPortPointId:
         typeof portMetadata?.prevPortPointId === "string"
           ? portMetadata.prevPortPointId

--- a/lib/solvers/RouteStitchingSolver/MultipleHighDensityRouteStitchSolver3.ts
+++ b/lib/solvers/RouteStitchingSolver/MultipleHighDensityRouteStitchSolver3.ts
@@ -144,8 +144,7 @@ export class MultipleHighDensityRouteStitchSolver3 extends BaseSolver {
     this.colorMap = params.colorMap ?? {}
     this.allowedLayerTransitionPointKeys =
       params.allowedLayerTransitionPointKeys
-    this.preserveTerminalPcbPortIds =
-      params.preserveTerminalPcbPortIds ?? false
+    this.preserveTerminalPcbPortIds = params.preserveTerminalPcbPortIds ?? false
 
     const canonicalHdRoutes = [...params.hdRoutes].sort(compareRoutes)
 

--- a/lib/solvers/RouteStitchingSolver/MultipleHighDensityRouteStitchSolver3.ts
+++ b/lib/solvers/RouteStitchingSolver/MultipleHighDensityRouteStitchSolver3.ts
@@ -40,6 +40,7 @@ export class MultipleHighDensityRouteStitchSolver3 extends BaseSolver {
   defaultTraceThickness: number
   defaultViaDiameter: number
   allowedLayerTransitionPointKeys?: Set<string>
+  preserveTerminalPcbPortIds: boolean
   private endpointIndex = new EndpointClusterIndex()
 
   private canStitchBetweenTerminals(params: {
@@ -57,6 +58,7 @@ export class MultipleHighDensityRouteStitchSolver3 extends BaseSolver {
       defaultTraceThickness: this.defaultTraceThickness,
       defaultViaDiameter: this.defaultViaDiameter,
       allowedLayerTransitionPointKeys: this.allowedLayerTransitionPointKeys,
+      preserveTerminalPcbPortIds: this.preserveTerminalPcbPortIds,
     })
 
     while (
@@ -136,11 +138,14 @@ export class MultipleHighDensityRouteStitchSolver3 extends BaseSolver {
     layerCount: number
     defaultViaDiameter?: number
     allowedLayerTransitionPointKeys?: Set<string>
+    preserveTerminalPcbPortIds?: boolean
   }) {
     super()
     this.colorMap = params.colorMap ?? {}
     this.allowedLayerTransitionPointKeys =
       params.allowedLayerTransitionPointKeys
+    this.preserveTerminalPcbPortIds =
+      params.preserveTerminalPcbPortIds ?? false
 
     const canonicalHdRoutes = [...params.hdRoutes].sort(compareRoutes)
 
@@ -417,6 +422,7 @@ export class MultipleHighDensityRouteStitchSolver3 extends BaseSolver {
       defaultTraceThickness: this.defaultTraceThickness,
       defaultViaDiameter: this.defaultViaDiameter,
       allowedLayerTransitionPointKeys: this.allowedLayerTransitionPointKeys,
+      preserveTerminalPcbPortIds: this.preserveTerminalPcbPortIds,
     })
   }
 

--- a/lib/solvers/RouteStitchingSolver/SingleHighDensityRouteStitchSolver3.ts
+++ b/lib/solvers/RouteStitchingSolver/SingleHighDensityRouteStitchSolver3.ts
@@ -141,16 +141,6 @@ export class SingleHighDensityRouteStitchSolver3 extends BaseSolver {
           )
         }
       }
-      for (const expectedPcbPortId of expectedPcbPortIds) {
-        const matchCount = taggedPcbPortIds.filter(
-          (pcbPortId) => pcbPortId === expectedPcbPortId,
-        ).length
-        if (matchCount > 1) {
-          throw new Error(
-            `SingleHighDensityRouteStitchSolver3 found PCB terminal "${expectedPcbPortId}" on multiple route endpoints of "${opts.connectionName}"`,
-          )
-        }
-      }
     }
 
     let bestDist = Infinity

--- a/lib/solvers/RouteStitchingSolver/SingleHighDensityRouteStitchSolver3.ts
+++ b/lib/solvers/RouteStitchingSolver/SingleHighDensityRouteStitchSolver3.ts
@@ -117,9 +117,7 @@ export class SingleHighDensityRouteStitchSolver3 extends BaseSolver {
       (opts.preserveTerminalPcbPortIds
         ? [opts.start.pcb_port_id, opts.end.pcb_port_id]
         : []
-      ).filter(
-        (pcbPortId): pcbPortId is string => pcbPortId !== undefined,
-      ),
+      ).filter((pcbPortId): pcbPortId is string => pcbPortId !== undefined),
     )
     if (
       opts.preserveTerminalPcbPortIds &&

--- a/lib/solvers/RouteStitchingSolver/SingleHighDensityRouteStitchSolver3.ts
+++ b/lib/solvers/RouteStitchingSolver/SingleHighDensityRouteStitchSolver3.ts
@@ -16,6 +16,7 @@ const VIA_PENALTY = 1000
 const GAP_PENALTY = 100000
 const GEOMETRIC_TOLERANCE = 1e-3
 type RoutePoint = HighDensityIntraNodeRoute["route"][number]
+type StitchTerminal = Point3 & { pcb_port_id?: string }
 export {
   MAX_STITCH_GAP_DISTANCE_3,
   MAX_TERMINAL_STITCH_GAP_DISTANCE_3,
@@ -47,20 +48,21 @@ export class SingleHighDensityRouteStitchSolver3 extends BaseSolver {
 
   mergedHdRoute!: HighDensityIntraNodeRoute
   remainingHdRoutes: HighDensityIntraNodeRoute[]
-  start: Point3
-  end: Point3
+  start: StitchTerminal
+  end: StitchTerminal
   colorMap: Record<string, string>
   allowedLayerTransitionPointKeys?: Set<string>
 
   constructor(opts: {
     connectionName: string
     hdRoutes: HighDensityIntraNodeRoute[]
-    start: Point3
-    end: Point3
+    start: StitchTerminal
+    end: StitchTerminal
     colorMap?: Record<string, string>
     defaultTraceThickness?: number
     defaultViaDiameter?: number
     allowedLayerTransitionPointKeys?: Set<string>
+    preserveTerminalPcbPortIds?: boolean
   }) {
     super()
     const canonicalHdRoutes = [...opts.hdRoutes].sort(compareRoutes)
@@ -94,6 +96,12 @@ export class SingleHighDensityRouteStitchSolver3 extends BaseSolver {
 
       this.mergedHdRoute = {
         connectionName: opts.connectionName,
+        ...(opts.preserveTerminalPcbPortIds && opts.start.pcb_port_id
+          ? { startPcbPortId: opts.start.pcb_port_id }
+          : {}),
+        ...(opts.preserveTerminalPcbPortIds && opts.end.pcb_port_id
+          ? { endPcbPortId: opts.end.pcb_port_id }
+          : {}),
         rootConnectionName: canonicalHdRoutes[0]?.rootConnectionName,
         route: routePoints,
         vias,
@@ -103,6 +111,48 @@ export class SingleHighDensityRouteStitchSolver3 extends BaseSolver {
       }
       this.solved = true
       return
+    }
+
+    const expectedPcbPortIds = new Set(
+      (opts.preserveTerminalPcbPortIds
+        ? [opts.start.pcb_port_id, opts.end.pcb_port_id]
+        : []
+      ).filter(
+        (pcbPortId): pcbPortId is string => pcbPortId !== undefined,
+      ),
+    )
+    if (
+      opts.preserveTerminalPcbPortIds &&
+      opts.start.pcb_port_id &&
+      opts.start.pcb_port_id === opts.end.pcb_port_id
+    ) {
+      throw new Error(
+        `SingleHighDensityRouteStitchSolver3 received duplicate PCB terminal "${opts.start.pcb_port_id}" for "${opts.connectionName}"`,
+      )
+    }
+
+    const taggedPcbPortIds = canonicalHdRoutes
+      .flatMap((route) => [route.startPcbPortId, route.endPcbPortId])
+      .filter((pcbPortId): pcbPortId is string => pcbPortId !== undefined)
+
+    if (expectedPcbPortIds.size > 0) {
+      for (const taggedPcbPortId of taggedPcbPortIds) {
+        if (!expectedPcbPortIds.has(taggedPcbPortId)) {
+          throw new Error(
+            `SingleHighDensityRouteStitchSolver3 found unknown PCB terminal "${taggedPcbPortId}" on "${opts.connectionName}"`,
+          )
+        }
+      }
+      for (const expectedPcbPortId of expectedPcbPortIds) {
+        const matchCount = taggedPcbPortIds.filter(
+          (pcbPortId) => pcbPortId === expectedPcbPortId,
+        ).length
+        if (matchCount > 1) {
+          throw new Error(
+            `SingleHighDensityRouteStitchSolver3 found PCB terminal "${expectedPcbPortId}" on multiple route endpoints of "${opts.connectionName}"`,
+          )
+        }
+      }
     }
 
     let bestDist = Infinity
@@ -167,9 +217,28 @@ export class SingleHighDensityRouteStitchSolver3 extends BaseSolver {
         comparePoints(firstRouteFirstPoint, firstRouteLastPoint) <= 0)
         ? firstRouteFirstPoint
         : firstRouteLastPoint
+    const closestFirstRoutePcbPortId =
+      closestFirstRoutePoint === firstRouteFirstPoint
+        ? firstRoute.startPcbPortId
+        : firstRoute.endPcbPortId
+    if (
+      closestFirstRoutePcbPortId &&
+      this.start.pcb_port_id &&
+      closestFirstRoutePcbPortId !== this.start.pcb_port_id
+    ) {
+      throw new Error(
+        `SingleHighDensityRouteStitchSolver3 terminal identity disagrees with route orientation for "${opts.connectionName}"`,
+      )
+    }
 
     this.mergedHdRoute = {
       connectionName: opts.connectionName,
+      ...(opts.preserveTerminalPcbPortIds && this.start.pcb_port_id
+        ? { startPcbPortId: this.start.pcb_port_id }
+        : {}),
+      ...(opts.preserveTerminalPcbPortIds && this.end.pcb_port_id
+        ? { endPcbPortId: this.end.pcb_port_id }
+        : {}),
       rootConnectionName: firstRoute.rootConnectionName,
       route: [
         {

--- a/lib/types/high-density-types.ts
+++ b/lib/types/high-density-types.ts
@@ -2,6 +2,7 @@ export type PortPoint = {
   connectionName: string
   rootConnectionName?: string
   portPointId?: string
+  pcb_port_id?: string
   x: number
   y: number
   z: number
@@ -36,6 +37,9 @@ export type NodeWithPortPoints = {
 export type HighDensityIntraNodeRoute = {
   connectionName: string
   rootConnectionName?: string
+  /** Terminal identities in route order, kept inert until terminal locking. */
+  startPcbPortId?: string
+  endPcbPortId?: string
   traceThickness: number
   viaDiameter: number
   route: Array<{

--- a/tests/high-density-terminal-port-ids.test.ts
+++ b/tests/high-density-terminal-port-ids.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test"
+import { HighDensitySolver } from "lib/solvers/HighDensitySolver/HighDensitySolver"
+import type { NodeWithPortPoints } from "lib/types/high-density-types"
+
+test("HighDensitySolver carries PCB terminal identities onto route endpoints", () => {
+  const start = {
+    connectionName: "terminal-test",
+    portPointId: "start",
+    pcb_port_id: "pcb_port_start",
+    x: 0,
+    y: 0,
+    z: 0,
+  }
+  const end = {
+    connectionName: "terminal-test",
+    portPointId: "end",
+    pcb_port_id: "pcb_port_end",
+    x: 2,
+    y: 0,
+    z: 0,
+  }
+  const node: NodeWithPortPoints = {
+    capacityMeshNodeId: "terminal-node",
+    center: { x: 1, y: 0 },
+    width: 2,
+    height: 1,
+    availableZ: [0, 1],
+    portPoints: [start, end],
+    portPointsInPairs: [[start, end]],
+  }
+  const solver = new HighDensitySolver({
+    nodePortPoints: [node],
+    layerCount: 2,
+    obstacles: [],
+    preserveTerminalPcbPortIds: true,
+  })
+
+  solver.solve()
+
+  expect(solver.failed).toBe(false)
+  expect(solver.routes).toHaveLength(1)
+  const route = solver.routes[0]!
+  expect([route.startPcbPortId, route.endPcbPortId].sort()).toEqual([
+    "pcb_port_end",
+    "pcb_port_start",
+  ])
+})

--- a/tests/high-density-terminal-port-ids.test.ts
+++ b/tests/high-density-terminal-port-ids.test.ts
@@ -1,6 +1,9 @@
 import { expect, test } from "bun:test"
 import { HighDensitySolver } from "lib/solvers/HighDensitySolver/HighDensitySolver"
-import type { NodeWithPortPoints } from "lib/types/high-density-types"
+import type {
+  HighDensityIntraNodeRoute,
+  NodeWithPortPoints,
+} from "lib/types/high-density-types"
 
 test("HighDensitySolver carries PCB terminal identities onto route endpoints", () => {
   const start = {
@@ -43,5 +46,78 @@ test("HighDensitySolver carries PCB terminal identities onto route endpoints", (
   expect([route.startPcbPortId, route.endPcbPortId].sort()).toEqual([
     "pcb_port_end",
     "pcb_port_start",
+  ])
+})
+
+test("HighDensitySolver allows routed fan-out from one PCB terminal", () => {
+  const terminal = {
+    connectionName: "terminal-fanout",
+    portPointId: "terminal",
+    pcb_port_id: "pcb_port_shared",
+    x: 0,
+    y: 0,
+    z: 0,
+  }
+  const branchA = {
+    connectionName: "terminal-fanout",
+    portPointId: "branch-a",
+    x: 2,
+    y: -1,
+    z: 0,
+  }
+  const branchB = {
+    connectionName: "terminal-fanout",
+    portPointId: "branch-b",
+    x: 2,
+    y: 1,
+    z: 0,
+  }
+  const node = {
+    capacityMeshNodeId: "terminal-fanout-node",
+    center: { x: 1, y: 0 },
+    width: 2,
+    height: 2,
+    availableZ: [0, 1],
+    portPoints: [terminal, branchA, branchB],
+    portPointsInPairs: [
+      [terminal, branchA],
+      [terminal, branchB],
+    ],
+  } satisfies NodeWithPortPoints
+  const solver = new HighDensitySolver({
+    nodePortPoints: [],
+    layerCount: 2,
+    obstacles: [],
+    preserveTerminalPcbPortIds: true,
+  })
+  const makeRoute = (end: { x: number; y: number; z: number }) =>
+    ({
+      connectionName: "terminal-fanout",
+      traceThickness: 0.15,
+      viaDiameter: 0.3,
+      route: [{ x: terminal.x, y: terminal.y, z: terminal.z }, end],
+      vias: [],
+    }) satisfies HighDensityIntraNodeRoute
+  const solvedRoutes = [
+    makeRoute({ x: branchA.x, y: branchA.y, z: branchA.z }),
+    makeRoute({ x: branchB.x, y: branchB.y, z: branchB.z }),
+  ]
+
+  const routes = (
+    solver as unknown as {
+      getSolvedRoutesWithTerminalPcbPortIds: (solver: {
+        nodeWithPortPoints: NodeWithPortPoints
+        solvedRoutes: HighDensityIntraNodeRoute[]
+      }) => HighDensityIntraNodeRoute[]
+    }
+  ).getSolvedRoutesWithTerminalPcbPortIds({
+    nodeWithPortPoints: node,
+    solvedRoutes,
+  })
+
+  expect(routes).toHaveLength(2)
+  expect(routes.map((route) => route.startPcbPortId)).toContainAllValues([
+    "pcb_port_shared",
+    "pcb_port_shared",
   ])
 })

--- a/tests/pipeline7-lock-terminal-ports.test.ts
+++ b/tests/pipeline7-lock-terminal-ports.test.ts
@@ -24,8 +24,12 @@ test("Pipeline7 locks direct and reversed PCB terminal endpoints", () => {
     connectionName: string,
     startX: number,
     endX: number,
+    startPcbPortId: string,
+    endPcbPortId: string,
   ): HighDensityRoute => ({
     connectionName,
+    startPcbPortId,
+    endPcbPortId,
     traceThickness: 0.15,
     viaDiameter: 0.3,
     route: [
@@ -35,9 +39,17 @@ test("Pipeline7 locks direct and reversed PCB terminal endpoints", () => {
     vias: [],
   })
 
+  const identityRoutes = [
+    makeRoute("direct", 0.03, 1.96, "pcb_port_a", "pcb_port_b"),
+    makeRoute("reversed", 11.97, 10.04, "pcb_port_d", "pcb_port_c"),
+  ]
+  const routesAfterSimplification = identityRoutes.map(
+    ({ startPcbPortId: _start, endPcbPortId: _end, ...route }) => route,
+  )
   const [direct, reversed] = lockHdRouteTerminals(
-    [makeRoute("direct", 0.03, 1.96), makeRoute("reversed", 11.97, 10.04)],
+    routesAfterSimplification,
     connections,
+    new Map(identityRoutes.map((route) => [route.connectionName, route])),
   )
 
   expect(direct?.route).toEqual([
@@ -48,4 +60,26 @@ test("Pipeline7 locks direct and reversed PCB terminal endpoints", () => {
     { x: 12, y: 0, z: 0, pcb_port_id: "pcb_port_d" },
     { x: 10, y: 0, z: 0, pcb_port_id: "pcb_port_c" },
   ])
+
+  const [identitySwapped] = lockHdRouteTerminals(
+    [makeRoute("direct", 0.03, 1.96, "pcb_port_b", "pcb_port_a")],
+    connections,
+  )
+  expect(identitySwapped!.route).toEqual([
+    { x: 2, y: 0, z: 0, pcb_port_id: "pcb_port_b" },
+    { x: 0, y: 0, z: 0, pcb_port_id: "pcb_port_a" },
+  ])
+
+  expect(() =>
+    lockHdRouteTerminals(
+      [makeRoute("direct", 0.03, 1.96, "unknown", "pcb_port_b")],
+      connections,
+    ),
+  ).toThrow("route endpoint IDs do not match connection terminal IDs")
+  expect(() =>
+    lockHdRouteTerminals(
+      [makeRoute("missing", 0.03, 1.96, "pcb_port_a", "pcb_port_b")],
+      connections,
+    ),
+  ).toThrow('connection "missing" was not found')
 })

--- a/tests/stitch-solver/single-high-density-route-stitch-gap-bridge.test.ts
+++ b/tests/stitch-solver/single-high-density-route-stitch-gap-bridge.test.ts
@@ -94,3 +94,32 @@ test("single stitch can cap a modest terminal endpoint gap", () => {
     { x: 0, y: 0, z: 0 },
   ])
 })
+
+test("single stitch accepts fan-out terminal tags", () => {
+  const terminalFanoutRoutes = [
+    {
+      ...makeRoute("conn", [
+        { x: 0, y: 0, z: 0 },
+        { x: 3, y: 0, z: 0 },
+      ]),
+      startPcbPortId: "pcb_port_start",
+    },
+    {
+      ...makeRoute("conn", [
+        { x: 0, y: 0, z: 0 },
+        { x: 6, y: 0, z: 0 },
+      ]),
+      startPcbPortId: "pcb_port_start",
+    },
+  ]
+  const solver = new SingleHighDensityRouteStitchSolver3({
+    connectionName: "conn",
+    start: { x: 0, y: 0, z: 0, pcb_port_id: "pcb_port_start" },
+    end: { x: 10, y: 0, z: 0, pcb_port_id: "pcb_port_end" },
+    hdRoutes: terminalFanoutRoutes,
+    preserveTerminalPcbPortIds: true,
+  })
+
+  expect(solver.mergedHdRoute.startPcbPortId).toBe("pcb_port_start")
+  expect(solver.mergedHdRoute.endPcbPortId).toBe("pcb_port_end")
+})

--- a/tests/tinyhypergraph-terminal-port-ids.test.ts
+++ b/tests/tinyhypergraph-terminal-port-ids.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test"
+import input from "../fixtures/features/portpointpathing/tinyhypergraph-port-bridge-repro-input.json"
+import { TinyHypergraphPortPointPathingSolver } from "lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver"
+
+test("TinyHypergraph port-point pathing assigns PCB terminal identities", () => {
+  const params = structuredClone(input) as any
+  params.preserveTerminalPcbPortIds = true
+  const [connection] = params.connections
+  connection.simpleRouteConnection.pointsToConnect[0].pcb_port_id =
+    "pcb_port_start"
+  connection.simpleRouteConnection.pointsToConnect[1].pcb_port_id =
+    "pcb_port_end"
+
+  const solver = new TinyHypergraphPortPointPathingSolver(params)
+  solver.solve()
+
+  const terminalPortPoints = solver
+    .getOutput()
+    .nodesWithPortPoints.flatMap((node) => node.portPoints)
+    .filter((portPoint) => portPoint.pcb_port_id)
+    .map(({ x, y, pcb_port_id }) => ({ x, y, pcb_port_id }))
+    .sort((a, b) => a.x - b.x)
+
+  expect(terminalPortPoints).toEqual([
+    { x: -4, y: -3, pcb_port_id: "pcb_port_start" },
+    { x: 4, y: -3, pcb_port_id: "pcb_port_end" },
+  ])
+})


### PR DESCRIPTION
## Summary

- preserve PCB terminal IDs from TinyHypergraph port-point pathing through high-density routing and stitching for Pipeline 7
- carry the identities as inert route-order metadata so earlier repair and optimization behavior remains unchanged
- lock final route endpoints by their preserved IDs instead of choosing an orientation from endpoint distance
- throw on malformed connections, duplicate terminal IDs, and unknown route terminal IDs

## Why

This follows up on @0hmX's review in #1659. The terminal-lock step previously inferred endpoint identity after simplification by comparing direct and reversed distances. That can associate a route endpoint with the wrong PCB port. Setting `pcb_port_id` on route points too early also changes optimization behavior, so this keeps a Pipeline-7-only sidecar until the existing terminal-lock boundary.

## Validation

- `bun run build`
- 23 affected tests across port-point pathing, high-density routing, repair, stitching, Pipeline 4 compatibility, open-route behavior, and Pipeline 7 integration
- Pipeline 7 full-frame SVG snapshot: `0.000%` difference with zero DRC errors
- repository-wide run: 400 passed / 53 skipped; all non-snapshot failures found by the run were fixed and rerun successfully
- remaining host SVG snapshot mismatches were reproduced on a clean `origin/main` worktree with identical percentages; stage geometry and final SVG hashes were byte-identical between this branch and `main`
