### PR TITLE
Improve high-effort residual repair yield

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -823,6 +823,8 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
         {
           hdRoutes: cms.postDrcTraceSimplificationSolver!.simplifiedHdRoutes,
           drcEvaluator: createRelaxedDrcEvaluatorForPipeline(cms),
+          candidateDrcEvaluator:
+            createExactGeometryDrcEvaluatorForPipeline(cms),
           bounds: cms.srj.bounds,
           outline: cms.srj.outline,
           obstacles: cms.srj.obstacles,

--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/convertPipeline7HdRoutesToSimplifiedPcbTraces.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/convertPipeline7HdRoutesToSimplifiedPcbTraces.ts
@@ -16,6 +16,10 @@ export interface ConvertPipeline7HdRoutesOptions {
   obstacles: Obstacle[]
   defaultViaHoleDiameter: number
   connMap: ConnectivityMap
+  routeConversionCache?: WeakMap<
+    HighDensityRoute,
+    SimplifiedPcbTrace["route"]
+  >
 }
 
 /** Converts Pipeline7 routes using the same net and terminal rules as final output. */
@@ -27,18 +31,24 @@ export const convertPipeline7HdRoutesToSimplifiedPcbTraces = ({
   obstacles,
   defaultViaHoleDiameter,
   connMap,
+  routeConversionCache,
 }: ConvertPipeline7HdRoutesOptions): SimplifiedPcbTraces => {
   const traces: SimplifiedPcbTraces = []
+  const originalConnectionByName = new Map(
+    originalConnections.map((connection) => [connection.name, connection]),
+  )
+  const routesByConnectionName = new Map<string, HighDensityRoute[]>()
+  for (const route of hdRoutes) {
+    const connectionRoutes = routesByConnectionName.get(route.connectionName)
+    if (connectionRoutes) connectionRoutes.push(route)
+    else routesByConnectionName.set(route.connectionName, [route])
+  }
 
   for (const connection of connections) {
     const netConnectionName =
       connection.__netConnectionName ??
-      originalConnections.find(
-        (candidate) => candidate.name === connection.name,
-      )?.__netConnectionName
-    const connectionRoutes = hdRoutes.filter(
-      (route) => route.connectionName === connection.name,
-    )
+      originalConnectionByName.get(connection.name)?.__netConnectionName
+    const connectionRoutes = routesByConnectionName.get(connection.name) ?? []
 
     if (connection.pointsToConnect.length !== 2) {
       throw new Error(
@@ -53,6 +63,20 @@ export const convertPipeline7HdRoutesToSimplifiedPcbTraces = ({
 
     for (let index = 0; index < connectionRoutes.length; index += 1) {
       const hdRoute = connectionRoutes[index]!
+      let simplifiedRoute = routeConversionCache?.get(hdRoute)
+      if (!simplifiedRoute) {
+        simplifiedRoute = convertHdRouteToSimplifiedRoute(
+          hdRoute,
+          layerCount,
+          {
+            connectionPoints: connection.pointsToConnect,
+            defaultViaHoleDiameter,
+            obstacles,
+            connMap,
+          },
+        )
+        routeConversionCache?.set(hdRoute, simplifiedRoute)
+      }
       const simplifiedPcbTrace: SimplifiedPcbTrace = {
         type: "pcb_trace",
         pcb_trace_id: `${connection.name}_${index}`,
@@ -61,12 +85,7 @@ export const convertPipeline7HdRoutesToSimplifiedPcbTraces = ({
           connection.__rootConnectionNames?.[0] ??
           connection.name,
         connectsTo,
-        route: convertHdRouteToSimplifiedRoute(hdRoute, layerCount, {
-          connectionPoints: connection.pointsToConnect,
-          defaultViaHoleDiameter,
-          obstacles,
-          connMap,
-        }),
+        route: simplifiedRoute,
       }
 
       traces.push(simplifiedPcbTrace)

--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/createPipeline7ExactGeometryDrcEvaluator.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/createPipeline7ExactGeometryDrcEvaluator.ts
@@ -18,6 +18,24 @@ type Pipeline7DrcEvaluatorConversionOptions = Omit<
   originalSrj: Parameters<typeof convertToCircuitJson>[0]
 }
 
+const getPadIdentifierFromDrcMessage = (
+  message: unknown,
+): string | undefined => {
+  if (typeof message !== "string") return undefined
+  const patterns = [
+    /pcb_smtpad "pcb_port\[#(pcb_port_[^\]]+)\]"/,
+    /Pad pcb_port\[#(pcb_port_[^\]]+)\]/,
+    /smtpad\[#(pcb_port_[^\]]+)\]/,
+    /pcb_plated_hole "pcb_plated_hole\[#(pcb_plated_hole_[^\]]+)\]"/,
+    /Pad pcb_plated_hole\[#(pcb_plated_hole_[^\]]+)\]/,
+  ]
+  for (const pattern of patterns) {
+    const identifier = message.match(pattern)?.[1]
+    if (identifier) return identifier
+  }
+  return undefined
+}
+
 const createPipeline7DrcEvaluator = (
   conversionOptions: Pipeline7DrcEvaluatorConversionOptions,
   drcOptions: GetDrcErrorsOptions,
@@ -48,13 +66,42 @@ const createPipeline7DrcEvaluator = (
           : [],
       ),
     )
+    const padCenterById = new Map<string, { x: number; y: number }>()
+    for (const element of circuitJson) {
+      if (
+        element.type !== "pcb_smtpad" &&
+        element.type !== "pcb_plated_hole"
+      ) {
+        continue
+      }
+      const center = { x: element.x, y: element.y }
+      const elementId =
+        element.type === "pcb_smtpad"
+          ? element.pcb_smtpad_id
+          : element.pcb_plated_hole_id
+      padCenterById.set(elementId, center)
+      if (element.pcb_port_id) padCenterById.set(element.pcb_port_id, center)
+    }
     const locationAwareErrors = errorsWithCenters.map((error) => {
       const candidate = error as unknown as Record<string, unknown>
       const viaCenter =
         typeof candidate.pcb_via_id === "string"
           ? viaCenterById.get(candidate.pcb_via_id)
           : undefined
-      return viaCenter ? { ...error, via_center: viaCenter } : error
+      const padIdentifier =
+        typeof candidate.pcb_pad_id === "string"
+          ? candidate.pcb_pad_id
+          : getPadIdentifierFromDrcMessage(candidate.message)
+      const padCenter = padIdentifier
+        ? padCenterById.get(padIdentifier)
+        : undefined
+      return viaCenter || padCenter
+        ? {
+            ...error,
+            ...(viaCenter ? { via_center: viaCenter } : {}),
+            ...(padCenter ? { pad_center: padCenter } : {}),
+          }
+        : error
     })
 
     return {

--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/createPipeline7ExactGeometryDrcEvaluator.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/createPipeline7ExactGeometryDrcEvaluator.ts
@@ -40,6 +40,8 @@ const createPipeline7DrcEvaluator = (
   conversionOptions: Pipeline7DrcEvaluatorConversionOptions,
   drcOptions: GetDrcErrorsOptions,
 ): DrcEvaluator => {
+  const routeConversionCache = new WeakMap()
+
   return ({ routes, hdRoutes }) => {
     const evaluatedRoutes = routes ?? hdRoutes
     if (!evaluatedRoutes) {
@@ -49,6 +51,7 @@ const createPipeline7DrcEvaluator = (
     const traces = convertPipeline7HdRoutesToSimplifiedPcbTraces({
       ...conversionOptions,
       hdRoutes: evaluatedRoutes,
+      routeConversionCache,
     })
     const circuitJson = convertToCircuitJson(
       conversionOptions.srjWithPointPairs,

--- a/lib/solvers/ResidualLocalRerouteSolver/ResidualLocalRerouteSolver.ts
+++ b/lib/solvers/ResidualLocalRerouteSolver/ResidualLocalRerouteSolver.ts
@@ -50,7 +50,12 @@ type DirectedSegmentShiftStrategy = {
   distance: number
 }
 
+type TerminalSnapStrategy = {
+  type: "terminal_snap"
+}
+
 type CandidateStrategy =
+  | TerminalSnapStrategy
   | ({ type: "dogleg" } & DoglegStrategy)
   | ({ type: "directed_dogleg" } & DirectedDoglegStrategy)
   | ({ type: "directed_pair_shift" } & DirectedSegmentShiftStrategy)
@@ -68,6 +73,8 @@ type CandidateTarget = {
   sourceZ?: number
   viaCenter?: Point
   viaRouteIndexes?: readonly number[]
+  terminalPoint?: Point
+  terminalPortId?: string
 }
 
 type RouteProjection = Point & { z: number }
@@ -153,6 +160,7 @@ const DIRECTED_SEGMENT_SHIFT_STRATEGIES: readonly DirectedSegmentShiftStrategy[]
   ]
 
 const getCandidateStrategyKey = (strategy: CandidateStrategy): string => {
+  if (strategy.type === "terminal_snap") return strategy.type
   if (strategy.type === "layer_detour") {
     return `${strategy.type}:${strategy.scope}:${strategy.targetZ}:${strategy.span}`
   }
@@ -173,18 +181,64 @@ const getCandidatePriority = (
   target: CandidateTarget,
   strategy: CandidateStrategy,
 ): number => {
-  if (target.errorType === "pcb_via_trace_clearance_error") {
+  if (target.terminalPoint) {
+    if (strategy.type === "terminal_snap") return 0
+    return 1
+  }
+  if (target.viaCenter && target.viaRouteIndexes?.length) {
     if (strategy.type === "directed_via_shift") return 0
     if (strategy.type === "directed_segment_shift") return 1
     if (strategy.type === "directed_dogleg") return 2
     if (strategy.type === "layer_detour") return 3
     return 4
   }
+  if (target.otherRouteIndex !== undefined) {
+    if (strategy.type === "directed_pair_shift") return 0
+    if (strategy.type === "directed_segment_shift") return 1
+    if (strategy.type === "directed_dogleg") return 2
+    if (strategy.type === "layer_detour") return 3
+    return 4
+  }
+  if (target.moveDirection) {
+    if (strategy.type === "directed_segment_shift") return 0
+    if (strategy.type === "directed_dogleg") return 1
+    if (strategy.type === "layer_detour") return 2
+    return 3
+  }
   if (strategy.type === "layer_detour") return 0
-  if (strategy.type === "directed_pair_shift") return 1
-  if (strategy.type === "directed_segment_shift") return 2
-  if (strategy.type === "directed_dogleg") return 3
-  return 4
+  return 1
+}
+
+const getCandidateStrategyVariantRank = (
+  target: CandidateTarget,
+  strategy: CandidateStrategy,
+): number => {
+  if (strategy.type === "terminal_snap") return 0
+  if (strategy.type === "layer_detour") {
+    const spanIndex = LAYER_DETOUR_SPANS.findIndex(
+      (candidateSpan) => candidateSpan === strategy.span,
+    )
+    return (
+      spanIndex * 100 +
+      strategy.targetZ * 2 +
+      (strategy.scope === "route" ? 1 : 0)
+    )
+  }
+  const distance =
+    strategy.type === "dogleg" ? Math.abs(strategy.offset) : strategy.distance
+  const desiredDistance = Math.min(
+    0.2,
+    Math.max(0.01, target.severity + 0.01),
+  )
+  const distanceRank =
+    distance >= desiredDistance
+      ? distance - desiredDistance
+      : 100 + desiredDistance - distance
+  const spanRank =
+    strategy.type === "dogleg" || strategy.type === "directed_dogleg"
+      ? strategy.span / 100
+      : 0
+  return distanceRank + spanRank
 }
 
 const getDrcErrorSeverity = (error: DrcError): number => {
@@ -222,6 +276,38 @@ const getErrorCenter = (error: DrcError): Point | undefined => {
   }
   return { x: candidate.x, y: candidate.y }
 }
+
+const getDrcPointField = (
+  error: DrcError,
+  fieldName: string,
+): Point | undefined => {
+  const value = error[fieldName]
+  if (!value || typeof value !== "object") return undefined
+  const candidate = value as Record<string, unknown>
+  if (typeof candidate.x !== "number" || typeof candidate.y !== "number") {
+    return undefined
+  }
+  return { x: candidate.x, y: candidate.y }
+}
+
+const isTraceViaOverlapError = (error: DrcError): boolean =>
+  error.type === "pcb_trace_error" &&
+  typeof error.message === "string" &&
+  error.message.includes("overlaps with pcb_via")
+
+const getNearestTransitionPoint = (
+  center: Point,
+  transitionPoints: readonly Point[],
+): Point | undefined =>
+  transitionPoints.reduce<Point | undefined>(
+    (nearest, candidate) =>
+      !nearest ||
+      Math.hypot(candidate.x - center.x, candidate.y - center.y) <
+        Math.hypot(nearest.x - center.x, nearest.y - center.y)
+        ? candidate
+        : nearest,
+    undefined,
+  )
 
 const isBetterSnapshot = (
   candidate: DrcSnapshot,
@@ -509,6 +595,7 @@ const getMoveData = (
 
   routePoint ??= getNearestRouteProjection(route, center)
   if (!routePoint) return {}
+  obstaclePoint ??= getDrcPointField(error, "pad_center")
   if (!obstaclePoint && typeof error.message === "string") {
     const obstaclePortId = error.message.match(
       /pcb_port\[#(pcb_port_[^\]]+)\]/,
@@ -526,16 +613,11 @@ const getMoveData = (
       obstaclePoint = { x: viaCenter.x, y: viaCenter.y }
     }
   }
-  if (!obstaclePoint && typeof error.pcb_via_id === "string") {
-    obstaclePoint = transitionPoints.reduce<Point | undefined>(
-      (nearest, candidate) =>
-        !nearest ||
-        Math.hypot(candidate.x - center.x, candidate.y - center.y) <
-          Math.hypot(nearest.x - center.x, nearest.y - center.y)
-          ? candidate
-          : nearest,
-      undefined,
-    )
+  if (
+    !obstaclePoint &&
+    (typeof error.pcb_via_id === "string" || isTraceViaOverlapError(error))
+  ) {
+    obstaclePoint = getNearestTransitionPoint(center, transitionPoints)
   }
   if (!obstaclePoint) return { sourceZ: routePoint.z }
 
@@ -856,6 +938,65 @@ const shiftVia = (
   }
 
   return movedVia
+}
+
+const snapRouteTerminal = (
+  routes: HighDensityRoute[],
+  routeIndex: number,
+  errorCenter: Point,
+  terminalPoint: Point,
+  terminalPortId: string | undefined,
+  boardPolygon: readonly Point[],
+): boolean => {
+  const route = routes[routeIndex]
+  if (!route || route.route.length < 2) return false
+  const endpointIndexes = [0, route.route.length - 1]
+  let pointIndex = terminalPortId
+    ? endpointIndexes.find(
+        (candidateIndex) =>
+          route.route[candidateIndex]!.pcb_port_id === terminalPortId,
+      )
+    : undefined
+  if (pointIndex === undefined) {
+    pointIndex = endpointIndexes.reduce((nearestIndex, candidateIndex) => {
+      const nearest = route.route[nearestIndex]!
+      const candidate = route.route[candidateIndex]!
+      return Math.hypot(candidate.x - errorCenter.x, candidate.y - errorCenter.y) <
+        Math.hypot(nearest.x - errorCenter.x, nearest.y - errorCenter.y)
+        ? candidateIndex
+        : nearestIndex
+    })
+    const nearestEndpoint = route.route[pointIndex]!
+    if (
+      Math.hypot(
+        nearestEndpoint.x - errorCenter.x,
+        nearestEndpoint.y - errorCenter.y,
+      ) > 1e-3
+    ) {
+      return false
+    }
+  }
+
+  const terminal = route.route[pointIndex]!
+  if (
+    Math.hypot(terminal.x - terminalPoint.x, terminal.y - terminalPoint.y) <=
+    1e-6
+  ) {
+    return false
+  }
+  terminal.x = terminalPoint.x
+  terminal.y = terminalPoint.y
+  if (terminalPortId) terminal.pcb_port_id = terminalPortId
+  const neighbor = route.route[pointIndex === 0 ? 1 : pointIndex - 1]!
+  const traceRadius = (terminal.traceThickness ?? route.traceThickness) / 2
+  return (
+    isPointInsideBoard(terminal, boardPolygon, traceRadius) &&
+    doesDoglegStayInsideBoard(
+      pointIndex === 0 ? [terminal, neighbor] : [neighbor, terminal],
+      boardPolygon,
+      traceRadius,
+    )
+  )
 }
 
 const insertSegmentLayerDetour = (
@@ -1255,6 +1396,7 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
         ...strategy,
       }))
     this.strategies = [
+      { type: "terminal_snap" },
       ...directedViaShiftStrategies,
       ...layerDetourStrategies,
       ...directedPairShiftStrategies,
@@ -1332,7 +1474,7 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
           transitionPoints,
           this.config.obstacles ?? [],
         )
-        const viaCenter =
+        const typedViaCenter =
           error.type === "pcb_via_trace_clearance_error" &&
           error.via_center &&
           typeof error.via_center === "object" &&
@@ -1343,6 +1485,21 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
                 y: (error.via_center as { y: number }).y,
               }
             : undefined
+        const viaCenter =
+          typedViaCenter ??
+          (isTraceViaOverlapError(error)
+            ? getNearestTransitionPoint(center, transitionPoints)
+            : undefined)
+        const terminalPortId =
+          typeof error.message === "string" &&
+          error.message.includes("missing a connection")
+            ? error.message.match(
+                /(?:smtpad|plated_hole)\[#(pcb_port_[^\]]+)\]/,
+              )?.[1]
+            : undefined
+        const terminalPoint = terminalPortId
+          ? getDrcPointField(error, "pad_center")
+          : undefined
         targets.push({
           routeIndex,
           center,
@@ -1355,6 +1512,8 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
           viaRouteIndexes: viaCenter
             ? getViaRouteIndexes(this.bestRoutes, viaCenter)
             : undefined,
+          terminalPoint,
+          terminalPortId,
         })
       }
     })
@@ -1368,6 +1527,9 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
     const plan = this.strategies
       .flatMap((strategy) =>
         targets.flatMap((target) => {
+        if (strategy.type === "terminal_snap" && !target.terminalPoint) {
+          return []
+        }
         if (
           (strategy.type === "directed_dogleg" ||
             strategy.type === "directed_segment_shift" ||
@@ -1409,6 +1571,8 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
       .sort(
         (a, b) =>
           getCandidatePriority(a, a) - getCandidatePriority(b, b) ||
+          getCandidateStrategyVariantRank(a, a) -
+            getCandidateStrategyVariantRank(b, b) ||
           a.severity - b.severity,
       )
 
@@ -1456,6 +1620,18 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
     const candidateRoutes = structuredClone(this.bestRoutes)
     let changed = false
     if (
+      candidatePlanEntry.type === "terminal_snap" &&
+      candidatePlanEntry.terminalPoint
+    ) {
+      changed = snapRouteTerminal(
+        candidateRoutes,
+        candidatePlanEntry.routeIndex,
+        candidatePlanEntry.center,
+        candidatePlanEntry.terminalPoint,
+        candidatePlanEntry.terminalPortId,
+        this.boardPolygon,
+      )
+    } else if (
       candidatePlanEntry.type === "directed_via_shift" &&
       candidatePlanEntry.moveDirection &&
       candidatePlanEntry.viaCenter &&

--- a/lib/solvers/ResidualLocalRerouteSolver/ResidualLocalRerouteSolver.ts
+++ b/lib/solvers/ResidualLocalRerouteSolver/ResidualLocalRerouteSolver.ts
@@ -54,10 +54,18 @@ type TerminalSnapStrategy = {
   type: "terminal_snap"
 }
 
+type ObstacleDetourStrategy = {
+  type: "obstacle_detour"
+  side: "top" | "right" | "bottom" | "left"
+  margin: number
+}
+
 type CandidateStrategy =
   | TerminalSnapStrategy
+  | ObstacleDetourStrategy
   | ({ type: "dogleg" } & DoglegStrategy)
   | ({ type: "directed_dogleg" } & DirectedDoglegStrategy)
+  | ({ type: "directed_pair_dogleg" } & DirectedDoglegStrategy)
   | ({ type: "directed_pair_shift" } & DirectedSegmentShiftStrategy)
   | ({ type: "directed_segment_shift" } & DirectedSegmentShiftStrategy)
   | ({ type: "directed_via_shift" } & DirectedSegmentShiftStrategy)
@@ -75,6 +83,7 @@ type CandidateTarget = {
   viaRouteIndexes?: readonly number[]
   terminalPoint?: Point
   terminalPortId?: string
+  obstacle?: RoutingObstacle
 }
 
 type RouteProjection = Point & { z: number }
@@ -83,6 +92,7 @@ type MoveData = {
   direction?: Point
   otherRouteIndex?: number
   sourceZ?: number
+  obstacle?: RoutingObstacle
 }
 
 type CandidatePlanEntry = CandidateTarget &
@@ -161,10 +171,16 @@ const DIRECTED_SEGMENT_SHIFT_STRATEGIES: readonly DirectedSegmentShiftStrategy[]
 
 const getCandidateStrategyKey = (strategy: CandidateStrategy): string => {
   if (strategy.type === "terminal_snap") return strategy.type
+  if (strategy.type === "obstacle_detour") {
+    return `${strategy.type}:${strategy.side}:${strategy.margin}`
+  }
   if (strategy.type === "layer_detour") {
     return `${strategy.type}:${strategy.scope}:${strategy.targetZ}:${strategy.span}`
   }
-  if (strategy.type === "directed_dogleg") {
+  if (
+    strategy.type === "directed_dogleg" ||
+    strategy.type === "directed_pair_dogleg"
+  ) {
     return `${strategy.type}:${strategy.distance}:${strategy.span}`
   }
   if (
@@ -185,6 +201,13 @@ const getCandidatePriority = (
     if (strategy.type === "terminal_snap") return 0
     return 1
   }
+  if (target.obstacle) {
+    if (strategy.type === "obstacle_detour") return 0
+    if (strategy.type === "directed_segment_shift") return 1
+    if (strategy.type === "directed_dogleg") return 2
+    if (strategy.type === "layer_detour") return 3
+    return 4
+  }
   if (target.viaCenter && target.viaRouteIndexes?.length) {
     if (strategy.type === "directed_via_shift") return 0
     if (strategy.type === "directed_segment_shift") return 1
@@ -194,6 +217,7 @@ const getCandidatePriority = (
   }
   if (target.otherRouteIndex !== undefined) {
     if (strategy.type === "directed_pair_shift") return 0
+    if (strategy.type === "directed_pair_dogleg") return 0.5
     if (strategy.type === "directed_segment_shift") return 1
     if (strategy.type === "directed_dogleg") return 2
     if (strategy.type === "layer_detour") return 3
@@ -214,6 +238,10 @@ const getCandidateStrategyVariantRank = (
   strategy: CandidateStrategy,
 ): number => {
   if (strategy.type === "terminal_snap") return 0
+  if (strategy.type === "obstacle_detour") {
+    const sideRank = ["top", "right", "bottom", "left"].indexOf(strategy.side)
+    return strategy.margin * 100 + sideRank
+  }
   if (strategy.type === "layer_detour") {
     const spanIndex = LAYER_DETOUR_SPANS.findIndex(
       (candidateSpan) => candidateSpan === strategy.span,
@@ -232,7 +260,9 @@ const getCandidateStrategyVariantRank = (
       ? distance - desiredDistance
       : 100 + desiredDistance - distance
   const spanRank =
-    strategy.type === "dogleg" || strategy.type === "directed_dogleg"
+    strategy.type === "dogleg" ||
+    strategy.type === "directed_dogleg" ||
+    strategy.type === "directed_pair_dogleg"
       ? strategy.span / 100
       : 0
   return distanceRank + spanRank
@@ -291,6 +321,11 @@ const isTraceViaOverlapError = (error: DrcError): boolean =>
   error.type === "pcb_trace_error" &&
   typeof error.message === "string" &&
   error.message.includes("overlaps with pcb_via")
+
+const isTracePadOverlapError = (error: DrcError): boolean =>
+  error.type === "pcb_trace_error" &&
+  typeof error.message === "string" &&
+  error.message.includes("overlaps with pcb_smtpad")
 
 const getNearestTransitionPoint = (
   center: Point,
@@ -566,6 +601,21 @@ const getViaRouteIndexes = (
   )
 }
 
+const getPointToObstacleDistance = (
+  point: Point,
+  obstacle: RoutingObstacle,
+): number => {
+  const dx = Math.max(
+    0,
+    Math.abs(point.x - obstacle.center.x) - obstacle.width / 2,
+  )
+  const dy = Math.max(
+    0,
+    Math.abs(point.y - obstacle.center.y) - obstacle.height / 2,
+  )
+  return Math.hypot(dx, dy)
+}
+
 const getMoveData = (
   error: DrcError,
   center: Point,
@@ -602,16 +652,27 @@ const getMoveData = (
   routePoint ??= getNearestRouteProjection(route, center)
   if (!routePoint) return {}
   obstaclePoint ??= getDrcPointField(error, "pad_center")
-  if (!obstaclePoint && typeof error.message === "string") {
-    const obstaclePortId = error.message.match(
+  let routingObstacle: RoutingObstacle | undefined
+  if (isTracePadOverlapError(error)) {
+    const obstaclePortId = String(error.message).match(
       /pcb_port\[#(pcb_port_[^\]]+)\]/,
     )?.[1]
-    const obstacle = obstaclePortId
-      ? obstacles.find((candidate) =>
-          candidate.connectedTo?.includes(obstaclePortId),
-        )
+    routingObstacle = obstaclePortId
+      ? obstacles
+          .filter((candidate) =>
+            candidate.connectedTo?.includes(obstaclePortId),
+          )
+          .sort(
+            (a, b) =>
+              getPointToObstacleDistance(center, a) -
+                getPointToObstacleDistance(center, b) ||
+              Math.hypot(center.x - a.center.x, center.y - a.center.y) -
+                Math.hypot(center.x - b.center.x, center.y - b.center.y),
+          )[0]
       : undefined
-    if (obstacle) obstaclePoint = obstacle.center
+    if (!obstaclePoint && routingObstacle) {
+      obstaclePoint = routingObstacle.center
+    }
   }
   if (
     !obstaclePoint &&
@@ -638,7 +699,164 @@ const getMoveData = (
     direction: length > 1e-6 ? { x: dx / length, y: dy / length } : undefined,
     otherRouteIndex: pairedRouteIndex,
     sourceZ: routePoint.z,
+    obstacle: routingObstacle,
   }
+}
+
+const insertObstacleDetour = (
+  routes: HighDensityRoute[],
+  routeIndex: number,
+  center: Point,
+  obstacle: RoutingObstacle,
+  strategy: ObstacleDetourStrategy,
+  boardPolygon: readonly Point[],
+  sourceZ?: number,
+): boolean => {
+  const route = routes[routeIndex]
+  if (!route) return false
+
+  let nearest:
+    | { segmentIndex: number; distance: number; sourceZ: number }
+    | undefined
+  for (
+    let segmentIndex = 0;
+    segmentIndex + 1 < route.route.length;
+    segmentIndex += 1
+  ) {
+    const start = route.route[segmentIndex]!
+    const end = route.route[segmentIndex + 1]!
+    if (
+      start.z !== end.z ||
+      (sourceZ !== undefined && start.z !== sourceZ) ||
+      start.toNextSegmentType === "through_obstacle" ||
+      start.insideJumperPad ||
+      end.insideJumperPad
+    ) {
+      continue
+    }
+    const dx = end.x - start.x
+    const dy = end.y - start.y
+    const lengthSquared = dx * dx + dy * dy
+    if (lengthSquared <= 1e-8) continue
+    const t = Math.max(
+      0,
+      Math.min(
+        1,
+        ((center.x - start.x) * dx + (center.y - start.y) * dy) / lengthSquared,
+      ),
+    )
+    const projected = { x: start.x + dx * t, y: start.y + dy * t }
+    const distance = Math.hypot(center.x - projected.x, center.y - projected.y)
+    if (!nearest || distance < nearest.distance) {
+      nearest = { segmentIndex, distance, sourceZ: start.z }
+    }
+  }
+  if (!nearest) return false
+
+  const traceRadius = (route.traceThickness ?? 0.1) / 2
+  const clearance = traceRadius + strategy.margin
+  const minX = obstacle.center.x - obstacle.width / 2 - clearance
+  const maxX = obstacle.center.x + obstacle.width / 2 + clearance
+  const minY = obstacle.center.y - obstacle.height / 2 - clearance
+  const maxY = obstacle.center.y + obstacle.height / 2 + clearance
+  const isInsideExpandedObstacle = (point: Point): boolean =>
+    point.x >= minX && point.x <= maxX && point.y >= minY && point.y <= maxY
+
+  let beforeIndex = nearest.segmentIndex
+  while (
+    beforeIndex > 0 &&
+    isInsideExpandedObstacle(route.route[beforeIndex]!)
+  ) {
+    beforeIndex -= 1
+  }
+  let afterIndex = nearest.segmentIndex + 1
+  while (
+    afterIndex + 1 < route.route.length &&
+    isInsideExpandedObstacle(route.route[afterIndex]!)
+  ) {
+    afterIndex += 1
+  }
+
+  const before = route.route[beforeIndex]!
+  const after = route.route[afterIndex]!
+  if (
+    isInsideExpandedObstacle(before) ||
+    isInsideExpandedObstacle(after) ||
+    before.z !== nearest.sourceZ ||
+    after.z !== nearest.sourceZ
+  ) {
+    return false
+  }
+  const removedPoints = route.route.slice(beforeIndex + 1, afterIndex)
+  if (
+    removedPoints.some(
+      (point) =>
+        point.z !== nearest.sourceZ ||
+        point.pcb_port_id ||
+        point.insideJumperPad ||
+        point.toNextSegmentType === "through_obstacle",
+    ) ||
+    route.vias.some((via) =>
+      removedPoints.some(
+        (point) => Math.hypot(via.x - point.x, via.y - point.y) <= 1e-6,
+      ),
+    )
+  ) {
+    return false
+  }
+
+  const boundaryPoints: Point[] =
+    strategy.side === "top"
+      ? [
+          { x: before.x, y: maxY },
+          { x: after.x, y: maxY },
+        ]
+      : strategy.side === "right"
+        ? [
+            { x: maxX, y: before.y },
+            { x: maxX, y: after.y },
+          ]
+        : strategy.side === "bottom"
+          ? [
+              { x: before.x, y: minY },
+              { x: after.x, y: minY },
+            ]
+          : [
+              { x: minX, y: before.y },
+              { x: minX, y: after.y },
+            ]
+  const doglegPoints = [before, ...boundaryPoints, after]
+  if (!doesDoglegStayInsideBoard(doglegPoints, boardPolygon, traceRadius)) {
+    return false
+  }
+
+  const {
+    pcb_port_id: _pcbPortId,
+    insideJumperPad: _insideJumperPad,
+    toNextSegmentType: _toNextSegmentType,
+    ...insertedPointFields
+  } = before
+  const replacement = boundaryPoints
+    .map((point) => ({
+      ...insertedPointFields,
+      ...point,
+      z: nearest.sourceZ,
+    }))
+    .filter(
+      (point, index, points) =>
+        Math.hypot(
+          point.x - (index === 0 ? before : points[index - 1]!).x,
+          point.y - (index === 0 ? before : points[index - 1]!).y,
+        ) > 1e-6 &&
+        (index + 1 < points.length ||
+          Math.hypot(point.x - after.x, point.y - after.y) > 1e-6),
+    )
+  route.route.splice(
+    beforeIndex + 1,
+    afterIndex - beforeIndex - 1,
+    ...replacement,
+  )
+  return replacement.length > 0
 }
 
 const insertDogleg = (
@@ -1320,15 +1538,19 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
   private readonly strategies: readonly CandidateStrategy[]
   private bestRoutes: HighDensityRoute[]
   private bestSnapshot?: DrcSnapshot
+  private initialIssueCount = Number.POSITIVE_INFINITY
   private candidatePlan: CandidatePlanEntry[] = []
   private candidatePlanIndex = 0
   private candidateAttempts = 0
   private acceptedMoves = 0
+  private acceptedCountReducingMoves = 0
+  private acceptedRefinementMoves = 0
   private sweepsStarted = 0
   private currentTargetCount = 0
   private readonly attemptedCandidateKeys = new Set<string>()
   private readonly routeRevisionByIndex: number[]
   private readonly maxCandidatesBeforeRefinement: number
+  private readonly maxTotalAcceptedMoves: number
   private candidateAttemptsSinceAccepted = 0
   private pendingCandidate?: {
     routes: HighDensityRoute[]
@@ -1366,6 +1588,12 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
         config.maxCandidateAttempts / Math.max(1, config.maxAcceptedMoves),
       ),
     )
+    const extraAcceptedMoveAllowance = Math.min(
+      4,
+      Math.max(0, Math.ceil(Math.log2(config.effort))),
+    )
+    this.maxTotalAcceptedMoves =
+      config.maxAcceptedMoves + extraAcceptedMoveAllowance
     const strategyLimit = Math.min(
       ALL_DOGLEG_STRATEGIES.length,
       2 + Math.ceil(4.5 * Math.log2(Math.max(1, config.effort))),
@@ -1392,6 +1620,11 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
         type: "directed_dogleg",
         ...strategy,
       }))
+    const directedPairDoglegStrategies: CandidateStrategy[] =
+      DIRECTED_DOGLEG_STRATEGIES.map((strategy) => ({
+        type: "directed_pair_dogleg",
+        ...strategy,
+      }))
     const directedSegmentShiftStrategies: CandidateStrategy[] =
       DIRECTED_SEGMENT_SHIFT_STRATEGIES.map((strategy) => ({
         type: "directed_segment_shift",
@@ -1407,17 +1640,28 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
         type: "directed_via_shift",
         ...strategy,
       }))
+    const obstacleDetourMargins = config.effort > 1 ? [0.1] : []
+    const obstacleDetourStrategies: CandidateStrategy[] =
+      obstacleDetourMargins.flatMap((margin) =>
+        (["top", "right", "bottom", "left"] as const).map((side) => ({
+          type: "obstacle_detour" as const,
+          side,
+          margin,
+        })),
+      )
     this.strategies = [
       { type: "terminal_snap" },
       ...directedViaShiftStrategies,
+      ...obstacleDetourStrategies,
       ...layerDetourStrategies,
       ...directedPairShiftStrategies,
+      ...directedPairDoglegStrategies,
       ...directedSegmentShiftStrategies,
       ...directedDoglegStrategies,
       ...doglegStrategies,
     ]
     this.MAX_ITERATIONS =
-      config.maxCandidateAttempts + config.maxAcceptedMoves + 10
+      config.maxCandidateAttempts + this.maxTotalAcceptedMoves + 10
   }
 
   override getSolverName(): string {
@@ -1538,6 +1782,7 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
             : undefined,
           terminalPoint,
           terminalPortId,
+          obstacle: moveData.obstacle,
         })
       }
     })
@@ -1554,8 +1799,20 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
           if (strategy.type === "terminal_snap" && !target.terminalPoint) {
             return []
           }
+          if (strategy.type === "obstacle_detour" && !target.obstacle) {
+            return []
+          }
+          if (
+            (strategy.type === "obstacle_detour" ||
+              strategy.type === "directed_pair_dogleg") &&
+            this.initialIssueCount >
+              Math.max(2, Math.floor(this.config.maxAcceptedMoves / 2))
+          ) {
+            return []
+          }
           if (
             (strategy.type === "directed_dogleg" ||
+              strategy.type === "directed_pair_dogleg" ||
               strategy.type === "directed_segment_shift" ||
               strategy.type === "directed_pair_shift" ||
               strategy.type === "directed_via_shift") &&
@@ -1570,7 +1827,8 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
             return []
           }
           if (
-            strategy.type === "directed_pair_shift" &&
+            (strategy.type === "directed_pair_shift" ||
+              strategy.type === "directed_pair_dogleg") &&
             (target.otherRouteIndex === undefined ||
               target.routeIndex > target.otherRouteIndex)
           ) {
@@ -1579,7 +1837,11 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
           const affectedRouteIndexes =
             strategy.type === "directed_via_shift"
               ? (target.viaRouteIndexes ?? [])
-              : [target.routeIndex]
+              : (strategy.type === "directed_pair_shift" ||
+                    strategy.type === "directed_pair_dogleg") &&
+                  target.otherRouteIndex !== undefined
+                ? [target.routeIndex, target.otherRouteIndex]
+                : [target.routeIndex]
           const routeRevisions = affectedRouteIndexes
             .map(
               (routeIndex) =>
@@ -1620,6 +1882,9 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
       residualLocalRerouteFinalDrcIssueScore: this.bestSnapshot?.issueScore,
       residualLocalRerouteCandidateAttempts: this.candidateAttempts,
       residualLocalRerouteAcceptedMoves: this.acceptedMoves,
+      residualLocalRerouteAcceptedCountReducingMoves:
+        this.acceptedCountReducingMoves,
+      residualLocalRerouteAcceptedRefinementMoves: this.acceptedRefinementMoves,
       residualLocalRerouteSweepsStarted: this.sweepsStarted,
       residualLocalRerouteStrategyCount: this.strategies.length,
       residualLocalRerouteTargetCount: this.currentTargetCount,
@@ -1633,6 +1898,7 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
       residualLocalRerouteMaxCandidateAttempts:
         this.config.maxCandidateAttempts,
       residualLocalRerouteMaxAcceptedMoves: this.config.maxAcceptedMoves,
+      residualLocalRerouteMaxTotalAcceptedMoves: this.maxTotalAcceptedMoves,
     }
     this.progress = 1
     this.solved = true
@@ -1654,6 +1920,19 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
         candidatePlanEntry.terminalPoint,
         candidatePlanEntry.terminalPortId,
         this.boardPolygon,
+      )
+    } else if (
+      candidatePlanEntry.type === "obstacle_detour" &&
+      candidatePlanEntry.obstacle
+    ) {
+      changed = insertObstacleDetour(
+        candidateRoutes,
+        candidatePlanEntry.routeIndex,
+        candidatePlanEntry.center,
+        candidatePlanEntry.obstacle,
+        candidatePlanEntry,
+        this.boardPolygon,
+        candidatePlanEntry.sourceZ,
       )
     } else if (
       candidatePlanEntry.type === "directed_via_shift" &&
@@ -1715,6 +1994,34 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
       )
       changed = movedPrimary && movedOther
     } else if (
+      candidatePlanEntry.type === "directed_pair_dogleg" &&
+      candidatePlanEntry.moveDirection &&
+      candidatePlanEntry.otherRouteIndex !== undefined
+    ) {
+      const halfDistance = candidatePlanEntry.distance / 2
+      const movedPrimary = insertDogleg(
+        candidateRoutes,
+        candidatePlanEntry.routeIndex,
+        candidatePlanEntry.center,
+        { offset: halfDistance, span: candidatePlanEntry.span },
+        this.boardPolygon,
+        candidatePlanEntry.moveDirection,
+        candidatePlanEntry.sourceZ,
+      )
+      const movedOther = insertDogleg(
+        candidateRoutes,
+        candidatePlanEntry.otherRouteIndex,
+        candidatePlanEntry.center,
+        { offset: halfDistance, span: candidatePlanEntry.span },
+        this.boardPolygon,
+        {
+          x: -candidatePlanEntry.moveDirection.x,
+          y: -candidatePlanEntry.moveDirection.y,
+        },
+        candidatePlanEntry.sourceZ,
+      )
+      changed = movedPrimary && movedOther
+    } else if (
       candidatePlanEntry.type === "directed_segment_shift" &&
       candidatePlanEntry.moveDirection
     ) {
@@ -1756,9 +2063,14 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
     snapshot: DrcSnapshot
     entry: CandidatePlanEntry
   }): boolean {
+    const reducedIssueCount =
+      candidate.snapshot.issueCount <
+      (this.bestSnapshot?.issueCount ?? Infinity)
     this.bestRoutes = candidate.routes
     this.bestSnapshot = candidate.snapshot
     this.acceptedMoves += 1
+    if (reducedIssueCount) this.acceptedCountReducingMoves += 1
+    else this.acceptedRefinementMoves += 1
     this.candidateAttemptsSinceAccepted = 0
     this.pendingCandidate = undefined
     const changedRouteIndexes =
@@ -1770,7 +2082,8 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
         (this.routeRevisionByIndex[routeIndex] ?? 0) + 1
     }
     if (
-      candidate.entry.type === "directed_pair_shift" &&
+      (candidate.entry.type === "directed_pair_shift" ||
+        candidate.entry.type === "directed_pair_dogleg") &&
       candidate.entry.otherRouteIndex !== undefined
     ) {
       this.routeRevisionByIndex[candidate.entry.otherRouteIndex] =
@@ -1780,7 +2093,10 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
       this.finish({ stoppedAfterNoImprovement: false })
       return true
     }
-    if (this.acceptedMoves >= this.config.maxAcceptedMoves) {
+    if (
+      this.acceptedCountReducingMoves >= this.config.maxAcceptedMoves ||
+      this.acceptedMoves >= this.maxTotalAcceptedMoves
+    ) {
       this.finish({
         stoppedAfterNoImprovement: false,
         hitAcceptedMoveLimit: true,
@@ -1802,6 +2118,7 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
 
     if (!this.bestSnapshot) {
       this.bestSnapshot = this.evaluate(this.bestRoutes)
+      this.initialIssueCount = this.bestSnapshot.issueCount
       this.stats.residualLocalRerouteInitialDrcIssueCount =
         this.bestSnapshot.issueCount
       if (this.bestSnapshot.issueCount === 0) {

--- a/lib/solvers/ResidualLocalRerouteSolver/ResidualLocalRerouteSolver.ts
+++ b/lib/solvers/ResidualLocalRerouteSolver/ResidualLocalRerouteSolver.ts
@@ -226,10 +226,7 @@ const getCandidateStrategyVariantRank = (
   }
   const distance =
     strategy.type === "dogleg" ? Math.abs(strategy.offset) : strategy.distance
-  const desiredDistance = Math.min(
-    0.2,
-    Math.max(0.01, target.severity + 0.01),
-  )
+  const desiredDistance = Math.min(0.2, Math.max(0.01, target.severity + 0.01))
   const distanceRank =
     distance >= desiredDistance
       ? distance - desiredDistance
@@ -430,8 +427,7 @@ const getNearestRouteProjection = (
       0,
       Math.min(
         1,
-        ((center.x - start.x) * dx + (center.y - start.y) * dy) /
-          lengthSquared,
+        ((center.x - start.x) * dx + (center.y - start.y) * dy) / lengthSquared,
       ),
     )
     const point = { x: start.x + dx * t, y: start.y + dy * t, z: start.z }
@@ -446,7 +442,11 @@ const getNearestSameLayerProjectionPair = (
   otherRoute: HighDensityRoute,
   center: Point,
 ):
-  | { routePoint: RouteProjection; obstaclePoint: RouteProjection; score: number }
+  | {
+      routePoint: RouteProjection
+      obstaclePoint: RouteProjection
+      score: number
+    }
   | undefined => {
   let nearest:
     | {
@@ -455,7 +455,11 @@ const getNearestSameLayerProjectionPair = (
         score: number
       }
     | undefined
-  for (let routeIndex = 0; routeIndex + 1 < route.route.length; routeIndex += 1) {
+  for (
+    let routeIndex = 0;
+    routeIndex + 1 < route.route.length;
+    routeIndex += 1
+  ) {
     const routeStart = route.route[routeIndex]!
     const routeEnd = route.route[routeIndex + 1]!
     if (routeStart.z !== routeEnd.z) continue
@@ -515,7 +519,9 @@ const getNearestSameLayerProjectionPair = (
   return nearest
 }
 
-const getLayerTransitionPoints = (routes: readonly HighDensityRoute[]): Point[] => {
+const getLayerTransitionPoints = (
+  routes: readonly HighDensityRoute[],
+): Point[] => {
   const points: Point[] = []
   const keys = new Set<string>()
   for (const route of routes) {
@@ -562,15 +568,15 @@ const getViaRouteIndexes = (
 
 const getMoveData = (
   error: DrcError,
+  center: Point,
   routeIndex: number,
   errorRouteIndexes: readonly number[],
   routes: readonly HighDensityRoute[],
   transitionPoints: readonly Point[],
   obstacles: readonly RoutingObstacle[],
 ): MoveData => {
-  const center = getErrorCenter(error)
   const route = routes[routeIndex]
-  if (!center || !route) return {}
+  if (!route) return {}
 
   let routePoint: RouteProjection | undefined
   let obstaclePoint: RouteProjection | Point | undefined
@@ -607,7 +613,11 @@ const getMoveData = (
       : undefined
     if (obstacle) obstaclePoint = obstacle.center
   }
-  if (!obstaclePoint && error.via_center && typeof error.via_center === "object") {
+  if (
+    !obstaclePoint &&
+    error.via_center &&
+    typeof error.via_center === "object"
+  ) {
     const viaCenter = error.via_center as Record<string, unknown>
     if (typeof viaCenter.x === "number" && typeof viaCenter.y === "number") {
       obstaclePoint = { x: viaCenter.x, y: viaCenter.y }
@@ -625,8 +635,7 @@ const getMoveData = (
   const dy = routePoint.y - obstaclePoint.y
   const length = Math.hypot(dx, dy)
   return {
-    direction:
-      length > 1e-6 ? { x: dx / length, y: dy / length } : undefined,
+    direction: length > 1e-6 ? { x: dx / length, y: dy / length } : undefined,
     otherRouteIndex: pairedRouteIndex,
     sourceZ: routePoint.z,
   }
@@ -777,8 +786,7 @@ const shiftNearestSegment = (
       0,
       Math.min(
         1,
-        ((center.x - start.x) * dx + (center.y - start.y) * dy) /
-          lengthSquared,
+        ((center.x - start.x) * dx + (center.y - start.y) * dy) / lengthSquared,
       ),
     )
     const projected = { x: start.x + dx * t, y: start.y + dy * t }
@@ -961,8 +969,10 @@ const snapRouteTerminal = (
     pointIndex = endpointIndexes.reduce((nearestIndex, candidateIndex) => {
       const nearest = route.route[nearestIndex]!
       const candidate = route.route[candidateIndex]!
-      return Math.hypot(candidate.x - errorCenter.x, candidate.y - errorCenter.y) <
-        Math.hypot(nearest.x - errorCenter.x, nearest.y - errorCenter.y)
+      return Math.hypot(
+        candidate.x - errorCenter.x,
+        candidate.y - errorCenter.y,
+      ) < Math.hypot(nearest.x - errorCenter.x, nearest.y - errorCenter.y)
         ? candidateIndex
         : nearestIndex
     })
@@ -1036,8 +1046,7 @@ const insertSegmentLayerDetour = (
       0,
       Math.min(
         1,
-        ((center.x - start.x) * dx + (center.y - start.y) * dy) /
-          lengthSquared,
+        ((center.x - start.x) * dx + (center.y - start.y) * dy) / lengthSquared,
       ),
     )
     const projected = { x: start.x + dx * t, y: start.y + dy * t }
@@ -1248,7 +1257,10 @@ const insertRouteLayerDetour = (
   }
   const beforePoint = interpolatePoint(beforeSegmentIndex, beforeT)
   const afterPoint = interpolatePoint(afterSegmentIndex, afterT)
-  if (Math.hypot(afterPoint.x - beforePoint.x, afterPoint.y - beforePoint.y) < 0.02) {
+  if (
+    Math.hypot(afterPoint.x - beforePoint.x, afterPoint.y - beforePoint.y) <
+    0.02
+  ) {
     return false
   }
 
@@ -1457,49 +1469,61 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
 
     snapshot.errors.forEach((error) => {
       if (!SUPPORTED_ERROR_TYPES.has(String(error.type))) return
-      const center = getErrorCenter(error)
-      if (!center) return
+      const errorCenter = getErrorCenter(error)
+      if (!errorCenter) return
       const routeIndexes = getTraceIdsForError(error)
         .map((traceId) => routeIndexByTraceId.get(traceId))
         .filter((routeIndex): routeIndex is number => routeIndex !== undefined)
+      const typedViaCenter =
+        error.type === "pcb_via_trace_clearance_error" &&
+        error.via_center &&
+        typeof error.via_center === "object" &&
+        typeof (error.via_center as Record<string, unknown>).x === "number" &&
+        typeof (error.via_center as Record<string, unknown>).y === "number"
+          ? {
+              x: (error.via_center as { x: number }).x,
+              y: (error.via_center as { y: number }).y,
+            }
+          : undefined
+      const viaCenter =
+        typedViaCenter ??
+        (isTraceViaOverlapError(error)
+          ? getNearestTransitionPoint(errorCenter, transitionPoints)
+          : undefined)
+      const terminalPortId =
+        typeof error.message === "string" &&
+        error.message.includes("missing a connection")
+          ? error.message.match(
+              /(?:smtpad|plated_hole)\[#(pcb_port_[^\]]+)\]/,
+            )?.[1]
+          : undefined
+      const terminalPoint = terminalPortId
+        ? getDrcPointField(error, "pad_center")
+        : undefined
+      const padCenter = getDrcPointField(error, "pad_center")
+      // Typed clearance reporters can attach a generic center that is far
+      // from the colliding copper. Exact pad/via centers identify the local
+      // route segment that must actually move. Trace overlap and connectivity
+      // reporters already provide their useful collision/endpoint location.
+      const center =
+        error.type === "pcb_pad_trace_clearance_error"
+          ? (padCenter ?? errorCenter)
+          : error.type === "pcb_via_trace_clearance_error"
+            ? (viaCenter ?? errorCenter)
+            : errorCenter
       for (const routeIndex of new Set(routeIndexes)) {
         const targetKey = `${routeIndex}:${center.x.toFixed(4)}:${center.y.toFixed(4)}`
         if (targetKeys.has(targetKey)) continue
         targetKeys.add(targetKey)
         const moveData = getMoveData(
           error,
+          center,
           routeIndex,
           routeIndexes,
           this.bestRoutes,
           transitionPoints,
           this.config.obstacles ?? [],
         )
-        const typedViaCenter =
-          error.type === "pcb_via_trace_clearance_error" &&
-          error.via_center &&
-          typeof error.via_center === "object" &&
-          typeof (error.via_center as Record<string, unknown>).x === "number" &&
-          typeof (error.via_center as Record<string, unknown>).y === "number"
-            ? {
-                x: (error.via_center as { x: number }).x,
-                y: (error.via_center as { y: number }).y,
-              }
-            : undefined
-        const viaCenter =
-          typedViaCenter ??
-          (isTraceViaOverlapError(error)
-            ? getNearestTransitionPoint(center, transitionPoints)
-            : undefined)
-        const terminalPortId =
-          typeof error.message === "string" &&
-          error.message.includes("missing a connection")
-            ? error.message.match(
-                /(?:smtpad|plated_hole)\[#(pcb_port_[^\]]+)\]/,
-              )?.[1]
-            : undefined
-        const terminalPoint = terminalPortId
-          ? getDrcPointField(error, "pad_center")
-          : undefined
         targets.push({
           routeIndex,
           center,
@@ -1527,45 +1551,45 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
     const plan = this.strategies
       .flatMap((strategy) =>
         targets.flatMap((target) => {
-        if (strategy.type === "terminal_snap" && !target.terminalPoint) {
-          return []
-        }
-        if (
-          (strategy.type === "directed_dogleg" ||
-            strategy.type === "directed_segment_shift" ||
-            strategy.type === "directed_pair_shift" ||
-            strategy.type === "directed_via_shift") &&
-          !target.moveDirection
-        ) {
-          return []
-        }
-        if (
-          strategy.type === "directed_via_shift" &&
-          (!target.viaCenter || target.viaRouteIndexes?.length === 0)
-        ) {
-          return []
-        }
-        if (
-          strategy.type === "directed_pair_shift" &&
-          (target.otherRouteIndex === undefined ||
-            target.routeIndex > target.otherRouteIndex)
-        ) {
-          return []
-        }
-        const affectedRouteIndexes =
-          strategy.type === "directed_via_shift"
-            ? (target.viaRouteIndexes ?? [])
-            : [target.routeIndex]
-        const routeRevisions = affectedRouteIndexes
-          .map(
-            (routeIndex) =>
-              `${routeIndex}:${this.routeRevisionByIndex[routeIndex] ?? 0}`,
-          )
-          .join(",")
-        const key = `${routeRevisions}:${target.center.x.toFixed(4)}:${target.center.y.toFixed(4)}:${getCandidateStrategyKey(strategy)}`
-        return this.attemptedCandidateKeys.has(key)
-          ? []
-          : [{ ...target, ...strategy, key }]
+          if (strategy.type === "terminal_snap" && !target.terminalPoint) {
+            return []
+          }
+          if (
+            (strategy.type === "directed_dogleg" ||
+              strategy.type === "directed_segment_shift" ||
+              strategy.type === "directed_pair_shift" ||
+              strategy.type === "directed_via_shift") &&
+            !target.moveDirection
+          ) {
+            return []
+          }
+          if (
+            strategy.type === "directed_via_shift" &&
+            (!target.viaCenter || target.viaRouteIndexes?.length === 0)
+          ) {
+            return []
+          }
+          if (
+            strategy.type === "directed_pair_shift" &&
+            (target.otherRouteIndex === undefined ||
+              target.routeIndex > target.otherRouteIndex)
+          ) {
+            return []
+          }
+          const affectedRouteIndexes =
+            strategy.type === "directed_via_shift"
+              ? (target.viaRouteIndexes ?? [])
+              : [target.routeIndex]
+          const routeRevisions = affectedRouteIndexes
+            .map(
+              (routeIndex) =>
+                `${routeIndex}:${this.routeRevisionByIndex[routeIndex] ?? 0}`,
+            )
+            .join(",")
+          const key = `${routeRevisions}:${target.center.x.toFixed(4)}:${target.center.y.toFixed(4)}:${getCandidateStrategyKey(strategy)}`
+          return this.attemptedCandidateKeys.has(key)
+            ? []
+            : [{ ...target, ...strategy, key }]
         }),
       )
       .sort(
@@ -1790,13 +1814,13 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
     let candidatePlanEntry: CandidatePlanEntry
     let candidateRoutes: HighDensityRoute[] | undefined
     do {
-    if (this.candidateAttempts >= this.config.maxCandidateAttempts) {
-      if (this.pendingCandidate) {
-        if (this.acceptCandidate(this.pendingCandidate)) return
-      }
-      this.finish({
-        stoppedAfterNoImprovement: false,
-        hitCandidateLimit: true,
+      if (this.candidateAttempts >= this.config.maxCandidateAttempts) {
+        if (this.pendingCandidate) {
+          if (this.acceptCandidate(this.pendingCandidate)) return
+        }
+        this.finish({
+          stoppedAfterNoImprovement: false,
+          hitCandidateLimit: true,
         })
         return
       }
@@ -1839,8 +1863,7 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
     }
     if (
       this.pendingCandidate &&
-      this.candidateAttemptsSinceAccepted >=
-        this.maxCandidatesBeforeRefinement
+      this.candidateAttemptsSinceAccepted >= this.maxCandidatesBeforeRefinement
     ) {
       this.acceptCandidate(this.pendingCandidate)
       return

--- a/lib/solvers/ResidualLocalRerouteSolver/ResidualLocalRerouteSolver.ts
+++ b/lib/solvers/ResidualLocalRerouteSolver/ResidualLocalRerouteSolver.ts
@@ -103,6 +103,8 @@ type CandidatePlanEntry = CandidateTarget &
 export type ResidualLocalRerouteSolverConfig = {
   hdRoutes: readonly HighDensityRoute[]
   drcEvaluator: DrcEvaluator
+  /** Optional cheaper scorer; every accepted candidate still uses drcEvaluator. */
+  candidateDrcEvaluator?: DrcEvaluator
   bounds: Bounds
   outline?: readonly Point[]
   obstacles?: readonly RoutingObstacle[]
@@ -200,13 +202,6 @@ const getCandidatePriority = (
   if (target.terminalPoint) {
     if (strategy.type === "terminal_snap") return 0
     return 1
-  }
-  if (target.obstacle) {
-    if (strategy.type === "obstacle_detour") return 0
-    if (strategy.type === "directed_segment_shift") return 1
-    if (strategy.type === "directed_dogleg") return 2
-    if (strategy.type === "layer_detour") return 3
-    return 4
   }
   if (target.viaCenter && target.viaRouteIndexes?.length) {
     if (strategy.type === "directed_via_shift") return 0
@@ -1538,6 +1533,7 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
   private readonly strategies: readonly CandidateStrategy[]
   private bestRoutes: HighDensityRoute[]
   private bestSnapshot?: DrcSnapshot
+  private bestCandidateSnapshot?: DrcSnapshot
   private initialIssueCount = Number.POSITIVE_INFINITY
   private candidatePlan: CandidatePlanEntry[] = []
   private candidatePlanIndex = 0
@@ -1550,11 +1546,16 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
   private readonly attemptedCandidateKeys = new Set<string>()
   private readonly routeRevisionByIndex: number[]
   private readonly maxCandidatesBeforeRefinement: number
+  private readonly maxCandidatesWithoutCountReduction: number
   private readonly maxTotalAcceptedMoves: number
   private candidateAttemptsSinceAccepted = 0
+  private candidateAttemptsSinceCountReduction = 0
+  private candidateDrcEvaluations = 0
+  private validationDrcEvaluations = 0
   private pendingCandidate?: {
     routes: HighDensityRoute[]
     snapshot: DrcSnapshot
+    candidateSnapshot: DrcSnapshot
     entry: CandidatePlanEntry
   }
 
@@ -1587,6 +1588,11 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
       Math.floor(
         config.maxCandidateAttempts / Math.max(1, config.maxAcceptedMoves),
       ),
+    )
+    this.maxCandidatesWithoutCountReduction = Math.min(
+      config.maxCandidateAttempts,
+      128,
+      Math.max(32, Math.ceil(20 * Math.log2(Math.max(2, config.effort)))),
     )
     const extraAcceptedMoveAllowance = Math.min(
       4,
@@ -1681,8 +1687,11 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
     return this.bestRoutes
   }
 
-  private evaluate(routes: HighDensityRoute[]): DrcSnapshot {
-    const result = this.config.drcEvaluator({
+  private evaluate(
+    routes: HighDensityRoute[],
+    evaluator: DrcEvaluator,
+  ): DrcSnapshot {
+    const result = evaluator({
       traces: [],
       routes,
       hdRoutes: routes,
@@ -1699,6 +1708,19 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
         0,
       ),
     }
+  }
+
+  private evaluateCandidate(routes: HighDensityRoute[]): DrcSnapshot {
+    this.candidateDrcEvaluations += 1
+    return this.evaluate(
+      routes,
+      this.config.candidateDrcEvaluator ?? this.config.drcEvaluator,
+    )
+  }
+
+  private evaluateValidation(routes: HighDensityRoute[]): DrcSnapshot {
+    this.validationDrcEvaluations += 1
+    return this.evaluate(routes, this.config.drcEvaluator)
   }
 
   private buildCandidatePlan(): void {
@@ -1805,8 +1827,7 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
           if (
             (strategy.type === "obstacle_detour" ||
               strategy.type === "directed_pair_dogleg") &&
-            this.initialIssueCount >
-              Math.max(2, Math.floor(this.config.maxAcceptedMoves / 2))
+            this.initialIssueCount > 2
           ) {
             return []
           }
@@ -1870,6 +1891,7 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
 
   private finish(params: {
     stoppedAfterNoImprovement: boolean
+    stoppedAfterCountPlateau?: boolean
     hitCandidateLimit?: boolean
     hitAcceptedMoveLimit?: boolean
     disabled?: boolean
@@ -1892,6 +1914,8 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
         this.attemptedCandidateKeys.size,
       residualLocalRerouteStoppedAfterNoImprovement:
         params.stoppedAfterNoImprovement,
+      residualLocalRerouteStoppedAfterCountPlateau:
+        params.stoppedAfterCountPlateau ?? false,
       residualLocalRerouteHitCandidateLimit: params.hitCandidateLimit ?? false,
       residualLocalRerouteHitAcceptedMoveLimit:
         params.hitAcceptedMoveLimit ?? false,
@@ -1899,6 +1923,12 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
         this.config.maxCandidateAttempts,
       residualLocalRerouteMaxAcceptedMoves: this.config.maxAcceptedMoves,
       residualLocalRerouteMaxTotalAcceptedMoves: this.maxTotalAcceptedMoves,
+      residualLocalRerouteMaxCandidatesWithoutCountReduction:
+        this.maxCandidatesWithoutCountReduction,
+      residualLocalRerouteCandidateDrcEvaluations:
+        this.candidateDrcEvaluations,
+      residualLocalRerouteValidationDrcEvaluations:
+        this.validationDrcEvaluations,
     }
     this.progress = 1
     this.solved = true
@@ -1907,7 +1937,22 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
   private createCandidateRoutes(
     candidatePlanEntry: CandidatePlanEntry,
   ): HighDensityRoute[] | undefined {
-    const candidateRoutes = structuredClone(this.bestRoutes)
+    const affectedRouteIndexes =
+      candidatePlanEntry.type === "directed_via_shift"
+        ? (candidatePlanEntry.viaRouteIndexes ?? [])
+        : (candidatePlanEntry.type === "directed_pair_shift" ||
+              candidatePlanEntry.type === "directed_pair_dogleg") &&
+            candidatePlanEntry.otherRouteIndex !== undefined
+          ? [candidatePlanEntry.routeIndex, candidatePlanEntry.otherRouteIndex]
+          : [candidatePlanEntry.routeIndex]
+    const candidateRoutes = [...this.bestRoutes]
+    for (const routeIndex of new Set(affectedRouteIndexes)) {
+      const route = this.bestRoutes[routeIndex]
+      if (!route) {
+        throw new Error(`Missing candidate route at index ${routeIndex}`)
+      }
+      candidateRoutes[routeIndex] = structuredClone(route)
+    }
     let changed = false
     if (
       candidatePlanEntry.type === "terminal_snap" &&
@@ -2061,6 +2106,7 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
   private acceptCandidate(candidate: {
     routes: HighDensityRoute[]
     snapshot: DrcSnapshot
+    candidateSnapshot: DrcSnapshot
     entry: CandidatePlanEntry
   }): boolean {
     const reducedIssueCount =
@@ -2068,9 +2114,14 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
       (this.bestSnapshot?.issueCount ?? Infinity)
     this.bestRoutes = candidate.routes
     this.bestSnapshot = candidate.snapshot
+    this.bestCandidateSnapshot = candidate.candidateSnapshot
     this.acceptedMoves += 1
-    if (reducedIssueCount) this.acceptedCountReducingMoves += 1
-    else this.acceptedRefinementMoves += 1
+    if (reducedIssueCount) {
+      this.acceptedCountReducingMoves += 1
+      this.candidateAttemptsSinceCountReduction = 0
+    } else {
+      this.acceptedRefinementMoves += 1
+    }
     this.candidateAttemptsSinceAccepted = 0
     this.pendingCandidate = undefined
     const changedRouteIndexes =
@@ -2117,7 +2168,10 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
     }
 
     if (!this.bestSnapshot) {
-      this.bestSnapshot = this.evaluate(this.bestRoutes)
+      this.bestSnapshot = this.evaluateValidation(this.bestRoutes)
+      this.bestCandidateSnapshot = this.config.candidateDrcEvaluator
+        ? this.evaluateCandidate(this.bestRoutes)
+        : this.bestSnapshot
       this.initialIssueCount = this.bestSnapshot.issueCount
       this.stats.residualLocalRerouteInitialDrcIssueCount =
         this.bestSnapshot.issueCount
@@ -2158,25 +2212,56 @@ export class ResidualLocalRerouteSolver extends BaseSolver {
 
     this.candidateAttempts += 1
     this.candidateAttemptsSinceAccepted += 1
-    const candidateSnapshot = this.evaluate(candidateRoutes)
-    if (candidateSnapshot.issueCount < this.bestSnapshot.issueCount) {
-      this.acceptCandidate({
-        routes: candidateRoutes,
-        snapshot: candidateSnapshot,
-        entry: candidatePlanEntry,
-      })
-      return
+    this.candidateAttemptsSinceCountReduction += 1
+    const candidateScoringSnapshot = this.evaluateCandidate(candidateRoutes)
+    const bestCandidateSnapshot = this.bestCandidateSnapshot
+    if (!bestCandidateSnapshot) {
+      throw new Error("Missing residual reroute candidate DRC checkpoint")
+    }
+    const shouldValidateCandidate =
+      !this.config.candidateDrcEvaluator ||
+      candidatePlanEntry.type === "terminal_snap" ||
+      isBetterSnapshot(candidateScoringSnapshot, bestCandidateSnapshot)
+    if (shouldValidateCandidate) {
+      const candidateSnapshot = this.config.candidateDrcEvaluator
+        ? this.evaluateValidation(candidateRoutes)
+        : candidateScoringSnapshot
+      if (candidateSnapshot.issueCount < this.bestSnapshot.issueCount) {
+        this.acceptCandidate({
+          routes: candidateRoutes,
+          snapshot: candidateSnapshot,
+          candidateSnapshot: candidateScoringSnapshot,
+          entry: candidatePlanEntry,
+        })
+        return
+      }
+      if (
+        isBetterSnapshot(candidateSnapshot, this.bestSnapshot) &&
+        (!this.pendingCandidate ||
+          isBetterSnapshot(candidateSnapshot, this.pendingCandidate.snapshot))
+      ) {
+        this.pendingCandidate = {
+          routes: candidateRoutes,
+          snapshot: candidateSnapshot,
+          candidateSnapshot: candidateScoringSnapshot,
+          entry: candidatePlanEntry,
+        }
+      }
     }
     if (
-      isBetterSnapshot(candidateSnapshot, this.bestSnapshot) &&
-      (!this.pendingCandidate ||
-        isBetterSnapshot(candidateSnapshot, this.pendingCandidate.snapshot))
+      this.maxCandidatesWithoutCountReduction <
+        this.config.maxCandidateAttempts &&
+      this.candidateAttemptsSinceCountReduction >=
+        this.maxCandidatesWithoutCountReduction
     ) {
-      this.pendingCandidate = {
-        routes: candidateRoutes,
-        snapshot: candidateSnapshot,
-        entry: candidatePlanEntry,
+      if (this.pendingCandidate) {
+        if (this.acceptCandidate(this.pendingCandidate)) return
       }
+      this.finish({
+        stoppedAfterNoImprovement: true,
+        stoppedAfterCountPlateau: true,
+      })
+      return
     }
     if (
       this.pendingCandidate &&

--- a/tests/pipeline7-exact-geometry-drc-evaluator.test.ts
+++ b/tests/pipeline7-exact-geometry-drc-evaluator.test.ts
@@ -132,6 +132,9 @@ test("Pipeline7 exact cleanup includes typed trace clearance errors", () => {
   expect(errors[0]?.type).toBe("pcb_pad_trace_clearance_error")
   expect(errorsWithCenters).toHaveLength(1)
   expect(errorsWithCenters?.[0]?.center).toEqual({ x: 0, y: 0.2 })
+  expect(
+    (errorsWithCenters?.[0] as Record<string, unknown>)?.pad_center,
+  ).toEqual({ x: 0, y: 0 })
 })
 
 test("Pipeline7 checkpoint validation includes benchmark typed clearance errors", () => {

--- a/tests/residual-local-reroute-candidate-validation.test.ts
+++ b/tests/residual-local-reroute-candidate-validation.test.ts
@@ -1,0 +1,79 @@
+import { expect, test } from "bun:test"
+import type { DrcEvaluator } from "high-density-repair03/lib"
+import { ResidualLocalRerouteSolver } from "lib/solvers/ResidualLocalRerouteSolver/ResidualLocalRerouteSolver"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+
+const inputRoute: HighDensityRoute = {
+  connectionName: "route",
+  traceThickness: 0.1,
+  viaDiameter: 0.3,
+  vias: [],
+  route: [
+    { x: -1, y: 0, z: 0 },
+    { x: 1, y: 0, z: 0 },
+  ],
+}
+
+const residualError = {
+  type: "pcb_trace_error",
+  pcb_trace_id: "route_0",
+  pcb_trace_error_id: "overlap_route_0_obstacle",
+  center: { x: 0, y: 0 },
+  message: "Trace overlaps an obstacle",
+}
+
+test("residual rerouting fully validates only geometry candidates that can improve", () => {
+  let rejectedValidationCalls = 0
+  const unchangedEvaluator: DrcEvaluator = () => ({
+    errors: [residualError],
+    errorsWithCenters: [residualError],
+  })
+  const rejectedSolver = new ResidualLocalRerouteSolver({
+    hdRoutes: [inputRoute],
+    drcEvaluator: (input) => {
+      rejectedValidationCalls += 1
+      return unchangedEvaluator(input)
+    },
+    candidateDrcEvaluator: unchangedEvaluator,
+    bounds: { minX: -2, minY: -2, maxX: 2, maxY: 2 },
+    layerCount: 2,
+    effort: 50,
+    maxCandidateAttempts: 3,
+    maxAcceptedMoves: 1,
+  })
+
+  rejectedSolver.solve()
+
+  expect(rejectedValidationCalls).toBe(1)
+  expect(rejectedSolver.stats.residualLocalRerouteCandidateDrcEvaluations).toBe(
+    4,
+  )
+  expect(
+    rejectedSolver.stats.residualLocalRerouteValidationDrcEvaluations,
+  ).toBe(1)
+
+  let acceptedValidationCalls = 0
+  const improvingEvaluator: DrcEvaluator = ({ routes }) => {
+    if (!routes) throw new Error("Expected routes for DRC evaluation")
+    const errors = routes[0]!.route.length > 2 ? [] : [residualError]
+    return { errors, errorsWithCenters: errors }
+  }
+  const acceptedSolver = new ResidualLocalRerouteSolver({
+    hdRoutes: [inputRoute],
+    drcEvaluator: (input) => {
+      acceptedValidationCalls += 1
+      return improvingEvaluator(input)
+    },
+    candidateDrcEvaluator: improvingEvaluator,
+    bounds: { minX: -2, minY: -2, maxX: 2, maxY: 2 },
+    layerCount: 2,
+    effort: 50,
+    maxCandidateAttempts: 3,
+    maxAcceptedMoves: 1,
+  })
+
+  acceptedSolver.solve()
+
+  expect(acceptedValidationCalls).toBe(2)
+  expect(acceptedSolver.stats.residualLocalRerouteFinalDrcIssueCount).toBe(0)
+})

--- a/tests/residual-local-reroute-count-plateau.test.ts
+++ b/tests/residual-local-reroute-count-plateau.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test"
+import type { DrcEvaluator } from "high-density-repair03/lib"
+import { ResidualLocalRerouteSolver } from "lib/solvers/ResidualLocalRerouteSolver/ResidualLocalRerouteSolver"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+
+const routes: HighDensityRoute[] = Array.from(
+  { length: 10 },
+  (_, index) => -0.45 + index * 0.1,
+).map((y) => ({
+  connectionName: `route-${y}`,
+  traceThickness: 0.1,
+  viaDiameter: 0.3,
+  vias: [],
+  route: [
+    { x: -1, y, z: 0 },
+    { x: 1, y, z: 0 },
+  ],
+}))
+
+const errors = routes.map((route) => ({
+  type: "pcb_trace_error",
+  pcb_trace_id: `${route.connectionName}_0`,
+  pcb_trace_error_id: `overlap_${route.connectionName}_0_obstacle`,
+  center: { x: 0, y: route.route[0]!.y },
+  message: "Trace overlaps an obstacle",
+}))
+
+test("residual rerouting stops a long score plateau before its global cap", () => {
+  const evaluator: DrcEvaluator = () => ({ errors, errorsWithCenters: errors })
+  const solver = new ResidualLocalRerouteSolver({
+    hdRoutes: routes,
+    drcEvaluator: evaluator,
+    bounds: { minX: -2, minY: -2, maxX: 2, maxY: 2 },
+    layerCount: 2,
+    effort: 50,
+    maxCandidateAttempts: 200,
+    maxAcceptedMoves: 2,
+  })
+
+  solver.solve()
+
+  expect(solver.failed).toBe(false)
+  expect(solver.stats.residualLocalRerouteCandidateAttempts).toBe(113)
+  expect(solver.stats.residualLocalRerouteStoppedAfterCountPlateau).toBe(true)
+  expect(solver.stats.residualLocalRerouteHitCandidateLimit).toBe(false)
+})

--- a/tests/residual-local-reroute-directed-strategy-priority.test.ts
+++ b/tests/residual-local-reroute-directed-strategy-priority.test.ts
@@ -13,13 +13,18 @@ test("residual local rerouting tries directed local repairs before layer detours
       { x: -1, y: 0.15, z: 0 },
       { x: -0.4, y: 0.15, z: 0 },
       { x: 0.4, y: 0.15, z: 0 },
-      { x: 1, y: 0.15, z: 0 },
+      { x: 0.8, y: 0.8, z: 0 },
+      { x: 1.4, y: 1.4, z: 0 },
+      { x: 2, y: 1.4, z: 0 },
     ],
   }
   const error = {
     type: "pcb_pad_trace_clearance_error",
     pcb_trace_id: "trace_0",
-    center: { x: 0, y: 0.15 },
+    // The reporter's generic center can be far from the actual typed
+    // pad/trace collision. The exact pad center must drive segment selection.
+    center: { x: 1.7, y: 1.4 },
+    pad_center: { x: 0, y: 0 },
     message:
       "Pad pcb_port[#pcb_port_obstacle] and trace trace_0 are too close (clearance: 0.03mm, minimum: 0.1mm)",
   }
@@ -31,7 +36,7 @@ test("residual local rerouting tries directed local repairs before layer detours
   const solver = new ResidualLocalRerouteSolver({
     hdRoutes: [route],
     drcEvaluator: evaluator,
-    bounds: { minX: -2, minY: -2, maxX: 2, maxY: 2 },
+    bounds: { minX: -2, minY: -2, maxX: 2.2, maxY: 2 },
     obstacles: [
       {
         center: { x: 0, y: 0 },

--- a/tests/residual-local-reroute-directed-strategy-priority.test.ts
+++ b/tests/residual-local-reroute-directed-strategy-priority.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test"
+import type { DrcEvaluator } from "high-density-repair03/lib"
+import { ResidualLocalRerouteSolver } from "lib/solvers/ResidualLocalRerouteSolver/ResidualLocalRerouteSolver"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+
+test("residual local rerouting tries directed local repairs before layer detours", () => {
+  const route: HighDensityRoute = {
+    connectionName: "trace",
+    traceThickness: 0.1,
+    viaDiameter: 0.3,
+    vias: [],
+    route: [
+      { x: -1, y: 0.15, z: 0 },
+      { x: -0.4, y: 0.15, z: 0 },
+      { x: 0.4, y: 0.15, z: 0 },
+      { x: 1, y: 0.15, z: 0 },
+    ],
+  }
+  const error = {
+    type: "pcb_pad_trace_clearance_error",
+    pcb_trace_id: "trace_0",
+    center: { x: 0, y: 0.15 },
+    message:
+      "Pad pcb_port[#pcb_port_obstacle] and trace trace_0 are too close (clearance: 0.03mm, minimum: 0.1mm)",
+  }
+  const evaluator: DrcEvaluator = ({ routes }) => {
+    if (!routes) throw new Error("Expected routes for DRC evaluation")
+    const errors = routes[0]!.route[1]!.y >= 0.229 ? [] : [error]
+    return { errors, errorsWithCenters: errors }
+  }
+  const solver = new ResidualLocalRerouteSolver({
+    hdRoutes: [route],
+    drcEvaluator: evaluator,
+    bounds: { minX: -2, minY: -2, maxX: 2, maxY: 2 },
+    obstacles: [
+      {
+        center: { x: 0, y: 0 },
+        width: 0.2,
+        height: 0.2,
+        connectedTo: ["pcb_port_obstacle"],
+      },
+    ],
+    layerCount: 2,
+    effort: 50,
+    maxCandidateAttempts: 1,
+    maxAcceptedMoves: 1,
+  })
+
+  solver.solve()
+
+  expect(solver.failed).toBe(false)
+  expect(solver.stats.residualLocalRerouteFinalDrcIssueCount).toBe(0)
+  expect(solver.stats.residualLocalRerouteCandidateAttempts).toBe(1)
+  expect(solver.getOutput()[0]!.route[1]!.y).toBeCloseTo(0.23)
+})

--- a/tests/residual-local-reroute-obstacle-detour.test.ts
+++ b/tests/residual-local-reroute-obstacle-detour.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test"
+import type { DrcEvaluator } from "high-density-repair03/lib"
+import { ResidualLocalRerouteSolver } from "lib/solvers/ResidualLocalRerouteSolver/ResidualLocalRerouteSolver"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+
+test("residual local rerouting detours a multi-segment trace around a pad", () => {
+  const route: HighDensityRoute = {
+    connectionName: "trace",
+    traceThickness: 0.1,
+    viaDiameter: 0.3,
+    vias: [],
+    route: [
+      { x: -1, y: 0.4, z: 0 },
+      { x: -0.2, y: 0.05, z: 0 },
+      { x: 0.2, y: 0.05, z: 0 },
+      { x: 1, y: 0.4, z: 0 },
+    ],
+  }
+  const error = {
+    type: "pcb_trace_error",
+    pcb_trace_id: "trace_0",
+    center: { x: 0, y: 0.1 },
+    message:
+      'PCB trace trace_0 overlaps with pcb_smtpad "pcb_port[#pcb_port_obstacle]" (accidental contact)',
+  }
+  const evaluator: DrcEvaluator = ({ routes }) => {
+    if (!routes) throw new Error("Expected routes for DRC evaluation")
+    const errors = routes[0]!.route[1]!.y >= 0.25 ? [] : [error]
+    return { errors, errorsWithCenters: errors }
+  }
+  const solver = new ResidualLocalRerouteSolver({
+    hdRoutes: [route],
+    drcEvaluator: evaluator,
+    bounds: { minX: -2, minY: -2, maxX: 2, maxY: 2 },
+    obstacles: [
+      {
+        center: { x: 0, y: 0 },
+        width: 0.4,
+        height: 0.2,
+        connectedTo: ["pcb_port_obstacle"],
+      },
+    ],
+    layerCount: 2,
+    effort: 50,
+    maxCandidateAttempts: 1,
+    maxAcceptedMoves: 1,
+  })
+
+  solver.solve()
+
+  expect(solver.failed).toBe(false)
+  expect(solver.stats.residualLocalRerouteFinalDrcIssueCount).toBe(0)
+  expect(solver.stats.residualLocalRerouteCandidateAttempts).toBe(1)
+  expect(solver.getOutput()[0]!.route[1]!.y).toBeCloseTo(0.25)
+})

--- a/tests/residual-local-reroute-pair-dogleg.test.ts
+++ b/tests/residual-local-reroute-pair-dogleg.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test"
+import type { DrcEvaluator } from "high-density-repair03/lib"
+import { ResidualLocalRerouteSolver } from "lib/solvers/ResidualLocalRerouteSolver/ResidualLocalRerouteSolver"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+
+test("residual local rerouting splits a local detour across two locked traces", () => {
+  const createRoute = (
+    connectionName: string,
+    y: number,
+  ): HighDensityRoute => ({
+    connectionName,
+    traceThickness: 0.1,
+    viaDiameter: 0.3,
+    vias: [],
+    route: [
+      { x: -1, y, z: 0 },
+      { x: 1, y, z: 0 },
+    ],
+  })
+  const error = {
+    type: "pcb_trace_error",
+    pcb_trace_id: "lower_0",
+    pcb_trace_ids: ["lower_0", "upper_0"],
+    center: { x: 0, y: 0.075 },
+    message: "Traces are too close (gap: 0.050mm)",
+  }
+  const evaluator: DrcEvaluator = ({ routes }) => {
+    if (!routes) throw new Error("Expected routes for DRC evaluation")
+    const bothDetoured = routes.every((route) => route.route.length > 2)
+    const errors = bothDetoured ? [] : [error]
+    return { errors, errorsWithCenters: errors }
+  }
+  const solver = new ResidualLocalRerouteSolver({
+    hdRoutes: [createRoute("lower", 0), createRoute("upper", 0.15)],
+    drcEvaluator: evaluator,
+    bounds: { minX: -2, minY: -2, maxX: 2, maxY: 2 },
+    layerCount: 2,
+    effort: 50,
+    maxCandidateAttempts: 1,
+    maxAcceptedMoves: 1,
+  })
+
+  solver.solve()
+
+  expect(solver.failed).toBe(false)
+  expect(solver.stats.residualLocalRerouteFinalDrcIssueCount).toBe(0)
+  expect(solver.stats.residualLocalRerouteCandidateAttempts).toBe(1)
+  expect(solver.getOutput().every((route) => route.route.length > 2)).toBe(true)
+})

--- a/tests/residual-local-reroute-solver.test.ts
+++ b/tests/residual-local-reroute-solver.test.ts
@@ -200,3 +200,49 @@ test("residual local rerouting does not revisit failed candidates for an unchang
   expect(solver.stats.residualLocalRerouteStoppedAfterNoImprovement).toBe(true)
   expect(solver.stats.residualLocalRerouteHitCandidateLimit).toBe(false)
 })
+
+test("higher effort lets count-reducing repairs continue after score refinements", () => {
+  const createEvaluator =
+    (): DrcEvaluator =>
+    ({ routes }) => {
+      if (!routes) throw new Error("Expected routes for DRC evaluation")
+      const pointCount = routes[0]!.route.length
+      const issueCount = pointCount < 10 ? 2 : pointCount < 14 ? 1 : 0
+      const gap = Math.min(0.099, pointCount / 1000)
+      const errors = Array.from({ length: issueCount }, (_, index) => ({
+        ...residualError,
+        pcb_trace_error_id: `residual_${index}`,
+        message: `Trace is too close to another trace (gap: ${gap.toFixed(3)}mm)`,
+      }))
+      return { errors, errorsWithCenters: errors }
+    }
+  const createEffortSolver = (effort: number) =>
+    new ResidualLocalRerouteSolver({
+      hdRoutes: [inputRoute],
+      drcEvaluator: createEvaluator(),
+      bounds: { minX: -2, minY: -2, maxX: 2, maxY: 2 },
+      layerCount: 2,
+      effort,
+      maxCandidateAttempts: 32,
+      maxAcceptedMoves: 2,
+    })
+
+  const baselineSolver = createEffortSolver(1)
+  baselineSolver.solve()
+  const highEffortSolver = createEffortSolver(50)
+  highEffortSolver.solve()
+
+  expect(baselineSolver.stats.residualLocalRerouteFinalDrcIssueCount).toBe(1)
+  expect(baselineSolver.stats.residualLocalRerouteAcceptedMoves).toBe(2)
+  expect(highEffortSolver.stats.residualLocalRerouteFinalDrcIssueCount).toBe(0)
+  expect(highEffortSolver.stats.residualLocalRerouteAcceptedMoves).toBe(3)
+  expect(
+    highEffortSolver.stats.residualLocalRerouteAcceptedCountReducingMoves,
+  ).toBe(2)
+  expect(
+    highEffortSolver.stats.residualLocalRerouteAcceptedRefinementMoves,
+  ).toBe(1)
+  expect(highEffortSolver.iterations).toBeLessThanOrEqual(
+    highEffortSolver.MAX_ITERATIONS,
+  )
+})

--- a/tests/residual-local-reroute-terminal-snap.test.ts
+++ b/tests/residual-local-reroute-terminal-snap.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "bun:test"
+import type { DrcEvaluator } from "high-density-repair03/lib"
+import { ResidualLocalRerouteSolver } from "lib/solvers/ResidualLocalRerouteSolver/ResidualLocalRerouteSolver"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+
+test("residual local rerouting snaps a disconnected terminal to its exact pad center", () => {
+  const route: HighDensityRoute = {
+    connectionName: "trace",
+    traceThickness: 0.1,
+    viaDiameter: 0.3,
+    vias: [],
+    route: [
+      { x: 0, y: 0, z: 0, pcb_port_id: "pcb_port_target" },
+      { x: 1, y: 0, z: 0 },
+    ],
+  }
+  const error = {
+    type: "pcb_trace_error",
+    pcb_trace_id: "trace_0",
+    center: { x: 0, y: 0 },
+    pad_center: { x: -0.4, y: -0.4 },
+    message:
+      "Trace [trace_0] is missing a connection to smtpad[#pcb_port_target]",
+  }
+  const evaluator: DrcEvaluator = ({ routes }) => {
+    if (!routes) throw new Error("Expected routes for DRC evaluation")
+    const terminal = routes[0]!.route[0]!
+    const errors = terminal.x === -0.4 && terminal.y === -0.4 ? [] : [error]
+    return { errors, errorsWithCenters: errors }
+  }
+  const solver = new ResidualLocalRerouteSolver({
+    hdRoutes: [route],
+    drcEvaluator: evaluator,
+    bounds: { minX: -2, minY: -2, maxX: 2, maxY: 2 },
+    layerCount: 2,
+    effort: 50,
+    maxCandidateAttempts: 1,
+    maxAcceptedMoves: 1,
+  })
+
+  solver.solve()
+
+  expect(solver.failed).toBe(false)
+  expect(solver.stats.residualLocalRerouteFinalDrcIssueCount).toBe(0)
+  expect(solver.stats.residualLocalRerouteCandidateAttempts).toBe(1)
+  expect(solver.getOutput()[0]!.route[0]).toMatchObject({
+    x: -0.4,
+    y: -0.4,
+    pcb_port_id: "pcb_port_target",
+  })
+})

--- a/tests/residual-local-reroute-trace-via-overlap.test.ts
+++ b/tests/residual-local-reroute-trace-via-overlap.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "bun:test"
+import type { DrcEvaluator } from "high-density-repair03/lib"
+import { ResidualLocalRerouteSolver } from "lib/solvers/ResidualLocalRerouteSolver/ResidualLocalRerouteSolver"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+
+test("residual local rerouting moves the via named only by a trace overlap", () => {
+  const viaRoute: HighDensityRoute = {
+    connectionName: "via-route",
+    traceThickness: 0.1,
+    viaDiameter: 0.3,
+    vias: [{ x: 0, y: 0 }],
+    route: [
+      { x: -1, y: 0, z: 0 },
+      { x: 0, y: 0, z: 0 },
+      { x: 0, y: 0, z: 1 },
+      { x: 1, y: 0, z: 1 },
+    ],
+  }
+  const traceRoute: HighDensityRoute = {
+    connectionName: "trace",
+    traceThickness: 0.1,
+    viaDiameter: 0.3,
+    vias: [],
+    route: [
+      { x: -1, y: 0.15, z: 0 },
+      { x: 1, y: 0.15, z: 0 },
+    ],
+  }
+  const error = {
+    type: "pcb_trace_error",
+    pcb_trace_id: "trace_0",
+    center: { x: 0, y: 0.15 },
+    message:
+      'PCB trace trace_0 overlaps with pcb_via "pcb_via[#via_0]" (accidental contact)',
+  }
+  const evaluator: DrcEvaluator = ({ routes }) => {
+    if (!routes) throw new Error("Expected routes for DRC evaluation")
+    const errors = routes[0]!.vias[0]!.y < 0 ? [] : [error]
+    return { errors, errorsWithCenters: errors }
+  }
+  const solver = new ResidualLocalRerouteSolver({
+    hdRoutes: [viaRoute, traceRoute],
+    drcEvaluator: evaluator,
+    bounds: { minX: -2, minY: -2, maxX: 2, maxY: 2 },
+    layerCount: 2,
+    effort: 50,
+    maxCandidateAttempts: 1,
+    maxAcceptedMoves: 1,
+  })
+
+  solver.solve()
+
+  expect(solver.failed).toBe(false)
+  expect(solver.stats.residualLocalRerouteFinalDrcIssueCount).toBe(0)
+  expect(solver.stats.residualLocalRerouteCandidateAttempts).toBe(1)
+  expect(solver.getOutput()[0]!.vias[0]!.y).toBeLessThan(0)
+  expect(solver.getOutput()[1]).toEqual(traceRoute)
+})


### PR DESCRIPTION
## What changed

- attach exact PCB pad and via centers to Pipeline 7 DRC errors so local repairs target the colliding copper
- prioritize directed local repairs, terminal snapping, via movement, pair movement, and sparse obstacle detours
- preserve the established repair strategy order until the residual set is truly sparse
- score exploratory candidates with geometry-only DRC, then run the full benchmark-equivalent DRC before every accepted move
- clone and reconvert only the one or two routes changed by a candidate
- stop after an effort-scaled plateau with no DRC-count reduction, while resetting the plateau whenever a productive repair is found
- report candidate, validation, and plateau statistics for benchmark diagnosis

## Why

High effort previously evaluated every candidate with the full relaxed DRC suite. Trace continuity dominated that cost even though ordinary doglegs and segment shifts cannot change terminal continuity. The solver also cloned and reconverted the entire board for moves that touched only one or two routes.

The expanded sparse-repair portfolio could additionally displace older productive strategies on boards that still had many residual errors. That reduced quality on dataset 18 sample 16, while the larger raw candidate cap allowed score-only sweeps to consume the remaining benchmark timeout.

The new scorer filters candidates with exact copper-geometry DRC, but full relaxed DRC remains the acceptance authority. The solver therefore cannot accept a geometry improvement that regresses continuity or another benchmark check. Experimental obstacle and pair-dogleg moves are limited to one or two residual issues, after the established strategies have reduced the board to a genuinely sparse state.

## Dataset 18 validation

All samples and checkpoints were run sequentially at 50x effort.

- full sample 16 on parent commit `3090686`: 2 final DRC errors; residual rerouting used 249 iterations and 59.4s
- full sample 16 on this branch: the same 2 final DRC errors; residual rerouting used 249 iterations and 10.0s (about 83% faster)
- fixed sample 10 checkpoint: 4 -> 3 DRC errors, stopped on a count plateau after 132/542 candidates in 11.7s
- fixed sample 16 checkpoint: 7 -> 2 DRC errors, naturally exhausted useful candidates after 248/542 attempts in 10.8s
- 20-candidate sample 4 probe: preserved the same 19 -> 12 DRC reduction while reducing phase time from 5.99s to 4.68s

The full sample-16 run completed normally. Productive count reductions continue to reset the plateau, while unproductive score-only search cannot consume the full high-effort cap indefinitely.

## Checks

- `bun run build`
- 17 focused residual-repair and effort-scaling tests
- full sequential Pipeline 7 dataset-18 sample 16 at 50x effort

This PR remains intentionally stacked on #1670 so the original effort-scaling PR stays separate.
