### PR TITLE
Bound same-net via merging by actual progress

### DIFF
--- a/lib/solvers/SameNetViaMergerSolver/SameNetViaMergerSolver.ts
+++ b/lib/solvers/SameNetViaMergerSolver/SameNetViaMergerSolver.ts
@@ -180,7 +180,6 @@ export class SameNetViaMergerSolver extends BaseSolver {
       ...input,
       obstacles: createObjectsWithZLayers(input.obstacles, input.layerCount),
     }
-    this.MAX_ITERATIONS = 1e6
     this.inputHdRoutes = this.input.inputHdRoutes
     this.mergedViaHdRoutes = structuredClone(this.inputHdRoutes)
     this.unprocessedRoutes = [...this.input.inputHdRoutes]
@@ -200,6 +199,11 @@ export class SameNetViaMergerSolver extends BaseSolver {
     this.viasByNet = new Map<string, Via[]>()
 
     this.rebuildVias()
+    const initialPhysicalViaCount = this.getPhysicalViaCount()
+    // Every successful pass removes at least one physical same-net via
+    // location. Leave one extra step for the final no-candidates check.
+    this.MAX_ITERATIONS = Math.max(1, initialPhysicalViaCount + 1)
+    this.stats.initialPhysicalViaCount = initialPhysicalViaCount
   }
 
   private rebuildVias(): void {
@@ -233,10 +237,23 @@ export class SameNetViaMergerSolver extends BaseSolver {
     }
   }
 
-  private getViaKey(via: Via): string {
-    return [via.routeIndex, via.x, via.y, via.layers.join(","), via.net].join(
-      ":",
-    )
+  private getPhysicalViaKey(via: Via): string {
+    return [via.net, via.x, via.y].join(":")
+  }
+
+  private getPhysicalViaCount(): number {
+    return new Set(this.vias.map((via) => this.getPhysicalViaKey(via))).size
+  }
+
+  private getViasByPhysicalLocation(): Map<string, Via[]> {
+    const viasByPhysicalLocation = new Map<string, Via[]>()
+    for (const via of this.vias) {
+      const key = this.getPhysicalViaKey(via)
+      const viasAtLocation = viasByPhysicalLocation.get(key)
+      if (viasAtLocation) viasAtLocation.push(via)
+      else viasByPhysicalLocation.set(key, [via])
+    }
+    return viasByPhysicalLocation
   }
 
   private dedupeRouteVias(route: HighDensityRoute): void {
@@ -251,8 +268,9 @@ export class SameNetViaMergerSolver extends BaseSolver {
 
   private getOffendingViaGroupsBatch(): Array<{ keep: Via; remove: Via[] }> {
     const groups: Array<{ keep: Via; remove: Via[] }> = []
-    const touchedViaKeys = new Set<string>()
+    const touchedPhysicalViaKeys = new Set<string>()
     const candidateGroups: Array<{ keep: Via; remove: Via[] }> = []
+    const viasByPhysicalLocation = this.getViasByPhysicalLocation()
 
     for (const viasInNet of this.viasByNet.values()) {
       if (viasInNet.length < 2) continue
@@ -281,7 +299,7 @@ export class SameNetViaMergerSolver extends BaseSolver {
         const cellX = Math.floor(keep.x / cellSize)
         const cellY = Math.floor(keep.y / cellSize)
         const neighborCellRadius = Math.ceil(NEAR_VIA_MERGE_DISTANCE_MULTIPLIER)
-        const remove: Via[] = []
+        const removeByPhysicalViaKey = new Map<string, Via>()
 
         for (let dx = -neighborCellRadius; dx <= neighborCellRadius; dx++) {
           for (let dy = -neighborCellRadius; dy <= neighborCellRadius; dy++) {
@@ -307,25 +325,35 @@ export class SameNetViaMergerSolver extends BaseSolver {
                 squaredDistance <=
                 directOverlapDistance * directOverlapDistance
               ) {
-                remove.push(candidate)
+                removeByPhysicalViaKey.set(
+                  this.getPhysicalViaKey(candidate),
+                  candidate,
+                )
                 continue
               }
 
+              const candidatePhysicalViaKey = this.getPhysicalViaKey(candidate)
+              const coLocatedCandidateVias = viasByPhysicalLocation.get(
+                candidatePhysicalViaKey,
+              ) ?? [candidate]
               if (
                 squaredDistance <= nearMergeDistance * nearMergeDistance &&
-                canMoveViaTo(candidate, keep, {
-                  connMap: this.connMap,
-                  mergedViaHdRoutes: this.mergedViaHdRoutes,
-                  hdRouteSHI: this.hdRouteSHI,
-                  obstacleSHI: this.obstacleSHI,
-                })
+                coLocatedCandidateVias.every((coLocatedCandidateVia) =>
+                  canMoveViaTo(coLocatedCandidateVia, keep, {
+                    connMap: this.connMap,
+                    mergedViaHdRoutes: this.mergedViaHdRoutes,
+                    hdRouteSHI: this.hdRouteSHI,
+                    obstacleSHI: this.obstacleSHI,
+                  }),
+                )
               ) {
-                remove.push(candidate)
+                removeByPhysicalViaKey.set(candidatePhysicalViaKey, candidate)
               }
             }
           }
         }
 
+        const remove = [...removeByPhysicalViaKey.values()]
         if (remove.length > 0) candidateGroups.push({ keep, remove })
       }
     }
@@ -342,18 +370,29 @@ export class SameNetViaMergerSolver extends BaseSolver {
     })
 
     for (const candidateGroup of candidateGroups) {
-      const keepKey = this.getViaKey(candidateGroup.keep)
-      if (touchedViaKeys.has(keepKey)) continue
+      const keepKey = this.getPhysicalViaKey(candidateGroup.keep)
+      if (touchedPhysicalViaKeys.has(keepKey)) continue
 
-      const remove = candidateGroup.remove.filter(
-        (viaToRemove) => !touchedViaKeys.has(this.getViaKey(viaToRemove)),
+      const removeLocations = candidateGroup.remove.filter(
+        (viaToRemove) =>
+          !touchedPhysicalViaKeys.has(this.getPhysicalViaKey(viaToRemove)),
       )
-      if (remove.length === 0) continue
+      if (removeLocations.length === 0) continue
+
+      // A physical same-net via can be represented by transitions on several
+      // route fragments. Move the whole co-located cluster atomically so one
+      // pass cannot split it and another pass move it back.
+      const remove = removeLocations.flatMap(
+        (viaToRemove) =>
+          viasByPhysicalLocation.get(this.getPhysicalViaKey(viaToRemove)) ?? [
+            viaToRemove,
+          ],
+      )
 
       groups.push({ keep: candidateGroup.keep, remove })
-      touchedViaKeys.add(keepKey)
-      for (const viaToRemove of remove) {
-        touchedViaKeys.add(this.getViaKey(viaToRemove))
+      touchedPhysicalViaKeys.add(keepKey)
+      for (const viaToRemove of removeLocations) {
+        touchedPhysicalViaKeys.add(this.getPhysicalViaKey(viaToRemove))
       }
     }
 
@@ -432,10 +471,13 @@ export class SameNetViaMergerSolver extends BaseSolver {
     const groups = this.getOffendingViaGroupsBatch()
 
     if (groups.length === 0) {
+      this.stats.finalPhysicalViaCount = this.getPhysicalViaCount()
       this.solved = true
       return
     }
 
+    const routesBeforeMerge = structuredClone(this.mergedViaHdRoutes)
+    const physicalViaCountBeforeMerge = this.getPhysicalViaCount()
     let mergedViaCount = 0
     for (const group of groups) {
       for (const viaToRemove of group.remove) {
@@ -445,8 +487,23 @@ export class SameNetViaMergerSolver extends BaseSolver {
     }
     this.rebuildVias()
     this.hdRouteSHI = new HighDensityRouteSpatialIndex(this.mergedViaHdRoutes)
+    const physicalViaCountAfterMerge = this.getPhysicalViaCount()
+
+    if (physicalViaCountAfterMerge >= physicalViaCountBeforeMerge) {
+      // This is a convergence guard, not a successful optimization. Restore
+      // the checkpoint so a cyclic batch cannot perturb routing geometry.
+      this.mergedViaHdRoutes = routesBeforeMerge
+      this.rebuildVias()
+      this.hdRouteSHI = new HighDensityRouteSpatialIndex(this.mergedViaHdRoutes)
+      this.stats.stoppedAfterNoPhysicalViaReduction = true
+      this.stats.finalPhysicalViaCount = physicalViaCountBeforeMerge
+      this.solved = true
+      return
+    }
+
     this.stats.mergedViaGroups = groups.length
     this.stats.mergedViaCount = mergedViaCount
+    this.stats.finalPhysicalViaCount = physicalViaCountAfterMerge
   }
 
   getMergedViaHdRoutes(): HighDensityRoute[] | null {

--- a/tests/solvers/same-net-via-merger-convergence.test.ts
+++ b/tests/solvers/same-net-via-merger-convergence.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { SameNetViaMergerSolver } from "lib/solvers/SameNetViaMergerSolver/SameNetViaMergerSolver"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+
+const makeViaRoute = (connectionName: string, x: number): HighDensityRoute => ({
+  connectionName,
+  traceThickness: 0.15,
+  viaDiameter: 0.3,
+  route: [
+    { x, y: 0, z: 0 },
+    { x, y: 0, z: 1 },
+  ],
+  vias: [{ x, y: 0 }],
+})
+
+test("SameNetViaMergerSolver restores a batch that does not reduce physical vias", () => {
+  const inputHdRoutes = [
+    makeViaRoute("route-a", 0),
+    makeViaRoute("route-b", 0.25),
+  ]
+  const solver = new SameNetViaMergerSolver({
+    inputHdRoutes,
+    obstacles: [],
+    colorMap: {},
+    layerCount: 2,
+    connMap: new ConnectivityMap({
+      net0: ["route-a", "route-b"],
+    }),
+  })
+  const [viaA, viaB] = solver.vias
+
+  if (!viaA || !viaB) {
+    throw new Error("Expected two input vias")
+  }
+
+  // Reproduce the old cyclic failure mode: two representatives swap their
+  // destinations while preserving the same number of physical vias.
+  Object.defineProperty(solver, "getOffendingViaGroupsBatch", {
+    value: () => [
+      { keep: viaB, remove: [viaA] },
+      { keep: viaA, remove: [viaB] },
+    ],
+  })
+
+  solver.step()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(solver.iterations).toBe(1)
+  expect(solver.stats.stoppedAfterNoPhysicalViaReduction).toBe(true)
+  expect(solver.getMergedViaHdRoutes()).toEqual(inputHdRoutes)
+})

--- a/tests/solvers/same-net-via-merger-direct-overlap-star.test.ts
+++ b/tests/solvers/same-net-via-merger-direct-overlap-star.test.ts
@@ -32,6 +32,7 @@ test("SameNetViaMergerSolver consolidates a chain within the near-merge radius",
   solver.solve()
 
   expect(solver.failed).toBe(false)
+  expect(solver.MAX_ITERATIONS).toBe(4)
   expect(solver.iterations).toBeLessThan(10)
 
   const routes = solver.getMergedViaHdRoutes()


### PR DESCRIPTION
## Summary

This is part 1 of the focused stack replacing #1670. It is independently mergeable.

Stack: **#1692** → #1693 → #1694 → #1695 → #1698 → #1699 → #1700

Same-net via merging now has a physical progress bound and rolls back a merge batch when it does not reduce the number of physical vias.

## What changed

- Group coincident route-fragment vias into one physical via before choosing a merge.
- Apply each physical-via merge atomically across all participating route fragments.
- Bound work to `physicalViaCount + 1` instead of a fixed 1,000,000 iterations.
- Restore the previous routes and stop when a merge batch makes no physical progress.

## Effect

| Case | Before | After |
| --- | ---: | ---: |
| Cyclic/no-progress reproducer | Could consume the 1,000,000-iteration allowance | Stops after 1 attempted batch and restores the input |
| Three-physical-via chain | 1,000,000 iteration allowance | Maximum of 4 iterations |

This removes the iteration leak without exposing a user-facing iteration setting.

## Checks

- `bun test tests/same-net-via-merger-convergence.test.ts tests/same-net-via-merger-direct-overlap-star.test.ts --timeout 9999999`
- `bun run build`
