### PR TITLE
Fix Pipeline7 rerip, density, and via regressions

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -549,15 +549,6 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
       return [
         {
           nodePortPoints: nodePortPointsSource,
-          nodePfById: new Map(
-            (
-              cms.portPointPathingSolver?.getOutput().inputNodeWithPortPoints ??
-              []
-            ).map((node) => [
-              node.capacityMeshNodeId,
-              cms.portPointPathingSolver?.computeNodePf(node) ?? null,
-            ]),
-          ),
           colorMap: cms.colorMap,
           connMap: cms.connMap,
           viaDiameter: cms.viaDiameter,

--- a/lib/solvers/HighDensitySolver/HighDensitySolver.ts
+++ b/lib/solvers/HighDensitySolver/HighDensitySolver.ts
@@ -17,7 +17,7 @@ import { BaseSolver } from "../BaseSolver"
 import { calculateNodeProbabilityOfFailure } from "../UnravelSolver/calculateCrossingProbabilityOfFailure"
 import {
   DEFAULT_MAX_GROWTH_ATTEMPTS,
-  getInitialScaleFactorForNode,
+  getInitialScaleFactorForNodePf,
   GrowShrinkHighDensityIntraNodeSolver,
 } from "../HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver"
 import { PortfolioSingleIntraNodeSolver } from "../HyperHighDensitySolver/PortfolioSingleIntraNodeSolver"
@@ -408,7 +408,7 @@ export class HighDensitySolver extends BaseSolver {
         this.growShrinkMaxInnerIterationsPerGrowthAttempt,
       fallbackToInvalidGeometryOnFailure:
         this.growShrinkFallbackToInvalidGeometryOnFailure,
-      initialScaleFactor: getInitialScaleFactorForNode(node, nodePf),
+      initialScaleFactor: getInitialScaleFactorForNodePf(nodePf),
     }
     this.activeSubSolver = this.useGrowShrinkHighDensityIntraNodeSolver
       ? new GrowShrinkHighDensityIntraNodeSolver(intraNodeSolverParams)

--- a/lib/solvers/HighDensitySolver/HighDensitySolver.ts
+++ b/lib/solvers/HighDensitySolver/HighDensitySolver.ts
@@ -1,8 +1,12 @@
 import { ConnectivityMap } from "circuit-json-to-connectivity-map"
 import type { GraphicsObject } from "graphics-debug"
 import { getGlobalInMemoryCache } from "lib/cache/setupGlobalCaches"
-import type { CapacityMeshNodeId } from "lib/types/capacity-mesh-types"
+import type {
+  CapacityMeshNode,
+  CapacityMeshNodeId,
+} from "lib/types/capacity-mesh-types"
 import { combineVisualizations } from "lib/utils/combineVisualizations"
+import { getIntraNodeCrossingsUsingCircle } from "lib/utils/getIntraNodeCrossingsUsingCircle"
 import { mergeRouteSegments } from "lib/utils/mergeRouteSegments"
 import type {
   HighDensityIntraNodeRoute,
@@ -10,8 +14,10 @@ import type {
 } from "../../types/high-density-types"
 import type { Obstacle } from "../../types/srj-types"
 import { BaseSolver } from "../BaseSolver"
+import { calculateNodeProbabilityOfFailure } from "../UnravelSolver/calculateCrossingProbabilityOfFailure"
 import {
   DEFAULT_MAX_GROWTH_ATTEMPTS,
+  getInitialScaleFactorForNode,
   GrowShrinkHighDensityIntraNodeSolver,
 } from "../HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver"
 import { PortfolioSingleIntraNodeSolver } from "../HyperHighDensitySolver/PortfolioSingleIntraNodeSolver"
@@ -275,6 +281,32 @@ export class HighDensitySolver extends BaseSolver {
       (this.stats.highDensityResizeCount ?? 0) + solver.growthAttempts
   }
 
+  private getOrComputeNodePf(node: NodeWithPortPoints): number {
+    const existingNodePf = this.nodePfById.get(node.capacityMeshNodeId)
+    if (existingNodePf !== undefined && existingNodePf !== null) {
+      return existingNodePf
+    }
+
+    const crossings = getIntraNodeCrossingsUsingCircle(node)
+    const capacityNode: CapacityMeshNode = {
+      capacityMeshNodeId: node.capacityMeshNodeId,
+      center: node.center,
+      width: node.width,
+      height: node.height,
+      layer: "",
+      availableZ: node.availableZ ?? [0, 1],
+      _containsTarget: node._containsTarget,
+    }
+    const nodePf = calculateNodeProbabilityOfFailure(
+      capacityNode,
+      crossings.numSameLayerCrossings,
+      crossings.numEntryExitLayerChanges,
+      crossings.numTransitionPairCrossings,
+    )
+    this.nodePfById.set(node.capacityMeshNodeId, nodePf)
+    return nodePf
+  }
+
   private getSolvedRoutesWithTerminalPcbPortIds(
     solver: HighDensityIntraNodeSolver,
   ): HighDensityIntraNodeRoute[] {
@@ -360,6 +392,7 @@ export class HighDensitySolver extends BaseSolver {
       return
     }
     const node = this.unsolvedNodePortPoints.pop()!
+    const nodePf = this.getOrComputeNodePf(node)
 
     const intraNodeSolverParams = {
       nodeWithPortPoints: node,
@@ -375,6 +408,7 @@ export class HighDensitySolver extends BaseSolver {
         this.growShrinkMaxInnerIterationsPerGrowthAttempt,
       fallbackToInvalidGeometryOnFailure:
         this.growShrinkFallbackToInvalidGeometryOnFailure,
+      initialScaleFactor: getInitialScaleFactorForNode(node, nodePf),
     }
     this.activeSubSolver = this.useGrowShrinkHighDensityIntraNodeSolver
       ? new GrowShrinkHighDensityIntraNodeSolver(intraNodeSolverParams)

--- a/lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver/GrowShrinkHighDensityIntraNodeSolver.ts
+++ b/lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver/GrowShrinkHighDensityIntraNodeSolver.ts
@@ -47,16 +47,6 @@ export const getInitialScaleFactorForNodePf = (
   return 2 ** growthAttempts
 }
 
-export const getInitialScaleFactorForNode = (
-  node: NodeWithPortPoints,
-  nodePf: number | null | undefined,
-  maxGrowthAttempts = DEFAULT_MAX_GROWTH_ATTEMPTS,
-): number =>
-  Math.max(
-    getInitialScaleFactorForNodePf(nodePf, maxGrowthAttempts),
-    node.portPoints.some((portPoint) => portPoint.cramped) ? 2 : 1,
-  )
-
 const scalePoint = <T extends { x: number; y: number }>(
   point: T,
   center: { x: number; y: number },

--- a/lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver/GrowShrinkHighDensityIntraNodeSolver.ts
+++ b/lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver/GrowShrinkHighDensityIntraNodeSolver.ts
@@ -23,7 +23,39 @@ export type GrowShrinkHighDensityIntraNodeSolverParams =
     maxGrowthAttempts?: number
     maxInnerIterationsPerGrowthAttempt?: number
     fallbackToInvalidGeometryOnFailure?: boolean
+    initialScaleFactor?: number
   }
+
+export const getInitialScaleFactorForNodePf = (
+  nodePf: number | null | undefined,
+  maxGrowthAttempts = DEFAULT_MAX_GROWTH_ATTEMPTS,
+  targetNodePf = 0.5,
+): number => {
+  if (
+    typeof nodePf !== "number" ||
+    !Number.isFinite(nodePf) ||
+    nodePf <= targetNodePf
+  ) {
+    return 1
+  }
+
+  const requiredLinearScale = Math.sqrt(nodePf / targetNodePf)
+  const growthAttempts = Math.min(
+    maxGrowthAttempts,
+    Math.ceil(Math.log2(requiredLinearScale)),
+  )
+  return 2 ** growthAttempts
+}
+
+export const getInitialScaleFactorForNode = (
+  node: NodeWithPortPoints,
+  nodePf: number | null | undefined,
+  maxGrowthAttempts = DEFAULT_MAX_GROWTH_ATTEMPTS,
+): number =>
+  Math.max(
+    getInitialScaleFactorForNodePf(nodePf, maxGrowthAttempts),
+    node.portPoints.some((portPoint) => portPoint.cramped) ? 2 : 1,
+  )
 
 const scalePoint = <T extends { x: number; y: number }>(
   point: T,
@@ -117,6 +149,15 @@ export class GrowShrinkHighDensityIntraNodeSolver extends BaseSolver {
     this.nodeWithPortPoints = params.nodeWithPortPoints
     this.maxGrowthAttempts =
       params.maxGrowthAttempts ?? DEFAULT_MAX_GROWTH_ATTEMPTS
+    const requestedInitialScaleFactor = Math.max(
+      1,
+      params.initialScaleFactor ?? 1,
+    )
+    this.growthAttempts = Math.min(
+      this.maxGrowthAttempts,
+      Math.ceil(Math.log2(requestedInitialScaleFactor)),
+    )
+    this.scaleFactor = 2 ** this.growthAttempts
     this.MAX_ITERATIONS =
       20_000_000 * (params.effort ?? 1) * (this.maxGrowthAttempts + 1)
 

--- a/lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver/index.ts
+++ b/lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver/index.ts
@@ -1,6 +1,5 @@
 export {
   DEFAULT_MAX_GROWTH_ATTEMPTS,
-  getInitialScaleFactorForNode,
   getInitialScaleFactorForNodePf,
   GrowShrinkHighDensityIntraNodeSolver,
   type GrowShrinkHighDensityIntraNodeSolverParams,

--- a/lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver/index.ts
+++ b/lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver/index.ts
@@ -1,5 +1,7 @@
 export {
   DEFAULT_MAX_GROWTH_ATTEMPTS,
+  getInitialScaleFactorForNode,
+  getInitialScaleFactorForNodePf,
   GrowShrinkHighDensityIntraNodeSolver,
   type GrowShrinkHighDensityIntraNodeSolverParams,
 } from "./GrowShrinkHighDensityIntraNodeSolver"

--- a/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
+++ b/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
@@ -254,8 +254,7 @@ const getViaHostRegion = (params: {
         params.minViaPadDiameter &&
       region.d.height + TERMINAL_REGION_CONTAINMENT_TOLERANCE >=
         params.minViaPadDiameter
-    const viaMargin =
-      params.minViaPadDiameter / 2 + TERMINAL_VIA_ROUTING_MARGIN
+    const viaMargin = params.minViaPadDiameter / 2 + TERMINAL_VIA_ROUTING_MARGIN
     const minViaX = region.d.center.x - halfWidth + viaMargin
     const maxViaX = region.d.center.x + halfWidth - viaMargin
     const minViaY = region.d.center.y - halfHeight + viaMargin

--- a/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
+++ b/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
@@ -18,6 +18,7 @@ import {
   DuplicateCongestedPortSolver,
   orderConnectionsByNetCardinality,
   SelectiveReripTinyHyperGraphSolver,
+  type Candidate,
   type DuplicateCongestedPortSolverReport,
   TinyHyperGraphSectionPipelineSolver,
   TinyHyperGraphSectionSolver,
@@ -37,6 +38,8 @@ import { getRegionNetIdByRegionId } from "./getRegionNetIdByRegionId"
 type RouteMetadata = {
   connectionId: string
   mutuallyConnectedNetworkId?: string
+  startRegionId?: string
+  endRegionId?: string
   simpleRouteConnection?: HgPortPointPathingSolverParams["connections"][number]["simpleRouteConnection"]
 }
 
@@ -62,6 +65,7 @@ type TinyBounds = {
 }
 
 type TinyRegionMetadata = {
+  serializedRegionId?: string
   bounds?: TinyBounds
   _qfpRegionType?: InputNodeWithPortPoints["_qfpRegionType"]
   _isNarrowQfpPadGap?: boolean
@@ -69,6 +73,7 @@ type TinyRegionMetadata = {
 }
 
 type TinyPortMetadata = {
+  serializedPortId?: string
   x?: number
   y?: number
   z?: number
@@ -108,6 +113,7 @@ const asTinyPortMetadata = (metadata: unknown): TinyPortMetadata =>
     : {}
 
 const TINY_TERMINAL_REGION_SIZE = 1e-6
+const TINY_TERMINAL_VIA_BRIDGE_PORT_PREFIX = "tiny-terminal:via-bridge-port:"
 const TERMINAL_REGION_CONTAINMENT_TOLERANCE = 1e-3
 const TERMINAL_VIA_ROUTING_MARGIN = 0.15
 const TINY_SOLVE_GRAPH_BASE_OPTIONS: TinyHyperGraphSolverOptions = {
@@ -227,7 +233,7 @@ const getSharedConnectionZ = (params: {
   return sharedZ ?? params.fallbackZ
 }
 
-const getViaHostRegion = (params: {
+const getViaHostPlacement = (params: {
   connection: TinyRouteConnection
   startPoint: ReturnType<typeof getRoutePoint>
   endPoint: ReturnType<typeof getRoutePoint>
@@ -236,11 +242,16 @@ const getViaHostRegion = (params: {
   minViaPadDiameter: number
   routeNetIndex: number
   regionNetIdByRegionId: Map<string, number>
-}): TinyRouteConnection["startRegion"] | undefined => {
+}):
+  | {
+      region: TinyRouteConnection["startRegion"]
+      point: { x: number; y: number }
+    }
+  | undefined => {
   const { connection, startPoint, endPoint, startZ, endZ } = params
   if (!startPoint || !endPoint || startZ === endZ) return undefined
 
-  return [connection.startRegion, connection.endRegion].find((region) => {
+  for (const region of [connection.startRegion, connection.endRegion]) {
     const halfWidth = region.d.width / 2
     const halfHeight = region.d.height / 2
     const containsStart =
@@ -280,14 +291,116 @@ const getViaHostRegion = (params: {
     const isReservedForRoute =
       params.regionNetIdByRegionId.get(region.regionId) === params.routeNetIndex
 
-    return (
+    if (
       containsStart &&
       containsEnd &&
       canFitVia &&
       viaIsInsideBothTerminalRegions &&
       isReservedForRoute
+    ) {
+      return { region, point: { x: viaX, y: viaY } }
+    }
+  }
+
+  return undefined
+}
+
+const getOverlappingRegionViaPlacement = (params: {
+  firstRegion: TinyRouteConnection["startRegion"]
+  secondRegion: TinyRouteConnection["startRegion"]
+  minViaPadDiameter: number
+}):
+  | {
+      region: TinyRouteConnection["startRegion"]
+      point: { x: number; y: number }
+      bridgeZ: number
+    }
+  | undefined => {
+  const { firstRegion, secondRegion } = params
+  const firstZ = firstRegion.d.availableZ[0]
+  const secondZ = secondRegion.d.availableZ[0]
+  if (
+    firstZ === undefined ||
+    secondZ === undefined ||
+    firstRegion.d.availableZ.some((z) => secondRegion.d.availableZ.includes(z))
+  ) {
+    return undefined
+  }
+
+  const overlapMinX = Math.max(
+    firstRegion.d.center.x - firstRegion.d.width / 2,
+    secondRegion.d.center.x - secondRegion.d.width / 2,
+  )
+  const overlapMaxX = Math.min(
+    firstRegion.d.center.x + firstRegion.d.width / 2,
+    secondRegion.d.center.x + secondRegion.d.width / 2,
+  )
+  const overlapMinY = Math.max(
+    firstRegion.d.center.y - firstRegion.d.height / 2,
+    secondRegion.d.center.y - secondRegion.d.height / 2,
+  )
+  const overlapMaxY = Math.min(
+    firstRegion.d.center.y + firstRegion.d.height / 2,
+    secondRegion.d.center.y + secondRegion.d.height / 2,
+  )
+  if (
+    overlapMinX > overlapMaxX + TERMINAL_REGION_CONTAINMENT_TOLERANCE ||
+    overlapMinY > overlapMaxY + TERMINAL_REGION_CONTAINMENT_TOLERANCE
+  ) {
+    return undefined
+  }
+
+  for (const [region, bridgeZ] of [
+    [firstRegion, secondZ],
+    [secondRegion, firstZ],
+  ] as const) {
+    if (
+      region.d.width + TERMINAL_REGION_CONTAINMENT_TOLERANCE <
+        params.minViaPadDiameter ||
+      region.d.height + TERMINAL_REGION_CONTAINMENT_TOLERANCE <
+        params.minViaPadDiameter
+    ) {
+      continue
+    }
+
+    const viaMargin = params.minViaPadDiameter / 2 + TERMINAL_VIA_ROUTING_MARGIN
+    const minViaX = Math.max(
+      overlapMinX,
+      region.d.center.x - region.d.width / 2 + viaMargin,
     )
-  })
+    const maxViaX = Math.min(
+      overlapMaxX,
+      region.d.center.x + region.d.width / 2 - viaMargin,
+    )
+    const minViaY = Math.max(
+      overlapMinY,
+      region.d.center.y - region.d.height / 2 + viaMargin,
+    )
+    const maxViaY = Math.min(
+      overlapMaxY,
+      region.d.center.y + region.d.height / 2 - viaMargin,
+    )
+    const overlapCenterX = (overlapMinX + overlapMaxX) / 2
+    const overlapCenterY = (overlapMinY + overlapMaxY) / 2
+    const viaX =
+      minViaX <= maxViaX
+        ? Math.min(maxViaX, Math.max(minViaX, overlapCenterX))
+        : overlapCenterX
+    const viaY =
+      minViaY <= maxViaY
+        ? Math.min(maxViaY, Math.max(minViaY, overlapCenterY))
+        : overlapCenterY
+    const isInsideBothRegions = [firstRegion, secondRegion].every(
+      (candidateRegion) =>
+        pointToBoxDistance({ x: viaX, y: viaY }, candidateRegion.d) <=
+        TERMINAL_REGION_CONTAINMENT_TOLERANCE,
+    )
+    if (isInsideBothRegions) {
+      return { region, point: { x: viaX, y: viaY }, bridgeZ }
+    }
+  }
+
+  return undefined
 }
 
 const toSerializedRegionData = (
@@ -360,6 +473,351 @@ const getTinyRouteConnectionsOrThrow = (
   })
 }
 
+const getRegionPairKey = (firstRegionId: string, secondRegionId: string) =>
+  firstRegionId < secondRegionId
+    ? `${firstRegionId}\u0000${secondRegionId}`
+    : `${secondRegionId}\u0000${firstRegionId}`
+
+type TinyConnectionLayerInfo = {
+  connection: TinyRouteConnection
+  netId: number
+  startZ: number
+  endZ: number
+}
+
+type PendingTerminalViaBridge = TinyConnectionLayerInfo & {
+  placement: NonNullable<ReturnType<typeof getViaHostPlacement>>
+}
+
+const getUnreachableConnectionIds = (params: {
+  connectionLayerInfo: TinyConnectionLayerInfo[]
+  regions: SerializedHyperGraph["regions"]
+  ports: SerializedHyperGraph["ports"]
+}): Set<string> => {
+  const regionById = new Map(
+    params.regions.map((region) => [region.regionId, region]),
+  )
+  const incidentPortsByRegionId = new Map<
+    string,
+    SerializedHyperGraph["ports"]
+  >()
+  for (const port of params.ports) {
+    for (const regionId of [port.region1Id, port.region2Id]) {
+      const incidentPorts = incidentPortsByRegionId.get(regionId) ?? []
+      incidentPorts.push(port)
+      incidentPortsByRegionId.set(regionId, incidentPorts)
+    }
+  }
+
+  const unreachableConnectionIds = new Set<string>()
+  for (const { connection, netId } of params.connectionLayerInfo) {
+    const startRegionId = connection.startRegion.regionId
+    const endRegionId = connection.endRegion.regionId
+    const queue = [startRegionId]
+    const visited = new Set([startRegionId])
+    let reachable = false
+
+    for (let queueIndex = 0; queueIndex < queue.length; queueIndex++) {
+      const regionId = queue[queueIndex]!
+      if (regionId === endRegionId) {
+        reachable = true
+        break
+      }
+
+      const region = regionById.get(regionId)
+      if (!region) continue
+      const reservedNetId = region.d.netId
+      if (reservedNetId !== undefined && reservedNetId !== netId) continue
+
+      for (const port of incidentPortsByRegionId.get(regionId) ?? []) {
+        const nextRegionId =
+          port.region1Id === regionId ? port.region2Id : port.region1Id
+        const nextRegion = regionById.get(nextRegionId)
+        if (!nextRegion) continue
+        const nextReservedNetId = nextRegion.d.netId
+        if (nextReservedNetId !== undefined && nextReservedNetId !== netId) {
+          continue
+        }
+        if (visited.has(nextRegionId)) continue
+        visited.add(nextRegionId)
+        queue.push(nextRegionId)
+      }
+    }
+
+    if (!reachable) {
+      unreachableConnectionIds.add(connection.connectionId)
+    }
+  }
+
+  return unreachableConnectionIds
+}
+
+const addTerminalViaBridge = (params: {
+  bridge: PendingTerminalViaBridge
+  regions: SerializedHyperGraph["regions"]
+  ports: SerializedHyperGraph["ports"]
+}) => {
+  const { connection, placement, startZ, endZ } = params.bridge
+  const serializedViaHostRegion = params.regions.find(
+    (region) => region.regionId === placement.region.regionId,
+  )
+  const startRegion = params.regions.find(
+    (region) => region.regionId === connection.startRegion.regionId,
+  )
+  const endRegion = params.regions.find(
+    (region) => region.regionId === connection.endRegion.regionId,
+  )
+  if (!serializedViaHostRegion || !startRegion || !endRegion) {
+    throw new Error(
+      `Could not map terminal via bridge regions for "${connection.connectionId}"`,
+    )
+  }
+
+  serializedViaHostRegion.d.availableZ = [
+    ...new Set([...serializedViaHostRegion.d.availableZ, startZ, endZ]),
+  ].sort((a, b) => a - b)
+
+  const viaBridgePortId = `${TINY_TERMINAL_VIA_BRIDGE_PORT_PREFIX}${connection.connectionId}`
+  const viaBridgeZ =
+    placement.region.regionId === connection.startRegion.regionId
+      ? endZ
+      : startZ
+  params.ports.push({
+    portId: viaBridgePortId,
+    region1Id: connection.startRegion.regionId,
+    region2Id: connection.endRegion.regionId,
+    d: {
+      portId: viaBridgePortId,
+      x: placement.point.x,
+      y: placement.point.y,
+      z: viaBridgeZ,
+      distToCentermostPortOnZ: 0,
+      _tinyTerminal: true,
+    },
+  })
+  startRegion.pointIds.push(viaBridgePortId)
+  endRegion.pointIds.push(viaBridgePortId)
+}
+
+const addOverlappingNetViaBridges = (params: {
+  input: TinyHypergraphInput
+  regions: SerializedHyperGraph["regions"]
+  ports: SerializedHyperGraph["ports"]
+  regionNetIdByRegionId: Map<string, number>
+  netIds: Set<number>
+}) => {
+  const serializedRegionById = new Map(
+    params.regions.map((region) => [region.regionId, region]),
+  )
+  const connectedRegionPairs = new Set(
+    params.ports.map((port) =>
+      getRegionPairKey(port.region1Id, port.region2Id),
+    ),
+  )
+  const targetRegionsByNetId = new Map<
+    number,
+    TinyRouteConnection["startRegion"][]
+  >()
+
+  for (const region of params.input.graph.regions) {
+    if (!region.d._containsTarget) continue
+    const netId = params.regionNetIdByRegionId.get(region.regionId)
+    if (netId === undefined || !params.netIds.has(netId)) continue
+    const netRegions = targetRegionsByNetId.get(netId) ?? []
+    netRegions.push(region)
+    targetRegionsByNetId.set(netId, netRegions)
+  }
+
+  for (const [netId, netRegions] of targetRegionsByNetId) {
+    for (let firstIndex = 0; firstIndex < netRegions.length; firstIndex++) {
+      const firstRegion = netRegions[firstIndex]!
+      for (
+        let secondIndex = firstIndex + 1;
+        secondIndex < netRegions.length;
+        secondIndex++
+      ) {
+        const secondRegion = netRegions[secondIndex]!
+        const regionPairKey = getRegionPairKey(
+          firstRegion.regionId,
+          secondRegion.regionId,
+        )
+        if (connectedRegionPairs.has(regionPairKey)) continue
+
+        const viaPlacement = getOverlappingRegionViaPlacement({
+          firstRegion,
+          secondRegion,
+          minViaPadDiameter: params.input.minViaPadDiameter ?? 0.3,
+        })
+        if (!viaPlacement) continue
+
+        const serializedFirstRegion = serializedRegionById.get(
+          firstRegion.regionId,
+        )
+        const serializedSecondRegion = serializedRegionById.get(
+          secondRegion.regionId,
+        )
+        const serializedViaHostRegion = serializedRegionById.get(
+          viaPlacement.region.regionId,
+        )
+        if (
+          !serializedFirstRegion ||
+          !serializedSecondRegion ||
+          !serializedViaHostRegion
+        ) {
+          throw new Error(
+            `Could not map overlapping target regions "${firstRegion.regionId}" and "${secondRegion.regionId}"`,
+          )
+        }
+
+        const viaBridgePortId = `tiny-net-via-bridge-port:${netId}:${firstRegion.regionId}:${secondRegion.regionId}`
+        params.ports.push({
+          portId: viaBridgePortId,
+          region1Id: firstRegion.regionId,
+          region2Id: secondRegion.regionId,
+          d: {
+            portId: viaBridgePortId,
+            x: viaPlacement.point.x,
+            y: viaPlacement.point.y,
+            z: viaPlacement.bridgeZ,
+            distToCentermostPortOnZ: 0,
+            _tinyTerminal: true,
+          },
+        })
+        serializedFirstRegion.pointIds.push(viaBridgePortId)
+        serializedSecondRegion.pointIds.push(viaBridgePortId)
+        serializedViaHostRegion.d.availableZ = [
+          ...new Set([
+            ...serializedViaHostRegion.d.availableZ,
+            ...firstRegion.d.availableZ,
+            ...secondRegion.d.availableZ,
+          ]),
+        ].sort((a, b) => a - b)
+        connectedRegionPairs.add(regionPairKey)
+      }
+    }
+  }
+}
+
+const addOverlappingTargetRegionAttachments = (params: {
+  input: TinyHypergraphInput
+  regions: SerializedHyperGraph["regions"]
+  ports: SerializedHyperGraph["ports"]
+  regionNetIdByRegionId: Map<string, number>
+  netIds: Set<number>
+}) => {
+  const serializedRegionById = new Map(
+    params.regions.map((region) => [region.regionId, region]),
+  )
+  const connectedRegionPairs = new Set(
+    params.ports.map((port) =>
+      getRegionPairKey(port.region1Id, port.region2Id),
+    ),
+  )
+
+  for (const targetRegion of params.input.graph.regions) {
+    if (!targetRegion.d._containsTarget) continue
+    const targetNetId = params.regionNetIdByRegionId.get(targetRegion.regionId)
+    if (targetNetId === undefined || !params.netIds.has(targetNetId)) continue
+
+    for (const candidateRegion of params.input.graph.regions) {
+      if (
+        candidateRegion.regionId === targetRegion.regionId ||
+        candidateRegion.d._containsTarget ||
+        candidateRegion.d._containsObstacle ||
+        candidateRegion.ports.length === 0
+      ) {
+        continue
+      }
+      const candidateNetId = params.regionNetIdByRegionId.get(
+        candidateRegion.regionId,
+      )
+      if (candidateNetId !== undefined && candidateNetId !== targetNetId) {
+        continue
+      }
+
+      const sharedZ = targetRegion.d.availableZ.find((z) =>
+        candidateRegion.d.availableZ.includes(z),
+      )
+      if (sharedZ !== undefined) continue
+      const overlapMinX = Math.max(
+        targetRegion.d.center.x - targetRegion.d.width / 2,
+        candidateRegion.d.center.x - candidateRegion.d.width / 2,
+      )
+      const overlapMaxX = Math.min(
+        targetRegion.d.center.x + targetRegion.d.width / 2,
+        candidateRegion.d.center.x + candidateRegion.d.width / 2,
+      )
+      const overlapMinY = Math.max(
+        targetRegion.d.center.y - targetRegion.d.height / 2,
+        candidateRegion.d.center.y - candidateRegion.d.height / 2,
+      )
+      const overlapMaxY = Math.min(
+        targetRegion.d.center.y + targetRegion.d.height / 2,
+        candidateRegion.d.center.y + candidateRegion.d.height / 2,
+      )
+      if (
+        overlapMaxX - overlapMinX <= TERMINAL_REGION_CONTAINMENT_TOLERANCE ||
+        overlapMaxY - overlapMinY <= TERMINAL_REGION_CONTAINMENT_TOLERANCE
+      ) {
+        continue
+      }
+
+      const viaPlacement = getOverlappingRegionViaPlacement({
+        firstRegion: targetRegion,
+        secondRegion: candidateRegion,
+        minViaPadDiameter: params.input.minViaPadDiameter ?? 0.3,
+      })
+      if (!viaPlacement) continue
+
+      const regionPairKey = getRegionPairKey(
+        targetRegion.regionId,
+        candidateRegion.regionId,
+      )
+      if (connectedRegionPairs.has(regionPairKey)) continue
+
+      const serializedTargetRegion = serializedRegionById.get(
+        targetRegion.regionId,
+      )
+      const serializedCandidateRegion = serializedRegionById.get(
+        candidateRegion.regionId,
+      )
+      if (!serializedTargetRegion || !serializedCandidateRegion) {
+        throw new Error(
+          `Could not map overlapping target attachment regions "${targetRegion.regionId}" and "${candidateRegion.regionId}"`,
+        )
+      }
+
+      const attachmentPortId = `tiny-target-attachment-port:${targetRegion.regionId}:${candidateRegion.regionId}`
+      params.ports.push({
+        portId: attachmentPortId,
+        region1Id: targetRegion.regionId,
+        region2Id: candidateRegion.regionId,
+        d: {
+          portId: attachmentPortId,
+          x: viaPlacement.point.x,
+          y: viaPlacement.point.y,
+          z: viaPlacement.bridgeZ,
+          distToCentermostPortOnZ: 0,
+          _tinyTerminal: true,
+        },
+      })
+      serializedTargetRegion.pointIds.push(attachmentPortId)
+      serializedCandidateRegion.pointIds.push(attachmentPortId)
+      const serializedViaHostRegion = serializedRegionById.get(
+        viaPlacement.region.regionId,
+      )!
+      serializedViaHostRegion.d.availableZ = [
+        ...new Set([
+          ...serializedViaHostRegion.d.availableZ,
+          ...targetRegion.d.availableZ,
+          ...candidateRegion.d.availableZ,
+        ]),
+      ].sort((a, b) => a - b)
+      connectedRegionPairs.add(regionPairKey)
+    }
+  }
+}
+
 const buildSerializedTinyGraph = (
   params: TinyHypergraphInput,
 ): SerializedHyperGraph => {
@@ -399,11 +857,9 @@ const buildSerializedTinyGraph = (
       simpleRouteConnection: connection.simpleRouteConnection,
     }),
   )
-  const serializedConnectionById = new Map(
-    connections.map((connection) => [connection.connectionId, connection]),
-  )
-
   const solvedRoutes: SerializedTinySolvedRoute[] = []
+  const connectionLayerInfo: TinyConnectionLayerInfo[] = []
+  const pendingTerminalViaBridges = new Map<string, PendingTerminalViaBridge>()
   for (const connection of params.connections) {
     const routeMetadata: RouteMetadata = {
       connectionId: connection.connectionId,
@@ -430,47 +886,35 @@ const buildSerializedTinyGraph = (
       regionAvailableZ: connection.endRegion.d.availableZ,
       layerCount: params.layerCount,
     })
-
-    let startAttachmentRegionId = connection.startRegion.regionId
-    let endAttachmentRegionId = connection.endRegion.regionId
-    // When opposite-layer pads overlap inside one same-net target region,
-    // model their through-via as the normal layer transition within that region.
-    const viaHostRegion = getViaHostRegion({
+    const layerInfo: TinyConnectionLayerInfo = {
       connection,
-      startPoint,
-      endPoint,
+      netId: routeNetIndex,
       startZ,
       endZ,
-      minViaPadDiameter: params.minViaPadDiameter ?? 0.3,
-      routeNetIndex,
-      regionNetIdByRegionId,
-    })
-    if (viaHostRegion) {
-      startAttachmentRegionId = viaHostRegion.regionId
-      endAttachmentRegionId = viaHostRegion.regionId
-      const serializedViaHostRegion = regions.find(
-        (region) => region.regionId === viaHostRegion.regionId,
-      )
-      if (!serializedViaHostRegion) {
-        throw new Error(
-          `Could not find via host region "${viaHostRegion.regionId}" for "${connection.connectionId}"`,
-        )
-      }
-      serializedViaHostRegion.d.availableZ = [
-        ...new Set([...serializedViaHostRegion.d.availableZ, startZ, endZ]),
-      ].sort((a, b) => a - b)
     }
+    connectionLayerInfo.push(layerInfo)
 
-    const serializedConnection = serializedConnectionById.get(
-      connection.connectionId,
-    )
-    if (!serializedConnection) {
-      throw new Error(
-        `Could not find serialized connection "${connection.connectionId}"`,
-      )
+    // When opposite-layer pads overlap inside one same-net target region,
+    // remember a legal local bridge. It is added only if the unmodified graph
+    // has no layer-aware path for this route.
+    const viaHostPlacement = params.preserveTerminalPcbPortIds
+      ? getViaHostPlacement({
+          connection,
+          startPoint,
+          endPoint,
+          startZ,
+          endZ,
+          minViaPadDiameter: params.minViaPadDiameter ?? 0.3,
+          routeNetIndex,
+          regionNetIdByRegionId,
+        })
+      : undefined
+    if (viaHostPlacement) {
+      pendingTerminalViaBridges.set(connection.connectionId, {
+        ...layerInfo,
+        placement: viaHostPlacement,
+      })
     }
-    serializedConnection.startRegionId = startAttachmentRegionId
-    serializedConnection.endRegionId = endAttachmentRegionId
 
     const startTerminalRegionId = `tiny-terminal:start-region:${connection.connectionId}`
     const endTerminalRegionId = `tiny-terminal:end-region:${connection.connectionId}`
@@ -519,7 +963,7 @@ const buildSerializedTinyGraph = (
 
     ports.push({
       portId: startTerminalPortId,
-      region1Id: startAttachmentRegionId,
+      region1Id: connection.startRegion.regionId,
       region2Id: startTerminalRegionId,
       d: {
         portId: startTerminalPortId,
@@ -536,7 +980,7 @@ const buildSerializedTinyGraph = (
 
     ports.push({
       portId: endTerminalPortId,
-      region1Id: endAttachmentRegionId,
+      region1Id: connection.endRegion.regionId,
       region2Id: endTerminalRegionId,
       d: {
         portId: endTerminalPortId,
@@ -552,10 +996,10 @@ const buildSerializedTinyGraph = (
     })
 
     const startRegion = regions.find(
-      (region) => region.regionId === startAttachmentRegionId,
+      (region) => region.regionId === connection.startRegion.regionId,
     )
     const endRegion = regions.find(
-      (region) => region.regionId === endAttachmentRegionId,
+      (region) => region.regionId === connection.endRegion.regionId,
     )
     startRegion?.pointIds.push(startTerminalPortId)
     endRegion?.pointIds.push(endTerminalPortId)
@@ -566,6 +1010,38 @@ const buildSerializedTinyGraph = (
       },
       path: [{ portId: startTerminalPortId }, { portId: endTerminalPortId }],
     } as SerializedTinySolvedRoute)
+  }
+
+  // Pipeline 7 preserves PCB terminal identities for downstream stitching.
+  // Add cross-layer topology only for routes that are actually disconnected,
+  // preserving path selection for healthy routes and for other pipelines.
+  if (params.preserveTerminalPcbPortIds) {
+    const graphUnreachableConnectionIds = getUnreachableConnectionIds({
+      connectionLayerInfo,
+      regions,
+      ports,
+    })
+    if (graphUnreachableConnectionIds.size > 0) {
+      for (const bridge of pendingTerminalViaBridges.values()) {
+        addTerminalViaBridge({ bridge, regions, ports })
+      }
+
+      const routeNetIds = new Set(connectionLayerInfo.map(({ netId }) => netId))
+      addOverlappingNetViaBridges({
+        input: params,
+        regions,
+        ports,
+        regionNetIdByRegionId,
+        netIds: routeNetIds,
+      })
+      addOverlappingTargetRegionAttachments({
+        input: params,
+        regions,
+        ports,
+        regionNetIdByRegionId,
+        netIds: routeNetIds,
+      })
+    }
   }
 
   return {
@@ -737,6 +1213,110 @@ const applyMetadataPortPenalties = (loaded: LoadedTinyGraph) => {
   return metadataPortPenaltyCount
 }
 
+class SelectiveReripTinyHyperGraphSolverWithViaBridges extends SelectiveReripTinyHyperGraphSolver {
+  override _setup() {
+    super._setup()
+    if (!this.failed) {
+      this.seedViaBridgeRoutes()
+    }
+  }
+
+  override resetRoutingStateForRerip() {
+    super.resetRoutingStateForRerip()
+    this.seedViaBridgeRoutes()
+  }
+
+  override _step() {
+    const ripCountBeforeStep = this.state.ripCount
+    super._step()
+    if (this.state.ripCount !== ripCountBeforeStep) {
+      this.seedViaBridgeRoutes()
+    }
+  }
+
+  private seedViaBridgeRoutes() {
+    const portIdBySerializedId = new Map<string, number>()
+    for (
+      let portId = 0;
+      portId < (this.topology.portMetadata?.length ?? 0);
+      portId++
+    ) {
+      const serializedPortId =
+        this.topology.portMetadata?.[portId]?.serializedPortId
+      if (typeof serializedPortId === "string") {
+        portIdBySerializedId.set(serializedPortId, portId)
+      }
+    }
+
+    const regionIdBySerializedId = new Map<string, number>()
+    for (
+      let regionId = 0;
+      regionId < (this.topology.regionMetadata?.length ?? 0);
+      regionId++
+    ) {
+      const serializedRegionId =
+        this.topology.regionMetadata?.[regionId]?.serializedRegionId
+      if (typeof serializedRegionId === "string") {
+        regionIdBySerializedId.set(serializedRegionId, regionId)
+      }
+    }
+
+    for (let routeId = 0; routeId < this.problem.routeCount; routeId++) {
+      const routeMetadata = this.problem.routeMetadata?.[
+        routeId
+      ] as RouteMetadata
+      const viaBridgePortId = portIdBySerializedId.get(
+        `${TINY_TERMINAL_VIA_BRIDGE_PORT_PREFIX}${routeMetadata.connectionId}`,
+      )
+      if (viaBridgePortId === undefined) continue
+
+      const alreadySeeded = this.state.regionSegments.some((segments) =>
+        segments.some(([segmentRouteId]) => segmentRouteId === routeId),
+      )
+      if (alreadySeeded) continue
+
+      const startRegionId = routeMetadata.startRegionId
+        ? regionIdBySerializedId.get(routeMetadata.startRegionId)
+        : undefined
+      const endRegionId = routeMetadata.endRegionId
+        ? regionIdBySerializedId.get(routeMetadata.endRegionId)
+        : undefined
+      if (startRegionId === undefined || endRegionId === undefined) {
+        throw new Error(
+          `Could not map via bridge regions for "${routeMetadata.connectionId}"`,
+        )
+      }
+
+      const startPortId = this.problem.routeStartPort[routeId]!
+      const endPortId = this.problem.routeEndPort[routeId]!
+      const startCandidate: Candidate = {
+        portId: startPortId,
+        nextRegionId: startRegionId,
+        f: 0,
+        g: 0,
+        h: 0,
+      }
+      const viaBridgeCandidate: Candidate = {
+        prevRegionId: startRegionId,
+        portId: viaBridgePortId,
+        nextRegionId: endRegionId,
+        prevCandidate: startCandidate,
+        f: 0,
+        g: 0,
+        h: 0,
+      }
+
+      this.state.unroutedRoutes = this.state.unroutedRoutes.filter(
+        (unroutedRouteId) => unroutedRouteId !== routeId,
+      )
+      this.state.currentRouteId = routeId
+      this.state.currentRouteNetId = this.problem.routeNet[routeId]
+      this.state.goalPortId = endPortId
+      this.onPathFound(viaBridgeCandidate)
+    }
+  }
+}
+
 class TinyHyperGraphSectionPipelineWithTerminalNetIds extends TinyHyperGraphSectionPipelineSolver {
   private configuredSolvers = new WeakSet<BaseSolver>()
   duplicatePortPenaltyCount = 0
@@ -761,7 +1341,8 @@ class TinyHyperGraphSectionPipelineWithTerminalNetIds extends TinyHyperGraphSect
           "Tiny hypergraph pipeline is missing the solveGraph stage",
         )
       }
-      solveGraphStep.solverClass = SelectiveReripTinyHyperGraphSolver
+      solveGraphStep.solverClass =
+        SelectiveReripTinyHyperGraphSolverWithViaBridges
     }
     this.MAX_ITERATIONS = getTinyHyperGraphPipelineMaxIterations(inputProblem)
   }

--- a/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
+++ b/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
@@ -1,4 +1,5 @@
 import type { SerializedHyperGraph } from "@tscircuit/hypergraph"
+import { pointToBoxDistance } from "@tscircuit/math-utils"
 import type { GraphicsObject } from "graphics-debug"
 import { BaseSolver } from "lib/solvers/BaseSolver"
 import type {
@@ -107,6 +108,8 @@ const asTinyPortMetadata = (metadata: unknown): TinyPortMetadata =>
     : {}
 
 const TINY_TERMINAL_REGION_SIZE = 1e-6
+const TERMINAL_REGION_CONTAINMENT_TOLERANCE = 1e-3
+const TERMINAL_VIA_ROUTING_MARGIN = 0.15
 const TINY_SOLVE_GRAPH_BASE_OPTIONS: TinyHyperGraphSolverOptions = {
   DISTANCE_TO_COST: 0.05,
   RIP_THRESHOLD_START: 0.05,
@@ -224,6 +227,70 @@ const getSharedConnectionZ = (params: {
   return sharedZ ?? params.fallbackZ
 }
 
+const getViaHostRegion = (params: {
+  connection: TinyRouteConnection
+  startPoint: ReturnType<typeof getRoutePoint>
+  endPoint: ReturnType<typeof getRoutePoint>
+  startZ: number
+  endZ: number
+  minViaPadDiameter: number
+  routeNetIndex: number
+  regionNetIdByRegionId: Map<string, number>
+}): TinyRouteConnection["startRegion"] | undefined => {
+  const { connection, startPoint, endPoint, startZ, endZ } = params
+  if (!startPoint || !endPoint || startZ === endZ) return undefined
+
+  return [connection.startRegion, connection.endRegion].find((region) => {
+    const halfWidth = region.d.width / 2
+    const halfHeight = region.d.height / 2
+    const containsStart =
+      pointToBoxDistance(startPoint, region.d) <=
+      TERMINAL_REGION_CONTAINMENT_TOLERANCE
+    const containsEnd =
+      pointToBoxDistance(endPoint, region.d) <=
+      TERMINAL_REGION_CONTAINMENT_TOLERANCE
+    const canFitVia =
+      region.d.width + TERMINAL_REGION_CONTAINMENT_TOLERANCE >=
+        params.minViaPadDiameter &&
+      region.d.height + TERMINAL_REGION_CONTAINMENT_TOLERANCE >=
+        params.minViaPadDiameter
+    const viaMargin =
+      params.minViaPadDiameter / 2 + TERMINAL_VIA_ROUTING_MARGIN
+    const minViaX = region.d.center.x - halfWidth + viaMargin
+    const maxViaX = region.d.center.x + halfWidth - viaMargin
+    const minViaY = region.d.center.y - halfHeight + viaMargin
+    const maxViaY = region.d.center.y + halfHeight - viaMargin
+    const midpointX = (startPoint.x + endPoint.x) / 2
+    const midpointY = (startPoint.y + endPoint.y) / 2
+    const viaX =
+      minViaX <= maxViaX
+        ? Math.min(maxViaX, Math.max(minViaX, midpointX))
+        : midpointX
+    const viaY =
+      minViaY <= maxViaY
+        ? Math.min(maxViaY, Math.max(minViaY, midpointY))
+        : midpointY
+    const viaIsInsideBothTerminalRegions = [
+      connection.startRegion,
+      connection.endRegion,
+    ].every(
+      (terminalRegion) =>
+        pointToBoxDistance({ x: viaX, y: viaY }, terminalRegion.d) <=
+        TERMINAL_REGION_CONTAINMENT_TOLERANCE,
+    )
+    const isReservedForRoute =
+      params.regionNetIdByRegionId.get(region.regionId) === params.routeNetIndex
+
+    return (
+      containsStart &&
+      containsEnd &&
+      canFitVia &&
+      viaIsInsideBothTerminalRegions &&
+      isReservedForRoute
+    )
+  })
+}
+
 const toSerializedRegionData = (
   region: HgPortPointPathingSolverParams["graph"]["regions"][number],
   netId?: number,
@@ -333,6 +400,9 @@ const buildSerializedTinyGraph = (
       simpleRouteConnection: connection.simpleRouteConnection,
     }),
   )
+  const serializedConnectionById = new Map(
+    connections.map((connection) => [connection.connectionId, connection]),
+  )
 
   const solvedRoutes: SerializedTinySolvedRoute[] = []
   for (const connection of params.connections) {
@@ -361,6 +431,47 @@ const buildSerializedTinyGraph = (
       regionAvailableZ: connection.endRegion.d.availableZ,
       layerCount: params.layerCount,
     })
+
+    let startAttachmentRegionId = connection.startRegion.regionId
+    let endAttachmentRegionId = connection.endRegion.regionId
+    // When opposite-layer pads overlap inside one same-net target region,
+    // model their through-via as the normal layer transition within that region.
+    const viaHostRegion = getViaHostRegion({
+      connection,
+      startPoint,
+      endPoint,
+      startZ,
+      endZ,
+      minViaPadDiameter: params.minViaPadDiameter ?? 0.3,
+      routeNetIndex,
+      regionNetIdByRegionId,
+    })
+    if (viaHostRegion) {
+      startAttachmentRegionId = viaHostRegion.regionId
+      endAttachmentRegionId = viaHostRegion.regionId
+      const serializedViaHostRegion = regions.find(
+        (region) => region.regionId === viaHostRegion.regionId,
+      )
+      if (!serializedViaHostRegion) {
+        throw new Error(
+          `Could not find via host region "${viaHostRegion.regionId}" for "${connection.connectionId}"`,
+        )
+      }
+      serializedViaHostRegion.d.availableZ = [
+        ...new Set([...serializedViaHostRegion.d.availableZ, startZ, endZ]),
+      ].sort((a, b) => a - b)
+    }
+
+    const serializedConnection = serializedConnectionById.get(
+      connection.connectionId,
+    )
+    if (!serializedConnection) {
+      throw new Error(
+        `Could not find serialized connection "${connection.connectionId}"`,
+      )
+    }
+    serializedConnection.startRegionId = startAttachmentRegionId
+    serializedConnection.endRegionId = endAttachmentRegionId
 
     const startTerminalRegionId = `tiny-terminal:start-region:${connection.connectionId}`
     const endTerminalRegionId = `tiny-terminal:end-region:${connection.connectionId}`
@@ -409,7 +520,7 @@ const buildSerializedTinyGraph = (
 
     ports.push({
       portId: startTerminalPortId,
-      region1Id: connection.startRegion.regionId,
+      region1Id: startAttachmentRegionId,
       region2Id: startTerminalRegionId,
       d: {
         portId: startTerminalPortId,
@@ -426,7 +537,7 @@ const buildSerializedTinyGraph = (
 
     ports.push({
       portId: endTerminalPortId,
-      region1Id: connection.endRegion.regionId,
+      region1Id: endAttachmentRegionId,
       region2Id: endTerminalRegionId,
       d: {
         portId: endTerminalPortId,
@@ -442,10 +553,10 @@ const buildSerializedTinyGraph = (
     })
 
     const startRegion = regions.find(
-      (region) => region.regionId === connection.startRegion.regionId,
+      (region) => region.regionId === startAttachmentRegionId,
     )
     const endRegion = regions.find(
-      (region) => region.regionId === connection.endRegion.regionId,
+      (region) => region.regionId === endAttachmentRegionId,
     )
     startRegion?.pointIds.push(startTerminalPortId)
     endRegion?.pointIds.push(endTerminalPortId)
@@ -525,7 +636,7 @@ const buildInputNodesWithPortPoints = (
       width: region.d.width,
       height: region.d.height,
       portPoints,
-      availableZ: region.d.availableZ,
+      availableZ: serializedRegion?.d.availableZ ?? region.d.availableZ,
       _containsObstacle: region.d._containsObstacle,
       _containsTarget: region.d._containsTarget,
       _offBoardConnectionId: region.d._offBoardConnectionId,
@@ -807,6 +918,7 @@ export class TinyHypergraphPortPointPathingSolver extends BaseSolver {
     HgPortPointPathingSolverParams["graph"]["regions"][number]
   >
   private originalRegionIds: Set<CapacityMeshNodeId>
+  private availableZByOriginalRegionId: Map<CapacityMeshNodeId, number[]>
 
   constructor(private params: HgPortPointPathingSolverParams) {
     super()
@@ -877,6 +989,11 @@ export class TinyHypergraphPortPointPathingSolver extends BaseSolver {
       params.graph.regions.map((region) => [region.regionId, region]),
     )
     this.originalRegionIds = new Set(this.originalRegionById.keys())
+    this.availableZByOriginalRegionId = new Map(
+      graphForTiny.regions
+        .filter((region) => this.originalRegionIds.has(region.regionId))
+        .map((region) => [region.regionId, [...region.d.availableZ]]),
+    )
     this.inputNodeWithPortPoints = buildInputNodesWithPortPoints(
       params,
       graphForTiny,
@@ -1062,7 +1179,9 @@ export class TinyHypergraphPortPointPathingSolver extends BaseSolver {
         height: originalRegion.d.height,
         portPoints,
         portPointsInPairs,
-        availableZ: originalRegion.d.availableZ,
+        availableZ:
+          this.availableZByOriginalRegionId.get(originalRegionId) ??
+          originalRegion.d.availableZ,
       })
     }
 

--- a/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
+++ b/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
@@ -15,8 +15,10 @@ import type {
 import { getIntraNodeCrossingsUsingCircle } from "lib/utils/getIntraNodeCrossingsUsingCircle"
 import { mapLayerNameToZ } from "lib/utils/mapLayerNameToZ"
 import {
+  createEmptyRegionIntersectionCache,
   DuplicateCongestedPortSolver,
   orderConnectionsByNetCardinality,
+  orderRoutesAfterSelectiveRerip,
   SelectiveReripTinyHyperGraphSolver,
   type Candidate,
   type DuplicateCongestedPortSolverReport,
@@ -67,9 +69,14 @@ type TinyBounds = {
 type TinyRegionMetadata = {
   serializedRegionId?: string
   bounds?: TinyBounds
+  center?: { x: number; y: number }
+  width?: number
+  height?: number
+  availableZ?: number[]
   _qfpRegionType?: InputNodeWithPortPoints["_qfpRegionType"]
   _isNarrowQfpPadGap?: boolean
   _offBoardConnectionId?: string
+  _tinyTargetAttachmentBridge?: boolean
 }
 
 type TinyPortMetadata = {
@@ -114,6 +121,8 @@ const asTinyPortMetadata = (metadata: unknown): TinyPortMetadata =>
 
 const TINY_TERMINAL_REGION_SIZE = 1e-6
 const TINY_TERMINAL_VIA_BRIDGE_PORT_PREFIX = "tiny-terminal:via-bridge-port:"
+const TINY_TARGET_ATTACHMENT_BRIDGE_REGION_PREFIX =
+  "tiny-target-attachment-bridge-region:"
 const TERMINAL_REGION_CONTAINMENT_TOLERANCE = 1e-3
 const TERMINAL_VIA_ROUTING_MARGIN = 0.15
 const TINY_SOLVE_GRAPH_BASE_OPTIONS: TinyHyperGraphSolverOptions = {
@@ -136,7 +145,7 @@ const TINY_SECTION_SOLVER_BASE_OPTIONS: TinyHyperGraphSectionSolverOptions = {
 }
 const DUPLICATE_PORT_TRAVERSAL_PENALTY = 150
 const DEFAULT_CRAMPED_PORT_TRAVERSAL_PENALTY = 150
-const MAX_CONNECTIONS_FOR_DUPLICATE_CONGESTED_PORT_PREPASS = 180
+const MAX_CONNECTIONS_FOR_DUPLICATE_CONGESTED_PORT_PREPASS = 500
 
 const getEffortScale = (effort: number) => Math.max(effort, 1e-2)
 
@@ -510,22 +519,27 @@ const getUnreachableConnectionIds = (params: {
   }
 
   const unreachableConnectionIds = new Set<string>()
-  for (const { connection, netId } of params.connectionLayerInfo) {
+  for (const {
+    connection,
+    netId,
+    startZ,
+    endZ,
+  } of params.connectionLayerInfo) {
     const startRegionId = connection.startRegion.regionId
     const endRegionId = connection.endRegion.regionId
-    const queue = [startRegionId]
-    const visited = new Set([startRegionId])
+    const queue = [{ regionId: startRegionId, z: startZ }]
+    const visited = new Set([`${startRegionId}\u0000${startZ}`])
     let reachable = false
 
     for (let queueIndex = 0; queueIndex < queue.length; queueIndex++) {
-      const regionId = queue[queueIndex]!
-      if (regionId === endRegionId) {
+      const { regionId, z } = queue[queueIndex]!
+      const region = regionById.get(regionId)
+      if (!region || !region.d.availableZ.includes(z)) continue
+      if (regionId === endRegionId && region.d.availableZ.includes(endZ)) {
         reachable = true
         break
       }
 
-      const region = regionById.get(regionId)
-      if (!region) continue
       const reservedNetId = region.d.netId
       if (reservedNetId !== undefined && reservedNetId !== netId) continue
 
@@ -538,9 +552,25 @@ const getUnreachableConnectionIds = (params: {
         if (nextReservedNetId !== undefined && nextReservedNetId !== netId) {
           continue
         }
-        if (visited.has(nextRegionId)) continue
-        visited.add(nextRegionId)
-        queue.push(nextRegionId)
+        const portZ = asTinyPortMetadata(port.d).z
+        const traversalLayers =
+          portZ === undefined
+            ? region.d.availableZ.filter((candidateZ: number) =>
+                nextRegion.d.availableZ.includes(candidateZ),
+              )
+            : [portZ]
+        for (const traversalZ of traversalLayers) {
+          if (
+            !region.d.availableZ.includes(traversalZ) ||
+            !nextRegion.d.availableZ.includes(traversalZ)
+          ) {
+            continue
+          }
+          const stateKey = `${nextRegionId}\u0000${traversalZ}`
+          if (visited.has(stateKey)) continue
+          visited.add(stateKey)
+          queue.push({ regionId: nextRegionId, z: traversalZ })
+        }
       }
     }
 
@@ -719,6 +749,17 @@ const addOverlappingTargetRegionAttachments = (params: {
     const targetNetId = params.regionNetIdByRegionId.get(targetRegion.regionId)
     if (targetNetId === undefined || !params.netIds.has(targetNetId)) continue
 
+    let bestAttachment:
+      | {
+          candidateRegion: TinyRouteConnection["startRegion"]
+          viaPlacement: NonNullable<
+            ReturnType<typeof getOverlappingRegionViaPlacement>
+          >
+          availableZCount: number
+          portCount: number
+          overlapArea: number
+        }
+      | undefined
     for (const candidateRegion of params.input.graph.regions) {
       if (
         candidateRegion.regionId === targetRegion.regionId ||
@@ -775,46 +816,96 @@ const addOverlappingTargetRegionAttachments = (params: {
       )
       if (connectedRegionPairs.has(regionPairKey)) continue
 
-      const serializedTargetRegion = serializedRegionById.get(
-        targetRegion.regionId,
-      )
-      const serializedCandidateRegion = serializedRegionById.get(
-        candidateRegion.regionId,
-      )
-      if (!serializedTargetRegion || !serializedCandidateRegion) {
-        throw new Error(
-          `Could not map overlapping target attachment regions "${targetRegion.regionId}" and "${candidateRegion.regionId}"`,
-        )
+      const overlapArea =
+        (overlapMaxX - overlapMinX) * (overlapMaxY - overlapMinY)
+      const availableZCount = candidateRegion.d.availableZ.length
+      const portCount = candidateRegion.ports.length
+      if (
+        !bestAttachment ||
+        availableZCount > bestAttachment.availableZCount ||
+        (availableZCount === bestAttachment.availableZCount &&
+          portCount > bestAttachment.portCount) ||
+        (availableZCount === bestAttachment.availableZCount &&
+          portCount === bestAttachment.portCount &&
+          overlapArea > bestAttachment.overlapArea)
+      ) {
+        bestAttachment = {
+          candidateRegion,
+          viaPlacement,
+          availableZCount,
+          portCount,
+          overlapArea,
+        }
       }
-
-      const attachmentPortId = `tiny-target-attachment-port:${targetRegion.regionId}:${candidateRegion.regionId}`
-      params.ports.push({
-        portId: attachmentPortId,
-        region1Id: targetRegion.regionId,
-        region2Id: candidateRegion.regionId,
-        d: {
-          portId: attachmentPortId,
-          x: viaPlacement.point.x,
-          y: viaPlacement.point.y,
-          z: viaPlacement.bridgeZ,
-          distToCentermostPortOnZ: 0,
-          _tinyTerminal: true,
-        },
-      })
-      serializedTargetRegion.pointIds.push(attachmentPortId)
-      serializedCandidateRegion.pointIds.push(attachmentPortId)
-      const serializedViaHostRegion = serializedRegionById.get(
-        viaPlacement.region.regionId,
-      )!
-      serializedViaHostRegion.d.availableZ = [
-        ...new Set([
-          ...serializedViaHostRegion.d.availableZ,
-          ...targetRegion.d.availableZ,
-          ...candidateRegion.d.availableZ,
-        ]),
-      ].sort((a, b) => a - b)
-      connectedRegionPairs.add(regionPairKey)
     }
+
+    if (!bestAttachment) continue
+    const { candidateRegion, viaPlacement } = bestAttachment
+    const regionPairKey = getRegionPairKey(
+      targetRegion.regionId,
+      candidateRegion.regionId,
+    )
+
+    const serializedTargetRegion = serializedRegionById.get(
+      targetRegion.regionId,
+    )
+    const serializedCandidateRegion = serializedRegionById.get(
+      candidateRegion.regionId,
+    )
+    if (!serializedTargetRegion || !serializedCandidateRegion) {
+      throw new Error(
+        `Could not map overlapping target attachment regions "${targetRegion.regionId}" and "${candidateRegion.regionId}"`,
+      )
+    }
+
+    const bridgeRegionId = `${TINY_TARGET_ATTACHMENT_BRIDGE_REGION_PREFIX}${targetRegion.regionId}:${candidateRegion.regionId}`
+    const targetAttachmentPortId = `tiny-target-attachment-port:${targetRegion.regionId}:${candidateRegion.regionId}:target`
+    const candidateAttachmentPortId = `tiny-target-attachment-port:${targetRegion.regionId}:${candidateRegion.regionId}:candidate`
+    const targetZ = targetRegion.d.availableZ[0]!
+    const candidateZ = candidateRegion.d.availableZ[0]!
+    const bridgeSize = params.input.minViaPadDiameter ?? 0.3
+    params.regions.push({
+      regionId: bridgeRegionId,
+      pointIds: [targetAttachmentPortId, candidateAttachmentPortId],
+      d: {
+        capacityMeshNodeId: bridgeRegionId,
+        center: { ...viaPlacement.point },
+        width: bridgeSize,
+        height: bridgeSize,
+        availableZ: [...new Set([targetZ, candidateZ])].sort((a, b) => a - b),
+        netId: targetNetId,
+        _tinyTargetAttachmentBridge: true,
+      },
+    })
+    params.ports.push({
+      portId: targetAttachmentPortId,
+      region1Id: targetRegion.regionId,
+      region2Id: bridgeRegionId,
+      d: {
+        portId: targetAttachmentPortId,
+        x: viaPlacement.point.x,
+        y: viaPlacement.point.y,
+        z: targetZ,
+        distToCentermostPortOnZ: 0,
+        _tinyTerminal: true,
+      },
+    })
+    params.ports.push({
+      portId: candidateAttachmentPortId,
+      region1Id: bridgeRegionId,
+      region2Id: candidateRegion.regionId,
+      d: {
+        portId: candidateAttachmentPortId,
+        x: viaPlacement.point.x,
+        y: viaPlacement.point.y,
+        z: candidateZ,
+        distToCentermostPortOnZ: 0,
+        _tinyTerminal: true,
+      },
+    })
+    serializedTargetRegion.pointIds.push(targetAttachmentPortId)
+    serializedCandidateRegion.pointIds.push(candidateAttachmentPortId)
+    connectedRegionPairs.add(regionPairKey)
   }
 }
 
@@ -1022,24 +1113,35 @@ const buildSerializedTinyGraph = (
       ports,
     })
     if (graphUnreachableConnectionIds.size > 0) {
+      const unreachableNetIds = new Set(
+        connectionLayerInfo
+          .filter(({ connection }) =>
+            graphUnreachableConnectionIds.has(connection.connectionId),
+          )
+          .map(({ netId }) => netId),
+      )
       for (const bridge of pendingTerminalViaBridges.values()) {
+        if (
+          !graphUnreachableConnectionIds.has(bridge.connection.connectionId)
+        ) {
+          continue
+        }
         addTerminalViaBridge({ bridge, regions, ports })
       }
 
-      const routeNetIds = new Set(connectionLayerInfo.map(({ netId }) => netId))
       addOverlappingNetViaBridges({
         input: params,
         regions,
         ports,
         regionNetIdByRegionId,
-        netIds: routeNetIds,
+        netIds: unreachableNetIds,
       })
       addOverlappingTargetRegionAttachments({
         input: params,
         regions,
         ports,
         regionNetIdByRegionId,
-        netIds: routeNetIds,
+        netIds: unreachableNetIds,
       })
     }
   }
@@ -1214,6 +1316,9 @@ const applyMetadataPortPenalties = (loaded: LoadedTinyGraph) => {
 }
 
 class SelectiveReripTinyHyperGraphSolverWithViaBridges extends SelectiveReripTinyHyperGraphSolver {
+  private readonly cycleRouteIds = new Set<number>()
+  private selectiveReripCycleEscapeCount = 0
+
   override _setup() {
     super._setup()
     if (!this.failed) {
@@ -1226,12 +1331,125 @@ class SelectiveReripTinyHyperGraphSolverWithViaBridges extends SelectiveReripTin
     this.seedViaBridgeRoutes()
   }
 
-  override _step() {
+  override _step(): void {
     const ripCountBeforeStep = this.state.ripCount
     super._step()
     if (this.state.ripCount !== ripCountBeforeStep) {
       this.seedViaBridgeRoutes()
     }
+  }
+
+  override onOutOfCandidates(): void {
+    const failedRouteId = this.state.currentRouteId
+    const reripStats = this.getSelectiveReripStats()
+    const previousFailedRouteId = reripStats.lastFailedRouteId
+    const previousFailureRippedCurrentRoute =
+      failedRouteId !== undefined &&
+      reripStats.lastRippedRouteIds.includes(failedRouteId)
+    const repeatedDirectOwnerRouteIds =
+      failedRouteId === undefined
+        ? []
+        : reripStats.failedOwnerPairs
+            .filter(
+              (pair) => pair.failedRouteId === failedRouteId && pair.count >= 2,
+            )
+            .map((pair) => pair.ownerRouteId)
+
+    if (
+      failedRouteId !== undefined &&
+      previousFailedRouteId !== undefined &&
+      previousFailedRouteId !== failedRouteId &&
+      previousFailureRippedCurrentRoute &&
+      repeatedDirectOwnerRouteIds.length > 0
+    ) {
+      const directPath = this.findRelaxedBlockerPath()
+      if (
+        directPath.found &&
+        repeatedDirectOwnerRouteIds.some((routeId) =>
+          directPath.owners.has(routeId),
+        )
+      ) {
+        const detectedCycleRouteIds = [
+          failedRouteId,
+          ...reripStats.lastRippedRouteIds,
+          ...directPath.owners,
+          previousFailedRouteId,
+        ]
+        if (
+          this.cycleRouteIds.size > 0 &&
+          !detectedCycleRouteIds.some((routeId) =>
+            this.cycleRouteIds.has(routeId),
+          )
+        ) {
+          this.cycleRouteIds.clear()
+        }
+        for (const routeId of detectedCycleRouteIds) {
+          this.cycleRouteIds.add(routeId)
+        }
+        const rippedRouteIds = new Set(this.cycleRouteIds)
+        rippedRouteIds.delete(failedRouteId)
+        this.rebuildCommittedStateForCycleEscape(rippedRouteIds)
+        this.state.ripCount++
+        this.state.currentRouteId = undefined
+        this.state.currentRouteNetId = undefined
+        this.state.unroutedRoutes = orderRoutesAfterSelectiveRerip({
+          failedRouteId,
+          pendingRouteIds: this.state.unroutedRoutes,
+          rippedRouteIds,
+        })
+        this.state.candidateQueue.clear()
+        this.resetCandidateBestCosts()
+        this.state.goalPortId = -1
+        this.selectiveReripCycleEscapeCount++
+        this.stats = {
+          ...this.stats,
+          selectiveReripCycleEscapeCount: this.selectiveReripCycleEscapeCount,
+          selectiveReripCycleRouteCount: this.cycleRouteIds.size,
+          lastCycleEscapeFailedRouteId: failedRouteId,
+          lastCycleEscapeRippedRouteIds: [...rippedRouteIds],
+        }
+        return
+      }
+    }
+
+    super.onOutOfCandidates()
+  }
+
+  private rebuildCommittedStateForCycleEscape(
+    rippedRouteIds: ReadonlySet<number>,
+  ): void {
+    this.state.regionSegments = this.state.regionSegments.map((segments) =>
+      segments.filter(([routeId]) => !rippedRouteIds.has(routeId)),
+    )
+    this.state.portAssignment.fill(-1)
+    this.state.regionIntersectionCaches = Array.from(
+      { length: this.topology.regionCount },
+      () => createEmptyRegionIntersectionCache(),
+    )
+
+    for (
+      let regionId = 0;
+      regionId < this.state.regionSegments.length;
+      regionId++
+    ) {
+      for (const [routeId, fromPortId, toPortId] of this.state.regionSegments[
+        regionId
+      ]!) {
+        const routeNetId = this.problem.routeNet[routeId]!
+        this.state.currentRouteNetId = routeNetId
+        for (const portId of [fromPortId, toPortId]) {
+          const assignedNetId = this.state.portAssignment[portId]!
+          if (assignedNetId !== -1 && assignedNetId !== routeNetId) {
+            throw new Error(
+              `SelectiveReripTinyHyperGraphSolver: cycle escape found cross-net ownership at port ${portId} between net ${assignedNetId} and net ${routeNetId}`,
+            )
+          }
+          this.state.portAssignment[portId] = routeNetId
+        }
+        this.appendSegmentToRegionCache(regionId, fromPortId, toPortId)
+      }
+    }
+    this.state.currentRouteNetId = undefined
   }
 
   private seedViaBridgeRoutes() {
@@ -1706,6 +1924,7 @@ export class TinyHypergraphPortPointPathingSolver extends BaseSolver {
         typeof portMetadata?.nextPortPointId === "string"
           ? portMetadata.nextPortPointId
           : undefined,
+      cramped: Boolean(portMetadata?.cramped),
     }
   }
 
@@ -1719,13 +1938,23 @@ export class TinyHypergraphPortPointPathingSolver extends BaseSolver {
     const regionMetadata = solvedTinySolver.topology.regionMetadata ?? []
 
     for (let regionId = 0; regionId < regionSegments.length; regionId++) {
-      const originalRegionId = regionMetadata[regionId]?.capacityMeshNodeId
-      if (!originalRegionId || !this.originalRegionIds.has(originalRegionId)) {
+      const metadata = asTinyRegionMetadata(regionMetadata[regionId])
+      const capacityMeshNodeId = regionMetadata[regionId]?.capacityMeshNodeId
+      const isTargetAttachmentBridge =
+        metadata._tinyTargetAttachmentBridge === true
+      if (
+        !capacityMeshNodeId ||
+        (!this.originalRegionIds.has(capacityMeshNodeId) &&
+          !isTargetAttachmentBridge)
+      ) {
         continue
       }
 
-      const originalRegion = this.originalRegionById.get(originalRegionId)
-      if (!originalRegion) continue
+      const originalRegion = this.originalRegionById.get(capacityMeshNodeId)
+      const center = originalRegion?.d.center ?? metadata.center
+      const width = originalRegion?.d.width ?? metadata.width
+      const height = originalRegion?.d.height ?? metadata.height
+      if (!center || width === undefined || height === undefined) continue
 
       const portPointsInPairs = regionSegments[regionId].map(
         ([routeId, fromPortId, toPortId]) => {
@@ -1753,15 +1982,17 @@ export class TinyHypergraphPortPointPathingSolver extends BaseSolver {
       }
 
       nodesWithPortPoints.push({
-        capacityMeshNodeId: originalRegion.d.capacityMeshNodeId,
-        center: originalRegion.d.center,
-        width: originalRegion.d.width,
-        height: originalRegion.d.height,
+        capacityMeshNodeId,
+        center,
+        width,
+        height,
         portPoints,
         portPointsInPairs,
         availableZ:
-          this.availableZByOriginalRegionId.get(originalRegionId) ??
-          originalRegion.d.availableZ,
+          this.availableZByOriginalRegionId.get(capacityMeshNodeId) ??
+          metadata.availableZ ??
+          [],
+        _containsTarget: originalRegion?.d._containsTarget,
       })
     }
 

--- a/lib/solvers/SameNetViaMergerSolver/SameNetViaMergerSolver.ts
+++ b/lib/solvers/SameNetViaMergerSolver/SameNetViaMergerSolver.ts
@@ -28,10 +28,38 @@ type Via = {
   net: string
   routeIndex: number
   layers: number[]
+  transitionLayers: number[]
 }
+
+type NearMergeCandidate = {
+  via: Via
+  squaredDistance: number
+}
+
+const pointIsAtVia = (
+  point: HighDensityRoute["route"][number],
+  via: Pick<Via, "x" | "y">,
+): boolean => point.x === via.x && point.y === via.y
 
 const NEAR_VIA_MERGE_DISTANCE_MULTIPLIER = 2.5
 const OBSTACLE_MARGIN = 0.1
+
+const getTransitionLayersAtVia = (
+  route: HighDensityRoute,
+  via: Pick<Via, "x" | "y">,
+): Set<number> => {
+  const transitionLayers = new Set<number>()
+  for (let i = 1; i < route.route.length; i++) {
+    const prev = route.route[i - 1]
+    const curr = route.route[i]
+    if (prev.z === curr.z) continue
+    if (!pointIsAtVia(prev, via) || !pointIsAtVia(curr, via)) continue
+
+    transitionLayers.add(prev.z)
+    transitionLayers.add(curr.z)
+  }
+  return transitionLayers
+}
 
 const getNetForRoute = (
   connMap: ConnectivityMap,
@@ -78,23 +106,18 @@ const canMoveViaTo = (
     )
   }
 
-  const transitionLayers = new Set<number>()
-  for (let i = 1; i < route.route.length; i++) {
-    const prev = route.route[i - 1]
-    const curr = route.route[i]
-    if (prev.z === curr.z) continue
-    if (prev.x !== viaToRemove.x || prev.y !== viaToRemove.y) continue
-    if (curr.x !== viaToRemove.x || curr.y !== viaToRemove.y) continue
-
-    transitionLayers.add(prev.z)
-    transitionLayers.add(curr.z)
-  }
-
-  if (transitionLayers.size === 0) {
+  const keepRoute = context.mergedViaHdRoutes[viaKeep.routeIndex]
+  if (!keepRoute) {
     throw new Error(
-      `SameNetViaMergerSolver could not find transition layers for via at (${viaToRemove.x}, ${viaToRemove.y})`,
+      `SameNetViaMergerSolver could not find route for via at index ${viaKeep.routeIndex}`,
     )
   }
+
+  // A via entry without a same-position route transition cannot be moved.
+  // It may represent a non-physical layer transition through a same-net pad.
+  const transitionLayers = new Set(viaToRemove.transitionLayers)
+  if (transitionLayers.size === 0) return false
+  if (viaKeep.transitionLayers.length === 0) return false
 
   for (const z of transitionLayers) {
     const traceThickness = route.traceThickness
@@ -223,6 +246,12 @@ export class SameNetViaMergerSolver extends BaseSolver {
           diameter: route.viaDiameter,
           net: getNetForRoute(this.connMap, route),
           layers,
+          transitionLayers: [
+            ...getTransitionLayersAtVia(route, {
+              x: viaPoint.x,
+              y: viaPoint.y,
+            }),
+          ],
           routeIndex: i,
         }
         this.vias.push(via)
@@ -282,6 +311,7 @@ export class SameNetViaMergerSolver extends BaseSolver {
         const cellY = Math.floor(keep.y / cellSize)
         const neighborCellRadius = Math.ceil(NEAR_VIA_MERGE_DISTANCE_MULTIPLIER)
         const remove: Via[] = []
+        const nearMergeCandidates: NearMergeCandidate[] = []
 
         for (let dx = -neighborCellRadius; dx <= neighborCellRadius; dx++) {
           for (let dy = -neighborCellRadius; dy <= neighborCellRadius; dy++) {
@@ -313,16 +343,32 @@ export class SameNetViaMergerSolver extends BaseSolver {
 
               if (
                 squaredDistance <= nearMergeDistance * nearMergeDistance &&
-                canMoveViaTo(candidate, keep, {
-                  connMap: this.connMap,
-                  mergedViaHdRoutes: this.mergedViaHdRoutes,
-                  hdRouteSHI: this.hdRouteSHI,
-                  obstacleSHI: this.obstacleSHI,
-                })
+                keep.transitionLayers.length > 0 &&
+                candidate.transitionLayers.length > 0
               ) {
-                remove.push(candidate)
+                nearMergeCandidates.push({ via: candidate, squaredDistance })
               }
             }
+          }
+        }
+
+        nearMergeCandidates.sort((a, b) => {
+          if (a.squaredDistance !== b.squaredDistance) {
+            return a.squaredDistance - b.squaredDistance
+          }
+          return a.via.routeIndex - b.via.routeIndex
+        })
+        const nearestCandidate = nearMergeCandidates[0]?.via
+        if (nearestCandidate) {
+          if (
+            canMoveViaTo(nearestCandidate, keep, {
+              connMap: this.connMap,
+              mergedViaHdRoutes: this.mergedViaHdRoutes,
+              hdRouteSHI: this.hdRouteSHI,
+              obstacleSHI: this.obstacleSHI,
+            })
+          ) {
+            remove.push(nearestCandidate)
           }
         }
 
@@ -376,10 +422,14 @@ export class SameNetViaMergerSolver extends BaseSolver {
       const prev = route[j - 1]
       const curr = route[j]
       if (prev.z === curr.z) continue
-      if (prev.x !== viaToRemove.x || prev.y !== viaToRemove.y) continue
-      if (curr.x !== viaToRemove.x || curr.y !== viaToRemove.y) continue
+      const transitionAnchorIndex = pointIsAtVia(prev, viaToRemove)
+        ? j - 1
+        : pointIsAtVia(curr, viaToRemove)
+          ? j
+          : -1
+      if (transitionAnchorIndex === -1) continue
 
-      let clusterStartIndex = j - 1
+      let clusterStartIndex = transitionAnchorIndex
       while (
         clusterStartIndex > 0 &&
         route[clusterStartIndex - 1]!.x === viaToRemove.x &&
@@ -388,7 +438,7 @@ export class SameNetViaMergerSolver extends BaseSolver {
         clusterStartIndex--
       }
 
-      let clusterEndIndex = j
+      let clusterEndIndex = transitionAnchorIndex
       while (
         clusterEndIndex < route.length - 1 &&
         route[clusterEndIndex + 1]!.x === viaToRemove.x &&

--- a/lib/solvers/UselessViaRemovalSolver/SingleRouteUselessViaRemovalSolver.ts
+++ b/lib/solvers/UselessViaRemovalSolver/SingleRouteUselessViaRemovalSolver.ts
@@ -501,16 +501,16 @@ export class SingleRouteUselessViaRemovalSolver extends BaseSolver {
   }
 
   getOptimizedHdRoute(): HighDensityRoute {
-    // TODO reconstruct the route from segments, we will need to recompute the
-    // vias
     const route = this.routeSections.flatMap((section) => section.points)
     const vias: HighDensityRoute["vias"] = []
     for (let i = 0; i < route.length - 1; i++) {
-      if (route[i].z !== route[i + 1].z) {
-        vias.push({
-          x: route[i].x,
-          y: route[i].y,
-        })
+      const current = route[i]
+      const next = route[i + 1]
+      if (
+        current.z !== next.z &&
+        current.toNextSegmentType !== "through_obstacle"
+      ) {
+        vias.push({ x: current.x, y: current.y })
       }
     }
     return {

--- a/lib/types/high-density-types.ts
+++ b/lib/types/high-density-types.ts
@@ -8,6 +8,8 @@ export type PortPoint = {
   z: number
   prevPortPointId?: string
   nextPortPointId?: string
+  /** The source edge could not provide normal spacing for this port. */
+  cramped?: boolean
 }
 
 export type NodeWithPortPoints = {
@@ -18,6 +20,7 @@ export type NodeWithPortPoints = {
   portPoints: PortPoint[]
   availableZ?: number[]
   portPointsInPairs?: [PortPoint, PortPoint][]
+  _containsTarget?: boolean
 }
 
 /**

--- a/tests/features/never-fail-growth-high-density/initial-scale-from-pf.test.ts
+++ b/tests/features/never-fail-growth-high-density/initial-scale-from-pf.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test"
+import { HighDensitySolver } from "lib/solvers/HighDensitySolver/HighDensitySolver"
+import {
+  getInitialScaleFactorForNode,
+  getInitialScaleFactorForNodePf,
+  GrowShrinkHighDensityIntraNodeSolver,
+} from "lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver"
+import { makeCrossingSingleLayerNode, makeNode } from "./test-helpers"
+
+test("initial grow/shrink scale is derived from estimated capacity pressure", () => {
+  expect(getInitialScaleFactorForNodePf(null)).toBe(1)
+  expect(getInitialScaleFactorForNodePf(0.5)).toBe(1)
+  expect(getInitialScaleFactorForNodePf(0.51)).toBe(2)
+  expect(getInitialScaleFactorForNodePf(2)).toBe(2)
+  expect(getInitialScaleFactorForNodePf(2.01)).toBe(4)
+  expect(getInitialScaleFactorForNodePf(100)).toBe(8)
+})
+
+test("cramped boundary ports start with enough room to restore spacing", () => {
+  const node = makeNode()
+  node.portPoints[0]!.cramped = true
+
+  expect(getInitialScaleFactorForNode(node, 0)).toBe(2)
+})
+
+test("HighDensitySolver starts an over-capacity node at its derived scale", () => {
+  const node = makeNode()
+  const solver = new HighDensitySolver({
+    nodePortPoints: [node],
+    nodePfById: new Map([[node.capacityMeshNodeId, 1.99]]),
+    useGrowShrinkHighDensityIntraNodeSolver: true,
+  })
+
+  solver.step()
+
+  expect(solver.activeSubSolver).toBeInstanceOf(
+    GrowShrinkHighDensityIntraNodeSolver,
+  )
+  expect(
+    (solver.activeSubSolver as GrowShrinkHighDensityIntraNodeSolver)
+      .scaleFactor,
+  ).toBe(2)
+  expect(
+    (solver.activeSubSolver as GrowShrinkHighDensityIntraNodeSolver)
+      .growthAttempts,
+  ).toBe(1)
+})
+
+test("HighDensitySolver computes pressure from the node it actually solves", () => {
+  const node = makeCrossingSingleLayerNode()
+  const solver = new HighDensitySolver({
+    nodePortPoints: [node],
+    useGrowShrinkHighDensityIntraNodeSolver: true,
+  })
+
+  solver.step()
+
+  expect(solver.nodePfById.get(node.capacityMeshNodeId)).toBe(1)
+  expect(
+    (solver.activeSubSolver as GrowShrinkHighDensityIntraNodeSolver)
+      .scaleFactor,
+  ).toBe(2)
+})

--- a/tests/features/never-fail-growth-high-density/initial-scale-from-pf.test.ts
+++ b/tests/features/never-fail-growth-high-density/initial-scale-from-pf.test.ts
@@ -1,7 +1,6 @@
 import { expect, test } from "bun:test"
 import { HighDensitySolver } from "lib/solvers/HighDensitySolver/HighDensitySolver"
 import {
-  getInitialScaleFactorForNode,
   getInitialScaleFactorForNodePf,
   GrowShrinkHighDensityIntraNodeSolver,
 } from "lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver"
@@ -16,11 +15,21 @@ test("initial grow/shrink scale is derived from estimated capacity pressure", ()
   expect(getInitialScaleFactorForNodePf(100)).toBe(8)
 })
 
-test("cramped boundary ports start with enough room to restore spacing", () => {
+test("cramped metadata does not pre-grow a low-pressure node", () => {
   const node = makeNode()
   node.portPoints[0]!.cramped = true
+  const solver = new HighDensitySolver({
+    nodePortPoints: [node],
+    useGrowShrinkHighDensityIntraNodeSolver: true,
+  })
 
-  expect(getInitialScaleFactorForNode(node, 0)).toBe(2)
+  solver.step()
+
+  expect(solver.nodePfById.get(node.capacityMeshNodeId)).toBe(0)
+  expect(
+    (solver.activeSubSolver as GrowShrinkHighDensityIntraNodeSolver)
+      .scaleFactor,
+  ).toBe(1)
 })
 
 test("HighDensitySolver starts an over-capacity node at its derived scale", () => {

--- a/tests/features/never-fail-growth-high-density/pipeline7-integration.test.ts
+++ b/tests/features/never-fail-growth-high-density/pipeline7-integration.test.ts
@@ -35,6 +35,7 @@ test("Pipeline7 high-density stage opts into GrowShrinkHighDensityIntraNodeSolve
   expect(
     (highDensityParams as any).growShrinkMaxInnerIterationsPerGrowthAttempt,
   ).toBeUndefined()
+  expect((highDensityParams as any).nodePfById).toBeUndefined()
 })
 
 test("Pipeline7 caps expensive post-processing stages for benchmark completion", () => {

--- a/tests/features/pipeline7-dataset-srj24-sample002-selective-rerip-cycle.test.ts
+++ b/tests/features/pipeline7-dataset-srj24-sample002-selective-rerip-cycle.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver7_MultiGraph } from "lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph"
+import { getIntraNodeCrossingsUsingCircle } from "lib/utils/getIntraNodeCrossingsUsingCircle"
+import { loadScenarioBySampleNumber } from "../../scripts/benchmark/scenarios"
+
+test("pipeline7 escapes the srj24 sample002 selective-rerip cycle", async (): Promise<void> => {
+  const { scenario } = await loadScenarioBySampleNumber("srj24", 2)
+  const solver = new AutoroutingPipelineSolver7_MultiGraph(scenario)
+
+  solver.solveUntilPhase("portPointPathingSolver")
+  while (
+    solver.getCurrentPhase() === "portPointPathingSolver" &&
+    !solver.failed &&
+    !solver.solved
+  ) {
+    solver.step()
+  }
+
+  const pathingSolver = solver.portPointPathingSolver
+  const solveGraphStats = (
+    pathingSolver as unknown as {
+      tinyPipelineSolver?: {
+        getSolver(name: string): { stats?: Record<string, unknown> } | undefined
+      }
+    }
+  ).tinyPipelineSolver?.getSolver("solveGraph")?.stats
+  const singleLayerCrossingNodes =
+    pathingSolver
+      ?.getOutput()
+      .nodesWithPortPoints.filter(
+        (node) =>
+          node.availableZ?.length === 1 &&
+          getIntraNodeCrossingsUsingCircle(node).numSameLayerCrossings > 0,
+      ) ?? []
+
+  expect(solver.failed).toBe(false)
+  expect(pathingSolver?.solved).toBe(true)
+  expect(solveGraphStats?.selectiveReripCycleEscapeCount).toBeGreaterThan(0)
+  expect(singleLayerCrossingNodes).toHaveLength(0)
+})

--- a/tests/solvers/same-net-via-merger-diagonal-near-merge.test.ts
+++ b/tests/solvers/same-net-via-merger-diagonal-near-merge.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { SameNetViaMergerSolver } from "lib/solvers/SameNetViaMergerSolver/SameNetViaMergerSolver"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+
+test("SameNetViaMergerSolver ignores a via without an anchored transition", () => {
+  const routes: HighDensityRoute[] = [
+    {
+      connectionName: "keep",
+      traceThickness: 0.15,
+      viaDiameter: 0.3,
+      route: [
+        { x: 0, y: 0, z: 0 },
+        { x: 0, y: 0, z: 1 },
+      ],
+      vias: [{ x: 0, y: 0 }],
+    },
+    {
+      connectionName: "diagonal-transition",
+      traceThickness: 0.15,
+      viaDiameter: 0.3,
+      route: [
+        { x: 1, y: 0, z: 1 },
+        { x: 1, y: 0, z: 0 },
+      ],
+      vias: [{ x: 0.5, y: 0 }],
+    },
+  ]
+  const solver = new SameNetViaMergerSolver({
+    inputHdRoutes: routes,
+    obstacles: [],
+    colorMap: {},
+    layerCount: 2,
+    connMap: new ConnectivityMap({
+      net0: routes.map((route) => route.connectionName),
+    }),
+  })
+
+  solver.solve()
+
+  expect(solver.failed).toBe(false)
+  expect(solver.getMergedViaHdRoutes()!.flatMap((route) => route.vias)).toEqual(
+    [
+      { x: 0, y: 0 },
+      { x: 0.5, y: 0 },
+    ],
+  )
+})

--- a/tests/solvers/useless-via-removal-through-obstacle.test.ts
+++ b/tests/solvers/useless-via-removal-through-obstacle.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { HighDensityRouteSpatialIndex } from "lib/data-structures/HighDensityRouteSpatialIndex"
+import { ObstacleSpatialHashIndex } from "lib/data-structures/ObstacleTree"
+import { SingleRouteUselessViaRemovalSolver } from "lib/solvers/UselessViaRemovalSolver/SingleRouteUselessViaRemovalSolver"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+
+test("does not recreate a via for a through-obstacle layer transition", () => {
+  const route: HighDensityRoute = {
+    connectionName: "through-obstacle-route",
+    traceThickness: 0.15,
+    viaDiameter: 0.3,
+    route: [
+      { x: -0.2, y: -2.9, z: 0, toNextSegmentType: "through_obstacle" },
+      { x: 0.2, y: -2.9, z: 1 },
+      { x: 1, y: -2.9, z: 1 },
+    ],
+    vias: [],
+  }
+  const solver = new SingleRouteUselessViaRemovalSolver({
+    obstacleSHI: new ObstacleSpatialHashIndex("flatbush", []),
+    hdRouteSHI: new HighDensityRouteSpatialIndex([route]),
+    unsimplifiedRoute: structuredClone(route),
+    connMap: new ConnectivityMap({ net0: [route.connectionName] }),
+  })
+
+  solver.solve()
+
+  const optimizedRoute = solver.getOptimizedHdRoute()
+  expect(solver.failed).toBe(false)
+  expect(optimizedRoute.vias).toEqual([])
+  expect(optimizedRoute.route).toEqual(route.route)
+})

--- a/tests/tinyhypergraph-large-connection-prepass.test.ts
+++ b/tests/tinyhypergraph-large-connection-prepass.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test"
+import input from "../fixtures/features/portpointpathing/tinyhypergraph-port-bridge-repro-input.json"
+import type { HgPortPointPathingSolverParams } from "lib/solvers/PortPointPathingSolver/hgportpointpathingsolver/types"
+import { TinyHypergraphPortPointPathingSolver } from "lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver"
+
+test("TinyHypergraph runs the congested-port prepass for large connection sets", () => {
+  const params = structuredClone(input) as HgPortPointPathingSolverParams
+  const template = params.connections[0]!
+  params.connections = Array.from({ length: 461 }, (_, index) => {
+    const connection = structuredClone(template)
+    connection.connectionId = `connection-${index}`
+    connection.mutuallyConnectedNetworkId = "shared-net"
+    connection.simpleRouteConnection!.name = `connection-${index}`
+    connection.simpleRouteConnection!.__rootConnectionNames = ["shared-net"]
+    connection.simpleRouteConnection!.pointsToConnect =
+      connection.simpleRouteConnection!.pointsToConnect.map((point) => ({
+        ...point,
+        pointId: `${point.pointId}-${index}`,
+      }))
+    return connection
+  })
+
+  const solver = new TinyHypergraphPortPointPathingSolver(params)
+  const prepassReport = (
+    solver as unknown as {
+      duplicateCongestedPortReport?: unknown
+    }
+  ).duplicateCongestedPortReport
+
+  expect(prepassReport).toBeDefined()
+})

--- a/tests/tinyhypergraph-overlapping-cross-layer-terminals.test.ts
+++ b/tests/tinyhypergraph-overlapping-cross-layer-terminals.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "bun:test"
+import input from "../fixtures/features/portpointpathing/tinyhypergraph-port-bridge-repro-input.json"
+import { TinyHypergraphPortPointPathingSolver } from "lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver"
+import type {
+  HgPortPointPathingSolverParams,
+  RegionHg,
+} from "lib/solvers/PortPointPathingSolver/hgportpointpathingsolver/types"
+
+test("TinyHypergraph routes overlapping cross-layer terminals through one target region", () => {
+  const startRegion: RegionHg = {
+    regionId: "bottom-target",
+    ports: [],
+    d: {
+      capacityMeshNodeId: "bottom-target",
+      center: { x: 0, y: 0 },
+      width: 0.59,
+      height: 0.64,
+      layer: "bottom",
+      availableZ: [1],
+      _containsTarget: true,
+    },
+  }
+  const endRegion: RegionHg = {
+    regionId: "top-target",
+    ports: [],
+    d: {
+      capacityMeshNodeId: "top-target",
+      center: { x: 0.17, y: 0 },
+      width: 0.254,
+      height: 0.254,
+      layer: "top",
+      availableZ: [0],
+      _containsTarget: true,
+    },
+  }
+  const params = structuredClone(input) as HgPortPointPathingSolverParams
+  params.graph = { regions: [startRegion, endRegion], ports: [] }
+  params.connections = [
+    {
+      connectionId: "cross-layer-targets",
+      startRegion,
+      endRegion,
+      simpleRouteConnection: {
+        name: "cross-layer-targets",
+        pointsToConnect: [
+          { x: 0, y: 0, layer: "bottom", pointId: "bottom-port" },
+          { x: 0.17, y: 0, layer: "top", pointId: "top-port" },
+        ],
+      },
+    },
+  ]
+  params.layerCount = 2
+
+  const solver = new TinyHypergraphPortPointPathingSolver(params)
+  solver.solve()
+
+  expect(solver.failed).toBe(false)
+  expect(solver.solved).toBe(true)
+  expect(solver.getOutput().nodesWithPortPoints).toEqual([
+    expect.objectContaining({
+      capacityMeshNodeId: "bottom-target",
+      availableZ: [0, 1],
+      portPoints: [
+        expect.objectContaining({ x: 0, y: 0, z: 1 }),
+        expect.objectContaining({ x: 0.17, y: 0, z: 0 }),
+      ],
+    }),
+  ])
+})

--- a/tests/tinyhypergraph-overlapping-cross-layer-terminals.test.ts
+++ b/tests/tinyhypergraph-overlapping-cross-layer-terminals.test.ts
@@ -44,13 +44,26 @@ test("TinyHypergraph routes overlapping cross-layer terminals through one target
       simpleRouteConnection: {
         name: "cross-layer-targets",
         pointsToConnect: [
-          { x: 0, y: 0, layer: "bottom", pointId: "bottom-port" },
-          { x: 0.17, y: 0, layer: "top", pointId: "top-port" },
+          {
+            x: 0,
+            y: 0,
+            layer: "bottom",
+            pointId: "bottom-port",
+            pcb_port_id: "bottom-port",
+          },
+          {
+            x: 0.17,
+            y: 0,
+            layer: "top",
+            pointId: "top-port",
+            pcb_port_id: "top-port",
+          },
         ],
       },
     },
   ]
   params.layerCount = 2
+  params.preserveTerminalPcbPortIds = true
 
   const solver = new TinyHypergraphPortPointPathingSolver(params)
   solver.solve()
@@ -62,8 +75,36 @@ test("TinyHypergraph routes overlapping cross-layer terminals through one target
       capacityMeshNodeId: "bottom-target",
       availableZ: [0, 1],
       portPoints: [
-        expect.objectContaining({ x: 0, y: 0, z: 1 }),
-        expect.objectContaining({ x: 0.17, y: 0, z: 0 }),
+        expect.objectContaining({
+          x: 0,
+          y: 0,
+          z: 1,
+          pcb_port_id: "bottom-port",
+        }),
+        expect.objectContaining({
+          x: 0.085,
+          y: 0,
+          z: 0,
+          portPointId: "tiny-terminal:via-bridge-port:cross-layer-targets",
+        }),
+      ],
+    }),
+    expect.objectContaining({
+      capacityMeshNodeId: "top-target",
+      availableZ: [0],
+      portPoints: [
+        expect.objectContaining({
+          x: 0.085,
+          y: 0,
+          z: 0,
+          portPointId: "tiny-terminal:via-bridge-port:cross-layer-targets",
+        }),
+        expect.objectContaining({
+          x: 0.17,
+          y: 0,
+          z: 0,
+          pcb_port_id: "top-port",
+        }),
       ],
     }),
   ])

--- a/tests/tinyhypergraph-overlapping-cross-layer-terminals.test.ts
+++ b/tests/tinyhypergraph-overlapping-cross-layer-terminals.test.ts
@@ -38,6 +38,7 @@ test("TinyHypergraph routes overlapping cross-layer terminals through one target
   params.connections = [
     {
       connectionId: "cross-layer-targets",
+      mutuallyConnectedNetworkId: "cross-layer-targets",
       startRegion,
       endRegion,
       simpleRouteConnection: {

--- a/tests/tinyhypergraph-target-attachment-cardinality.test.ts
+++ b/tests/tinyhypergraph-target-attachment-cardinality.test.ts
@@ -1,0 +1,112 @@
+import type { SerializedHyperGraph } from "@tscircuit/hypergraph"
+import { expect, test } from "bun:test"
+import input from "../fixtures/features/portpointpathing/tinyhypergraph-port-bridge-repro-input.json"
+import type {
+  HgPortPointPathingSolverParams,
+  RegionHg,
+  RegionPortHg,
+} from "lib/solvers/PortPointPathingSolver/hgportpointpathingsolver/types"
+import { TinyHypergraphPortPointPathingSolver } from "lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver"
+
+test("TinyHypergraph adds only the strongest cross-layer attachment for each target", () => {
+  const params = structuredClone(input) as HgPortPointPathingSolverParams
+  const targetRegion = params.graph.regions.find(
+    (region) => region.regionId === "bl",
+  )!
+  const networkRegion = params.graph.regions.find(
+    (region) => region.regionId === "left-bridge",
+  )!
+  targetRegion.d._containsTarget = true
+  params.graph.ports = params.graph.ports.filter(
+    (port) => port.d.portId !== "p5",
+  )
+  for (const region of params.graph.regions) {
+    region.ports = region.ports.filter((port) => port.d.portId !== "p5")
+  }
+
+  const singleLayerCandidate: RegionHg = {
+    regionId: "single-layer-candidate",
+    ports: [],
+    d: {
+      capacityMeshNodeId: "single-layer-candidate",
+      center: { ...targetRegion.d.center },
+      width: 1.5,
+      height: 1.5,
+      layer: "top",
+      availableZ: [1],
+    },
+  }
+  const multilayerCandidate: RegionHg = {
+    regionId: "multilayer-candidate",
+    ports: [],
+    d: {
+      capacityMeshNodeId: "multilayer-candidate",
+      center: { ...targetRegion.d.center },
+      width: 1.5,
+      height: 1.5,
+      layer: "top",
+      availableZ: [1, 2],
+    },
+  }
+  const singleLayerPort: RegionPortHg = {
+    portId: "candidate-port-1",
+    region1: singleLayerCandidate,
+    region2: networkRegion,
+    d: {
+      portId: "candidate-port-1",
+      x: -3.5,
+      y: -1.5,
+      z: 1,
+      distToCentermostPortOnZ: 0,
+      regions: [singleLayerCandidate, networkRegion],
+    },
+  }
+  const multilayerPort: RegionPortHg = {
+    portId: "candidate-port-2",
+    region1: multilayerCandidate,
+    region2: networkRegion,
+    d: {
+      portId: "candidate-port-2",
+      x: -3.5,
+      y: -2.5,
+      z: 1,
+      distToCentermostPortOnZ: 0,
+      regions: [multilayerCandidate, networkRegion],
+    },
+  }
+  singleLayerCandidate.ports.push(singleLayerPort)
+  multilayerCandidate.ports.push(multilayerPort)
+  networkRegion.ports.push(singleLayerPort, multilayerPort)
+  networkRegion.d.availableZ = [0, 1, 2]
+  params.graph.regions.push(singleLayerCandidate, multilayerCandidate)
+  params.graph.ports.push(singleLayerPort, multilayerPort)
+  params.layerCount = 3
+  params.preserveTerminalPcbPortIds = true
+
+  const solver = new TinyHypergraphPortPointPathingSolver(params)
+  const serializedGraph = (
+    solver as unknown as {
+      tinyPipelineSolver: {
+        inputProblem: { serializedHyperGraph: SerializedHyperGraph }
+      }
+    }
+  ).tinyPipelineSolver.inputProblem.serializedHyperGraph
+  const attachmentPorts = serializedGraph.ports.filter((port) =>
+    port.portId.startsWith("tiny-target-attachment-port:bl:"),
+  )
+  const bridgeRegions = serializedGraph.regions.filter((region) =>
+    region.regionId.startsWith("tiny-target-attachment-bridge-region:bl:"),
+  )
+
+  expect(bridgeRegions).toHaveLength(1)
+  expect(bridgeRegions[0]?.d.netId).toBeDefined()
+  expect(attachmentPorts).toHaveLength(2)
+  expect(
+    attachmentPorts.some((port) => port.region2Id === "multilayer-candidate"),
+  ).toBe(true)
+  expect(
+    serializedGraph.regions.find(
+      (region) => region.regionId === "multilayer-candidate",
+    )?.d.availableZ,
+  ).toEqual([1, 2])
+})


### PR DESCRIPTION
## Root causes

- **SRJ24 sample 4 reachability:** overlapping cross-layer terminals were attached by mutating shared region layers and by adding every overlapping candidate. That polluted unrelated routes and allowed same-net MST terminals to migrate.
- **SRJ24 sample 2 rerip timeout:** selective rerip alternated between a failed route and an alternate owner while leaving the repeated direct blocker committed. The same route pairs were ripped and restored until the iteration limit.
- **SRJ24 sample 3 rerip timeout:** the congested-port prepass was skipped solely because the sample exceeded the old 180-connection cutoff.
- **SRJ24 sample 1 high-density timeout:** Pipeline 7 eagerly computed pressure for stale, pre-distribution nodes, while the severe 8-layer node actually sent to high-density routing always began at scale 1. It then spent millions of iterations growing reactively.
- **SRJ24 sample 4 simplification crash:** a `through_obstacle` layer transition was reconstructed as a physical via; `SameNetViaMergerSolver` later tried to move that unanchored via and could not find transition layers.

## What changed

- preserve PCB terminal identity and original region layers
- add at most one deterministic, net-reserved target attachment, only for a net that is initially unreachable
- make the precheck layer-aware and scope terminal/net bridges to the unreachable route set
- detect selective-rerip ping-pong and reroute the connected conflict set while preserving unrelated committed routes and rebuilding ownership/intersection caches
- run the congested-port prepass for the affected large connection set
- compute/cache pressure from the final node being solved and seed grow/shrink scale only from measured capacity pressure
- keep `through_obstacle` transitions out of the physical via list and only merge vias with anchored route transitions

## Evidence

- PR-base SRJ24 sample 2 pathing emits **9** illegal single-layer crossing regions; this branch emits **0**
- the full PR-base sample 2 run ends with **43** exact DRC errors; the equivalent branch run ends with **26**
- SRJ24 sample 2 now exits selective rerip normally; the focused dataset regression confirms the cycle escape fired and the pathing stage solved
- SRJ24 sample 3 completes TinyHypergraph pathing with the congested-port prepass
- SRJ24 sample 1's stuck 44-route node has measured pressure **3.97**; starting it at the derived scale 4 solves it in **15.1s**, while scale 2 was still searching after 60s
- low-pressure `bugreport63` nodes are no longer pre-grown merely because they carry cramped-port metadata; its existing SVG snapshot passes unchanged
- SRJ24 sample 4 completes both the previously failing reachability and trace-simplification paths
- SRJ18 sample 3 completes Pipeline 7 without the unknown PCB terminal error

## Validation

- `bun run format:check`
- `bunx tsc --noEmit`
- `bun run build`
- 12 focused regressions passed, including live SRJ24 sample 2 pathing, terminal attachment cardinality, large-connection prepass, pressure-derived initial scaling, through-obstacle via removal, and unanchored same-net via handling

All GitHub Actions checks pass, including all five test shards.
