### PR TITLE
fix: getEffortScale handles undefined effort, preventing NaN MAX_ITERATIONS

### DIFF
--- a/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
+++ b/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
@@ -129,7 +129,8 @@ const DUPLICATE_PORT_TRAVERSAL_PENALTY = 150
 const DEFAULT_CRAMPED_PORT_TRAVERSAL_PENALTY = 150
 const MAX_CONNECTIONS_FOR_DUPLICATE_CONGESTED_PORT_PREPASS = 180
 
-const getEffortScale = (effort: number) => Math.max(effort, 1e-2)
+const getEffortScale = (effort: number | undefined) =>
+  Math.max(Number.isFinite(effort) ? (effort as number) : 1, 1e-2)
 
 const getTinyViaSizeOptions = (
   minViaPadDiameter?: number,


### PR DESCRIPTION
﻿## Problem

`getEffortScale(undefined)` returns `NaN`. `Math.max(undefined, 1e-2)` is `NaN` in JavaScript, so every `MAX_ITERATIONS: Math.ceil(N * getEffortScale(params.effort))` becomes `NaN`. The solver reports "ran out of iterations" on the very first step and produces 0 traces.

Closes #1525

## Root Cause

`AutoroutingPipelineSolver4` defaults its own `this.effort = mutableOpts.effort ?? 1` but does not thread that default into `HgPortPointPathingSolverParams.effort`. So `params.effort` is `undefined` inside `TinyHypergraphPortPointPathingSolver`, specifically for boards whose `connections.length` is under `MAX_CONNECTIONS_FOR_DUPLICATE_CONGESTED_PORT_PREPASS`.

```js
Math.max(undefined, 1e-2)  // => NaN
```

## Fix

One-line guard in `getEffortScale`:
```ts
// Before:
const getEffortScale = (effort: number) => Math.max(effort, 1e-2)

// After:
const getEffortScale = (effort: number | undefined) =>
  Math.max(Number.isFinite(effort) ? (effort as number) : 1, 1e-2)
```

Defaults to `1` (the same value `AutoroutingPipelineSolver4` uses) when `effort` is `undefined`.
