### PR TITLE
Update Repair 03 solver to PR 29

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "zdwiel-dataset": "git+https://github.com/dwiel/tscircuit-benchmark.git#be36518b5bf51755dae92c230061ab3cf4e3e063",
     "high-density-repair01": "git+https://github.com/tscircuit/high-density-repair01.git#cefc7be547ff727bd31573ac096b850da847af46",
     "high-density-repair02": "https://codeload.github.com/tscircuit/high-density-repair02/tar.gz/2afc0cbba3bf2f7eb6b9cd33615d21e9ad9352d4",
-    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#adb38a0d75fbac5c78971ec39eda15d0ae683a4a",
+    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#43fa2b891e9d4e5fb29688d7dc7df7f20b3e94ad",
     "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- pin `high-density-repair03` to `tscircuit/high-density-repair03#29` commit `43fa2b891e9d4e5fb29688d7dc7df7f20b3e94ad`

## Why

This makes the autorouter consume the Repair 03 changes from tscircuit/high-density-repair03#29 so they can be benchmarked in this repository.

## Validation

- Not run; benchmark will be triggered manually with the `/benchmark` PR comment.