### PR TITLE
update high-density-repair03 to merged main commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "zdwiel-dataset": "git+https://github.com/dwiel/tscircuit-benchmark.git#be36518b5bf51755dae92c230061ab3cf4e3e063",
     "high-density-repair01": "git+https://github.com/tscircuit/high-density-repair01.git#cefc7be547ff727bd31573ac096b850da847af46",
     "high-density-repair02": "https://codeload.github.com/tscircuit/high-density-repair02/tar.gz/2afc0cbba3bf2f7eb6b9cd33615d21e9ad9352d4",
-    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#adb38a0d75fbac5c78971ec39eda15d0ae683a4a",
+    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#8039567f5a86b6be9e4b40ca4be5989c8158ce8c",
     "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- update the `high-density-repair03` dependency pin from the former PR head `adb38a0d` to the latest `main` commit `8039567f`
- keep the autorouter on the merged version of the via-in-pad DRC repair

## Why

The autorouter was pinned directly to the head commit of `high-density-repair03#26` while that change was under review. That PR is now merged, so the dependency should reference the resulting commit on `main`.

## Impact

Autorouter builds now consume the merged `high-density-repair03` mainline commit instead of the pre-merge PR head.

## Validation

- `bun install` — resolved `high-density-repair03#8039567`
- `bun run build` — passed, including declaration generation
