### PR TITLE
fix: preserve per-connection nominalTraceWidth through mergeConnections (#1721 D2)

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -632,7 +632,13 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
         connMap: cms.connMap,
         colorMap: cms.colorMap,
         minTraceWidth: cms.minTraceWidth,
-        connection: cms.srj.connections,
+        // Point-pair connections carry per-edge nominalTraceWidths for merged
+        // nets, so routes resolve widths by their own connection name first.
+        // Original connections are kept for the rootConnectionName fallback.
+        connection: [
+          ...cms.srj.connections,
+          ...cms.srjWithPointPairs!.connections,
+        ] as SimpleRouteConnection[],
         obstacleMargin: cms.srj.minTraceToPadEdgeClearance ?? 0.15,
         layerCount: cms.srj.layerCount,
       },

--- a/lib/solvers/NetToPointPairsSolver/NetToPointPairsSolver.ts
+++ b/lib/solvers/NetToPointPairsSolver/NetToPointPairsSolver.ts
@@ -6,7 +6,10 @@ import {
 import { BaseSolver } from "../BaseSolver"
 import { buildMinimumSpanningTree } from "./buildMinimumSpanningTree"
 import { GraphicsObject } from "graphics-debug"
-import { mergeConnections } from "./mergeConnections"
+import {
+  getNominalTraceWidthsForMstEdges,
+  mergeConnections,
+} from "./mergeConnections"
 import { seededRandom } from "lib/utils/cloneAndShuffleArray"
 
 export const getExternalConnectionState = (
@@ -175,9 +178,14 @@ export class NetToPointPairsSolver extends BaseSolver {
     const edges = buildMinimumSpanningTree(connection.pointsToConnect, {
       extraEdges: zeroWeightEdges,
     })
+    const edgeNominalTraceWidths = getNominalTraceWidthsForMstEdges(
+      connection,
+      edges,
+    )
 
     let mstIdx = 0
-    for (const edge of edges) {
+    for (let edgeIndex = 0; edgeIndex < edges.length; edgeIndex++) {
+      const edge = edges[edgeIndex]
       if (areExternallyConnected(pointIdToGroup, edge.from, edge.to)) continue
       this.newConnections.push({
         pointsToConnect: [edge.from, edge.to],
@@ -186,6 +194,7 @@ export class NetToPointPairsSolver extends BaseSolver {
           connection.name,
         ],
         __netConnectionName: connection.__netConnectionName,
+        nominalTraceWidth: edgeNominalTraceWidths[edgeIndex],
       })
     }
   }

--- a/lib/solvers/NetToPointPairsSolver/mergeConnections.ts
+++ b/lib/solvers/NetToPointPairsSolver/mergeConnections.ts
@@ -8,6 +8,98 @@ import {
 import { DSU } from "lib/utils/dsu"
 import { getPointKey } from "lib/utils/getPointKey"
 
+type MstEdgeLike = {
+  from: ConnectionPoint
+  to: ConnectionPoint
+}
+
+/**
+ * Resolves a nominalTraceWidth for every MST edge of a (possibly merged)
+ * connection. Returns one width (or undefined) per edge, in edge order.
+ *
+ * For merged connections we use the width constraints recorded by
+ * `mergeConnections`: an original connection with nominalTraceWidth W requires
+ * every tree edge on the path between its points to be at least W, because the
+ * MST may reroute that connection's current through edges whose endpoints
+ * belong to other (possibly narrower) connections. Each edge takes the widest
+ * width among the constraints whose path crosses it; edges crossed by no
+ * constraint get no width and are routed at the default.
+ *
+ * For unmerged connections the connection's own nominalTraceWidth applies to
+ * every edge.
+ */
+export function getNominalTraceWidthsForMstEdges(
+  connection: SimpleRouteConnection,
+  mstEdges: MstEdgeLike[],
+): Array<number | undefined> {
+  const constraints = connection.__nominalTraceWidthConstraints
+  if (!constraints || constraints.length === 0) {
+    return mstEdges.map(() => connection.nominalTraceWidth)
+  }
+
+  // Build tree adjacency: pointKey -> [neighbor pointKey, edge index]
+  const adjacency = new Map<PointKey, Array<[PointKey, number]>>()
+  mstEdges.forEach((mstEdge, edgeIndex) => {
+    const fromKey = getPointKey(mstEdge.from)
+    const toKey = getPointKey(mstEdge.to)
+    if (!adjacency.has(fromKey)) adjacency.set(fromKey, [])
+    if (!adjacency.has(toKey)) adjacency.set(toKey, [])
+    adjacency.get(fromKey)!.push([toKey, edgeIndex])
+    adjacency.get(toKey)!.push([fromKey, edgeIndex])
+  })
+
+  const edgeNominalTraceWidths: Array<number | undefined> = mstEdges.map(
+    () => undefined,
+  )
+
+  for (const constraint of constraints) {
+    const terminalKeys = constraint.pointKeys.filter((pointKey) =>
+      adjacency.has(pointKey),
+    )
+    if (terminalKeys.length < 2) continue
+
+    // BFS from the first terminal, recording each visited point's parent edge
+    const rootKey = terminalKeys[0]
+    const parentOf = new Map<PointKey, [PointKey, number]>()
+    const visited = new Set<PointKey>([rootKey])
+    const queue: PointKey[] = [rootKey]
+    while (queue.length > 0) {
+      const currentKey = queue.shift()!
+      for (const [neighborKey, edgeIndex] of adjacency.get(currentKey) ?? []) {
+        if (visited.has(neighborKey)) continue
+        visited.add(neighborKey)
+        parentOf.set(neighborKey, [currentKey, edgeIndex])
+        queue.push(neighborKey)
+      }
+    }
+
+    // Walk each remaining terminal back to the root; the union of these walks
+    // is the minimal subtree spanning the constraint's points.
+    const markedEdgeIndices = new Set<number>()
+    for (let i = 1; i < terminalKeys.length; i++) {
+      let walkKey: PointKey = terminalKeys[i]
+      while (walkKey !== rootKey) {
+        const parentEntry = parentOf.get(walkKey)
+        if (!parentEntry) break // Terminal unreachable from root (disconnected)
+        const [parentKey, edgeIndex] = parentEntry
+        if (markedEdgeIndices.has(edgeIndex)) break // Already-walked branch
+        markedEdgeIndices.add(edgeIndex)
+        walkKey = parentKey
+      }
+    }
+
+    for (const edgeIndex of markedEdgeIndices) {
+      const existingWidth = edgeNominalTraceWidths[edgeIndex]
+      edgeNominalTraceWidths[edgeIndex] =
+        existingWidth === undefined
+          ? constraint.nominalTraceWidth
+          : Math.max(existingWidth, constraint.nominalTraceWidth)
+    }
+  }
+
+  return edgeNominalTraceWidths
+}
+
 /**
  * Merges SimpleRouteConnections that share common ConnectionPoints into single connections.
  * This is useful for grouping related traces/nets that were defined separately
@@ -89,6 +181,10 @@ export function mergeConnections(
     const mergedExternallyConnectedPointIds: PointId[][] = []
     const mergedNetConnectionNames: Set<string> = new Set()
     let nominalTraceWidth: number | undefined = undefined
+    const nominalTraceWidthConstraints: Array<{
+      nominalTraceWidth: number
+      pointKeys: PointKey[]
+    }> = []
 
     simpleRouteConnectionGroup.forEach((simpleRouteConnection) => {
       // Collect unique points
@@ -125,13 +221,29 @@ export function mergeConnections(
         mergedNetConnectionNames.add(simpleRouteConnection.__netConnectionName)
       }
 
-      // Take the nominalTraceWidth from the first connection for now
-      // A more robust solution might average or pick the max/min based on context
-      if (
-        nominalTraceWidth === undefined &&
-        simpleRouteConnection.nominalTraceWidth !== undefined
-      ) {
-        nominalTraceWidth = simpleRouteConnection.nominalTraceWidth
+      // Record each connection's nominalTraceWidth and points as a width
+      // constraint so MST edges can later resolve a per-edge width (see
+      // getNominalTraceWidthsForMstEdges). Nested constraints from an earlier
+      // merge are carried through unchanged. The merged connection's own
+      // nominalTraceWidth is the widest in the group (order-independent).
+      if (simpleRouteConnection.__nominalTraceWidthConstraints) {
+        nominalTraceWidthConstraints.push(
+          ...simpleRouteConnection.__nominalTraceWidthConstraints,
+        )
+      } else if (simpleRouteConnection.nominalTraceWidth !== undefined) {
+        nominalTraceWidthConstraints.push({
+          nominalTraceWidth: simpleRouteConnection.nominalTraceWidth,
+          pointKeys: simpleRouteConnection.pointsToConnect.map(getPointKey),
+        })
+      }
+      if (simpleRouteConnection.nominalTraceWidth !== undefined) {
+        nominalTraceWidth =
+          nominalTraceWidth === undefined
+            ? simpleRouteConnection.nominalTraceWidth
+            : Math.max(
+                nominalTraceWidth,
+                simpleRouteConnection.nominalTraceWidth,
+              )
       }
     })
 
@@ -152,7 +264,11 @@ export function mergeConnections(
           ? Array.from(mergedNetConnectionNames).join("__") // Combine unique net connection names
           : undefined,
       __rootConnectionNames: Array.from(mergedRootConnectionNames),
-      nominalTraceWidth: nominalTraceWidth, // Keep the first found nominalTraceWidth
+      nominalTraceWidth: nominalTraceWidth, // Widest nominalTraceWidth in the group
+      __nominalTraceWidthConstraints:
+        nominalTraceWidthConstraints.length > 0
+          ? nominalTraceWidthConstraints
+          : undefined,
     }
 
     mergedSimpleRouteConnections.push(newSimpleRouteConnection)

--- a/lib/solvers/NetToPointPairsSolver2_OffBoardConnection/NetToPointPairsSolver2_OffBoardConnection.ts
+++ b/lib/solvers/NetToPointPairsSolver2_OffBoardConnection/NetToPointPairsSolver2_OffBoardConnection.ts
@@ -10,6 +10,7 @@ import {
   NetToPointPairsSolver,
 } from "../NetToPointPairsSolver/NetToPointPairsSolver"
 import { buildMinimumSpanningTree } from "../NetToPointPairsSolver/buildMinimumSpanningTree"
+import { getNominalTraceWidthsForMstEdges } from "../NetToPointPairsSolver/mergeConnections"
 
 /**
  * Extends the base NetToPointPairsSolver with an optimization that utilizes
@@ -158,9 +159,21 @@ export class NetToPointPairsSolver2_OffBoardConnection extends NetToPointPairsSo
       currentConnection.pointsToConnect,
       { extraEdges: zeroWeightEdges },
     )
+    // Widths are resolved from the original MST edges: an off-board
+    // substitute point is electrically equivalent, so each edge keeps the
+    // width of the points it conceptually connects.
+    const edgeNominalTraceWidths = getNominalTraceWidthsForMstEdges(
+      currentConnection,
+      minimumSpanningTreeEdges,
+    )
 
     let mstEdgeIndex = 0
-    for (const mstEdge of minimumSpanningTreeEdges) {
+    for (
+      let edgeIndex = 0;
+      edgeIndex < minimumSpanningTreeEdges.length;
+      edgeIndex++
+    ) {
+      const mstEdge = minimumSpanningTreeEdges[edgeIndex]
       if (areExternallyConnected(pointIdToGroup, mstEdge.from, mstEdge.to)) {
         continue
       }
@@ -177,6 +190,7 @@ export class NetToPointPairsSolver2_OffBoardConnection extends NetToPointPairsSo
           currentConnection.name,
         ],
         __netConnectionName: currentConnection.__netConnectionName,
+        nominalTraceWidth: edgeNominalTraceWidths[edgeIndex],
       })
     }
   }

--- a/lib/types/srj-types.ts
+++ b/lib/types/srj-types.ts
@@ -96,6 +96,17 @@ export interface SimpleRouteConnection {
   isOffBoard?: boolean
   __netConnectionName?: string
   nominalTraceWidth?: number
+  /**
+   * Width requirements of the original connections that were merged into this
+   * connection. Each entry records one original connection's nominalTraceWidth
+   * and the PointKeys of the points it connected, so MST pair connections can
+   * derive a per-edge nominalTraceWidth: every tree edge on the path between a
+   * constraint's points must be at least that constraint's width.
+   */
+  __nominalTraceWidthConstraints?: Array<{
+    nominalTraceWidth: number
+    pointKeys: PointKey[]
+  }>
   pointsToConnect: Array<ConnectionPoint>
 
   /** @deprecated DO NOT USE **/

--- a/tests/solvers/net-to-point-pairs-offboard-trace-widths.test.ts
+++ b/tests/solvers/net-to-point-pairs-offboard-trace-widths.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test"
+import { NetToPointPairsSolver2_OffBoardConnection } from "lib/solvers/NetToPointPairsSolver2_OffBoardConnection/NetToPointPairsSolver2_OffBoardConnection"
+import type { ConnectionPoint, SimpleRouteJson } from "lib/types"
+
+// Regression test for https://github.com/tscircuit/tscircuit-autorouter/issues/1721
+// Same scenario as net-to-point-pairs-trace-widths.test.ts but for the
+// off-board-aware solver used by the default pipeline: merged nets must keep a
+// per-edge nominalTraceWidth on the MST pair connections.
+test("NetToPointPairsSolver2_OffBoardConnection keeps per-edge nominalTraceWidth for merged nets", () => {
+  const srj = {
+    bounds: { minX: 0, maxX: 3, minY: 0, maxY: 1 },
+    layerCount: 2,
+    minTraceWidth: 0.1,
+    obstacles: [],
+    connections: [
+      {
+        name: "wide_trace",
+        nominalTraceWidth: 0.8,
+        pointsToConnect: [
+          { x: 0, y: 0, layer: "top", pointId: "p0" },
+          { x: 1, y: 0, layer: "top", pointId: "p1" },
+        ],
+      },
+      {
+        name: "narrow_trace",
+        nominalTraceWidth: 0.25,
+        pointsToConnect: [
+          { x: 1, y: 0, layer: "top", pointId: "p1" },
+          { x: 2, y: 0, layer: "top", pointId: "p2" },
+        ],
+      },
+    ],
+  } satisfies SimpleRouteJson
+
+  const solver = new NetToPointPairsSolver2_OffBoardConnection(
+    structuredClone(srj),
+  )
+  solver.solve()
+
+  const pairConnections = solver.getNewSimpleRouteJson().connections
+  expect(pairConnections).toHaveLength(2)
+
+  const touchesX = (points: ConnectionPoint[], x: number): boolean =>
+    points.some((point) => point.x === x)
+
+  const wideEdge = pairConnections.find((connection) =>
+    touchesX(connection.pointsToConnect, 0),
+  )
+  const narrowEdge = pairConnections.find((connection) =>
+    touchesX(connection.pointsToConnect, 2),
+  )
+
+  expect(wideEdge?.nominalTraceWidth).toBe(0.8)
+  expect(narrowEdge?.nominalTraceWidth).toBe(0.25)
+})

--- a/tests/solvers/net-to-point-pairs-star-trace-widths.test.ts
+++ b/tests/solvers/net-to-point-pairs-star-trace-widths.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "bun:test"
+import { NetToPointPairsSolver } from "lib/solvers/NetToPointPairsSolver/NetToPointPairsSolver"
+import type { ConnectionPoint, SimpleRouteJson } from "lib/types"
+
+// Regression test for https://github.com/tscircuit/tscircuit-autorouter/issues/1721
+// A wide (0.8) and a narrow (0.25) connection share a hub point, and the MST
+// reroutes the wide connection's path THROUGH the narrow connection's endpoint
+// (hub -> narrow -> wide is shorter than hub -> wide directly). Every edge on
+// the wide connection's path must still be 0.8 wide, even the edge whose
+// endpoints belong to the narrow connection.
+test("NetToPointPairsSolver widens through-path MST edges to the widest crossing connection", () => {
+  const srj = {
+    bounds: { minX: -1, maxX: 3, minY: -1, maxY: 1 },
+    layerCount: 2,
+    minTraceWidth: 0.1,
+    obstacles: [],
+    connections: [
+      {
+        name: "narrow_stub",
+        nominalTraceWidth: 0.25,
+        pointsToConnect: [
+          { x: 0, y: 0, layer: "top" }, // hub
+          { x: 1, y: 0, layer: "top" }, // narrow endpoint, on the way to wide
+        ],
+      },
+      {
+        name: "wide_trace",
+        nominalTraceWidth: 0.8,
+        pointsToConnect: [
+          { x: 0, y: 0, layer: "top" }, // hub
+          { x: 2, y: 0, layer: "top" }, // wide endpoint
+        ],
+      },
+    ],
+  } satisfies SimpleRouteJson
+
+  const solver = new NetToPointPairsSolver(structuredClone(srj))
+  solver.solve()
+
+  const pairConnections = solver.getNewSimpleRouteJson().connections
+  expect(pairConnections).toHaveLength(2)
+
+  const touchesX = (points: ConnectionPoint[], x: number): boolean =>
+    points.some((point) => point.x === x)
+
+  // MST is hub(0,0) - narrow(1,0) - wide(2,0). The wide connection's current
+  // flows hub -> narrow -> wide, so BOTH edges must be 0.8.
+  const hubToNarrowEdge = pairConnections.find((connection) =>
+    touchesX(connection.pointsToConnect, 0),
+  )
+  const narrowToWideEdge = pairConnections.find((connection) =>
+    touchesX(connection.pointsToConnect, 2),
+  )
+
+  expect(hubToNarrowEdge?.nominalTraceWidth).toBe(0.8)
+  expect(narrowToWideEdge?.nominalTraceWidth).toBe(0.8)
+})

--- a/tests/solvers/net-to-point-pairs-trace-widths.test.ts
+++ b/tests/solvers/net-to-point-pairs-trace-widths.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "bun:test"
+import { NetToPointPairsSolver } from "lib/solvers/NetToPointPairsSolver/NetToPointPairsSolver"
+import type { ConnectionPoint, SimpleRouteJson } from "lib/types"
+
+// Regression test for https://github.com/tscircuit/tscircuit-autorouter/issues/1721
+// Two connections with different nominalTraceWidths share a point, so they are
+// merged into one net. Each MST pair connection must keep the width of the
+// original connection its edge belongs to, instead of inheriting the first
+// connection's width (or no width at all).
+test("NetToPointPairsSolver keeps per-edge nominalTraceWidth for merged nets", () => {
+  const srj = {
+    bounds: { minX: 0, maxX: 3, minY: 0, maxY: 1 },
+    layerCount: 2,
+    minTraceWidth: 0.1,
+    obstacles: [],
+    connections: [
+      {
+        name: "wide_trace",
+        nominalTraceWidth: 0.8,
+        pointsToConnect: [
+          { x: 0, y: 0, layer: "top" },
+          { x: 1, y: 0, layer: "top" },
+        ],
+      },
+      {
+        name: "narrow_trace",
+        nominalTraceWidth: 0.25,
+        pointsToConnect: [
+          { x: 1, y: 0, layer: "top" },
+          { x: 2, y: 0, layer: "top" },
+        ],
+      },
+    ],
+  } satisfies SimpleRouteJson
+
+  const solver = new NetToPointPairsSolver(structuredClone(srj))
+  solver.solve()
+
+  const pairConnections = solver.getNewSimpleRouteJson().connections
+  expect(pairConnections).toHaveLength(2)
+
+  const touchesX = (points: ConnectionPoint[], x: number): boolean =>
+    points.some((point) => point.x === x)
+
+  const wideEdge = pairConnections.find((connection) =>
+    touchesX(connection.pointsToConnect, 0),
+  )
+  const narrowEdge = pairConnections.find((connection) =>
+    touchesX(connection.pointsToConnect, 2),
+  )
+
+  expect(wideEdge?.nominalTraceWidth).toBe(0.8)
+  expect(narrowEdge?.nominalTraceWidth).toBe(0.25)
+})


### PR DESCRIPTION
Partially addresses #1721 (root-cause analysis: https://github.com/tscircuit/tscircuit-autorouter/issues/1721#issuecomment-5038119381)

## Scope

This PR fixes only the **merge-plumbing defect (D2 in the linked analysis)**: per-connection `nominalTraceWidth` was lost whenever connections were merged into a net. It does NOT touch the `TraceWidthSolver` all-or-nothing width schedule that silently falls back to `minTraceWidth` on a single mid-route pinch (D1) — that is a design question awaiting maintainer input, so e.g. the 1.0mm motor traces in the issue's repro that collapse to 0.1mm through a pinched region still do (they route through padstacks that force the narrow schedule). It also leaves the output attribution of merged-net traces to `rootConnectionNames[0]` (D3) unchanged.

## What was broken (D2)

Three stacked losses, all merge-order dependent:

1. `mergeConnections` kept only the **first-found** `nominalTraceWidth` of a merged group ("Take the nominalTraceWidth from the first connection for now").
2. The MST pair connections created by `NetToPointPairsSolver._step` / `NetToPointPairsSolver2_OffBoardConnection._step` **dropped `nominalTraceWidth` entirely**.
3. Pipeline 7 passed the **pre-merge** `srj.connections` to `TraceWidthSolver`, so every `*_mstN` route missed the by-name lookup and resolved via the `rootConnectionName` fallback — i.e. the whole merged net inherited `rootConnectionNames[0]`'s width.

Net effect: in the issue's rp2040 repro, merged nets mixing 0.25mm and 0.8mm (or 0.1 and 0.25) connections all routed at whichever width belonged to the first root.

## Fix

- `mergeConnections` now records each original connection's width + point keys as a `__nominalTraceWidthConstraints` entry on the merged connection (and the merged connection's own `nominalTraceWidth` becomes the group max instead of first-found, so it is order-independent).
- New `getNominalTraceWidthsForMstEdges` resolves a per-edge width over the MST: **every tree edge on the path between a constraint's points must be at least that constraint's width** (max over crossing constraints). Per-endpoint width rules are not sufficient here — the MST can reroute a wide connection's current *through* a narrower connection's endpoint (this exact case occurs in the repro: a 4-connection 0.8/0.25 star where the 0.8 path runs through the 0.25 pad; a min-of-endpoints rule under-widths the through-path edges).
- Both `NetToPointPairsSolver` variants stamp the resolved per-edge width on the pair connections they emit.
- Pipeline 7's `traceWidthSolver` step now passes `[...srj.connections, ...srjWithPointPairs.connections]` so routes resolve widths by their own pair-connection name first; the original connections are kept so the existing `rootConnectionName` fallback behavior is preserved for anything without a per-edge width.

Other pipelines (3/4/6/8, Assignable2) still pass only `srj.connections`; they now benefit from the corrected merged-connection widths but were left unrewired to keep this diff to the default pipeline the issue reproduces on — happy to follow up if you want the same one-liner applied there.

## Tests (red → green)

New, all fail on `main` (pair connections have `nominalTraceWidth: undefined`) and pass with the fix:

- `tests/solvers/net-to-point-pairs-trace-widths.test.ts` — 0.8mm and 0.25mm connections sharing a point: each MST pair connection keeps its own width.
- `tests/solvers/net-to-point-pairs-offboard-trace-widths.test.ts` — same for `NetToPointPairsSolver2_OffBoardConnection` (the solver pipeline 7 actually uses).
- `tests/solvers/net-to-point-pairs-star-trace-widths.test.ts` — the through-path case: MST routes a 0.8mm connection through a 0.25mm connection's endpoint; both edges must be 0.8.

Existing related tests pass: `tests/solvers/merge-connections-missing-roots.test.ts`, `tests/solvers/net-to-point-pairs-root.test.ts`, `tests/features/tracewidthsolver/tracewidthsolver01/02.test.ts`, `tests/features/pour-via-escape/pour-via-escape01*.test.ts` (exercises the other `mergeConnections` consumer). `tsc --noEmit` clean. (I ran targeted test files only — my machine can't run the full suite.)

## Repro evidence (rp2040 board from the issue's gist, default pipeline)

Isolating the `TraceWidthSolver` stage with identical input routes, old wiring vs fixed wiring: **24 routes change width, all increases toward their requested width, zero decreases.** Examples:

- merged net `source_trace_47__source_trace_132__source_net_3` (0.1 + 0.25 + 0.25): before, all 25 MST edges routed at **0.1** — the 0.25 connections' widths were silently discarded; after, the edges on the 0.25 connections' paths get **0.25** (a few 0.175/0.1 where D1's pinch fallback still bites).
- `source_trace_29__87__89` and `source_trace_16__91` (0.1 + 0.15 nets): before all **0.1**, after **0.15** on the 0.15 connections' paths.
- the 0.8/0.25 star `source_trace_109..112`: per-edge requests are now correct (0.8 on all through-path edges) instead of whole-net inheritance from `rootConnectionNames[0]`.

Full-pipeline before/after diff on the repro shows exactly those three merged nets changing and nothing else; the `requested=1 output=[0.1]` motor-trace collapses remain, as expected, because they are D1.
