### PR TITLE
fix: handle undefined effort in getEffortScale (#1525)

### DIFF
--- a/lib/solvers/PortPointPathingSolver/hgportpointpathingsolver/HgPortPointPathingSolverClass.ts
+++ b/lib/solvers/PortPointPathingSolver/hgportpointpathingsolver/HgPortPointPathingSolverClass.ts
@@ -56,7 +56,7 @@ export class HgPortPointPathingSolver extends HyperGraphSolver<
     this.totalRipCount = 0
     if (params.weights.MAX_ITERATIONS_PER_PATH > 0) {
       this.MAX_ITERATIONS =
-        params.weights.MAX_ITERATIONS_PER_PATH * params.effort
+        params.weights.MAX_ITERATIONS_PER_PATH * (params.effort ?? 1)
     }
   }
 

--- a/lib/solvers/PortPointPathingSolver/hgportpointpathingsolver/types.ts
+++ b/lib/solvers/PortPointPathingSolver/hgportpointpathingsolver/types.ts
@@ -92,7 +92,7 @@ export interface HgPortPointPathingSolverParams {
   colorMap?: Record<string, string>
   inputSolvedRoutes?: SolvedRoutesHg[]
   layerCount: number
-  effort: number
+  effort?: number
   preserveTerminalPcbPortIds?: boolean
   minViaPadDiameter?: number
   flags: {

--- a/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
+++ b/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
@@ -129,7 +129,8 @@ const DUPLICATE_PORT_TRAVERSAL_PENALTY = 150
 const DEFAULT_CRAMPED_PORT_TRAVERSAL_PENALTY = 150
 const MAX_CONNECTIONS_FOR_DUPLICATE_CONGESTED_PORT_PREPASS = 180
 
-const getEffortScale = (effort: number) => Math.max(effort, 1e-2)
+export const getEffortScale = (effort?: number) =>
+  Math.max(Number.isFinite(effort) ? (effort as number) : 1, 1e-2)
 
 const getTinyViaSizeOptions = (
   minViaPadDiameter?: number,
@@ -139,7 +140,7 @@ const getTinyViaSizeOptions = (
     : {}
 
 const getTinyHyperGraphSolveGraphOptions = (
-  effort: number,
+  effort?: number,
   minViaPadDiameter?: number,
 ): TinyHyperGraphSolverOptions => {
   const effortScale = getEffortScale(effort)
@@ -153,7 +154,7 @@ const getTinyHyperGraphSolveGraphOptions = (
 }
 
 const getTinyHyperGraphSectionSolverOptions = (
-  effort: number,
+  effort?: number,
   minViaPadDiameter?: number,
 ): TinyHyperGraphSectionSolverOptions => {
   const effortScale = getEffortScale(effort)
@@ -168,7 +169,7 @@ const getTinyHyperGraphSectionSolverOptions = (
 
 const getTinyHyperGraphPipelineInput = (
   serializedHyperGraph: SerializedHyperGraph,
-  effort: number,
+  effort?: number,
   minViaPadDiameter?: number,
 ): TinyHyperGraphSectionPipelineInput => ({
   serializedHyperGraph,

--- a/tests/get-effort-scale.test.ts
+++ b/tests/get-effort-scale.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "bun:test"
+import { getEffortScale } from "../lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver"
+
+test("getEffortScale handles undefined and numeric values correctly", () => {
+  // undefined should fallback to 1
+  expect(getEffortScale(undefined)).toBe(1)
+  // NaN should fallback to 1
+  expect(getEffortScale(Number.NaN)).toBe(1)
+  // Normal effort value
+  expect(getEffortScale(2)).toBe(2)
+  // Fractional effort value above minimum
+  expect(getEffortScale(0.5)).toBe(0.5)
+  // Very small effort should be floored at 0.01 (1e-2)
+  expect(getEffortScale(0.001)).toBe(0.01)
+})


### PR DESCRIPTION
## Summary

Closes #1525

When `params.effort` is `undefined`, `Math.max(undefined, 1e-2)` in `getEffortScale` evaluates to `NaN`. This causes `MAX_ITERATIONS` to evaluate to `NaN` across downstream solvers, triggering an immediate 'ran out of iterations' failure on small boards.

This PR updates `getEffortScale` to safely handle `undefined` or non-numeric effort inputs by defaulting to `1`.

## Testing

- Added unit test `tests/get-effort-scale.test.ts` verifying `undefined`, `NaN`, normal, and minimum effort scale calculations.
- All unit tests pass 100%.
