### PR TITLE
test: repro — per-connection nominalTraceWidth lost when connections merge (#1721)

### DIFF
--- a/tests/bugs/__snapshots__/repro-connection-width-loss-1721.snap.svg
+++ b/tests/bugs/__snapshots__/repro-connection-width-loss-1721.snap.svg
@@ -1,0 +1,55 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="4,0 4,3" data-type="line" data-label="" points="563.4782608695652,396.84782608695656 563.4782608695652,214.23913043478262" fill="none" stroke="red" stroke-width="15.217391304347828"/></g><g><polyline data-points="-4,0 4,0" data-type="line" data-label="" points="76.52173913043475,396.84782608695656 563.4782608695652,396.84782608695656" fill="none" stroke="red" stroke-width="15.217391304347828"/></g><g><rect data-type="rect" data-label="top
+power_thick" data-x="-4" data-y="0" x="39.999999999999986" y="360.32608695652175" width="73.04347826086953" height="73.04347826086962" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.016428571428571428"/></g><g><rect data-type="rect" data-label="top
+power_thick, branch_to_sense" data-x="4" data-y="0" x="526.9565217391305" y="360.32608695652175" width="73.0434782608695" height="73.04347826086962" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.016428571428571428"/></g><g><rect data-type="rect" data-label="top
+branch_to_sense" data-x="4" data-y="3" x="555.8695652173914" y="206.63043478260872" width="15.217391304347757" height="15.217391304347814" fill="rgba(255,0,0,0.5)" stroke="black" stroke-width="0.016428571428571428"/></g><g><circle data-type="point" data-label="branch_to_sense
+branch_to_sense
+top" data-x="4" data-y="0" cx="563.4782608695652" cy="396.84782608695656" r="3" fill="hsl(0, 100%, 50%)"/></g><g><circle data-type="point" data-label="branch_to_sense
+branch_to_sense
+top" data-x="4" data-y="3" cx="563.4782608695652" cy="214.23913043478262" r="3" fill="hsl(0, 100%, 50%)"/></g><g><circle data-type="point" data-label="power_thick
+power_thick
+top" data-x="-4" data-y="0" cx="76.52173913043475" cy="396.84782608695656" r="3" fill="hsl(170, 100%, 50%)"/></g><g><circle data-type="point" data-label="power_thick
+power_thick
+top" data-x="4" data-y="0" cx="563.4782608695652" cy="396.84782608695656" r="3" fill="hsl(170, 100%, 50%)"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":60.86956521739131,"c":0,"e":320,"b":0,"d":-60.86956521739131,"f":396.84782608695656};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/bugs/repro-connection-width-loss-1721.test.ts
+++ b/tests/bugs/repro-connection-width-loss-1721.test.ts
@@ -1,0 +1,97 @@
+import { expect, test } from "bun:test"
+import { getSvgFromGraphicsObject } from "graphics-debug"
+import { AutoroutingPipelineSolver, convertSrjToGraphicsObject } from "lib"
+import type { SimpleRouteJson } from "lib/types"
+
+/**
+ * Repro for #1721: per-connection nominalTraceWidth is lost when connections
+ * sharing a point are merged.
+ *
+ * Two connections share the pad at (4, 0), so mergeConnections combines them
+ * into one group. The merged group keeps the FIRST nominalTraceWidth it
+ * encounters (mergeConnections.ts, "Take the nominalTraceWidth from the first
+ * connection"), so the 0.25mm sense-branch width wins and the 0.8mm power
+ * connection is routed at 0.25mm.
+ *
+ * The assertions below pin the CURRENT (buggy) behavior so the width loss is
+ * observable; the snapshot shows the power trace rendered at branch width.
+ */
+const srj: SimpleRouteJson = {
+  layerCount: 2,
+  minTraceWidth: 0.15,
+  bounds: { minX: -6, maxX: 6, minY: -5, maxY: 5 },
+  obstacles: [
+    {
+      type: "rect",
+      layers: ["top"],
+      center: { x: -4, y: 0 },
+      width: 1.2,
+      height: 1.2,
+      connectedTo: ["power_thick"],
+    },
+    {
+      type: "rect",
+      layers: ["top"],
+      center: { x: 4, y: 0 },
+      width: 1.2,
+      height: 1.2,
+      connectedTo: ["power_thick", "branch_to_sense"],
+    },
+    {
+      type: "rect",
+      layers: ["top"],
+      center: { x: 4, y: 3 },
+      width: 0.25,
+      height: 0.25,
+      connectedTo: ["branch_to_sense"],
+    },
+  ],
+  connections: [
+    // Listed first → its 0.25mm width is applied to the whole merged group
+    {
+      name: "branch_to_sense",
+      nominalTraceWidth: 0.25,
+      pointsToConnect: [
+        { x: 4, y: 0, layer: "top" },
+        { x: 4, y: 3, layer: "top" },
+      ],
+    },
+    {
+      name: "power_thick",
+      nominalTraceWidth: 0.8,
+      pointsToConnect: [
+        { x: -4, y: 0, layer: "top" },
+        { x: 4, y: 0, layer: "top" },
+      ],
+    },
+  ],
+}
+
+test("repro-connection-width-loss-1721", () => {
+  const solver = new AutoroutingPipelineSolver(srj)
+  solver.solve()
+  expect(solver.failed).toBe(false)
+
+  const out = solver.getOutputSimpleRouteJson()
+  const wireWidths = new Set<number>()
+  for (const trace of out.traces ?? []) {
+    for (const seg of trace.route) {
+      if (seg.route_type === "wire") wireWidths.add(seg.width)
+    }
+  }
+  const widths = [...wireWidths].sort((a, b) => a - b)
+  console.log("requested widths: [0.25, 0.8] — output wire widths:", widths)
+
+  // BUG(#1721): the requested 0.8mm width never appears in the routed output…
+  expect(widths.some((w) => w >= 0.8)).toBe(false)
+  // …every wire is emitted at the 0.25mm width of the branch connection that
+  // happened to be listed first. Once the width is preserved, this test should
+  // be flipped to assert the power_thick wires ARE 0.8mm.
+  expect(widths).toEqual([0.25])
+
+  expect(
+    getSvgFromGraphicsObject(convertSrjToGraphicsObject(out), {
+      backgroundColor: "white",
+    }),
+  ).toMatchSvgSnapshot(import.meta.path)
+})


### PR DESCRIPTION
Repro-only PR for #1721, as requested in the #1736 discussion — no fix included, just a minimal failing case pinned as a test + visual snapshot.

## Setup

Three pads, two connections that share the pad at `(4, 0)` (so they belong to the same net and get merged):

- `power_thick` — `nominalTraceWidth: 0.8`, between the two 1.2 mm pads
- `branch_to_sense` — `nominalTraceWidth: 0.25`, from the right pad up to a 0.25 mm pad (listed **first** in `connections`)

## Observed on `main` (v0.0.710)

```
requested widths: [0.25, 0.8] — output wire widths: [ 0.25 ]
```

Every wire in the output — including the long power run between the two big pads — comes out at **0.25 mm**. The requested 0.8 mm never appears. The snapshot makes it visible: the power trace and the sense stub are rendered at the identical thin width.

## Mechanism

`mergeConnections.ts` collapses the group into a single connection and keeps only the **first-found** `nominalTraceWidth` ("Take the nominalTraceWidth from the first connection") — so whichever connection happens to be listed first wins the width for the whole net, and the MST point-pairs generated for the merged group carry that single width (or none). Swapping the order of the two `connections` entries flips the outcome, which is what makes this order-dependent rather than a deliberate policy.

The test asserts the *current* behavior (`widths == [0.25]`, no `>= 0.8` wire) so it passes on `main` and documents the loss; a fix would flip those two assertions. Happy to rebase #1736 on top of this once you've confirmed the repro looks right.