### PR TITLE
Label point-pair lines by net

### DIFF
--- a/lib/solvers/NetToPointPairsSolver/NetToPointPairsSolver.ts
+++ b/lib/solvers/NetToPointPairsSolver/NetToPointPairsSolver.ts
@@ -216,7 +216,7 @@ export class NetToPointPairsSolver extends BaseSolver {
           x: point.x,
           y: point.y,
           color: "red",
-          label: connection.name,
+          label: point.pcb_port_id ?? point.pointId,
         })
       })
 
@@ -243,6 +243,7 @@ export class NetToPointPairsSolver extends BaseSolver {
             connection.pointsToConnect[b],
           ],
           strokeColor: "rgba(255,0,0,0.25)",
+          label: connection.name,
         })
       }
     })
@@ -257,7 +258,7 @@ export class NetToPointPairsSolver extends BaseSolver {
           x: point.x,
           y: point.y,
           color: color,
-          label: connection.name,
+          label: point.pcb_port_id ?? point.pointId,
         })
       })
 
@@ -270,6 +271,7 @@ export class NetToPointPairsSolver extends BaseSolver {
               connection.pointsToConnect[j],
             ],
             strokeColor: color,
+            label: connection.name,
           })
         }
       }


### PR DESCRIPTION
## Summary

- label each point-to-connect with its PCB port ID
- label each generated or pending connection line with its net name
- keep shared points from displaying ambiguous net names

## Why

A point can participate in multiple nets, while each point-pair line represents one connection. Moving net labels to lines makes the visualization unambiguous and leaves point labels available for port identity.

## Validation

Previously validated with focused solver checks and a TypeScript build. No test files are included in this pull request; GitHub CI will provide the review validation.