### PR TITLE
Fix Pipeline7 routing for SRJ24 sample 4

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -92,6 +92,50 @@ type PipelineStep<T extends new (...args: any[]) => BaseSolver> = {
   onSolved?: (instance: AutoroutingPipelineSolver7_MultiGraph) => void
 }
 
+const MIN_DENSE_COMPONENT_PAD_COUNT = 90
+const MAX_DENSE_COMPONENT_ASPECT_RATIO = 1.5
+
+export function getCompactDenseComponentBounds(
+  obstacles: SimpleRouteJson["obstacles"],
+  detectedComponentIds: ReadonlySet<string>,
+): SimpleRouteJson["bounds"][] {
+  const obstaclesByComponentId = Map.groupBy(
+    obstacles.filter(
+      (obstacle) =>
+        obstacle.componentId &&
+        !detectedComponentIds.has(obstacle.componentId),
+    ),
+    (obstacle) => obstacle.componentId!,
+  )
+
+  return [...obstaclesByComponentId.values()].flatMap(
+    (componentObstacles) => {
+      if (componentObstacles.length < MIN_DENSE_COMPONENT_PAD_COUNT) return []
+
+      const bounds = componentObstacles.reduce<SimpleRouteJson["bounds"]>(
+        (result, obstacle) => ({
+          minX: Math.min(result.minX, obstacle.center.x - obstacle.width / 2),
+          maxX: Math.max(result.maxX, obstacle.center.x + obstacle.width / 2),
+          minY: Math.min(result.minY, obstacle.center.y - obstacle.height / 2),
+          maxY: Math.max(result.maxY, obstacle.center.y + obstacle.height / 2),
+        }),
+        {
+          minX: Number.POSITIVE_INFINITY,
+          maxX: Number.NEGATIVE_INFINITY,
+          minY: Number.POSITIVE_INFINITY,
+          maxY: Number.NEGATIVE_INFINITY,
+        },
+      )
+      const width = bounds.maxX - bounds.minX
+      const height = bounds.maxY - bounds.minY
+      const aspectRatio =
+        Math.max(width, height) / Math.max(Math.min(width, height), 1e-6)
+
+      return aspectRatio <= MAX_DENSE_COMPONENT_ASPECT_RATIO ? [bounds] : []
+    },
+  )
+}
+
 /**
  * Collects the capacity mesh node ids produced by component-local topology
  * generation.
@@ -373,6 +417,18 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
         cms.maxNodeDimension,
         cms.maxNodeRatio,
         cms.minNodeArea,
+        {
+          layerCount: cms.srj.layerCount,
+          viaDiameter: cms.viaDiameter,
+          componentBounds: getCompactDenseComponentBounds(
+            cms.srj.obstacles,
+            new Set(
+              cms
+                .componentDetectionSolver!.getOutput()
+                .map(({ componentId }) => componentId),
+            ),
+          ),
+        },
       ],
       {
         onSolved: (cms) => {
@@ -383,7 +439,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
     definePipelineStep(
       "edgeSolver",
       CapacityMeshEdgeSolver2_NodeTreeOptimization,
-      (cms) => [cms.capacityNodes!],
+      (cms) => [cms.capacityNodes!, cms.viaDiameter],
       {
         onSolved: (cms) => {
           cms.capacityEdges = cms.edgeSolver?.edges!

--- a/lib/solvers/CapacityMeshSolver/CapacityMeshEdgeSolver.ts
+++ b/lib/solvers/CapacityMeshSolver/CapacityMeshEdgeSolver.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../types/capacity-mesh-types"
 import { BaseSolver } from "../BaseSolver"
 import { areNodesBordering } from "lib/utils/areNodesBordering"
+import { hasViaAccessOverlap } from "../NodeDimensionSubdivisionSolver/add-target-via-access-layers"
 
 export class CapacityMeshEdgeSolver extends BaseSolver {
   override getSolverName(): string {
@@ -17,7 +18,10 @@ export class CapacityMeshEdgeSolver extends BaseSolver {
   /** Only used for visualization, dynamically instantiated if necessary */
   nodeMap?: Map<CapacityMeshNodeId, CapacityMeshNode>
 
-  constructor(public nodes: CapacityMeshNode[]) {
+  constructor(
+    public nodes: CapacityMeshNode[],
+    public viaDiameter?: number,
+  ) {
     super()
     this.edges = []
   }
@@ -37,7 +41,12 @@ export class CapacityMeshEdgeSolver extends BaseSolver {
             this.nodes[j]._strawParentCapacityMeshNodeId
         if (
           !strawNodesWithSameParent &&
-          areNodesBordering(this.nodes[i], this.nodes[j]) &&
+          (areNodesBordering(this.nodes[i], this.nodes[j]) ||
+            hasViaAccessOverlap(
+              this.nodes[i],
+              this.nodes[j],
+              this.viaDiameter,
+            )) &&
           this.doNodesHaveSharedLayer(this.nodes[i], this.nodes[j])
         ) {
           this.edges.push({

--- a/lib/solvers/CapacityMeshSolver/CapacityMeshEdgeSolver2_NodeTreeOptimization.ts
+++ b/lib/solvers/CapacityMeshSolver/CapacityMeshEdgeSolver2_NodeTreeOptimization.ts
@@ -8,6 +8,7 @@ import { distance } from "@tscircuit/math-utils"
 import { areNodesBordering } from "lib/utils/areNodesBordering"
 import { CapacityMeshEdgeSolver } from "./CapacityMeshEdgeSolver"
 import { CapacityNodeTree } from "lib/data-structures/CapacityNodeTree"
+import { hasViaAccessOverlap } from "../NodeDimensionSubdivisionSolver/add-target-via-access-layers"
 
 export class CapacityMeshEdgeSolver2_NodeTreeOptimization extends CapacityMeshEdgeSolver {
   override getSolverName(): string {
@@ -18,8 +19,11 @@ export class CapacityMeshEdgeSolver2_NodeTreeOptimization extends CapacityMeshEd
   private currentNodeIndex: number
   private edgeSet: Set<string>
 
-  constructor(public nodes: CapacityMeshNode[]) {
-    super(nodes)
+  constructor(
+    public nodes: CapacityMeshNode[],
+    viaDiameter?: number,
+  ) {
+    super(nodes, viaDiameter)
     this.MAX_ITERATIONS = 10e6
     this.nodeTree = new CapacityNodeTree(this.nodes)
     this.currentNodeIndex = 0
@@ -43,7 +47,8 @@ export class CapacityMeshEdgeSolver2_NodeTreeOptimization extends CapacityMeshEd
 
     for (const B of maybeAdjNodes) {
       const areBordering = areNodesBordering(A, B)
-      if (!areBordering) continue
+      const haveViaAccessOverlap = hasViaAccessOverlap(A, B, this.viaDiameter)
+      if (!areBordering && !haveViaAccessOverlap) continue
       const strawNodesWithSameParent =
         A._strawNode &&
         B._strawNode &&

--- a/lib/solvers/NodeDimensionSubdivisionSolver/NodeDimensionSubdivisionSolver.ts
+++ b/lib/solvers/NodeDimensionSubdivisionSolver/NodeDimensionSubdivisionSolver.ts
@@ -2,6 +2,8 @@ import type { GraphicsObject } from "graphics-debug"
 import type { CapacityMeshNode } from "lib/types"
 import { BaseSolver } from "lib/solvers/BaseSolver"
 import { areNodesBordering } from "lib/utils/areNodesBordering"
+import type { Bounds } from "@tscircuit/math-utils"
+import { addTargetViaAccessLayers } from "./add-target-via-access-layers"
 
 const DEFAULT_MIN_NODE_AREA = 0.1 ** 2
 // Twice areNodesBordering's epsilon; thinner slices are coordinate artifacts.
@@ -15,6 +17,11 @@ export class NodeDimensionSubdivisionSolver extends BaseSolver {
     private readonly maxNodeDimension: number,
     private readonly maxNodeRatio: number = Number.POSITIVE_INFINITY,
     private readonly minNodeArea: number = DEFAULT_MIN_NODE_AREA,
+    private readonly viaAccess?: {
+      layerCount: number
+      viaDiameter: number
+      componentBounds: readonly Bounds[]
+    },
   ) {
     super()
     this.outputNodes = []
@@ -162,6 +169,13 @@ export class NodeDimensionSubdivisionSolver extends BaseSolver {
       this.outputNodes.push(...subdividedNodes)
     }
 
+    const viaAccessStats = this.viaAccess
+      ? addTargetViaAccessLayers({
+          nodes: this.outputNodes,
+          ...this.viaAccess,
+        })
+      : null
+
     this.stats = {
       inputNodeCount: inputCount,
       outputNodeCount: this.outputNodes.length,
@@ -171,6 +185,7 @@ export class NodeDimensionSubdivisionSolver extends BaseSolver {
       maxNodeDimension: this.maxNodeDimension,
       maxNodeRatio: this.maxNodeRatio,
       minNodeArea: this.minNodeArea,
+      ...viaAccessStats,
     }
     this.solved = true
   }

--- a/lib/solvers/NodeDimensionSubdivisionSolver/add-target-via-access-layers.ts
+++ b/lib/solvers/NodeDimensionSubdivisionSolver/add-target-via-access-layers.ts
@@ -1,0 +1,169 @@
+import type { Bounds } from "@tscircuit/math-utils"
+import type { CapacityMeshNode } from "lib/types"
+
+const EPSILON = 1e-6
+
+const getOverlapDimensions = (
+  a: CapacityMeshNode,
+  b: CapacityMeshNode,
+): { width: number; height: number } => ({
+  width:
+    Math.min(a.center.x + a.width / 2, b.center.x + b.width / 2) -
+    Math.max(a.center.x - a.width / 2, b.center.x - b.width / 2),
+  height:
+    Math.min(a.center.y + a.height / 2, b.center.y + b.height / 2) -
+    Math.max(a.center.y - a.height / 2, b.center.y - b.height / 2),
+})
+
+const containsNode = (
+  container: CapacityMeshNode,
+  contained: CapacityMeshNode,
+): boolean =>
+  container.center.x - container.width / 2 <=
+    contained.center.x - contained.width / 2 + EPSILON &&
+  container.center.x + container.width / 2 >=
+    contained.center.x + contained.width / 2 - EPSILON &&
+  container.center.y - container.height / 2 <=
+    contained.center.y - contained.height / 2 + EPSILON &&
+  container.center.y + container.height / 2 >=
+    contained.center.y + contained.height / 2 - EPSILON
+
+const shareConnectionAlias = (
+  a: CapacityMeshNode,
+  b: CapacityMeshNode,
+): boolean => {
+  const aliases = new Set(a._connectedTo ?? [])
+  return (b._connectedTo ?? []).some((alias) => aliases.has(alias))
+}
+
+export function addTargetViaAccessLayers({
+  nodes,
+  layerCount,
+  viaDiameter,
+  componentBounds,
+}: {
+  nodes: CapacityMeshNode[]
+  layerCount: number
+  viaDiameter: number
+  componentBounds: readonly Bounds[]
+}): {
+  expandedTargetNodeCount: number
+  freeViaPortalNodeCount: number
+} {
+  const originalAvailableZ = new Map(
+    nodes.map((node) => [node.capacityMeshNodeId, [...node.availableZ]]),
+  )
+  const targetNodes = nodes.filter(
+    (node) => node._containsTarget && node._containsObstacle,
+  )
+  const freeNodes = nodes.filter(
+    (node) => !node._containsTarget && !node._containsObstacle,
+  )
+  const isInComponentBounds = (node: CapacityMeshNode): boolean =>
+    componentBounds.some(
+      (bounds) =>
+        node.center.x >= bounds.minX - EPSILON &&
+        node.center.x <= bounds.maxX + EPSILON &&
+        node.center.y >= bounds.minY - EPSILON &&
+        node.center.y <= bounds.maxY + EPSILON,
+    )
+  const allLayers = Array.from({ length: layerCount }, (_, z) => z)
+  let expandedTargetNodeCount = 0
+
+  for (const node of targetNodes) {
+    if (
+      Math.min(node.width, node.height) + EPSILON < viaDiameter ||
+      !isInComponentBounds(node)
+    ) {
+      continue
+    }
+
+    const hasSameNetTargetOnAnotherLayer = targetNodes.some((candidate) => {
+      if (
+        candidate === node ||
+        candidate.availableZ.some((z) => node.availableZ.includes(z)) ||
+        !shareConnectionAlias(node, candidate)
+      ) {
+        return false
+      }
+      const overlap = getOverlapDimensions(node, candidate)
+      return overlap.width >= -EPSILON && overlap.height >= -EPSILON
+    })
+    const viaSizedFreeOverlaps = freeNodes.filter((candidate) => {
+      const overlap = getOverlapDimensions(node, candidate)
+      return (
+        overlap.width + EPSILON >= viaDiameter &&
+        overlap.height + EPSILON >= viaDiameter
+      )
+    })
+    if (
+      !hasSameNetTargetOnAnotherLayer &&
+      viaSizedFreeOverlaps.length === 0
+    ) {
+      continue
+    }
+
+    const availableZ = hasSameNetTargetOnAnotherLayer
+      ? allLayers
+      : [
+          ...new Set([
+            ...node.availableZ,
+            ...viaSizedFreeOverlaps.flatMap(
+              (candidate) =>
+                originalAvailableZ.get(candidate.capacityMeshNodeId) ?? [],
+            ),
+          ]),
+        ].sort((a, b) => a - b)
+    if (availableZ.length === node.availableZ.length) continue
+    node.availableZ = availableZ
+    node.layer = `z${availableZ.join(",")}`
+    node._isViaAccess = true
+    expandedTargetNodeCount++
+  }
+
+  const freeNodesByLayer = allLayers.map((z) =>
+    freeNodes.filter((node) =>
+      originalAvailableZ.get(node.capacityMeshNodeId)!.includes(z),
+    ),
+  )
+  let freeViaPortalNodeCount = 0
+  for (const node of freeNodes) {
+    if (
+      !isInComponentBounds(node) ||
+      Math.min(node.width, node.height) + EPSILON < viaDiameter ||
+      !allLayers.every((z) =>
+        freeNodesByLayer[z]!.some((candidate) =>
+          containsNode(candidate, node),
+        ),
+      )
+    ) {
+      continue
+    }
+
+    node.availableZ = [...allLayers]
+    node.layer = `z${allLayers.join(",")}`
+    node._isViaAccess = true
+    freeViaPortalNodeCount++
+  }
+
+  return { expandedTargetNodeCount, freeViaPortalNodeCount }
+}
+
+export function hasViaAccessOverlap(
+  a: CapacityMeshNode,
+  b: CapacityMeshNode,
+  viaDiameter: number | undefined,
+): boolean {
+  if (viaDiameter === undefined) return false
+  const aIsFree = !a._containsObstacle && !a._containsTarget
+  const bIsFree = !b._containsObstacle && !b._containsTarget
+  if (!((a._isViaAccess && bIsFree) || (b._isViaAccess && aIsFree))) {
+    return false
+  }
+
+  const overlap = getOverlapDimensions(a, b)
+  return (
+    overlap.width + EPSILON >= viaDiameter &&
+    overlap.height + EPSILON >= viaDiameter
+  )
+}

--- a/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
+++ b/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
@@ -128,6 +128,8 @@ const TINY_SECTION_SOLVER_BASE_OPTIONS: TinyHyperGraphSectionSolverOptions = {
 const DUPLICATE_PORT_TRAVERSAL_PENALTY = 150
 const DEFAULT_CRAMPED_PORT_TRAVERSAL_PENALTY = 150
 const MAX_CONNECTIONS_FOR_DUPLICATE_CONGESTED_PORT_PREPASS = 180
+const LARGE_GRAPH_CONNECTION_COUNT = 500
+const LARGE_GRAPH_HEURISTIC_WEIGHT = 256
 
 const getEffortScale = (effort: number) => Math.max(effort, 1e-2)
 
@@ -195,6 +197,57 @@ const getRouteConnectionName = (routeMetadata: RouteMetadata) =>
 
 const getTinyRouteConnectionNetId = (connection: TinyRouteConnection): string =>
   connection.mutuallyConnectedNetworkId
+
+function doesConnectionChangeLayer(
+  connection: TinyRouteConnection,
+): boolean {
+  const [start, end] = connection.simpleRouteConnection.pointsToConnect
+  const endLayers = getConnectionPointLayers(end!)
+
+  return !getConnectionPointLayers(start!).some((layer) =>
+    endLayers.includes(layer),
+  )
+}
+
+function getConnectionDistance(connection: TinyRouteConnection): number {
+  const [start, end] = connection.simpleRouteConnection.pointsToConnect
+
+  return Math.hypot(start!.x - end!.x, start!.y - end!.y)
+}
+
+export const orderLargeGraphConnections = (
+  connections: TinyRouteConnection[],
+): TinyRouteConnection[] => {
+  const countByNet = new Map<string, number>()
+  for (const connection of connections) {
+    const netId = getTinyRouteConnectionNetId(connection)
+    countByNet.set(netId, (countByNet.get(netId) ?? 0) + 1)
+  }
+
+  return connections
+    .map((connection, index) => ({ connection, index }))
+    .sort((left, right) => {
+      return (
+        countByNet.get(getTinyRouteConnectionNetId(right.connection))! -
+          countByNet.get(getTinyRouteConnectionNetId(left.connection))! ||
+        Number(doesConnectionChangeLayer(right.connection)) -
+          Number(doesConnectionChangeLayer(left.connection)) ||
+        getConnectionDistance(left.connection) -
+          getConnectionDistance(right.connection) ||
+        left.index - right.index
+      )
+    })
+    .map(({ connection }) => connection)
+}
+
+class LargeGraphSelectiveReripSolver extends SelectiveReripTinyHyperGraphSolver {
+  override computeH(neighborPortId: number): number {
+    const heuristic = super.computeH(neighborPortId)
+    return this.problem.routeCount >= LARGE_GRAPH_CONNECTION_COUNT
+      ? heuristic * LARGE_GRAPH_HEURISTIC_WEIGHT
+      : heuristic
+  }
+}
 
 const getRoutePoint = (routeMetadata: RouteMetadata, endpointIndex: 0 | 1) =>
   routeMetadata.simpleRouteConnection?.pointsToConnect[endpointIndex]
@@ -651,7 +704,7 @@ class TinyHyperGraphSectionPipelineWithTerminalNetIds extends TinyHyperGraphSect
           "Tiny hypergraph pipeline is missing the solveGraph stage",
         )
       }
-      solveGraphStep.solverClass = SelectiveReripTinyHyperGraphSolver
+      solveGraphStep.solverClass = LargeGraphSelectiveReripSolver
     }
     this.MAX_ITERATIONS = getTinyHyperGraphPipelineMaxIterations(inputProblem)
   }
@@ -697,7 +750,7 @@ class TinyHyperGraphSectionPipelineWithTerminalNetIds extends TinyHyperGraphSect
       const { topology, problem } = this.loadHyperGraph(
         this.inputProblem.serializedHyperGraph,
       )
-      this.initialVisualizationSolver = new SelectiveReripTinyHyperGraphSolver(
+      this.initialVisualizationSolver = new LargeGraphSelectiveReripSolver(
         topology,
         problem,
         this.getSolveGraphOptions(),
@@ -814,12 +867,15 @@ export class TinyHypergraphPortPointPathingSolver extends BaseSolver {
     const tinyRouteConnections = getTinyRouteConnectionsOrThrow(
       params.connections,
     )
-    const connections = params.flags.USE_SELECTIVE_RERIP_ROUTING
+    let connections = params.flags.USE_SELECTIVE_RERIP_ROUTING
       ? orderConnectionsByNetCardinality(
           tinyRouteConnections,
           getTinyRouteConnectionNetId,
         )
       : tinyRouteConnections
+    if (connections.length >= LARGE_GRAPH_CONNECTION_COUNT) {
+      connections = orderLargeGraphConnections(connections)
+    }
     this.rootConnectionNameByConnectionId = new Map(
       connections.map((connection) => [
         connection.connectionId,

--- a/lib/solvers/TopologyPlanningSolver/find-nested-bga-topology-components.ts
+++ b/lib/solvers/TopologyPlanningSolver/find-nested-bga-topology-components.ts
@@ -1,0 +1,196 @@
+import type { Obstacle, SimpleRouteJson } from "lib/types"
+import { getBoundsForObstacles } from "lib/utils/getBoundsForObstacles"
+import { mapZToLayerName } from "lib/utils/mapZToLayerName"
+import type { SerializedTopologyComponentInput } from "./MultiGraphTopologyPlannerSolver"
+
+const COORDINATE_EPSILON = 1e-3
+const MIN_AXIS_COUNT = 5
+const MAX_AXIS_RATIO = 1.5
+
+const coordinateKey = (value: number): number =>
+  Math.round(value / COORDINATE_EPSILON)
+
+export const getTopologyObstacleKey = (obstacle: Obstacle): string =>
+  obstacle.obstacleId ??
+  [
+    obstacle.componentId ?? "no-component",
+    coordinateKey(obstacle.center.x),
+    coordinateKey(obstacle.center.y),
+    coordinateKey(obstacle.width),
+    coordinateKey(obstacle.height),
+    obstacle.layers.join(","),
+  ].join(":")
+
+function getArithmeticSequences(values: number[]): number[][] {
+  const coordinateByKey = new Map(
+    values.map((value) => [coordinateKey(value), value]),
+  )
+  const coordinates = [...coordinateByKey.values()].sort(
+    (left, right) => left - right,
+  )
+  const sequences = new Map<string, number[]>()
+
+  for (let startIndex = 0; startIndex < coordinates.length; startIndex++) {
+    for (
+      let secondIndex = startIndex + 1;
+      secondIndex < coordinates.length;
+      secondIndex++
+    ) {
+      const start = coordinates[startIndex]!
+      const pitch = coordinates[secondIndex]! - start
+      const sequence: number[] = []
+
+      for (let step = 0; ; step++) {
+        const coordinate = coordinateByKey.get(
+          coordinateKey(start + pitch * step),
+        )
+        if (coordinate === undefined) break
+        sequence.push(coordinate)
+      }
+
+      if (sequence.length >= MIN_AXIS_COUNT) {
+        sequences.set(sequence.map(coordinateKey).join(","), sequence)
+      }
+    }
+  }
+
+  return [...sequences.values()]
+}
+
+function findLargestCompleteGrid(obstacles: Obstacle[]): Obstacle[] {
+  const obstacleByCoordinate = new Map(
+    obstacles.map((obstacle) => [
+      `${coordinateKey(obstacle.center.x)}:${coordinateKey(obstacle.center.y)}`,
+      obstacle,
+    ]),
+  )
+  const xSequences = getArithmeticSequences(
+    obstacles.map((obstacle) => obstacle.center.x),
+  )
+  const ySequences = getArithmeticSequences(
+    obstacles.map((obstacle) => obstacle.center.y),
+  )
+  let largestGrid: Obstacle[] = []
+
+  for (const xCoordinates of xSequences) {
+    for (const yCoordinates of ySequences) {
+      const axisRatio = Math.max(
+        xCoordinates.length / yCoordinates.length,
+        yCoordinates.length / xCoordinates.length,
+      )
+      if (axisRatio > MAX_AXIS_RATIO) continue
+
+      const grid = xCoordinates.flatMap((x) =>
+        yCoordinates.flatMap((y) => {
+          const obstacle = obstacleByCoordinate.get(
+            `${coordinateKey(x)}:${coordinateKey(y)}`,
+          )
+          return obstacle ? [obstacle] : []
+        }),
+      )
+
+      if (
+        grid.length === xCoordinates.length * yCoordinates.length &&
+        grid.length > largestGrid.length
+      ) {
+        largestGrid = grid
+      }
+    }
+  }
+
+  return largestGrid
+}
+
+function findNestedBgaObstacles({
+  inputSrj,
+  excludedComponentIds,
+}: {
+  inputSrj: SimpleRouteJson
+  excludedComponentIds: ReadonlySet<string>
+}): Array<{ componentId: string; obstacles: Obstacle[] }> {
+  const obstaclesByComponent = new Map<string, Obstacle[]>()
+
+  for (const obstacle of inputSrj.obstacles) {
+    if (
+      !obstacle.componentId ||
+      excludedComponentIds.has(obstacle.componentId)
+    ) {
+      continue
+    }
+    const componentObstacles =
+      obstaclesByComponent.get(obstacle.componentId) ?? []
+    componentObstacles.push(obstacle)
+    obstaclesByComponent.set(obstacle.componentId, componentObstacles)
+  }
+
+  return [...obstaclesByComponent.entries()].flatMap(
+    ([componentId, componentObstacles]) => {
+      const obstaclesByPadGeometry = new Map<string, Obstacle[]>()
+      for (const obstacle of componentObstacles) {
+        const geometryKey = [
+          coordinateKey(obstacle.width),
+          coordinateKey(obstacle.height),
+          obstacle.layers.join(","),
+        ].join(":")
+        const matchingObstacles =
+          obstaclesByPadGeometry.get(geometryKey) ?? []
+        matchingObstacles.push(obstacle)
+        obstaclesByPadGeometry.set(geometryKey, matchingObstacles)
+      }
+
+      const nestedGrid = [...obstaclesByPadGeometry.values()].reduce(
+        (largest, obstacles) => {
+          const candidate = findLargestCompleteGrid(obstacles)
+          return candidate.length > largest.length ? candidate : largest
+        },
+        [] as Obstacle[],
+      )
+
+      return nestedGrid.length > 0 &&
+        nestedGrid.length < componentObstacles.length
+        ? [{ componentId, obstacles: nestedGrid }]
+        : []
+    },
+  )
+}
+
+export function findNestedBgaTopologyComponents({
+  inputSrj,
+  excludedComponentIds,
+}: {
+  inputSrj: SimpleRouteJson
+  excludedComponentIds: ReadonlySet<string>
+}): SerializedTopologyComponentInput[] {
+  return findNestedBgaObstacles({ inputSrj, excludedComponentIds }).map(
+    ({ componentId, obstacles }, index) => {
+      const bounds = getBoundsForObstacles(obstacles)
+      const nestedComponentId = `${componentId}__nested_bga_${index}`
+      const zLayers = Array.from({ length: inputSrj.layerCount }, (_, z) => z)
+
+      return {
+        componentId: nestedComponentId,
+        componentKind: "bga",
+        memberObstacleIds: obstacles.map(getTopologyObstacleKey),
+        memberObstacles: obstacles,
+        replacementObstacle: {
+          obstacleId: `${nestedComponentId}_bounds`,
+          componentId: nestedComponentId,
+          type: "rect",
+          layers: zLayers.map((z) =>
+            mapZToLayerName(z, inputSrj.layerCount),
+          ),
+          __zLayers: zLayers,
+          center: {
+            x: (bounds.minX + bounds.maxX) / 2,
+            y: (bounds.minY + bounds.maxY) / 2,
+          },
+          width: bounds.maxX - bounds.minX,
+          height: bounds.maxY - bounds.minY,
+          connectedTo: [
+            ...new Set(obstacles.flatMap((obstacle) => obstacle.connectedTo)),
+          ],
+        },
+      }
+    },
+  )
+}

--- a/lib/solvers/TopologyPlanningSolver/topologyPlanningShared.ts
+++ b/lib/solvers/TopologyPlanningSolver/topologyPlanningShared.ts
@@ -27,6 +27,10 @@ import type {
   MultiGraphTopologyPlannerSolverParams,
   SerializedTopologyComponentInput,
 } from "./MultiGraphTopologyPlannerSolver"
+import {
+  findNestedBgaTopologyComponents,
+  getTopologyObstacleKey,
+} from "./find-nested-bga-topology-components"
 
 export interface NormalizedTopologyPlannerInput {
   globalNoConnectionSrj: SimpleRouteJson
@@ -105,7 +109,14 @@ export function createComponentSrj({
     .filter((obstacle) =>
       doBoundsOverlap(getBoundingBox(obstacle), componentBounds),
     )
-    .map((obstacle) => ({ ...obstacle }))
+    .map((obstacle) => ({
+      ...obstacle,
+      ...(component.memberObstacleIds.includes(
+        getTopologyObstacleKey(obstacle),
+      )
+        ? { componentId: component.componentId }
+        : {}),
+    }))
 
   return {
     ...structuredClone(inputSrj),
@@ -123,7 +134,18 @@ export function normalizeInput(
     detectedComponents,
     inputSrj: input.inputSrj,
   })
-  const globalNoConnectionSrj =
+  const nestedBgaComponents =
+    input.components === undefined &&
+    input.globalNoConnectionSrj === undefined &&
+    input.brokenSrj === undefined
+      ? findNestedBgaTopologyComponents({
+          inputSrj: input.inputSrj,
+          excludedComponentIds: new Set(
+            detectedComponents.map((component) => component.componentId),
+          ),
+        })
+      : []
+  const baseGlobalNoConnectionSrj =
     input.globalNoConnectionSrj ??
     (detectedComponents.length > 0
       ? createComponentObstacleSrj({
@@ -132,11 +154,28 @@ export function normalizeInput(
         })
       : input.inputSrj) ??
     input.brokenSrj?.componentsAsObstaclesSrj
-  const components =
-    input.components ??
-    serializedDetectedComponents ??
-    input.brokenSrj?.components ??
-    []
+  const nestedMemberObstacleIds = new Set(
+    nestedBgaComponents.flatMap((component) => component.memberObstacleIds),
+  )
+  const globalNoConnectionSrj =
+    nestedBgaComponents.length === 0
+      ? baseGlobalNoConnectionSrj
+      : {
+          ...baseGlobalNoConnectionSrj,
+          obstacles: [
+            ...baseGlobalNoConnectionSrj.obstacles.filter(
+              (obstacle) =>
+                !nestedMemberObstacleIds.has(getTopologyObstacleKey(obstacle)),
+            ),
+            ...nestedBgaComponents.map(
+              (component) => component.replacementObstacle,
+            ),
+          ],
+        }
+  const components = input.components ?? [
+    ...serializedDetectedComponents,
+    ...nestedBgaComponents,
+  ]
 
   if (!globalNoConnectionSrj) {
     throw new Error(

--- a/lib/types/capacity-mesh-types.ts
+++ b/lib/types/capacity-mesh-types.ts
@@ -33,6 +33,7 @@ export interface CapacityMeshNode {
   _isNarrowQfpPadGap?: boolean
   _soicRegionType?: "center" | "pad" | "pad-gap"
   _isComponentTopologyNode?: boolean
+  _isViaAccess?: boolean
   _connectedTo?: string[]
 
   _parent?: CapacityMeshNode

--- a/tests/features/topology/large-graph-connection-order.test.ts
+++ b/tests/features/topology/large-graph-connection-order.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test"
+import { orderLargeGraphConnections } from "lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver"
+
+function createConnection(
+  connectionId: string,
+  mutuallyConnectedNetworkId: string,
+  end: { x: number; y: number; layer: string },
+) {
+  return {
+    connectionId,
+    mutuallyConnectedNetworkId,
+    startRegion: {},
+    endRegion: {},
+    simpleRouteConnection: {
+      name: connectionId,
+      pointsToConnect: [
+        { x: 0, y: 0, layer: "top" },
+        end,
+      ],
+    },
+  }
+}
+
+test("orders larger nets first and cross-layer routes first within each net", () => {
+  const smallNet = createConnection("small-net", "net-b", {
+    x: 0.1,
+    y: 0,
+    layer: "top",
+  })
+  const sameLayer = createConnection("same-layer", "net-a", {
+    x: 1,
+    y: 0,
+    layer: "top",
+  })
+  const crossLayer = createConnection("cross-layer", "net-a", {
+    x: 10,
+    y: 0,
+    layer: "bottom",
+  })
+
+  const ordered = orderLargeGraphConnections([
+    sameLayer,
+    smallNet,
+    crossLayer,
+  ] as any)
+
+  expect(ordered.map((connection) => connection.connectionId)).toEqual([
+    "cross-layer",
+    "same-layer",
+    "small-net",
+  ])
+})

--- a/tests/features/topology/nested-bga-topology.test.ts
+++ b/tests/features/topology/nested-bga-topology.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test"
+import { findNestedBgaTopologyComponents } from "lib/solvers/TopologyPlanningSolver/find-nested-bga-topology-components"
+import { createComponentSrj } from "lib/solvers/TopologyPlanningSolver/topologyPlanningShared"
+import type { Obstacle, SimpleRouteJson } from "lib/types"
+
+const createPad = (
+  obstacleId: string,
+  x: number,
+  y: number,
+): Obstacle => ({
+  obstacleId,
+  componentId: "U1",
+  type: "rect",
+  layers: ["top"],
+  center: { x, y },
+  width: 0.2,
+  height: 0.2,
+  connectedTo: [],
+})
+
+test("uses a complete pad grid inside a mixed component as BGA topology", () => {
+  const grid = Array.from({ length: 25 }, (_, index) =>
+    createPad(`grid-${index}`, index % 5, Math.floor(index / 5)),
+  )
+  const perimeter = Array.from({ length: 7 }, (_, index) =>
+    createPad(`edge-${index}`, index * 0.46 - 1, -2),
+  )
+  const inputSrj: SimpleRouteJson = {
+    layerCount: 4,
+    minTraceWidth: 0.1,
+    obstacles: [...grid, ...perimeter],
+    connections: [],
+    bounds: { minX: -3, maxX: 7, minY: -3, maxY: 7 },
+  }
+
+  const [component] = findNestedBgaTopologyComponents({
+    inputSrj,
+    excludedComponentIds: new Set(),
+  })
+
+  expect(component?.componentKind).toBe("bga")
+  expect(component?.memberObstacleIds).toHaveLength(25)
+  const componentSrj = createComponentSrj({
+    inputSrj,
+    component: component!,
+  })
+  expect(
+    componentSrj.obstacles.filter(
+      (obstacle) => obstacle.componentId === component!.componentId,
+    ),
+  ).toHaveLength(25)
+})

--- a/tests/features/topology/target-via-access-layers.test.ts
+++ b/tests/features/topology/target-via-access-layers.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "bun:test"
+import {
+  addTargetViaAccessLayers,
+  hasViaAccessOverlap,
+} from "lib/solvers/NodeDimensionSubdivisionSolver/add-target-via-access-layers"
+import type { CapacityMeshNode } from "lib/types"
+
+function createNode(
+  capacityMeshNodeId: string,
+  availableZ: number[],
+  overrides: Partial<CapacityMeshNode>,
+): CapacityMeshNode {
+  return {
+    capacityMeshNodeId,
+    center: { x: 0, y: 0 },
+    width: 0.4,
+    height: 0.4,
+    layer: `z${availableZ.join(",")}`,
+    availableZ,
+    ...overrides,
+  }
+}
+
+test("promotes physically overlapping target and free regions to via-access layers", () => {
+  const nodes = [
+    createNode("target-top", [0], {
+      _containsTarget: true,
+      _containsObstacle: true,
+      _connectedTo: ["net-1"],
+    }),
+    createNode("target-bottom", [1], {
+      _containsTarget: true,
+      _containsObstacle: true,
+      _connectedTo: ["net-1"],
+    }),
+    createNode("free-top", [0], {}),
+    createNode("free-bottom", [1], {}),
+  ]
+
+  const stats = addTargetViaAccessLayers({
+    nodes,
+    layerCount: 2,
+    viaDiameter: 0.3,
+    componentBounds: [{ minX: -1, maxX: 1, minY: -1, maxY: 1 }],
+  })
+
+  expect(stats).toEqual({
+    expandedTargetNodeCount: 2,
+    freeViaPortalNodeCount: 2,
+  })
+  expect(nodes.every((node) => node.availableZ.join(",") === "0,1")).toBe(true)
+  expect(hasViaAccessOverlap(nodes[0]!, nodes[2]!, 0.3)).toBe(true)
+})


### PR DESCRIPTION
## What changed

- Detect a complete nested BGA pad grid inside a mixed component and plan that grid as component-local topology.
- Preserve physically valid, via-sized cross-layer access between dense-component target and free capacity regions.
- For hypergraphs with at least 500 connections, route cross-layer pairs first within each net and use a stronger A* heuristic.

## Root cause

SRJ24 sample 4 contains a complete 13x13 BGA grid inside a 337-pad mixed component. Whole-component BGA detection rejects that component because of its additional perimeter pads, so the global topology reserved the BGA area without generating a legal component-local escape topology. After recognizing the nested grid, dense target/free regions still retained disjoint layer availability even where a via physically fits. Once those topology problems were fixed, the resulting 841-route hypergraph needed cross-layer routes prioritized to finish within the existing effort-1 iteration cap.

## Scope and impact

- Nested-grid detection requires a complete rectangular grid with at least 5 positions per axis.
- Via-access promotion is restricted to undetected compact components with at least 90 pads and a maximum 1.5 aspect ratio, and only applies where a via-sized physical overlap exists.
- The routing policy change applies only to graphs with at least 500 connections.
- No terminal normalization, route stitching, or high-density solver behavior is changed.
- No snapshots are changed.

Compared with the superseded broad approach, this PR is reduced from 42 files / 4,264 additions to 12 files / 719 additions.

## Verification

- `bun run build`
- `bun test tests/features/topology/nested-bga-topology.test.ts tests/features/topology/target-via-access-layers.test.ts tests/features/topology/large-graph-connection-order.test.ts tests/node-dimension-subdivision-solver.test.ts tests/node-dimension-subdivision-connectivity-bridge.test.ts --timeout 9999999`
- Pipeline7, SRJ24 sample 4, effort 1: `Success: yes` on latest main; pathing, high-density routing, stitching, and exact DRC stages completed.
- Pipeline7, SRJ24 sample 2, effort 1: `Success: yes`; the former duplicate `pcb_port_118` stitching failure is absent.
- Pipeline7, SRJ18 sample 3, effort 1: `Success: yes`; the former unknown `pcb_port_50` stitching failure is absent.
- Pipeline7, SRJ18 sample 6, effort 1: pathing and stitching complete; the former large-problem iteration exhaustion is absent. The full runner also completed successfully before rebasing onto main's newly pinned exact-DRC repair.

Relaxed DRC remains failing for these benchmark outputs, as it does for the other solved SRJ24 scenarios; this PR fixes solver completion, not DRC quality.
