### PR TITLE
Fix PR benchmark main baseline lookup

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -375,7 +375,7 @@ jobs:
           BENCHMARK_SAMPLE_TIMEOUT_BASE_MS: ${{ vars.BENCHMARK_TASK_TIMEOUT_PER_EFFORT_MS || vars.BENCHMARK_TASK_TIMEOUT_MS || '60000' }}
           BENCHMARK_HEARTBEAT_INTERVAL_MS: ${{ vars.BENCHMARK_HEARTBEAT_INTERVAL_MS || '30000' }}
           BENCHMARK_TERMINATE_TIMEOUT_MS: ${{ vars.BENCHMARK_TERMINATE_TIMEOUT_MS || '1000' }}
-          BENCHMARK_MAIN_DATASETS: ${{ steps.main-datasets.outputs.datasets_json }}
+          BENCHMARK_MAIN_DATASETS: ${{ steps.main-datasets.outputs.datasets_json || '[]' }}
           BENCHMARK_REPOSITORY: ${{ github.repository }}
           BENCHMARK_WORKFLOW_NAME: ${{ github.workflow }}
           BENCHMARK_EVENT_NAME: ${{ github.event_name }}
@@ -439,7 +439,7 @@ jobs:
           NODE
 
       - name: Download main branch benchmark result
-        if: github.event_name == 'workflow_dispatch' && inputs.pr_number != ''
+        if: always() && github.event_name == 'workflow_dispatch' && inputs.pr_number != ''
         env:
           GH_TOKEN: ${{ secrets.TSCIRCUIT_BOT_GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary

- provide an explicit empty main-dataset list when PR benchmarks run through `workflow_dispatch`
- download the available main benchmark artifact even if an earlier workflow step fails

## Root cause

[PR #1743](https://github.com/tscircuit/tscircuit-autorouter/pull/1743) added raw benchmark metadata that requires `BENCHMARK_MAIN_DATASETS`. The dataset-loading step only runs for pushes to `main`, so PR-dispatched benchmarks received an empty value and failed before the existing main-artifact download step. Result comments then incorrectly reported that no previous main run was available.

## Impact

`/benchmark` and `/benchmark-all` PR runs can complete metadata generation and display the matching dataset from the latest successful main benchmark artifact. This changes workflow plumbing only; benchmark and solver behavior are unchanged.

## Validation

- validated metadata parsing with `workflow_dispatch` using `[]`
- validated metadata parsing with the full main dataset list
- `bun test tests/main-branch-benchmark-datasets.test.ts --timeout 9999999`
- `bun run build`
- parsed `.github/workflows/benchmark.yml` as YAML
- `git diff --check`