### PR TITLE
Add bus types to SimpleRouteJson

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ interface SimpleRouteJson {
   minTraceWidth: number
   obstacles: Obstacle[]
   connections: Array<SimpleRouteConnection>
+  buses?: Array<SimpleRouteBus>
   bounds: { minX: number; maxX: number; minY: number; maxY: number }
   traces?: SimplifiedPcbTraces // Optional for input
 }
@@ -79,7 +80,17 @@ interface SimpleRouteConnection {
   name: string
   pointsToConnect: Array<{ x: number; y: number; layer: string }>
 }
+
+interface SimpleRouteBus {
+  busId: string
+  connectionNames: string[] // Ordered SimpleRouteConnection names
+  maxLengthSkew?: number // Maximum routed-length difference in millimeters
+}
 ```
+
+`maxLengthSkew` records the maximum permitted routed-length difference for the
+bus. Bus metadata is preserved in the output so routing implementations can
+apply the constraint without losing the original membership or ordering.
 
 ### Output Format
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -72,6 +72,18 @@ export type {
   GlobalDrcBranchPortfolioSolverParams,
   GlobalDrcForceImproveSolverParams,
   HighDensityRoute,
+} from "high-density-repair03/lib"
+export type {
+  BusId,
+  ConnectionPoint,
+  DifferentialPair,
+  MultiLayerConnectionPoint,
+  Obstacle,
+  SimpleRouteBus,
+  SimpleRouteConnection,
   SimpleRouteJson,
   SimplifiedPcbTrace,
-} from "high-density-repair03/lib"
+  SimplifiedPcbTraces,
+  SingleLayerConnectionPoint,
+  TerminalViaHint,
+} from "./types/srj-types"

--- a/lib/types/srj-types.ts
+++ b/lib/types/srj-types.ts
@@ -55,9 +55,11 @@ export interface SimpleRouteJson {
   min_via_pad_diameter?: number
   defaultObstacleMargin?: number
   minTraceToPadEdgeClearance?: number
+  minViaEdgeToPadEdgeClearance?: number
   obstacles: Obstacle[]
   connections: Array<SimpleRouteConnection>
   differentialPairs?: Array<DifferentialPair>
+  buses?: Array<SimpleRouteBus>
   bounds: { minX: number; maxX: number; minY: number; maxY: number }
   outline?: Array<{ x: number; y: number }>
   traces?: SimplifiedPcbTraces
@@ -69,7 +71,15 @@ export interface SimpleRouteJson {
 
 export interface DifferentialPair {
   connectionNames: [string, string]
-  lengthTolerance: 0.1
+  lengthTolerance: number
+}
+
+export interface SimpleRouteBus {
+  busId: BusId
+  /** SimpleRouteJson connection names belonging to this bus, in bus order. */
+  connectionNames: string[]
+  /** Maximum permitted routed-length difference in millimeters. */
+  maxLengthSkew?: number
 }
 
 export interface Obstacle {
@@ -78,6 +88,9 @@ export interface Obstacle {
   componentId?: string
   type: "rect"
   layers: string[]
+  /** Public z-layer indexes supplied by SimpleRouteJson producers. */
+  zLayers?: number[]
+  /** Canonicalized z-layer indexes used by autorouter internals. */
   __zLayers?: number[]
   center: { x: number; y: number }
   width: number
@@ -92,8 +105,11 @@ export interface Obstacle {
 
 export interface SimpleRouteConnection {
   name: string
+  rootConnectionName?: RootConnectionName
+  mergedConnectionNames?: string[]
   __rootConnectionNames?: string[]
   isOffBoard?: boolean
+  netConnectionName?: string
   __netConnectionName?: string
   nominalTraceWidth?: number
   pointsToConnect: Array<ConnectionPoint>
@@ -114,6 +130,8 @@ export interface SimplifiedPcbTrace {
         y: number
         width: number
         layer: string
+        start_pcb_port_id?: string
+        end_pcb_port_id?: string
       }
     | {
         route_type: "via"

--- a/lib/utils/create-srj-with-board-valid-obstacle-layers.ts
+++ b/lib/utils/create-srj-with-board-valid-obstacle-layers.ts
@@ -10,7 +10,7 @@ function getObstacleZLayersOnBoard(
   layerCount: number,
 ): number[] {
   const explicitZLayers = getUniqueValidZLayers(
-    obstacle.__zLayers ?? [],
+    obstacle.__zLayers ?? obstacle.zLayers ?? [],
     layerCount,
   )
   if (explicitZLayers.length > 0) return explicitZLayers
@@ -35,6 +35,7 @@ function createObstacleWithBoardValidLayers(
   return {
     ...obstacle,
     layers: zLayers.map((z) => mapZToLayerName(z, layerCount)),
+    zLayers,
     __zLayers: zLayers,
   }
 }

--- a/tests/features/simple-route-json-bus-types.test.ts
+++ b/tests/features/simple-route-json-bus-types.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test"
+import { PreprocessSimpleRouteJsonSolver } from "lib/autorouter-pipelines/AutoroutingPipeline4_TinyHypergraph/PreprocessSimpleRouteJsonSolver"
+import type { SimpleRouteJson } from "lib"
+
+test("preserves SimpleRouteJson bus metadata during preprocessing", () => {
+  const srj: SimpleRouteJson = {
+    layerCount: 2,
+    minTraceWidth: 0.1,
+    obstacles: [],
+    connections: [
+      {
+        name: "data0",
+        pointsToConnect: [
+          { x: -1, y: 0, layer: "top" },
+          { x: 1, y: 0, layer: "top" },
+        ],
+      },
+      {
+        name: "data1",
+        pointsToConnect: [
+          { x: -1, y: 1, layer: "top" },
+          { x: 1, y: 1, layer: "top" },
+        ],
+      },
+    ],
+    buses: [
+      {
+        busId: "data",
+        connectionNames: ["data0", "data1"],
+        maxLengthSkew: 0.1,
+      },
+    ],
+    bounds: { minX: -2, minY: -2, maxX: 2, maxY: 2 },
+  }
+  const solver = new PreprocessSimpleRouteJsonSolver(srj)
+
+  solver.solve()
+
+  expect(solver.getOutputSimpleRouteJson().buses).toEqual(srj.buses)
+})

--- a/tests/utils/layer-count-normalization.test.ts
+++ b/tests/utils/layer-count-normalization.test.ts
@@ -35,5 +35,14 @@ test("normalizes obstacle layers to the board layer count", (): void => {
     createSrjWithBoardValidObstacleLayers(srj).obstacles[0]!
 
   expect(outputObstacle.layers).toEqual(["top", "bottom"])
+  expect(outputObstacle.zLayers).toEqual([0, 1])
   expect(outputObstacle.__zLayers).toEqual([0, 1])
+
+  const explicitZLayerObstacle = createSrjWithBoardValidObstacleLayers({
+    ...srj,
+    obstacles: [{ ...obstacle, layers: ["top"], zLayers: [0, 1] }],
+  }).obstacles[0]!
+
+  expect(explicitZLayerObstacle.layers).toEqual(["top", "bottom"])
+  expect(explicitZLayerObstacle.__zLayers).toEqual([0, 1])
 })


### PR DESCRIPTION
## Summary

- make `lib/types/srj-types.ts` the canonical public source for the SimpleRouteJson type family
- stop re-exporting or intersecting SimpleRouteJson and SimplifiedPcbTrace from `high-density-repair03`
- preserve the previously exposed SRJ surface locally, including `zLayers`, connection root metadata, via-to-pad clearance, and terminal wire port IDs
- normalize public `zLayers` into the autorouter's internal `__zLayers` representation
- add a `SimpleRouteBus` type with `busId`, ordered `connectionNames`, and optional `maxLengthSkew`
- verify public bus metadata survives preprocessing

```ts
buses: [
  {
    busId: "data",
    connectionNames: ["data0", "data1", "data2"],
    maxLengthSkew: 0.1,
  },
]
```

## Ownership

`@tscircuit/capacity-autorouter` now defines and exports its own SRJ types. `high-density-repair03` remains an implementation dependency for DRC repair, but it no longer supplies the autorouter package's public SimpleRouteJson definition.

## Scope

This PR proposes the SRJ representation only. It does not add bus length-matching behavior, change routing, or alter via-in-pad defaults.

## Validation

- `bun run build`
- `bun run format:check`
- `bun test tests/features/simple-route-json-bus-types.test.ts tests/utils/layer-count-normalization.test.ts`

All checks pass locally.