### PR TITLE
Make via-in-pad repair opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ interface SimpleRouteJson {
   minTraceWidth: number
   obstacles: Obstacle[]
   connections: Array<SimpleRouteConnection>
+  allowViaInPad?: boolean // Defaults to false
   bounds: { minX: number; maxX: number; minY: number; maxY: number }
   traces?: SimplifiedPcbTraces // Optional for input
 }
@@ -80,6 +81,10 @@ interface SimpleRouteConnection {
   pointsToConnect: Array<{ x: number; y: number; layer: string }>
 }
 ```
+
+Via-in-pad is disabled by default because it normally requires filled and
+capped vias. Set `allowViaInPad: true` only when the selected fabrication
+process supports it.
 
 ### Output Format
 

--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -45,6 +45,7 @@ import {
 import { getPresuppliedTraceVisualization } from "lib/utils/getPresuppliedTraceVisualization"
 import { calculateOptimalCapacityDepth } from "lib/utils/getTunedTotalCapacity1"
 import { getViaDimensions } from "lib/utils/getViaDimensions"
+import { isViaInPadEnabled } from "lib/utils/isViaInPadEnabled"
 import {
   AvailableSegmentPointSolver,
   type SharedEdgeSegment,
@@ -689,7 +690,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
             enableLargeBoardBroadFallback: false,
             enableTargetedErrorSweep: true,
             enablePostSolveClearanceRelaxation: false,
-            enableViaInPadLayerMoves: true,
+            enableViaInPadLayerMoves: isViaInPadEnabled(cms.originalSrj),
             viaInPadMaxIterations: 32,
             broadMaxIterations: 8,
             broadPassMultiplier: 3,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -72,6 +72,17 @@ export type {
   GlobalDrcBranchPortfolioSolverParams,
   GlobalDrcForceImproveSolverParams,
   HighDensityRoute,
+} from "high-density-repair03/lib"
+export type {
+  BusId,
+  ConnectionPoint,
+  DifferentialPair,
+  MultiLayerConnectionPoint,
+  Obstacle,
+  SimpleRouteConnection,
   SimpleRouteJson,
   SimplifiedPcbTrace,
-} from "high-density-repair03/lib"
+  SimplifiedPcbTraces,
+  SingleLayerConnectionPoint,
+  TerminalViaHint,
+} from "./types/srj-types"

--- a/lib/types/srj-types.ts
+++ b/lib/types/srj-types.ts
@@ -55,9 +55,16 @@ export interface SimpleRouteJson {
   min_via_pad_diameter?: number
   defaultObstacleMargin?: number
   minTraceToPadEdgeClearance?: number
+  minViaEdgeToPadEdgeClearance?: number
   obstacles: Obstacle[]
   connections: Array<SimpleRouteConnection>
   differentialPairs?: Array<DifferentialPair>
+  /**
+   * Allows DRC repair to place layer transitions at terminal pad centers.
+   * Defaults to false because via-in-pad requires a fabrication process that
+   * explicitly supports filled and capped vias.
+   */
+  allowViaInPad?: boolean
   bounds: { minX: number; maxX: number; minY: number; maxY: number }
   outline?: Array<{ x: number; y: number }>
   traces?: SimplifiedPcbTraces
@@ -69,7 +76,7 @@ export interface SimpleRouteJson {
 
 export interface DifferentialPair {
   connectionNames: [string, string]
-  lengthTolerance: 0.1
+  lengthTolerance: number
 }
 
 export interface Obstacle {
@@ -78,6 +85,9 @@ export interface Obstacle {
   componentId?: string
   type: "rect"
   layers: string[]
+  /** Public z-layer indexes supplied by SimpleRouteJson producers. */
+  zLayers?: number[]
+  /** Canonicalized z-layer indexes used by autorouter internals. */
   __zLayers?: number[]
   center: { x: number; y: number }
   width: number
@@ -92,8 +102,11 @@ export interface Obstacle {
 
 export interface SimpleRouteConnection {
   name: string
+  rootConnectionName?: RootConnectionName
+  mergedConnectionNames?: string[]
   __rootConnectionNames?: string[]
   isOffBoard?: boolean
+  netConnectionName?: string
   __netConnectionName?: string
   nominalTraceWidth?: number
   pointsToConnect: Array<ConnectionPoint>
@@ -114,6 +127,8 @@ export interface SimplifiedPcbTrace {
         y: number
         width: number
         layer: string
+        start_pcb_port_id?: string
+        end_pcb_port_id?: string
       }
     | {
         route_type: "via"

--- a/lib/utils/create-srj-with-board-valid-obstacle-layers.ts
+++ b/lib/utils/create-srj-with-board-valid-obstacle-layers.ts
@@ -10,7 +10,7 @@ function getObstacleZLayersOnBoard(
   layerCount: number,
 ): number[] {
   const explicitZLayers = getUniqueValidZLayers(
-    obstacle.__zLayers ?? [],
+    obstacle.__zLayers ?? obstacle.zLayers ?? [],
     layerCount,
   )
   if (explicitZLayers.length > 0) return explicitZLayers
@@ -35,6 +35,7 @@ function createObstacleWithBoardValidLayers(
   return {
     ...obstacle,
     layers: zLayers.map((z) => mapZToLayerName(z, layerCount)),
+    zLayers,
     __zLayers: zLayers,
   }
 }

--- a/lib/utils/isViaInPadEnabled.ts
+++ b/lib/utils/isViaInPadEnabled.ts
@@ -1,0 +1,5 @@
+import type { SimpleRouteJson } from "lib/types"
+
+/** Via-in-pad is an explicit fabrication opt-in, never an automatic repair. */
+export const isViaInPadEnabled = (srj: SimpleRouteJson) =>
+  srj.allowViaInPad ?? false

--- a/tests/features/via-in-pad-default.test.ts
+++ b/tests/features/via-in-pad-default.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "bun:test"
+import type { SimpleRouteJson } from "lib"
+import { isViaInPadEnabled } from "lib/utils/isViaInPadEnabled"
+
+const baseSrj: SimpleRouteJson = {
+  layerCount: 2,
+  minTraceWidth: 0.1,
+  obstacles: [],
+  connections: [],
+  bounds: { minX: -1, minY: -1, maxX: 1, maxY: 1 },
+}
+
+test("requires SimpleRouteJson to explicitly enable via-in-pad repair", () => {
+  expect(isViaInPadEnabled(baseSrj)).toBe(false)
+  expect(isViaInPadEnabled({ ...baseSrj, allowViaInPad: false })).toBe(false)
+  expect(isViaInPadEnabled({ ...baseSrj, allowViaInPad: true })).toBe(true)
+})

--- a/tests/utils/layer-count-normalization.test.ts
+++ b/tests/utils/layer-count-normalization.test.ts
@@ -35,5 +35,14 @@ test("normalizes obstacle layers to the board layer count", (): void => {
     createSrjWithBoardValidObstacleLayers(srj).obstacles[0]!
 
   expect(outputObstacle.layers).toEqual(["top", "bottom"])
+  expect(outputObstacle.zLayers).toEqual([0, 1])
   expect(outputObstacle.__zLayers).toEqual([0, 1])
+
+  const explicitZLayerObstacle = createSrjWithBoardValidObstacleLayers({
+    ...srj,
+    obstacles: [{ ...obstacle, layers: ["top"], zLayers: [0, 1] }],
+  }).obstacles[0]!
+
+  expect(explicitZLayerObstacle.layers).toEqual(["top", "bottom"])
+  expect(explicitZLayerObstacle.__zLayers).toEqual([0, 1])
 })


### PR DESCRIPTION
## Summary

- make `lib/types/srj-types.ts` the canonical public source for the SimpleRouteJson type family
- stop re-exporting or intersecting SimpleRouteJson and SimplifiedPcbTrace from `high-density-repair03`
- preserve the previously exposed SRJ surface locally and normalize public `zLayers` for internal routing
- add `allowViaInPad?: boolean` directly to the autorouter-owned SimpleRouteJson type
- default the setting to `false`
- enable Pipeline 7's terminal-pad layer moves only when `allowViaInPad: true` is supplied
- document the fabrication implication and add regression coverage

## Root cause

Pipeline 7 unconditionally passed `enableViaInPadLayerMoves: true` to the final DRC branch portfolio. That repair moves a surface route onto another layer and places the transitions at its terminal pad centers, which can silently require a filled-and-capped via-in-pad process.

## Dataset verification

On the same 64-connection BGA routing input:

- prior captured output: 137 vias, 34 geometrically inside pad rectangles
- default with this change: 125 vias, 0 inside pad rectangles

Ordinary escape vias remain available; only terminal-pad transitions require explicit opt-in.

## Ownership and scope

`@tscircuit/capacity-autorouter` owns the exported SRJ definitions in this PR; `repair03` is only an implementation dependency. This PR contains no bus schema or bus length-matching changes.

## Validation

- `bun run build`
- `bun run format:check`
- `bun test tests/features/via-in-pad-default.test.ts tests/bugs/bugreport52-a9573e.test.ts tests/utils/layer-count-normalization.test.ts`
- end-to-end Pipeline 7 run on the 64-connection BGA input

All checks pass locally.