### PR TITLE
fix: keep the widest nominalTraceWidth when merging connections (#1721)

### DIFF
--- a/lib/solvers/NetToPointPairsSolver/mergeConnections.ts
+++ b/lib/solvers/NetToPointPairsSolver/mergeConnections.ts
@@ -134,7 +134,10 @@ export function mergeConnections(
         nominalTraceWidth =
           nominalTraceWidth === undefined
             ? simpleRouteConnection.nominalTraceWidth
-            : Math.max(nominalTraceWidth, simpleRouteConnection.nominalTraceWidth)
+            : Math.max(
+                nominalTraceWidth,
+                simpleRouteConnection.nominalTraceWidth,
+              )
       }
     })
 

--- a/lib/solvers/NetToPointPairsSolver/mergeConnections.ts
+++ b/lib/solvers/NetToPointPairsSolver/mergeConnections.ts
@@ -125,13 +125,16 @@ export function mergeConnections(
         mergedNetConnectionNames.add(simpleRouteConnection.__netConnectionName)
       }
 
-      // Take the nominalTraceWidth from the first connection for now
-      // A more robust solution might average or pick the max/min based on context
-      if (
-        nominalTraceWidth === undefined &&
-        simpleRouteConnection.nominalTraceWidth !== undefined
-      ) {
-        nominalTraceWidth = simpleRouteConnection.nominalTraceWidth
+      // Keep the widest requested nominalTraceWidth across the merged group.
+      // These widths are minimum requirements (e.g. a 1mm motor output), so
+      // taking the first one found would silently drop a wider requirement
+      // whenever it merged with a thinner branch on the same net, and would
+      // make the result depend on connection order.
+      if (simpleRouteConnection.nominalTraceWidth !== undefined) {
+        nominalTraceWidth =
+          nominalTraceWidth === undefined
+            ? simpleRouteConnection.nominalTraceWidth
+            : Math.max(nominalTraceWidth, simpleRouteConnection.nominalTraceWidth)
       }
     })
 
@@ -152,7 +155,7 @@ export function mergeConnections(
           ? Array.from(mergedNetConnectionNames).join("__") // Combine unique net connection names
           : undefined,
       __rootConnectionNames: Array.from(mergedRootConnectionNames),
-      nominalTraceWidth: nominalTraceWidth, // Keep the first found nominalTraceWidth
+      nominalTraceWidth: nominalTraceWidth, // Widest requested width in the group
     }
 
     mergedSimpleRouteConnections.push(newSimpleRouteConnection)

--- a/tests/solvers/merge-connections-nominal-trace-width.test.ts
+++ b/tests/solvers/merge-connections-nominal-trace-width.test.ts
@@ -1,0 +1,126 @@
+import { expect, test } from "bun:test"
+import { mergeConnections } from "lib/solvers/NetToPointPairsSolver/mergeConnections"
+
+test("merging keeps the widest requested nominalTraceWidth", () => {
+  // A 1mm motor output merged with a thin branch on the same net. Taking the
+  // first value found would silently drop the 1mm requirement.
+  const connections = mergeConnections([
+    {
+      name: "thin_branch",
+      nominalTraceWidth: 0.15,
+      pointsToConnect: [
+        { x: 0, y: 0, layer: "top" },
+        { x: 1, y: 0, layer: "top" },
+      ],
+    },
+    {
+      name: "motor_output",
+      nominalTraceWidth: 1,
+      pointsToConnect: [
+        { x: 1, y: 0, layer: "top" },
+        { x: 2, y: 0, layer: "top" },
+      ],
+    },
+  ])
+
+  expect(connections).toHaveLength(1)
+  expect(connections[0]?.nominalTraceWidth).toBe(1)
+})
+
+test("width is order independent when the wide connection comes first", () => {
+  const connections = mergeConnections([
+    {
+      name: "motor_output",
+      nominalTraceWidth: 1,
+      pointsToConnect: [
+        { x: 1, y: 0, layer: "top" },
+        { x: 2, y: 0, layer: "top" },
+      ],
+    },
+    {
+      name: "thin_branch",
+      nominalTraceWidth: 0.15,
+      pointsToConnect: [
+        { x: 0, y: 0, layer: "top" },
+        { x: 1, y: 0, layer: "top" },
+      ],
+    },
+  ])
+
+  expect(connections).toHaveLength(1)
+  expect(connections[0]?.nominalTraceWidth).toBe(1)
+})
+
+test("connections without a requested width stay undefined", () => {
+  const connections = mergeConnections([
+    {
+      name: "a",
+      pointsToConnect: [
+        { x: 0, y: 0, layer: "top" },
+        { x: 1, y: 0, layer: "top" },
+      ],
+    },
+    {
+      name: "b",
+      pointsToConnect: [
+        { x: 1, y: 0, layer: "top" },
+        { x: 2, y: 0, layer: "top" },
+      ],
+    },
+  ])
+
+  expect(connections).toHaveLength(1)
+  expect(connections[0]?.nominalTraceWidth).toBeUndefined()
+})
+
+test("a single requested width survives merging with unspecified branches", () => {
+  const connections = mergeConnections([
+    {
+      name: "unspecified",
+      pointsToConnect: [
+        { x: 0, y: 0, layer: "top" },
+        { x: 1, y: 0, layer: "top" },
+      ],
+    },
+    {
+      name: "power",
+      nominalTraceWidth: 0.8,
+      pointsToConnect: [
+        { x: 1, y: 0, layer: "top" },
+        { x: 2, y: 0, layer: "top" },
+      ],
+    },
+  ])
+
+  expect(connections).toHaveLength(1)
+  expect(connections[0]?.nominalTraceWidth).toBe(0.8)
+})
+
+test("separate nets keep their own widths", () => {
+  const connections = mergeConnections([
+    {
+      name: "motor",
+      nominalTraceWidth: 1,
+      pointsToConnect: [
+        { x: 0, y: 0, layer: "top" },
+        { x: 1, y: 0, layer: "top" },
+      ],
+    },
+    {
+      name: "signal",
+      nominalTraceWidth: 0.15,
+      pointsToConnect: [
+        { x: 5, y: 5, layer: "top" },
+        { x: 6, y: 5, layer: "top" },
+      ],
+    },
+  ])
+
+  expect(connections).toHaveLength(2)
+  expect(
+    connections.find((c) => c.name === "motor")?.nominalTraceWidth,
+  ).toBe(1)
+  expect(
+    connections.find((c) => c.name === "signal")?.nominalTraceWidth,
+  ).toBe(0.15)
+})

--- a/tests/solvers/merge-connections-nominal-trace-width.test.ts
+++ b/tests/solvers/merge-connections-nominal-trace-width.test.ts
@@ -117,10 +117,8 @@ test("separate nets keep their own widths", () => {
   ])
 
   expect(connections).toHaveLength(2)
-  expect(
-    connections.find((c) => c.name === "motor")?.nominalTraceWidth,
-  ).toBe(1)
-  expect(
-    connections.find((c) => c.name === "signal")?.nominalTraceWidth,
-  ).toBe(0.15)
+  expect(connections.find((c) => c.name === "motor")?.nominalTraceWidth).toBe(1)
+  expect(connections.find((c) => c.name === "signal")?.nominalTraceWidth).toBe(
+    0.15,
+  )
 })


### PR DESCRIPTION
Addresses the root cause behind #1721, where 1.0 mm motor traces were emitted at 0.15 mm.

### Root cause

`mergeConnections` merges every `SimpleRouteConnection` that shares a point into one connection, but it kept only the **first** `nominalTraceWidth` it happened to encounter:

```ts
// Take the nominalTraceWidth from the first connection for now
// A more robust solution might average or pick the max/min based on context
if (nominalTraceWidth === undefined && conn.nominalTraceWidth !== undefined) {
  nominalTraceWidth = conn.nominalTraceWidth
}
```

These widths are minimum requirements. When a 1 mm motor output merged with a thinner branch on the same net, whichever connection came first won — so the 1 mm requirement was silently dropped and the route fell back to the default width.

This also explains the otherwise puzzling detail in the report that the loss is *branch/merge dependent* rather than a global parsing failure: nets whose wide connection happened to be visited first kept 0.8 mm, and nets where a thin branch came first lost it. The outcome depended on connection order.

### Fix

Take the **maximum** requested width across the merged group, so a merge can never narrow a trace below what any member asked for. Connections that request nothing still merge to `undefined` and keep the existing default behavior.

### Tests

Added `tests/solvers/merge-connections-nominal-trace-width.test.ts` with 5 cases: widest-wins, order independence (the failing direction and the passing one), no-width-stays-undefined, a single width surviving merges with unspecified branches, and separate nets keeping their own widths.

The widest-wins case fails on `main` with `Expected: 1, Received: 0.15` and passes here.

### Verification

Full `bun test`: **411 pass / 13 fail**, versus **406 pass / 13 fail** on an unmodified checkout — same 13 pre-existing failures (bugreport fixtures hitting the 5 s timeout), plus the 5 new tests. No regressions.

Note this fixes width preservation through connection merging. If #1721 also involves width loss further down the pipeline (e.g. in `TraceWidthSolver` or HD route conversion), that would be a separate follow-up — happy to dig in if you can confirm from the gist data.