### PR TITLE
Add DRC-guarded trace simplifier

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -62,6 +62,11 @@ export { PortfolioSingleIntraNodeSolver } from "./solvers/HyperHighDensitySolver
 export { HyperSingleIntraNodeSolver } from "./solvers/HyperHighDensitySolver/HyperSingleIntraNodeSolver"
 export { GrowShrinkHighDensityIntraNodeSolver } from "./solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver"
 export {
+  DrcGuardedTraceSimplificationSolver,
+  type DrcGuardedTraceSimplificationDecision,
+  type DrcGuardedTraceSimplificationSolverParams,
+} from "./solvers/TraceSimplificationSolver/drc-guarded-trace-simplification-solver"
+export {
   GlobalDrcBranchPortfolioSolver,
   GlobalDrcForceImproveSolver,
 } from "high-density-repair03/lib"

--- a/lib/solvers/TraceSimplificationSolver/drc-guarded-trace-simplification-solver.ts
+++ b/lib/solvers/TraceSimplificationSolver/drc-guarded-trace-simplification-solver.ts
@@ -1,0 +1,93 @@
+import type {
+  DrcEvaluator,
+  DrcSnapshot,
+  SimpleRouteJson,
+} from "high-density-repair03/lib"
+import { getDrcSnapshot } from "high-density-repair03/lib/solvers/GlobalDrcForceImproveSolver/solverHelpers"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+import { TraceSimplificationSolver } from "./TraceSimplificationSolver"
+
+type TraceSimplificationSolverParams = ConstructorParameters<
+  typeof TraceSimplificationSolver
+>[0]
+
+export type DrcGuardedTraceSimplificationSolverParams =
+  TraceSimplificationSolverParams & {
+    readonly srj: SimpleRouteJson
+    readonly drcEvaluator: DrcEvaluator
+  }
+
+export type DrcGuardedTraceSimplificationDecision = {
+  accepted: boolean
+  inputDrc: DrcSnapshot
+  candidateDrc: DrcSnapshot
+}
+
+export class DrcGuardedTraceSimplificationSolver extends TraceSimplificationSolver {
+  readonly inputHdRoutes: HighDensityRoute[]
+  readonly drcSrj: SimpleRouteJson
+  readonly drcEvaluator: DrcEvaluator
+  readonly drcConnMap: TraceSimplificationSolverParams["connMap"]
+  decision?: DrcGuardedTraceSimplificationDecision
+
+  constructor(params: DrcGuardedTraceSimplificationSolverParams) {
+    const { srj, drcEvaluator, ...simplificationParams } = params
+    super(simplificationParams)
+    this.inputHdRoutes = structuredClone(Array.from(params.hdRoutes))
+    this.drcSrj = srj
+    this.drcEvaluator = drcEvaluator
+    this.drcConnMap = params.connMap
+  }
+
+  override getSolverName(): string {
+    return "DrcGuardedTraceSimplificationSolver"
+  }
+
+  override _step(): void {
+    super._step()
+    if (!this.solved || this.failed || this.decision) return
+
+    const candidateHdRoutes = this.simplifiedHdRoutes
+    const inputDrc = getDrcSnapshot(
+      this.drcSrj,
+      this.inputHdRoutes,
+      this.drcEvaluator,
+      this.drcConnMap,
+    )
+    const candidateDrc = getDrcSnapshot(
+      this.drcSrj,
+      candidateHdRoutes,
+      this.drcEvaluator,
+      this.drcConnMap,
+    )
+    const accepted =
+      candidateDrc.count < inputDrc.count ||
+      (candidateDrc.count === inputDrc.count &&
+        candidateDrc.issueScore <= inputDrc.issueScore)
+
+    this.decision = { accepted, inputDrc, candidateDrc }
+    if (!accepted) this.hdRoutes = this.inputHdRoutes
+    this.stats = {
+      drcGuardedSimplificationAccepted: accepted,
+      drcGuardedSimplificationInputIssueCount: inputDrc.count,
+      drcGuardedSimplificationCandidateIssueCount: candidateDrc.count,
+      drcGuardedSimplificationInputIssueScore: inputDrc.issueScore,
+      drcGuardedSimplificationCandidateIssueScore: candidateDrc.issueScore,
+      drcGuardedSimplificationInputViaCount: this.inputHdRoutes.reduce(
+        (count, route) => count + route.vias.length,
+        0,
+      ),
+      drcGuardedSimplificationCandidateViaCount: candidateHdRoutes.reduce(
+        (count, route) => count + route.vias.length,
+        0,
+      ),
+    }
+  }
+
+  getOutput(): HighDensityRoute[] {
+    if (!this.solved || this.failed || !this.decision) {
+      throw new Error("Cannot get DRC-guarded simplification output before solve")
+    }
+    return this.simplifiedHdRoutes
+  }
+}

--- a/tests/solvers/drc-guarded-trace-simplification.test.ts
+++ b/tests/solvers/drc-guarded-trace-simplification.test.ts
@@ -1,0 +1,82 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import type { DrcEvaluator, SimpleRouteJson } from "high-density-repair03/lib"
+import { DrcGuardedTraceSimplificationSolver } from "lib/solvers/TraceSimplificationSolver/drc-guarded-trace-simplification-solver"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+
+const srj: SimpleRouteJson = {
+  bounds: { minX: -2, minY: -2, maxX: 2, maxY: 2 },
+  connections: [
+    {
+      name: "editable",
+      pointsToConnect: [
+        { x: -1, y: 0, layer: "top" },
+        { x: 1, y: 0, layer: "top" },
+      ],
+    },
+  ],
+  obstacles: [],
+  layerCount: 2,
+  minTraceWidth: 0.15,
+  minViaDiameter: 0.3,
+}
+
+const routeWithRemovableVias: HighDensityRoute = {
+  connectionName: "editable",
+  traceThickness: 0.15,
+  viaDiameter: 0.3,
+  route: [
+    { x: -1, y: 0, z: 0 },
+    { x: -0.5, y: 0, z: 0 },
+    { x: -0.5, y: 0, z: 1 },
+    { x: 0.5, y: 0, z: 1 },
+    { x: 0.5, y: 0, z: 0 },
+    { x: 1, y: 0, z: 0 },
+  ],
+  vias: [
+    { x: -0.5, y: 0 },
+    { x: 0.5, y: 0 },
+  ],
+}
+
+const createSolver = (
+  drcEvaluator: DrcEvaluator,
+): DrcGuardedTraceSimplificationSolver =>
+  new DrcGuardedTraceSimplificationSolver({
+    hdRoutes: [structuredClone(routeWithRemovableVias)],
+    obstacles: [],
+    connMap: new ConnectivityMap({}),
+    colorMap: {},
+    defaultViaDiameter: 0.3,
+    layerCount: 2,
+    srj,
+    drcEvaluator,
+  })
+
+test("DRC-guarded simplification accepts safe via removal and rejects a DRC regression", () => {
+  const acceptingSolver = createSolver(() => [])
+  acceptingSolver.solve()
+
+  expect(acceptingSolver.failed).toBe(false)
+  expect(acceptingSolver.decision?.accepted).toBe(true)
+  expect(acceptingSolver.getOutput()[0]?.vias).toHaveLength(0)
+
+  const viaRemovalDrcEvaluator: DrcEvaluator = ({ routes }) => {
+    const vias = routes?.[0]?.vias ?? []
+    if (vias.length > 0) return []
+    return [
+      {
+        message: "The layer detour represented by these vias is required",
+        pcb_trace_id: "editable_0",
+      },
+    ]
+  }
+  const rejectingSolver = createSolver(viaRemovalDrcEvaluator)
+  rejectingSolver.solve()
+
+  expect(rejectingSolver.failed).toBe(false)
+  expect(rejectingSolver.decision?.inputDrc.count).toBe(0)
+  expect(rejectingSolver.decision?.candidateDrc.count).toBe(1)
+  expect(rejectingSolver.decision?.accepted).toBe(false)
+  expect(rejectingSolver.getOutput()).toEqual([routeWithRemovableVias])
+})


### PR DESCRIPTION
## Summary

- add `DrcGuardedTraceSimplificationSolver` as a small subclass of the existing trace simplifier
- evaluate the input and simplified candidate with the caller-provided DRC evaluator
- accept candidates with fewer DRC issues, or equal issue count with no higher issue score
- retain the original routes when simplification would regress DRC
- expose the decision, DRC snapshots, via-count stats, and solver types from the package entrypoint

## Why

Final DRC repair can introduce redundant geometry and vias after the normal simplification phase. Running the existing simplifier again can clean those up, but only if the result is checked against the same DRC used by repair. This is the reusable, pipeline-independent prerequisite for a small Pipeline9 wiring PR.

This PR intentionally does not change Pipeline7 or Pipeline9 phase ordering, so existing pipeline output remains unchanged.

## Validation

- `bun test --timeout 9999999 tests/solvers/drc-guarded-trace-simplification.test.ts tests/features/trace-simplification-immutable-routes.test.ts`
- targeted e2e3 and bugreport snapshot checks after confirming pipeline output is unchanged
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`

The new regression test proves both sides of the guard: safe removal of two redundant vias is accepted, while the same candidate is rejected when the DRC evaluator reports a new issue.