### PR TITLE
Make via-in-pad repair opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ interface SimpleRouteJson {
   obstacles: Obstacle[]
   connections: Array<SimpleRouteConnection>
   buses?: Array<SimpleRouteBus>
+  allowViaInPad?: boolean
   bounds: { minX: number; maxX: number; minY: number; maxY: number }
   traces?: SimplifiedPcbTraces // Optional for input
 }
@@ -91,6 +92,10 @@ interface SimpleRouteBus {
 `maxLengthSkew` records the maximum permitted routed-length difference for the
 bus. Bus metadata is preserved in the output so routing implementations can
 apply the constraint without losing the original membership or ordering.
+
+Via-in-pad repair is disabled by default because it generally requires filled
+and capped vias. Set `allowViaInPad: true` only when the fabrication process
+supports it.
 
 ### Output Format
 

--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -689,7 +689,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
             enableLargeBoardBroadFallback: false,
             enableTargetedErrorSweep: true,
             enablePostSolveClearanceRelaxation: false,
-            enableViaInPadLayerMoves: true,
+            enableViaInPadLayerMoves: cms.originalSrj.allowViaInPad ?? false,
             viaInPadMaxIterations: 32,
             broadMaxIterations: 8,
             broadPassMultiplier: 3,

--- a/lib/types/srj-types.ts
+++ b/lib/types/srj-types.ts
@@ -60,6 +60,11 @@ export interface SimpleRouteJson {
   connections: Array<SimpleRouteConnection>
   differentialPairs?: Array<DifferentialPair>
   buses?: Array<SimpleRouteBus>
+  /**
+   * Allows DRC repair to place layer transitions inside connected pads.
+   * Defaults to false because via-in-pad generally requires filled and capped vias.
+   */
+  allowViaInPad?: boolean
   bounds: { minX: number; maxX: number; minY: number; maxY: number }
   outline?: Array<{ x: number; y: number }>
   traces?: SimplifiedPcbTraces

--- a/tests/features/via-in-pad-opt-in.test.ts
+++ b/tests/features/via-in-pad-opt-in.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "bun:test"
+import * as dataset01 from "@tscircuit/autorouting-dataset-01"
+import { AutoroutingPipelineSolver7_MultiGraph } from "lib"
+import type { SimpleRouteJson } from "lib/types"
+
+const circuit003 = (dataset01 as Record<string, unknown>)
+  .circuit003 as SimpleRouteJson
+
+test("Pipeline 7 requires an explicit via-in-pad opt-in", () => {
+  for (const allowViaInPad of [undefined, false, true] as const) {
+    const input: SimpleRouteJson = {
+      ...structuredClone(circuit003),
+      allowViaInPad,
+    }
+    const solver = new AutoroutingPipelineSolver7_MultiGraph(input, {
+      cacheProvider: null,
+    })
+
+    solver.solve()
+
+    const [params] =
+      solver.exactGeometryDrcForceImproveSolver!.getConstructorParams()
+    expect(params.enableViaInPadLayerMoves).toBe(allowViaInPad ?? false)
+  }
+})


### PR DESCRIPTION
## Summary

- add optional `allowViaInPad` to the autorouter-owned `SimpleRouteJson` type
- pass the option to Pipeline 7's DRC repair solver, defaulting to `false` when omitted
- document the fabrication implication and add focused coverage for omitted, `false`, and `true` values

## Scope

This is intentionally limited to the autorouter SRJ type and the Pipeline 7 repair handoff. No `circuit-json` or `high-density-repair03` changes are needed; repair03 already exposes `enableViaInPadLayerMoves` with an off-by-default behavior.

The branch was created directly from current upstream `main` at `b31d5a115e78caca6fb76d7bcbd2eac4e23e29c2`.

## Validation

Local tests and benchmarks were not run at the author's request; GitHub CI will provide validation.

## Related

- tscircuit/props#759
- tscircuit/tscircuit-autorouter#1769