### PR TITLE
Cap Pipeline 7 exact DRC evaluations

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -686,6 +686,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
             drcEvaluator: relaxedDrcEvaluator,
             viaInPadDrcEvaluator: relaxedDrcEvaluator,
             maxIterations: 32,
+            maxCandidateEvaluations: 12,
             enableLargeBoardBroadFallback: false,
             enableTargetedErrorSweep: true,
             enablePostSolveClearanceRelaxation: false,

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "zdwiel-dataset": "git+https://github.com/dwiel/tscircuit-benchmark.git#be36518b5bf51755dae92c230061ab3cf4e3e063",
     "high-density-repair01": "git+https://github.com/tscircuit/high-density-repair01.git#cefc7be547ff727bd31573ac096b850da847af46",
     "high-density-repair02": "https://codeload.github.com/tscircuit/high-density-repair02/tar.gz/2afc0cbba3bf2f7eb6b9cd33615d21e9ad9352d4",
-    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#a469074c59c1fa4e3f6410089ce5a63608d0c0dc",
+    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#84b96a1529dc8aca70a06714905f087c685ab4d7",
     "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d"
   },
   "dependencies": {

--- a/tests/features/never-fail-growth-high-density/pipeline7-integration.test.ts
+++ b/tests/features/never-fail-growth-high-density/pipeline7-integration.test.ts
@@ -70,6 +70,7 @@ test("Pipeline7 caps expensive post-processing stages for benchmark completion",
     netToPointPairsSolver: { newConnections: [] },
   } as any)
   expect((exactGeometryDrcParams as any).maxIterations).toBe(32)
+  expect((exactGeometryDrcParams as any).maxCandidateEvaluations).toBe(12)
   expect((exactGeometryDrcParams as any).drcEvaluator).toBeFunction()
   expect((exactGeometryDrcParams as any).viaInPadDrcEvaluator).toBe(
     (exactGeometryDrcParams as any).drcEvaluator,


### PR DESCRIPTION
## Summary

- update `high-density-repair03` to commit `84b96a1529dc8aca70a06714905f087c685ab4d7`
- cap Pipeline 7 exact-geometry repair at 12 candidate DRC evaluations
- assert the new budget in the existing Pipeline 7 integration coverage

## Why

Pipeline 7 already set `maxIterations: 32`, but Repair03 could perform multiple expensive full-board DRC evaluations per solver step. On large `srj18` boards, `GlobalDrcBranchPortfolioSolver` could therefore consume the 360-second worker limit.

The new Repair03 budget directly caps expensive candidate evaluations across portfolio branches while retaining the best evaluated output.

## Dependency

Depends on tscircuit/high-density-repair03#33. This PR pins the exact head commit from that upstream PR.

## Validation

Local tests and benchmarks were intentionally not run for this publish operation, per request. CI should validate the change.