### PR TITLE
Preserve unmapped immutable routes during via merging

### DIFF
--- a/lib/solvers/SameNetViaMergerSolver/SameNetViaMergerSolver.ts
+++ b/lib/solvers/SameNetViaMergerSolver/SameNetViaMergerSolver.ts
@@ -35,15 +35,20 @@ type Via = {
 const NEAR_VIA_MERGE_DISTANCE_MULTIPLIER = 2.5
 const OBSTACLE_MARGIN = 0.1
 
+const tryGetNetForRoute = (
+  connMap: ConnectivityMap,
+  route: HighDensityRoute,
+): string | undefined =>
+  connMap.idToNetMap[route.connectionName] ??
+  (route.rootConnectionName
+    ? connMap.idToNetMap[route.rootConnectionName]
+    : undefined)
+
 const getNetForRoute = (
   connMap: ConnectivityMap,
   route: HighDensityRoute,
 ): string => {
-  const net =
-    connMap.idToNetMap[route.connectionName] ??
-    (route.rootConnectionName
-      ? connMap.idToNetMap[route.rootConnectionName]
-      : undefined)
+  const net = tryGetNetForRoute(connMap, route)
   if (!net) {
     throw new Error(
       `SameNetViaMergerSolver could not find net for route "${route.connectionName}"`,
@@ -117,7 +122,9 @@ const canMoveViaTo = (
 
     for (const { conflictingRoute, distance } of conflictingRoutes) {
       if (conflictingRoute.connectionName === route.connectionName) continue
-      if (getNetForRoute(context.connMap, conflictingRoute) === viaToRemove.net)
+      if (
+        tryGetNetForRoute(context.connMap, conflictingRoute) === viaToRemove.net
+      )
         continue
 
       const minDistance =

--- a/tests/features/trace-simplification-immutable-routes.test.ts
+++ b/tests/features/trace-simplification-immutable-routes.test.ts
@@ -376,3 +376,47 @@ test("same-net via merging collision-checks immutable routes without emitting th
   expect(countViaLocations(guardedRoutes)).toBe(2)
   expect(immutableRoute).toEqual(immutableSnapshot)
 })
+
+test("same-net via merging treats unmapped immutable routes as blocking copper", () => {
+  const makeViaRoute = (
+    connectionName: string,
+    viaX: number,
+  ): HighDensityRoute => ({
+    connectionName,
+    traceThickness: 0.15,
+    viaDiameter: 0.3,
+    route: [
+      { x: viaX - 0.25, y: 0, z: 0 },
+      { x: viaX, y: 0, z: 0 },
+      { x: viaX, y: 0, z: 1 },
+      { x: viaX - 0.25, y: 0, z: 1 },
+    ],
+    vias: [{ x: viaX, y: 0 }],
+  })
+  const immutableSnapshot = structuredClone(immutableRoute)
+  const solver = new SameNetViaMergerSolver({
+    inputHdRoutes: [
+      makeViaRoute("editable_a", -0.25),
+      makeViaRoute("editable_b", 0.25),
+    ],
+    otherHdRoutes: [immutableRoute],
+    obstacles: [],
+    colorMap: {},
+    layerCount: 2,
+    connMap: new ConnectivityMap({
+      editable_net: ["editable_a", "editable_b"],
+    }),
+  })
+
+  solver.solve()
+
+  expect(solver.failed).toBe(false)
+  expect(
+    new Set(
+      solver
+        .getMergedViaHdRoutes()!
+        .flatMap((route) => route.vias.map((via) => `${via.x}:${via.y}`)),
+    ).size,
+  ).toBe(2)
+  expect(immutableRoute).toEqual(immutableSnapshot)
+})


### PR DESCRIPTION
## Summary

- allow collision-only immutable routes to omit connectivity-map entries during same-net via merging
- conservatively treat an unmapped immutable route as different-net blocking copper
- retain the existing hard failure when a mutable route has no resolvable net
- add regression coverage proving the immutable route blocks a via move without being emitted or mutated

## Root cause

Pipeline9 passes pre-routed traces to trace simplification as `otherHdRoutes`. `SameNetViaMergerSolver` includes those routes in its collision index, but it previously required every conflicting route to resolve through the mutable connection map. SRJ23 preloaded fragments have generated IDs such as `source_net_5_fixed_5_2` that are intentionally absent from that map, so simplification failed after routing had already succeeded.

## Impact

This removes the simplification failures for SRJ23 samples 2, 8, and 9 without changing or rerouting the preloaded traces. The targeted benchmark is now 100% solved and 100% relaxed-DRC clean for those three samples.

## Verification

- `bun test tests/features/trace-simplification-immutable-routes.test.ts tests/solvers/same-net-via-merger-direct-overlap-star.test.ts --timeout 60000` (6 passed)
- `bun run format:check`
- `bunx tsc --noEmit`
- `./benchmark.sh --pipeline 9 --dataset srj23 --sample-numbers 2,8,9 --concurrency 3 --effort 1 --sample-timeout 60s` (3/3 solved, 3/3 relaxed DRC clean)