### PR TITLE
Repair DRC conflicts with safe trace layer moves

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -677,6 +677,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
             enableLargeBoardBroadFallback: false,
             enableTargetedErrorSweep: true,
             enablePostSolveClearanceRelaxation: false,
+            enableSafeTraceLayerMoves: true,
             enableViaInPadLayerMoves: cms.originalSrj.allowViaInPad ?? false,
             viaInPadMaxIterations: 32,
             broadMaxIterations: 8,

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "zdwiel-dataset": "git+https://github.com/dwiel/tscircuit-benchmark.git#be36518b5bf51755dae92c230061ab3cf4e3e063",
     "high-density-repair01": "git+https://github.com/tscircuit/high-density-repair01.git#cefc7be547ff727bd31573ac096b850da847af46",
     "high-density-repair02": "https://codeload.github.com/tscircuit/high-density-repair02/tar.gz/2afc0cbba3bf2f7eb6b9cd33615d21e9ad9352d4",
-    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#5a963f132a640b38ec75d3ea2f72af2125636d3b",
+    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#99ccf2776b2bc37e1ac9d2c6ab754f9d8ba25025",
     "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d"
   },
   "dependencies": {

--- a/tests/bugs/bugreport-b5b3b9d8-drc-count.test.ts
+++ b/tests/bugs/bugreport-b5b3b9d8-drc-count.test.ts
@@ -41,5 +41,5 @@ test("bugreport-b5b3b9d8 pipeline7 records current total DRC errors", () => {
     viaClearance: 0.1,
   })
 
-  expect(errors).toHaveLength(1)
+  expect(errors).toHaveLength(0)
 })

--- a/tests/features/__snapshots__/safe-trace-layer-repair-visual.snap.svg
+++ b/tests/features/__snapshots__/safe-trace-layer-repair-visual.snap.svg
@@ -1,0 +1,94 @@
+<svg width="1132" height="436" viewBox="0 0 1132 436" xmlns="http://www.w3.org/2000/svg">
+  <g transform="translate(0, 0) scale(1, 1) translate(0, 0)">
+    <rect width="100%" height="100%" fill="white"/><text x="16" y="22" font-family="monospace" font-size="15" font-weight="700" fill="#111">BEFORE • 2 DRC ERRORS</text><text x="16" y="43" font-family="monospace" font-size="12" fill="#444">Purple markers show both trace crossings.</text><text x="16" y="61" font-family="monospace" font-size="12" fill="#444">The internal conflict is bounded by four vias.</text><g transform="translate(0 76)"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="-2,-0.7 -0.5,-0.7" data-type="line" data-label="terminal z0" points="140,229 245,229" fill="none" stroke="rgba(37, 99, 235, 0.42)" stroke-width="7"/></g><g><polyline data-points="-0.5,-0.7 0.5,-0.7" data-type="line" data-label="terminal z0" points="245,229 315,229" fill="none" stroke="rgba(37, 99, 235, 0.42)" stroke-width="7"/></g><g><polyline data-points="0.5,-0.7 2,-0.7" data-type="line" data-label="terminal z0" points="315,229 420,229" fill="none" stroke="rgba(37, 99, 235, 0.42)" stroke-width="7"/></g><g><polyline data-points="0,-1.2 0,-0.2" data-type="line" data-label="terminalBlocker z0" points="280,264 280,194" fill="none" stroke="rgba(37, 99, 235, 0.42)" stroke-width="7"/></g><g><polyline data-points="-2,0.8 -1,0.8" data-type="line" data-label="internal z0" points="140,124 210,124" fill="none" stroke="rgba(37, 99, 235, 0.42)" stroke-width="7"/></g><g><polyline data-points="-1,0.8 -0.5,0.8" data-type="line" data-label="internal z2" points="210,124 245,124" fill="none" stroke="rgba(5, 150, 105, 0.42)" stroke-width="7"/></g><g><polyline data-points="-0.5,0.8 0.5,0.8" data-type="line" data-label="internal z1" points="245,124 315,124" fill="none" stroke="rgba(220, 38, 38, 0.42)" stroke-width="7"/></g><g><polyline data-points="0.5,0.8 1,0.8" data-type="line" data-label="internal z2" points="315,124 350,124" fill="none" stroke="rgba(5, 150, 105, 0.42)" stroke-width="7"/></g><g><polyline data-points="1,0.8 2,0.8" data-type="line" data-label="internal z0" points="350,124 420,124" fill="none" stroke="rgba(37, 99, 235, 0.42)" stroke-width="7"/></g><g><polyline data-points="0,0.3 0,1.3" data-type="line" data-label="internalBlocker z1" points="280,159 280,89" fill="none" stroke="rgba(220, 38, 38, 0.42)" stroke-width="7"/></g><g><rect data-type="rect" data-label="board bounds" data-x="0" data-y="0" x="70" y="40" width="420" height="280" fill="rgba(255, 255, 255, 0)" stroke="#0f172a" stroke-width="0.014285714285714285"/></g><g><rect data-type="rect" data-label="" data-x="-2" data-y="-0.7" x="126" y="215" width="28" height="28" fill="rgba(148, 163, 184, 0.58)" stroke="#64748b" stroke-width="0.014285714285714285"/></g><g><rect data-type="rect" data-label="" data-x="2" data-y="-0.7" x="406" y="215" width="28" height="28" fill="rgba(148, 163, 184, 0.58)" stroke="#64748b" stroke-width="0.014285714285714285"/></g><circle data-type="circle" data-label="" data-x="-1" data-y="0.8" cx="210" cy="124" r="10.5" fill="rgba(17, 24, 39, 0.5)" stroke="rgba(248, 250, 252, 0.5)" stroke-width="0.014285714285714285"/><circle data-type="circle" data-label="" data-x="-0.5" data-y="0.8" cx="245" cy="124" r="10.5" fill="rgba(17, 24, 39, 0.5)" stroke="rgba(248, 250, 252, 0.5)" stroke-width="0.014285714285714285"/><circle data-type="circle" data-label="" data-x="0.5" data-y="0.8" cx="315" cy="124" r="10.5" fill="rgba(17, 24, 39, 0.5)" stroke="rgba(248, 250, 252, 0.5)" stroke-width="0.014285714285714285"/><circle data-type="circle" data-label="" data-x="1" data-y="0.8" cx="350" cy="124" r="10.5" fill="rgba(17, 24, 39, 0.5)" stroke="rgba(248, 250, 252, 0.5)" stroke-width="0.014285714285714285"/><circle data-type="circle" data-label="" data-x="0" data-y="-0.7" cx="280" cy="229" r="15.4" fill="rgba(147, 51, 234, 0.38)" stroke="#7e22ce" stroke-width="0.014285714285714285"/><circle data-type="circle" data-label="" data-x="0" data-y="0.8" cx="280" cy="124" r="15.4" fill="rgba(147, 51, 234, 0.38)" stroke="#7e22ce" stroke-width="0.014285714285714285"/><g><circle data-type="point" data-label="terminal" data-x="-2" data-y="-0.7" cx="140" cy="229" r="3" fill="#111827"/></g><g><circle data-type="point" data-label="terminal" data-x="2" data-y="-0.7" cx="420" cy="229" r="3" fill="#111827"/></g><g><circle data-type="point" data-label="terminalBlocker" data-x="0" data-y="-1.2" cx="280" cy="264" r="3" fill="#111827"/></g><g><circle data-type="point" data-label="terminalBlocker" data-x="0" data-y="-0.2" cx="280" cy="194" r="3" fill="#111827"/></g><g><circle data-type="point" data-label="internal" data-x="-2" data-y="0.8" cx="140" cy="124" r="3" fill="#111827"/></g><g><circle data-type="point" data-label="internal" data-x="2" data-y="0.8" cx="420" cy="124" r="3" fill="#111827"/></g><g><circle data-type="point" data-label="internalBlocker" data-x="0" data-y="0.3" cx="280" cy="159" r="3" fill="#111827"/></g><g><circle data-type="point" data-label="internalBlocker" data-x="0" data-y="1.3" cx="280" cy="89" r="3" fill="#111827"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="360" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="560" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '560');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '360');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":70,"c":0,"e":280,"b":0,"d":-70,"f":180};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></g>
+  </g>
+  <g transform="translate(572, 0) scale(1, 1) translate(0, 0)">
+    <rect width="100%" height="100%" fill="white"/><text x="16" y="22" font-family="monospace" font-size="15" font-weight="700" fill="#111">AFTER • 0 DRC ERRORS</text><text x="16" y="43" font-family="monospace" font-size="12" fill="#444">Green z2 spans bypass both crossing traces.</text><text x="16" y="61" font-family="monospace" font-size="12" fill="#444">Terminal vias clear pads; internal vias collapse 4 → 2.</text><g transform="translate(0 76)"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="-2,-0.7 -1.6499986577223733,-0.7" data-type="line" data-label="terminal z0" points="140,229 164.50009395943385,229" fill="none" stroke="rgba(37, 99, 235, 0.42)" stroke-width="7"/></g><g><polyline data-points="-1.6499986577223733,-0.7 -0.5,-0.7" data-type="line" data-label="terminal z2" points="164.50009395943385,229 245,229" fill="none" stroke="rgba(5, 150, 105, 0.42)" stroke-width="7"/></g><g><polyline data-points="-0.5,-0.7 0.5,-0.7" data-type="line" data-label="terminal z2" points="245,229 315,229" fill="none" stroke="rgba(5, 150, 105, 0.42)" stroke-width="7"/></g><g><polyline data-points="0.5,-0.7 1.6499986577223733,-0.7" data-type="line" data-label="terminal z2" points="315,229 395.49990604056615,229" fill="none" stroke="rgba(5, 150, 105, 0.42)" stroke-width="7"/></g><g><polyline data-points="1.6499986577223733,-0.7 2,-0.7" data-type="line" data-label="terminal z0" points="395.49990604056615,229 420,229" fill="none" stroke="rgba(37, 99, 235, 0.42)" stroke-width="7"/></g><g><polyline data-points="0,-1.2 0,-0.2" data-type="line" data-label="terminalBlocker z0" points="280,264 280,194" fill="none" stroke="rgba(37, 99, 235, 0.42)" stroke-width="7"/></g><g><polyline data-points="-2,0.8 -1,0.8" data-type="line" data-label="internal z0" points="140,124 210,124" fill="none" stroke="rgba(37, 99, 235, 0.42)" stroke-width="7"/></g><g><polyline data-points="-1,0.8 -0.5,0.8" data-type="line" data-label="internal z2" points="210,124 245,124" fill="none" stroke="rgba(5, 150, 105, 0.42)" stroke-width="7"/></g><g><polyline data-points="-0.5,0.8 0.5,0.8" data-type="line" data-label="internal z2" points="245,124 315,124" fill="none" stroke="rgba(5, 150, 105, 0.42)" stroke-width="7"/></g><g><polyline data-points="0.5,0.8 1,0.8" data-type="line" data-label="internal z2" points="315,124 350,124" fill="none" stroke="rgba(5, 150, 105, 0.42)" stroke-width="7"/></g><g><polyline data-points="1,0.8 2,0.8" data-type="line" data-label="internal z0" points="350,124 420,124" fill="none" stroke="rgba(37, 99, 235, 0.42)" stroke-width="7"/></g><g><polyline data-points="0,0.3 0,1.3" data-type="line" data-label="internalBlocker z1" points="280,159 280,89" fill="none" stroke="rgba(220, 38, 38, 0.42)" stroke-width="7"/></g><g><rect data-type="rect" data-label="board bounds" data-x="0" data-y="0" x="70" y="40" width="420" height="280" fill="rgba(255, 255, 255, 0)" stroke="#0f172a" stroke-width="0.014285714285714285"/></g><g><rect data-type="rect" data-label="" data-x="-2" data-y="-0.7" x="126" y="215" width="28" height="28" fill="rgba(148, 163, 184, 0.58)" stroke="#64748b" stroke-width="0.014285714285714285"/></g><g><rect data-type="rect" data-label="" data-x="2" data-y="-0.7" x="406" y="215" width="28" height="28" fill="rgba(148, 163, 184, 0.58)" stroke="#64748b" stroke-width="0.014285714285714285"/></g><circle data-type="circle" data-label="" data-x="-1.65" data-y="-0.7" cx="164.5" cy="229" r="10.5" fill="rgba(17, 24, 39, 0.5)" stroke="rgba(248, 250, 252, 0.5)" stroke-width="0.014285714285714285"/><circle data-type="circle" data-label="" data-x="1.65" data-y="-0.7" cx="395.5" cy="229" r="10.5" fill="rgba(17, 24, 39, 0.5)" stroke="rgba(248, 250, 252, 0.5)" stroke-width="0.014285714285714285"/><circle data-type="circle" data-label="" data-x="-1" data-y="0.8" cx="210" cy="124" r="10.5" fill="rgba(17, 24, 39, 0.5)" stroke="rgba(248, 250, 252, 0.5)" stroke-width="0.014285714285714285"/><circle data-type="circle" data-label="" data-x="1" data-y="0.8" cx="350" cy="124" r="10.5" fill="rgba(17, 24, 39, 0.5)" stroke="rgba(248, 250, 252, 0.5)" stroke-width="0.014285714285714285"/><circle data-type="circle" data-label="" data-x="0" data-y="-0.7" cx="280" cy="229" r="15.4" fill="rgba(34, 197, 94, 0.42)" stroke="#16a34a" stroke-width="0.014285714285714285"/><circle data-type="circle" data-label="" data-x="0" data-y="0.8" cx="280" cy="124" r="15.4" fill="rgba(34, 197, 94, 0.42)" stroke="#16a34a" stroke-width="0.014285714285714285"/><g><circle data-type="point" data-label="terminal" data-x="-2" data-y="-0.7" cx="140" cy="229" r="3" fill="#111827"/></g><g><circle data-type="point" data-label="terminal" data-x="2" data-y="-0.7" cx="420" cy="229" r="3" fill="#111827"/></g><g><circle data-type="point" data-label="terminalBlocker" data-x="0" data-y="-1.2" cx="280" cy="264" r="3" fill="#111827"/></g><g><circle data-type="point" data-label="terminalBlocker" data-x="0" data-y="-0.2" cx="280" cy="194" r="3" fill="#111827"/></g><g><circle data-type="point" data-label="internal" data-x="-2" data-y="0.8" cx="140" cy="124" r="3" fill="#111827"/></g><g><circle data-type="point" data-label="internal" data-x="2" data-y="0.8" cx="420" cy="124" r="3" fill="#111827"/></g><g><circle data-type="point" data-label="internalBlocker" data-x="0" data-y="0.3" cx="280" cy="159" r="3" fill="#111827"/></g><g><circle data-type="point" data-label="internalBlocker" data-x="0" data-y="1.3" cx="280" cy="89" r="3" fill="#111827"/></g><g id="crosshair__stack1" style="display: none"><line id="crosshair-h__stack1" y1="0" y2="360" stroke="#666" stroke-width="0.5"/><line id="crosshair-v__stack1" x1="0" x2="560" stroke="#666" stroke-width="0.5"/><text id="coordinates__stack1" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '560');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '360');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":70,"c":0,"e":280,"b":0,"d":-70,"f":180};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></g>
+  </g>
+</svg>

--- a/tests/features/safe-trace-layer-repair-visual.test.ts
+++ b/tests/features/safe-trace-layer-repair-visual.test.ts
@@ -1,0 +1,265 @@
+import { expect, test } from "bun:test"
+import { getSvgFromGraphicsObject, type GraphicsObject } from "graphics-debug"
+import { stackSvgsHorizontally } from "stack-svgs"
+import { VisualizedGlobalDrcForceImproveSolver } from "high-density-repair03/fixture-support/VisualizedGlobalDrcForceImproveSolver"
+import type {
+  DrcEvaluator,
+  HighDensityRoute,
+  SimpleRouteJson,
+} from "high-density-repair03/lib"
+
+const addPanelHeader = ({
+  svg,
+  title,
+  details,
+}: {
+  svg: string
+  title: string
+  details: [string, string]
+}) => {
+  const headerHeight = 76
+  const bodyStart = svg.indexOf(">") + 1
+  const bodyEnd = svg.lastIndexOf("</svg>")
+  const width = Number(svg.match(/\bwidth="([^"]+)"/)?.[1] ?? 560)
+  const height = Number(svg.match(/\bheight="([^"]+)"/)?.[1] ?? 360)
+
+  return `<svg width="${width}" height="${
+    height + headerHeight
+  }" viewBox="0 0 ${width} ${
+    height + headerHeight
+  }" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><text x="16" y="22" font-family="monospace" font-size="15" font-weight="700" fill="#111">${title}</text><text x="16" y="43" font-family="monospace" font-size="12" fill="#444">${details[0]}</text><text x="16" y="61" font-family="monospace" font-size="12" fill="#444">${details[1]}</text><g transform="translate(0 ${headerHeight})">${svg.slice(
+    bodyStart,
+    bodyEnd,
+  )}</g></svg>`
+}
+
+test("visualizes safe layer moves at internal and terminal boundaries", () => {
+  const srj: SimpleRouteJson = {
+    bounds: { minX: -3, minY: -2, maxX: 3, maxY: 2 },
+    connections: [
+      {
+        name: "terminal",
+        pointsToConnect: [
+          { x: -2, y: -0.7, layer: "top", pointId: "terminal-start" },
+          { x: 2, y: -0.7, layer: "top", pointId: "terminal-end" },
+        ],
+      },
+      {
+        name: "terminalBlocker",
+        pointsToConnect: [
+          { x: 0, y: -1.2, layer: "top", pointId: "terminal-blocker-a" },
+          { x: 0, y: -0.2, layer: "top", pointId: "terminal-blocker-b" },
+        ],
+      },
+      {
+        name: "internal",
+        pointsToConnect: [
+          { x: -2, y: 0.8, layer: "top", pointId: "internal-start" },
+          { x: 2, y: 0.8, layer: "top", pointId: "internal-end" },
+        ],
+      },
+      {
+        name: "internalBlocker",
+        pointsToConnect: [
+          { x: 0, y: 0.3, layer: "top", pointId: "internal-blocker-a" },
+          { x: 0, y: 1.3, layer: "top", pointId: "internal-blocker-b" },
+        ],
+      },
+    ],
+    obstacles: [
+      {
+        type: "rect",
+        layers: ["top"],
+        center: { x: -2, y: -0.7 },
+        width: 0.4,
+        height: 0.4,
+        connectedTo: ["terminal", "terminal-start"],
+      },
+      {
+        type: "rect",
+        layers: ["top"],
+        center: { x: 2, y: -0.7 },
+        width: 0.4,
+        height: 0.4,
+        connectedTo: ["terminal", "terminal-end"],
+      },
+    ],
+    layerCount: 3,
+    minTraceWidth: 0.1,
+    minViaDiameter: 0.3,
+  }
+  const hdRoutes: HighDensityRoute[] = [
+    {
+      connectionName: "terminal",
+      route: [
+        {
+          x: -2,
+          y: -0.7,
+          z: 0,
+          pcb_port_id: "terminal-start",
+        },
+        { x: -0.5, y: -0.7, z: 0 },
+        { x: 0.5, y: -0.7, z: 0 },
+        { x: 2, y: -0.7, z: 0, pcb_port_id: "terminal-end" },
+      ],
+      vias: [],
+      traceThickness: 0.1,
+      viaDiameter: 0.3,
+    },
+    {
+      connectionName: "terminalBlocker",
+      route: [
+        { x: 0, y: -1.2, z: 0 },
+        { x: 0, y: -0.2, z: 0 },
+      ],
+      vias: [],
+      traceThickness: 0.1,
+      viaDiameter: 0.3,
+    },
+    {
+      connectionName: "internal",
+      route: [
+        { x: -2, y: 0.8, z: 0, pcb_port_id: "internal-start" },
+        { x: -1, y: 0.8, z: 0 },
+        { x: -1, y: 0.8, z: 2 },
+        { x: -0.5, y: 0.8, z: 2 },
+        { x: -0.5, y: 0.8, z: 1 },
+        { x: 0.5, y: 0.8, z: 1 },
+        { x: 0.5, y: 0.8, z: 2 },
+        { x: 1, y: 0.8, z: 2 },
+        { x: 1, y: 0.8, z: 0 },
+        { x: 2, y: 0.8, z: 0, pcb_port_id: "internal-end" },
+      ],
+      vias: [
+        { x: -1, y: 0.8 },
+        { x: -0.5, y: 0.8 },
+        { x: 0.5, y: 0.8 },
+        { x: 1, y: 0.8 },
+      ],
+      traceThickness: 0.1,
+      viaDiameter: 0.3,
+    },
+    {
+      connectionName: "internalBlocker",
+      route: [
+        { x: 0, y: 0.3, z: 1 },
+        { x: 0, y: 1.3, z: 1 },
+      ],
+      vias: [],
+      traceThickness: 0.1,
+      viaDiameter: 0.3,
+    },
+  ]
+  const drcEvaluator: DrcEvaluator = ({ hdRoutes, routes }) => {
+    const candidateRoutes = hdRoutes ?? routes ?? []
+    const terminal = candidateRoutes.find(
+      (route) => route.connectionName === "terminal",
+    )
+    const internal = candidateRoutes.find(
+      (route) => route.connectionName === "internal",
+    )
+    const terminalRepaired =
+      terminal?.route.some((point) => point.z === 2) &&
+      terminal.vias.length === 2 &&
+      terminal.vias.every((via) => Math.abs(via.x) > 1.5)
+    const internalRepaired =
+      internal?.route
+        .filter((point) => Math.abs(point.x) <= 0.5)
+        .every((point) => point.z === 2) && internal.vias.length === 2
+    const errors = [
+      ...(!terminalRepaired
+        ? [
+            {
+              type: "pcb_trace_error",
+              pcb_trace_id: "terminalBlocker_0",
+              pcb_trace_error_id: "overlap_terminalBlocker_0_terminal_0",
+              center: { x: 0, y: -0.7 },
+              message: "Terminal trace crosses another trace",
+            },
+          ]
+        : []),
+      ...(!internalRepaired
+        ? [
+            {
+              type: "pcb_trace_error",
+              pcb_trace_id: "internal_0",
+              pcb_trace_error_id: "overlap_internal_0_internalBlocker_0",
+              center: { x: 0, y: 0.8 },
+              message: "Internal trace span crosses another trace",
+            },
+          ]
+        : []),
+    ]
+    return { errors, errorsWithCenters: errors }
+  }
+  const solverParams = {
+    srj,
+    hdRoutes,
+    drcEvaluator,
+    maxIterations: 16,
+    enableLargeBoardBroadFallback: false,
+    enablePostSolveClearanceRelaxation: false,
+    enableSafeTraceLayerMoves: true,
+    enableViaInPadLayerMoves: false,
+  }
+  const solver = new VisualizedGlobalDrcForceImproveSolver(solverParams)
+  const beforeGraphics = solver.visualize()
+
+  solver.solve()
+
+  const terminal = solver
+    .getOutput()
+    .find((route) => route.connectionName === "terminal")!
+  const internal = solver
+    .getOutput()
+    .find((route) => route.connectionName === "internal")!
+  expect(solver.failed).toBe(false)
+  expect(solver.stats.initialDrcIssueCount).toBe(2)
+  expect(solver.stats.finalDrcIssueCount).toBe(0)
+  expect(solver.stats.globalDrcForceImproveViaInPadCandidatesAccepted).toBe(0)
+  expect(terminal.vias).toHaveLength(2)
+  expect(terminal.vias.every((via) => Math.abs(via.x) > 1.5)).toBe(true)
+  expect(internal.vias).toEqual([
+    { x: -1, y: 0.8 },
+    { x: 1, y: 0.8 },
+  ])
+  expect(terminal.route[0]?.pcb_port_id).toBe("terminal-start")
+  expect(terminal.route.at(-1)?.pcb_port_id).toBe("terminal-end")
+  expect(internal.route[0]?.pcb_port_id).toBe("internal-start")
+  expect(internal.route.at(-1)?.pcb_port_id).toBe("internal-end")
+
+  const renderFrame = (graphics: GraphicsObject): string =>
+    getSvgFromGraphicsObject(graphics, {
+      backgroundColor: "white",
+      svgWidth: 560,
+      svgHeight: 360,
+      hideInlineLabels: true,
+    })
+
+  expect(
+    stackSvgsHorizontally(
+      [
+        addPanelHeader({
+          svg: renderFrame(beforeGraphics),
+          title: "BEFORE • 2 DRC ERRORS",
+          details: [
+            "Purple markers show both trace crossings.",
+            "The internal conflict is bounded by four vias.",
+          ],
+        }),
+        addPanelHeader({
+          svg: renderFrame(solver.visualize()),
+          title: "AFTER • 0 DRC ERRORS",
+          details: [
+            "Green z2 spans bypass both crossing traces.",
+            "Terminal vias clear pads; internal vias collapse 4 → 2.",
+          ],
+        }),
+      ],
+      {
+        gap: 12,
+        normalizeSize: false,
+      },
+    ),
+  ).toMatchSvgSnapshot(import.meta.path)
+})


### PR DESCRIPTION
## Issue

Pipeline 7 can finish with trace-to-trace or pad-to-trace DRC errors. Moving an entire route to another layer fixed some of these errors, but routes connected to terminals received layer transitions inside their pads. That introduced via-in-pad geometry and caused routing regressions. Incomplete repairs could also be kept even when trace DRC remained.

## Implementation

This PR enables the safe trace-layer repair implemented in [high-density-repair03#41](https://github.com/tscircuit/high-density-repair03/pull/41).

The repair:

- selects the same-layer span nearest the DRC conflict instead of moving the whole route
- tries deterministic, bounded span expansions on another legal layer
- reuses existing layer transitions for internal spans
- places terminal transitions beyond the connected pad boundary
- accepts a candidate only when full-board DRC strictly improves without increasing via-related DRC
- commits the repair phase only when all trace and pad-to-trace errors are resolved; otherwise it restores the original routes

This is one repair operation with separate handling for internal and terminal boundaries. Existing via-in-pad behavior remains opt-in.

## Validation

The before/after SVG test covers both boundary cases and verifies DRC improves from 2 errors to 0 while terminal identities are preserved. All hosted build, format, typecheck, and test checks pass.
