### PR TITLE
test(pathing): visualize large-graph prepass cutoff

### DIFF
--- a/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
+++ b/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
@@ -140,7 +140,17 @@ const TINY_SECTION_SOLVER_BASE_OPTIONS: TinyHyperGraphSectionSolverOptions = {
 }
 const DUPLICATE_PORT_TRAVERSAL_PENALTY = 150
 const DEFAULT_CRAMPED_PORT_TRAVERSAL_PENALTY = 150
-const MAX_CONNECTIONS_FOR_DUPLICATE_CONGESTED_PORT_PREPASS = 180
+export const MAX_CONNECTIONS_FOR_DUPLICATE_CONGESTED_PORT_PREPASS = 180
+
+export const shouldRunDuplicateCongestedPortPrepass = ({
+  hasPreloadedTraceOccupancy,
+  connectionCount,
+}: {
+  hasPreloadedTraceOccupancy: boolean
+  connectionCount: number
+}) =>
+  !hasPreloadedTraceOccupancy &&
+  connectionCount <= MAX_CONNECTIONS_FOR_DUPLICATE_CONGESTED_PORT_PREPASS
 
 const getEffortScale = (effort: number) => Math.max(effort, 1e-2)
 
@@ -908,11 +918,13 @@ export class TinyHypergraphPortPointPathingSolver extends BaseSolver {
       getSerializedPreloadedTraceStats(serializedGraph)
     const hasPreloadedTraceOccupancy =
       preloadedTraceStats.preloadedPortCount > 0
-    const shouldRunDuplicateCongestedPortPrepass =
-      !hasPreloadedTraceOccupancy &&
-      connections.length <= MAX_CONNECTIONS_FOR_DUPLICATE_CONGESTED_PORT_PREPASS
+    const shouldRunDuplicateCongestedPortPrepassForGraph =
+      shouldRunDuplicateCongestedPortPrepass({
+        hasPreloadedTraceOccupancy,
+        connectionCount: connections.length,
+      })
     let graphForTiny = serializedGraph
-    if (shouldRunDuplicateCongestedPortPrepass) {
+    if (shouldRunDuplicateCongestedPortPrepassForGraph) {
       const duplicateCongestedPortSolver = new DuplicateCongestedPortSolver(
         serializedGraph,
         {

--- a/tests/features/port-point-pathing/__snapshots__/duplicate-congested-port-prepass-cutoff.snap.svg
+++ b/tests/features/port-point-pathing/__snapshots__/duplicate-congested-port-prepass-cutoff.snap.svg
@@ -1,0 +1,44 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="0,0 4.6,0" data-type="line" data-label="" points="62.65734265734267,515.9455035635681 577.3426573426573,515.9455035635681" fill="none" stroke="rgba(25,25,25,0.62)" stroke-width="5.594405594405593"/></g><g><polyline data-points="4.6,0 4.6,3.1" data-type="line" data-label="" points="577.3426573426573,515.9455035635681 577.3426573426573,169.0923567104213" fill="none" stroke="rgba(25,25,25,0.62)" stroke-width="5.594405594405593"/></g><g><polyline data-points="4.6,3.1 0,3.1" data-type="line" data-label="" points="577.3426573426573,169.0923567104213 62.65734265734267,169.0923567104213" fill="none" stroke="rgba(25,25,25,0.62)" stroke-width="5.594405594405593"/></g><g><polyline data-points="0,3.1 0,0" data-type="line" data-label="" points="62.65734265734267,169.0923567104213 62.65734265734267,515.9455035635681" fill="none" stroke="rgba(25,25,25,0.62)" stroke-width="5.594405594405593"/></g><g><polyline data-points="0.7901666666666665,2.585 4.790166666666666,2.585" data-type="line" data-label="" points="151.06759906759902,226.7147343327989 598.6200466200464,226.7147343327989" fill="none" stroke="rgba(60,70,80,0.6)" stroke-width="2.7972027972027966"/></g><g><polyline data-points="1.3901666666666666,0.5850000000000002 1.3901666666666666,2.835" data-type="line" data-label="" points="218.20046620046617,450.4909581090226 218.20046620046617,198.74270636077097" fill="none" stroke="rgba(180,90,20,0.9)" stroke-width="3.916083916083916" stroke-dasharray="0.08 0.06"/></g><g><rect data-type="rect" data-label="Duplicate-congested-port prepass gate step:1 layer:all" data-x="2.3" data-y="1.55" x="62.65734265734267" y="169.0923567104213" width="514.6853146853146" height="346.85314685314677" fill="rgba(255,255,255,0)" stroke="rgba(25,25,25,0.42)" stroke-width="0.008937500000000001"/></g><circle data-type="circle" data-label="" data-x="1.1234999999999997" data-y="2.085" cx="188.36363636363632" cy="282.65879027685486" r="13.426573426573423" fill="rgba(40,170,95,0.8)" stroke="rgba(20,105,55,1)" stroke-width="0.008937500000000001"/><circle data-type="circle" data-label="" data-x="3.5934999999999997" data-y="0.9850000000000002" cx="464.72727272727263" cy="405.7357133537779" r="13.426573426573423" fill="rgba(205,65,65,0.8)" stroke="rgba(140,30,30,1)" stroke-width="0.008937500000000001"/><text data-type="text" data-label="0" data-x="0.7901666666666665" data-y="2.665" x="151.06759906759902" y="217.76368538174995" fill="black" font-size="12.307692307692305" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge">0</text><text data-type="text" data-label="1,200 connections" data-x="4.790166666666666" data-y="2.665" x="598.6200466200464" y="217.76368538174995" fill="black" font-size="12.307692307692305" font-family="sans-serif" text-anchor="end" dominant-baseline="text-after-edge">1,200 connections</text><text data-type="text" data-label="current prepass cutoff: 180" data-x="1.3901666666666666" data-y="2.865" x="218.20046620046617" y="195.38606300412755" fill="black" font-size="12.307692307692305" font-family="sans-serif" text-anchor="middle" dominant-baseline="text-after-edge">current prepass cutoff: 180</text><text data-type="text" data-label="100-connection graph: prepass runs" data-x="1.1234999999999997" data-y="1.8850000000000002" x="188.36363636363632" y="305.0364126544772" fill="black" font-size="14.545454545454543" font-family="sans-serif" text-anchor="middle" dominant-baseline="text-before-edge">100-connection graph: prepass runs</text><text data-type="text" data-label="srj24 sample 4: prepass skipped" data-x="3.5934999999999997" data-y="0.7850000000000001" x="464.72727272727263" y="428.11333573140024" fill="black" font-size="14.545454545454543" font-family="sans-serif" text-anchor="middle" dominant-baseline="text-before-edge">srj24 sample 4: prepass skipped</text><text data-type="text" data-label="green = prepass runs · red = skipped by the production cutoff" data-x="0.7901666666666665" data-y="0.3350000000000002" x="151.06759906759902" y="478.4629860810506" fill="black" font-size="11.188811188811187" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge">green = prepass runs · red = skipped by the production cutoff</text><text data-type="text" data-label="Duplicate-congested-port prepass gate" data-x="0" data-y="3.5025258761987796" x="62.65734265734267" y="124.05449643643198" fill="rgb(18,18,18)" font-size="22.436151468409527" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge">Duplicate-congested-port prepass gate</text><text data-type="text" data-label="step:1" data-x="1.3054054054054052" data-y="3.27794" x="208.71668871668868" y="149.18298608105067" fill="rgb(190,92,12)" font-size="22.436151468409527" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge">step:1</text><text data-type="text" data-label=" layer:all" data-x="2.051351351351351" data-y="3.27794" x="292.1791721791721" y="149.18298608105067" fill="rgb(120,58,175)" font-size="22.436151468409527" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge"> layer:all</text><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":111.88811188811187,"c":0,"e":62.65734265734267,"b":0,"d":-111.88811188811187,"f":515.9455035635681};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/features/port-point-pathing/duplicate-congested-port-prepass-cutoff.test.ts
+++ b/tests/features/port-point-pathing/duplicate-congested-port-prepass-cutoff.test.ts
@@ -1,0 +1,102 @@
+import { expect, test } from "bun:test"
+import type { GraphicsObject } from "graphics-debug"
+import {
+  MAX_CONNECTIONS_FOR_DUPLICATE_CONGESTED_PORT_PREPASS,
+  shouldRunDuplicateCongestedPortPrepass,
+} from "lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver"
+import { getGraphicsSvgFrames } from "tests/fixtures/solver-svg-frames"
+
+test("visualizes the duplicate-port prepass connection cutoff", async () => {
+  const scenarios = [
+    { label: "100-connection graph", connectionCount: 100, y: 0.7 },
+    { label: "srj24 sample 4", connectionCount: 841, y: -0.4 },
+  ].map((scenario) => ({
+    ...scenario,
+    shouldRun: shouldRunDuplicateCongestedPortPrepass({
+      hasPreloadedTraceOccupancy: false,
+      connectionCount: scenario.connectionCount,
+    }),
+  }))
+  const scaleMax = 1_200
+  const toX = (connectionCount: number) => (connectionCount / scaleMax) * 4
+  const cutoffX = toX(MAX_CONNECTIONS_FOR_DUPLICATE_CONGESTED_PORT_PREPASS)
+  const graphics: GraphicsObject = {
+    lines: [
+      {
+        points: [
+          { x: 0, y: 1.2 },
+          { x: 4, y: 1.2 },
+        ],
+        strokeColor: "rgba(60,70,80,0.6)",
+        strokeWidth: 0.025,
+      },
+      {
+        points: [
+          { x: cutoffX, y: -0.8 },
+          { x: cutoffX, y: 1.45 },
+        ],
+        strokeColor: "rgba(180,90,20,0.9)",
+        strokeWidth: 0.035,
+        strokeDash: "0.08 0.06",
+      },
+    ],
+    circles: scenarios.map((scenario) => ({
+      center: { x: toX(scenario.connectionCount), y: scenario.y },
+      radius: 0.12,
+      fill: scenario.shouldRun ? "rgba(40,170,95,0.8)" : "rgba(205,65,65,0.8)",
+      stroke: scenario.shouldRun ? "rgba(20,105,55,1)" : "rgba(140,30,30,1)",
+      label: `${scenario.connectionCount} connections`,
+    })),
+    texts: [
+      {
+        x: 0,
+        y: 1.28,
+        text: "0",
+        anchorSide: "bottom_left",
+        fontSize: 0.11,
+      },
+      {
+        x: 4,
+        y: 1.28,
+        text: "1,200 connections",
+        anchorSide: "bottom_right",
+        fontSize: 0.11,
+      },
+      {
+        x: cutoffX,
+        y: 1.48,
+        text: `current prepass cutoff: ${MAX_CONNECTIONS_FOR_DUPLICATE_CONGESTED_PORT_PREPASS}`,
+        anchorSide: "bottom_center",
+        fontSize: 0.11,
+      },
+      ...scenarios.map((scenario) => ({
+        x: toX(scenario.connectionCount),
+        y: scenario.y - 0.2,
+        text: `${scenario.label}: ${scenario.shouldRun ? "prepass runs" : "prepass skipped"}`,
+        anchorSide: "top_center" as const,
+        fontSize: 0.13,
+      })),
+      {
+        x: 0,
+        y: -1.05,
+        text: "green = prepass runs · red = skipped by the production cutoff",
+        anchorSide: "bottom_left",
+        fontSize: 0.1,
+      },
+    ],
+  }
+  const svg = getGraphicsSvgFrames({
+    frames: [
+      {
+        name: "Duplicate-congested-port prepass gate",
+        step: 1,
+        graphics,
+      },
+    ],
+    columns: 1,
+    cellWidth: 4.6,
+    cellHeight: 3.1,
+  })
+
+  await expect(svg).toMatchSvgSnapshot(import.meta.path, { scale: 2 })
+})


### PR DESCRIPTION
Stacked on #1819, which restores sample 4's missing cross-layer topology path.

## Problem

Before the main tiny-hypergraph solve, `DuplicateCongestedPortSolver` can independently trace each connection, find boundary ports that many routes want to use, and add nearby alternatives.

That prepass currently runs only when a graph has at most 180 connections. `srj24` sample 4 has 841 connections, so the prepass is skipped. The main selective-rerip solve then repeatedly rearranges congested routes and runs out of iterations.

## Reproduction

![Large-graph prepass cutoff](https://raw.githubusercontent.com/tscircuit/tscircuit-autorouter/agent/repro-srj24-sample4-route-budget/tests/features/port-point-pathing/__snapshots__/duplicate-congested-port-prepass-cutoff.snap.svg?v=prepass-cutoff-repro-1)

The orange line is the production connection-count cutoff. The two points call the same production predicate as the solver: a 100-connection graph runs the prepass, while sample 4 is red because 841 is above 180.

This PR only extracts the existing predicate and constant so the behavior can be tested and visualized. It does not change which graphs run the prepass.

The fix is stacked in #1821 and uses this exact test source unchanged.

## Verification

- `bun test tests/features/port-point-pathing/duplicate-congested-port-prepass-cutoff.test.ts`
- `bun run build`
- `bun run format:check`
