### PR TITLE
Pin post-processing pass-through terminal fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@tscircuit/hypergraph": "^0.0.71",
     "@tscircuit/jumper-topology-generator": "^0.0.4",
     "@tscircuit/krt-wasm": "^0.1.0",
-    "@tscircuit/length-matching-solver": "git+https://github.com/tscircuit/length-matching-solver.git#09ecefbd5d312b9d168f78dc62b3c5e8455582e0",
+    "@tscircuit/length-matching-solver": "git+https://github.com/tscircuit/length-matching-solver.git#51077feba02cec4a59e7fa7882670926c8a351fd",
     "@tscircuit/math-utils": "^0.0.36",
     "@tscircuit/rectdiff": "git+https://github.com/tscircuit/rectdiff.git#ba0f5e0356fa95572c44b2c5539b1a159bd6c7b6",
     "@tscircuit/solver-utils": "^0.0.16",


### PR DESCRIPTION
## Stack

Stacked on autorouter stitch fix #1832.

The implementation lives in the correct owning repository:

- reproduction: tscircuit/length-matching-solver#34
- fix: tscircuit/length-matching-solver#35

## Problem

After #1832 clears sample 4's shared-root stitching failure, Pipeline7 reaches `PostProcessingSolver` and fails on `source_trace_261__source_net_261_mst1`.

Sample 4 has no differential pairs. Post-processing therefore uses its existing pass-through path, which returns a structured clone of every HD route. The validator still rejected the route's legitimate internal branch terminal `pcb_port_873`, even though pass-through never edits that geometry.

## Fix

Pin `@tscircuit/length-matching-solver` to the upstream fix commit.

The upstream change keeps validating terminal IDs, and keeps the endpoint-only rule for routes that can be rerouted. It skips only that placement rule in no-pair pass-through mode, where the complete route and all metadata are returned unchanged.

This autorouter PR contains no solver workaround or metadata rewrite: its entire diff is the dependency SHA.

## Snapshot

This is the unchanged upstream reproduction. Red boxes are pads, blue is routed copper, and the circle is the via. It uses sample 4's real route, endpoint IDs, and internal branch terminal. After the fix, pass-through returns the same route and terminal IDs.

![Post-processing pass-through fix](https://raw.githubusercontent.com/tscircuit/length-matching-solver/51077feba02cec4a59e7fa7882670926c8a351fd/tests/post-processing/passthrough/__snapshots__/internal-terminal-metadata.snap.svg)

## Validation

- upstream full suite — 61/61 passed
- upstream focused unchanged SVG snapshot — passed and asserts exact route equality
- upstream typecheck, structure check, and build — passed
- autorouter focused shared-root stitching snapshot — passed
- autorouter build — passed
- autorouter GitHub Actions test suite — 5/5 shards passed
- hosted Pipeline7 srj24 sample 4 benchmark — solved in 2276.3s with 576 vias (relaxed DRC: failed)
- hosted srj24 sample 2 regression — solved in 549.4s with 309 vias
- hosted srj18 sample 3 regression — solved in 38.1s with 81 vias
- hosted srj18 sample 6 regression — solved in 947.1s with 266 vias (improved from the main-branch timeout)
