### PR TITLE
Use physical capacity for duplicated graph ports

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -473,6 +473,8 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
             effort: cms.effort,
             preserveTerminalPcbPortIds: true,
             minViaPadDiameter: cms.viaDiameter,
+            minTraceWidth: cms.minTraceWidth,
+            traceClearance: 0.1,
             flags: {
               FORCE_CENTER_FIRST: true,
               RIPPING_ENABLED: true,

--- a/lib/solvers/PortPointPathingSolver/hgportpointpathingsolver/types.ts
+++ b/lib/solvers/PortPointPathingSolver/hgportpointpathingsolver/types.ts
@@ -98,6 +98,8 @@ export interface HgPortPointPathingSolverParams {
   effort: number
   preserveTerminalPcbPortIds?: boolean
   minViaPadDiameter?: number
+  minTraceWidth?: number
+  traceClearance?: number
   flags: {
     FORCE_CENTER_FIRST: boolean
     RIPPING_ENABLED: boolean

--- a/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
+++ b/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
@@ -951,9 +951,8 @@ export class TinyHypergraphPortPointPathingSolver extends BaseSolver {
       )
       duplicateCongestedPortSolver.solve()
       if (duplicateCongestedPortSolver.failed) {
-        throw new Error(
-          `Duplicate congested port prepass failed: ${duplicateCongestedPortSolver.error ?? "unknown error"}`,
-        )
+        this.duplicateCongestedPortError =
+          duplicateCongestedPortSolver.error ?? "unknown error"
       } else {
         this.duplicateCongestedPortReport = duplicateCongestedPortSolver.report
         graphForTiny = duplicateCongestedPortSolver.getOutput()

--- a/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
+++ b/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
@@ -929,6 +929,13 @@ export class TinyHypergraphPortPointPathingSolver extends BaseSolver {
         serializedGraph,
         {
           duplicatePortProximity: 0.05,
+          ...(params.minTraceWidth !== undefined
+            ? {
+                minimumDuplicatePortSpacing:
+                  params.minTraceWidth + (params.traceClearance ?? 0),
+                duplicatePortWidth: params.minTraceWidth,
+              }
+            : {}),
           routeSolveOptions: {
             ...getTinyViaSizeOptions(params.minViaPadDiameter),
             USE_SPARSE_CANDIDATE_STORAGE: true,
@@ -944,8 +951,9 @@ export class TinyHypergraphPortPointPathingSolver extends BaseSolver {
       )
       duplicateCongestedPortSolver.solve()
       if (duplicateCongestedPortSolver.failed) {
-        this.duplicateCongestedPortError =
-          duplicateCongestedPortSolver.error ?? "unknown error"
+        throw new Error(
+          `Duplicate congested port prepass failed: ${duplicateCongestedPortSolver.error ?? "unknown error"}`,
+        )
       } else {
         this.duplicateCongestedPortReport = duplicateCongestedPortSolver.report
         graphForTiny = duplicateCongestedPortSolver.getOutput()

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "recharts": "^2.15.1",
     "tailwind-merge": "^3.2.0",
     "terser": "^5.43.1",
-    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#67fbfcdd76307873552324814437a0b3ffe797bd",
+    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#63ff5e59140f486f880e6337172273c3a0db72ca",
     "tiny-hypergraph-poly": "git+https://github.com/tscircuit/tiny-hypergraph.git#7b93b4c",
     "tsup": "^8.3.6",
     "typescript": "^5.9.3",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "recharts": "^2.15.1",
     "tailwind-merge": "^3.2.0",
     "terser": "^5.43.1",
-    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#7c28e65018989c7f1f21b3e2ee2ef749fb4d9e01",
+    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#67fbfcdd76307873552324814437a0b3ffe797bd",
     "tiny-hypergraph-poly": "git+https://github.com/tscircuit/tiny-hypergraph.git#7b93b4c",
     "tsup": "^8.3.6",
     "typescript": "^5.9.3",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "recharts": "^2.15.1",
     "tailwind-merge": "^3.2.0",
     "terser": "^5.43.1",
-    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#1fe25466462dfacf371e15ca494bc8b8f869aa30",
+    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#7c28e65018989c7f1f21b3e2ee2ef749fb4d9e01",
     "tiny-hypergraph-poly": "git+https://github.com/tscircuit/tiny-hypergraph.git#7b93b4c",
     "tsup": "^8.3.6",
     "typescript": "^5.9.3",


### PR DESCRIPTION
## Root cause

Pipeline7 asked `tiny-hypergraph` to duplicate congested graph ports, but it supplied only a fixed 0.05 mm placement band. The prepass could therefore advertise more routes through an opening than the opening could physically carry.

In the real sample 4 case, seven lane centers were only 0.007 mm apart even though the trace is 0.1 mm wide and relaxed DRC requires 0.1 mm clearance.

## Integration

This PR pins [tiny-hypergraph#136](https://github.com/tscircuit/tiny-hypergraph/pull/136) and gives the prepass the two physical values it needs:

- trace width: `minTraceWidth`
- center spacing: `minTraceWidth + 0.1 mm clearance`

The upstream solver then exposes only the lanes that fit the real shared boundary. Excess routes remain in the hypergraph search and are sent through another opening or layer.

## Step visualization

| Step | Graph state |
| --- | --- |
| 1. Reproduction | ![Seven overlapping graph lanes](https://raw.githubusercontent.com/tscircuit/tiny-hypergraph/agent/repro-duplicate-port-physical-capacity/tests/solver/__snapshots__/duplicate-congested-port-physical-capacity-repro.snap.svg) |
| 2. Capacity-aware output | ![Two legal graph lanes](https://raw.githubusercontent.com/tscircuit/tiny-hypergraph/agent/fix-duplicate-port-clearance/tests/solver/__snapshots__/duplicate-congested-port-physical-capacity-repro.snap.svg) |

Blue rectangles are the real adjacent regions, red is the 0.1 mm trace body, orange shows the required 0.2 mm pitch, and black dots are graph lane centers.

## Validation

- Autorouter build: `bun run build`
- Exact srj24 sample 4 Pipeline7 run through `portPointPathingSolver`: completed at 1× effort with the normal 2,000,000-step solve budget.
- Full sample 3/4 routing and relaxed DRC will run in the hosted benchmark on the top PR in this stack, not as a local benchmark.

Stacked on #1833. Upstream reproduction: [tiny-hypergraph#135](https://github.com/tscircuit/tiny-hypergraph/pull/135).
