### PR TITLE
Pin physical duplicate lane coordinates

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "recharts": "^2.15.1",
     "tailwind-merge": "^3.2.0",
     "terser": "^5.43.1",
-    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#63ff5e59140f486f880e6337172273c3a0db72ca",
+    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#299a5240fe1a00d989e058fabc046b36d3f844da",
     "tiny-hypergraph-poly": "git+https://github.com/tscircuit/tiny-hypergraph.git#7b93b4c",
     "tsup": "^8.3.6",
     "typescript": "^5.9.3",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "recharts": "^2.15.1",
     "tailwind-merge": "^3.2.0",
     "terser": "^5.43.1",
-    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#299a5240fe1a00d989e058fabc046b36d3f844da",
+    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#55c621c0197c5242f0af09374d032c3193e019ae",
     "tiny-hypergraph-poly": "git+https://github.com/tscircuit/tiny-hypergraph.git#7b93b4c",
     "tsup": "^8.3.6",
     "typescript": "^5.9.3",


### PR DESCRIPTION
## Stack

Stacked on #1841. This replaces the unsuccessful downstream ordering approach in #1842/#1844.

Upstream:

- reproduction: [tiny-hypergraph#137](https://github.com/tscircuit/tiny-hypergraph/pull/137)
- fix: [tiny-hypergraph#138](https://github.com/tscircuit/tiny-hypergraph/pull/138)

## Problem

Autorouter supplies trace width and clearance to the duplicate-port prepass. The prepass calculated legal physical lane centers, but discarded them when the boundary had enough capacity and used a synthetic 0.05 mm cluster instead.

Pathing therefore checked boundary order on different coordinates than the physical solver received later. A graph route that looked valid could become overlapping or crossed when converted to real traces.

## Fix

Pin the upstream fix. Duplicated ports now have real physical coordinates for boundary ordering, crossing checks, output, and visualization.

The upstream change keeps those physical coordinates separate from optional distance-cost coordinates. This preserves the previous route-length preference, so correcting the topology does not also retune path selection across the board.

This autorouter diff is only the dependency SHA. It adds no downstream patch, new pipeline stage, region type, or invalid-geometry fallback.

## Same fixture before and after

| Before | After |
| --- | --- |
| ![Synthetic 0.025 mm lane spacing](https://raw.githubusercontent.com/tscircuit/tiny-hypergraph/agent/repro-physical-duplicate-lane-placement/tests/solver/__snapshots__/duplicate-congested-port-physical-placement-repro.snap.svg) | ![Physical 0.200 mm lane spacing](https://raw.githubusercontent.com/tscircuit/tiny-hypergraph/agent/fix-physical-duplicate-lane-placement/tests/solver/__snapshots__/duplicate-congested-port-physical-placement-repro.snap.svg) |

Blue rectangles are adjacent graph regions, teal is their shared boundary, red is the real 0.1 mm trace body, orange is the required 0.2 mm trace-plus-clearance envelope, and black points are the physical graph-port positions used for boundary ordering. The internal distance-cost coordinates are intentionally not shown because they do not describe physical geometry.

## Verification

- upstream GitHub-hosted Bun Test: passed ([run](https://github.com/tscircuit/tiny-hypergraph/actions/runs/30742421235))
- autorouter GitHub-hosted checks: the dependency changes route topology and still has snapshot regressions to resolve
- hosted Pipeline7 `srj24` sample 4 benchmark: **failed** in high-density routing after 1505.8 s ([run](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/30742508072), [result](https://github.com/tscircuit/tscircuit-autorouter/pull/1845#issuecomment-5156964695))
- conclusion: this fixes a real duplicate-port coordinate bug, but it is not sufficient to make sample 4 pass
- nothing was run locally
