### PR TITLE
test: reproduce sample 4 pathing crossings

### DIFF
--- a/tests/features/srj24-sample4-boundary-order-handoff.test.ts
+++ b/tests/features/srj24-sample4-boundary-order-handoff.test.ts
@@ -93,6 +93,9 @@ test(
 
     const afterUniform = solver.uniformPortDistributionSolver!.getOutput()
     const afterCrossings = findDifferentNetSingleLayerCrossings(afterUniform)
+    const affectedNodeIds = new Set(
+      [...beforeCrossings, ...afterCrossings].map(({ nodeId }) => nodeId),
+    )
 
     console.log(
       "srj24 sample 4 boundary-order handoff",
@@ -100,6 +103,12 @@ test(
         {
           beforeUniform: beforeCrossings,
           afterUniform: afterCrossings,
+          affectedNodesBeforeUniform: beforeUniform.filter((node) =>
+            affectedNodeIds.has(node.capacityMeshNodeId),
+          ),
+          affectedNodesAfterUniform: afterUniform.filter((node) =>
+            affectedNodeIds.has(node.capacityMeshNodeId),
+          ),
         },
         null,
         2,

--- a/tests/features/srj24-sample4-boundary-order-handoff.test.ts
+++ b/tests/features/srj24-sample4-boundary-order-handoff.test.ts
@@ -36,6 +36,8 @@ const findDifferentNetSingleLayerCrossings = (
   const crossings: Crossing[] = []
 
   for (const node of nodes) {
+    if (node.availableZ.length !== 1) continue
+
     const pairs = node.portPointsInPairs ?? []
     for (let firstIndex = 0; firstIndex < pairs.length; firstIndex++) {
       const first = pairs[firstIndex]!

--- a/tests/features/srj24-sample4-boundary-order-handoff.test.ts
+++ b/tests/features/srj24-sample4-boundary-order-handoff.test.ts
@@ -1,0 +1,110 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver7_MultiGraph } from "lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph"
+import type { NodeWithPortPoints } from "lib/types/high-density-types"
+import { loadScenarioBySampleNumber } from "../../scripts/benchmark/scenarios"
+
+type PointPair = NonNullable<NodeWithPortPoints["portPointsInPairs"]>[number]
+
+type Crossing = {
+  nodeId: string
+  firstConnection: string
+  secondConnection: string
+  firstPortIds: [string | undefined, string | undefined]
+  secondPortIds: [string | undefined, string | undefined]
+}
+
+const crossProduct = (
+  a: { x: number; y: number },
+  b: { x: number; y: number },
+  c: { x: number; y: number },
+) => (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x)
+
+const segmentsCrossStrictly = (first: PointPair, second: PointPair) => {
+  const [a, b] = first
+  const [c, d] = second
+  const firstSideA = crossProduct(a, b, c)
+  const firstSideB = crossProduct(a, b, d)
+  const secondSideA = crossProduct(c, d, a)
+  const secondSideB = crossProduct(c, d, b)
+
+  return firstSideA * firstSideB < 0 && secondSideA * secondSideB < 0
+}
+
+const findDifferentNetSingleLayerCrossings = (
+  nodes: NodeWithPortPoints[],
+): Crossing[] => {
+  const crossings: Crossing[] = []
+
+  for (const node of nodes) {
+    const pairs = node.portPointsInPairs ?? []
+    for (let firstIndex = 0; firstIndex < pairs.length; firstIndex++) {
+      const first = pairs[firstIndex]!
+      if (first[0].z !== first[1].z) continue
+
+      for (
+        let secondIndex = firstIndex + 1;
+        secondIndex < pairs.length;
+        secondIndex++
+      ) {
+        const second = pairs[secondIndex]!
+        if (second[0].z !== second[1].z || first[0].z !== second[0].z) {
+          continue
+        }
+        if (first[0].rootConnectionName === second[0].rootConnectionName) {
+          continue
+        }
+        if (!segmentsCrossStrictly(first, second)) continue
+
+        crossings.push({
+          nodeId: node.capacityMeshNodeId,
+          firstConnection: first[0].connectionName,
+          secondConnection: second[0].connectionName,
+          firstPortIds: [first[0].portPointId, first[1].portPointId],
+          secondPortIds: [second[0].portPointId, second[1].portPointId],
+        })
+      }
+    }
+  }
+
+  return crossings
+}
+
+test(
+  "srj24 sample 4 keeps single-layer boundary ordering through uniform distribution",
+  async (): Promise<void> => {
+    const { scenario } = await loadScenarioBySampleNumber("srj24", 4, 1)
+    const solver = new AutoroutingPipelineSolver7_MultiGraph(scenario, {
+      effort: 1,
+      cacheProvider: null,
+    })
+
+    solver.solveUntilPhase("uniformPortDistributionSolver")
+    expect(solver.failed).toBe(false)
+
+    const beforeUniform =
+      solver.portPointPathingSolver!.getOutput().nodesWithPortPoints
+    const beforeCrossings =
+      findDifferentNetSingleLayerCrossings(beforeUniform)
+
+    solver.solveUntilPhase("highDensityRouteSolver")
+    expect(solver.failed).toBe(false)
+
+    const afterUniform = solver.uniformPortDistributionSolver!.getOutput()
+    const afterCrossings = findDifferentNetSingleLayerCrossings(afterUniform)
+
+    console.log(
+      "srj24 sample 4 boundary-order handoff",
+      JSON.stringify(
+        {
+          beforeUniform: beforeCrossings,
+          afterUniform: afterCrossings,
+        },
+        null,
+        2,
+      ),
+    )
+
+    expect(afterCrossings).toEqual([])
+  },
+  { timeout: 600_000 },
+)

--- a/tests/features/srj24-sample4-boundary-order-handoff.test.ts
+++ b/tests/features/srj24-sample4-boundary-order-handoff.test.ts
@@ -6,11 +6,9 @@ import { loadScenarioBySampleNumber } from "../../scripts/benchmark/scenarios"
 type PointPair = NonNullable<NodeWithPortPoints["portPointsInPairs"]>[number]
 
 type Crossing = {
-  nodeId: string
-  firstConnection: string
-  secondConnection: string
-  firstPortIds: [string | undefined, string | undefined]
-  secondPortIds: [string | undefined, string | undefined]
+  node: NodeWithPortPoints
+  first: PointPair
+  second: PointPair
 }
 
 const crossProduct = (
@@ -58,11 +56,9 @@ const findDifferentNetSingleLayerCrossings = (
         if (!segmentsCrossStrictly(first, second)) continue
 
         crossings.push({
-          nodeId: node.capacityMeshNodeId,
-          firstConnection: first[0].connectionName,
-          secondConnection: second[0].connectionName,
-          firstPortIds: [first[0].portPointId, first[1].portPointId],
-          secondPortIds: [second[0].portPointId, second[1].portPointId],
+          node,
+          first,
+          second,
         })
       }
     }
@@ -71,8 +67,40 @@ const findDifferentNetSingleLayerCrossings = (
   return crossings
 }
 
+const summarizePoint = (
+  point: PointPair[number],
+  node: NodeWithPortPoints,
+) => {
+  const bounds = {
+    minX: node.center.x - node.width / 2,
+    maxX: node.center.x + node.width / 2,
+    minY: node.center.y - node.height / 2,
+    maxY: node.center.y + node.height / 2,
+  }
+
+  return {
+    portPointId: point.portPointId,
+    connectionName: point.connectionName,
+    rootConnectionName: point.rootConnectionName,
+    x: point.x,
+    y: point.y,
+    z: point.z,
+    distanceToNodeBoundary: Math.min(
+      Math.abs(point.x - bounds.minX),
+      Math.abs(point.x - bounds.maxX),
+      Math.abs(point.y - bounds.minY),
+      Math.abs(point.y - bounds.maxY),
+    ),
+    insideNodeBounds:
+      point.x >= bounds.minX &&
+      point.x <= bounds.maxX &&
+      point.y >= bounds.minY &&
+      point.y <= bounds.maxY,
+  }
+}
+
 test(
-  "srj24 sample 4 keeps single-layer boundary ordering through uniform distribution",
+  "srj24 sample 4 pathing does not cross different nets in a single-layer node",
   async (): Promise<void> => {
     const { scenario } = await loadScenarioBySampleNumber("srj24", 4, 1)
     const solver = new AutoroutingPipelineSolver7_MultiGraph(scenario, {
@@ -83,39 +111,39 @@ test(
     solver.solveUntilPhase("uniformPortDistributionSolver")
     expect(solver.failed).toBe(false)
 
-    const beforeUniform =
+    const pathingOutput =
       solver.portPointPathingSolver!.getOutput().nodesWithPortPoints
-    const beforeCrossings =
-      findDifferentNetSingleLayerCrossings(beforeUniform)
-
-    solver.solveUntilPhase("highDensityRouteSolver")
-    expect(solver.failed).toBe(false)
-
-    const afterUniform = solver.uniformPortDistributionSolver!.getOutput()
-    const afterCrossings = findDifferentNetSingleLayerCrossings(afterUniform)
-    const affectedNodeIds = new Set(
-      [...beforeCrossings, ...afterCrossings].map(({ nodeId }) => nodeId),
-    )
+    const crossings = findDifferentNetSingleLayerCrossings(pathingOutput)
+    const firstCrossing = crossings[0]
 
     console.log(
-      "srj24 sample 4 boundary-order handoff",
+      "srj24 sample 4 single-layer crossing",
       JSON.stringify(
-        {
-          beforeUniform: beforeCrossings,
-          afterUniform: afterCrossings,
-          affectedNodesBeforeUniform: beforeUniform.filter((node) =>
-            affectedNodeIds.has(node.capacityMeshNodeId),
-          ),
-          affectedNodesAfterUniform: afterUniform.filter((node) =>
-            affectedNodeIds.has(node.capacityMeshNodeId),
-          ),
-        },
+        firstCrossing
+          ? {
+              crossingCount: crossings.length,
+              node: {
+                capacityMeshNodeId:
+                  firstCrossing.node.capacityMeshNodeId,
+                center: firstCrossing.node.center,
+                width: firstCrossing.node.width,
+                height: firstCrossing.node.height,
+                availableZ: firstCrossing.node.availableZ,
+              },
+              firstPair: firstCrossing.first.map((point) =>
+                summarizePoint(point, firstCrossing.node),
+              ),
+              secondPair: firstCrossing.second.map((point) =>
+                summarizePoint(point, firstCrossing.node),
+              ),
+            }
+          : { crossingCount: 0 },
         null,
         2,
       ),
     )
 
-    expect(afterCrossings).toEqual([])
+    expect(crossings.length).toBe(0)
   },
   { timeout: 600_000 },
 )


### PR DESCRIPTION
## Stack

Stacked on #1845, which gives duplicated graph ports real physical lane coordinates.

## Problem

Port-point pathing must not connect two different nets as crossing chords inside a node that has only one available layer. There is no second copper layer inside that node where one route can pass over the other.

The earlier version of this PR compared pathing with uniform port distribution. That was misleading: the crossing already exists in the pathing output.

## Reproduction

The test runs srj24 sample 4 only through port-point pathing and checks every route pair in every single-layer node before uniform distribution or high-density routing runs.

The hosted result finds 382 different-net crossings. The first is in cmn_188, which has only z0. All four endpoints report zero distance from the real node boundary, so this is real invalid pathing topology rather than a drawing approximation.

[Hosted reproduction run](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/30913283091)

## Root cause and fix stack

The same bug has a small native tiny-hypergraph reproduction and fix:

- [tiny-hypergraph #139](https://github.com/tscircuit/tiny-hypergraph/pull/139) shows the timeout-only greedy fallback committing a crossing.
- [tiny-hypergraph #140](https://github.com/tscircuit/tiny-hypergraph/pull/140) keeps hard crossing rejection in greedy routing and validates the final endpoint hop.

Those PRs use one unchanged solver fixture and its native SVG snapshot. Before the fix, both crossing routes are committed as solid lines. After the fix, the invalid route stays uncommitted as a dashed request.

## Validation

- GitHub Actions only; nothing was run locally.
- This reproduction fails with Received: 382, Expected: 0.
- The upstream fix suite passes on GitHub Actions.
