### PR TITLE
Reject invalid greedy final routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "recharts": "^2.15.1",
     "tailwind-merge": "^3.2.0",
     "terser": "^5.43.1",
-    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#55c621c0197c5242f0af09374d032c3193e019ae",
+    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#2ac358656476d25c4a938a75cac464b499d1bdbf",
     "tiny-hypergraph-poly": "git+https://github.com/tscircuit/tiny-hypergraph.git#7b93b4c",
     "tsup": "^8.3.6",
     "typescript": "^5.9.3",


### PR DESCRIPTION
## Stack

Stacked on #1845. The upstream solver reproduction and fix are tscircuit/tiny-hypergraph#139 and tscircuit/tiny-hypergraph#140.

## Problem

When port-point pathing reached its timeout fallback, the greedy final-route solver could accept a same-layer crossing that normal search had rejected. The invalid topology then reached high-density routing and produced intersecting, broken traces.

## Change

Pin the GitHub-hosted, tested tiny-hypergraph fix from tscircuit/tiny-hypergraph#140.

The upstream change makes the timeout fallback preserve hard rejections and validates the last hop into an endpoint. It does not add a pipeline stage, topology type, or geometry cleanup pass.

## Visual reproduction

The same upstream fixture is used before and after the fix:

| Before: invalid crossing accepted | After: invalid crossing rejected |
| --- | --- |
| ![Before: both crossing routes are solid](https://raw.githubusercontent.com/tscircuit/tiny-hypergraph/agent/repro-greedy-final-route-hard-constraints/tests/solver/__snapshots__/greedy-final-route-hard-constraints.snap.svg) | ![After: only the legal route is solid](https://raw.githubusercontent.com/tscircuit/tiny-hypergraph/agent/fix-greedy-final-route-hard-constraints/tests/solver/__snapshots__/greedy-final-route-hard-constraints.snap.svg) |

Solid lines are committed routes. The dashed horizontal line in the fixed image is the route request left unrouted because its only path is illegal.

## Hosted validation

- [upstream full test and snapshot suite passed](https://github.com/tscircuit/tiny-hypergraph/actions/runs/30744558151)
- exact `srj24` sample 4 benchmark: pending on this PR
- nothing was run locally
