### PR TITLE
test(pathing): reproduce sample 4 selective-rerip stall

### DIFF
--- a/lib/solvers/TopologyMergingSolver/get-cross-layer-target-access.ts
+++ b/lib/solvers/TopologyMergingSolver/get-cross-layer-target-access.ts
@@ -17,6 +17,7 @@ import type {
 type CrossLayerAccessOverlap = {
   bounds: Bounds
   availableZ: number[]
+  isTarget: boolean
 }
 
 const getConnectionAliases = (node: CapacityMeshNode): string[] => [
@@ -205,6 +206,7 @@ function getAlignedCrossLayerAccessRegions({
         doesBoundsContainPoint(blocker, center),
       )
       const accessLayers = crossLayerAccessOverlaps.flatMap((candidate) =>
+        !candidate.isTarget &&
         doesBoundsContainPoint(candidate.bounds, center)
           ? candidate.availableZ
           : [],
@@ -280,7 +282,15 @@ function addCrossLayerAccessToTarget({
       if (!isFree && !isSameNetTarget) return []
 
       const bounds = getCrossLayerAccessOverlap(node, candidate)
-      return bounds ? [{ bounds, availableZ: [...candidate.availableZ] }] : []
+      return bounds
+        ? [
+            {
+              bounds,
+              availableZ: [...candidate.availableZ],
+              isTarget: !isFree,
+            },
+          ]
+        : []
     },
   )
   if (crossLayerAccessOverlaps.length === 0) return [node]
@@ -312,12 +322,12 @@ function addCrossLayerAccessToTarget({
     ...node.availableZ,
     ...crossLayerSameNetTargets.flatMap((target) => target.availableZ),
   ])
+  const targetIntersections = crossLayerSameNetTargets.flatMap((target) => {
+    const intersection = getCrossLayerAccessOverlap(node, target)
+    return intersection ? [intersection] : []
+  })
   if (reachableZ) {
     const accessZ = reachableZ.filter((z) => targetConnectionLayers.has(z))
-    const targetIntersections = crossLayerSameNetTargets.flatMap((target) => {
-      const intersection = getCrossLayerAccessOverlap(node, target)
-      return intersection ? [intersection] : []
-    })
     // Preserve the existing uniform-target behavior. Partial access below is
     // only needed when different XY areas have different layer roles.
     const xCoordinates = getCanonicalCoordinates([
@@ -353,6 +363,13 @@ function addCrossLayerAccessToTarget({
       ? slices
       : [node]
   }
+
+  const hasViaSizedTargetOverlap = targetIntersections.some(
+    (bounds) =>
+      Math.min(bounds.maxX - bounds.minX, bounds.maxY - bounds.minY) >=
+      viaDiameter,
+  )
+  if (hasViaSizedTargetOverlap) return [node]
 
   const regions = getAlignedCrossLayerAccessRegions({
     targetBounds: nodeBounds,

--- a/lib/solvers/TopologyMergingSolver/get-cross-layer-target-access.ts
+++ b/lib/solvers/TopologyMergingSolver/get-cross-layer-target-access.ts
@@ -72,6 +72,74 @@ function getReachableLayers({
   return [...reachableLayers].sort((a, b) => a - b)
 }
 
+function getUniformCrossLayerAccess({
+  targetBounds,
+  crossLayerAccessOverlaps,
+  blockerBounds,
+  targetLayers,
+}: {
+  targetBounds: Bounds
+  crossLayerAccessOverlaps: CrossLayerAccessOverlap[]
+  blockerBounds: Bounds[]
+  targetLayers: number[]
+}): number[] | null {
+  const xCoordinates = getCanonicalCoordinates([
+    targetBounds.minX,
+    targetBounds.maxX,
+    ...crossLayerAccessOverlaps.flatMap(({ bounds }) => [
+      bounds.minX,
+      bounds.maxX,
+    ]),
+    ...blockerBounds.flatMap((bounds) => [bounds.minX, bounds.maxX]),
+  ])
+  const yCoordinates = getCanonicalCoordinates([
+    targetBounds.minY,
+    targetBounds.maxY,
+    ...crossLayerAccessOverlaps.flatMap(({ bounds }) => [
+      bounds.minY,
+      bounds.maxY,
+    ]),
+    ...blockerBounds.flatMap((bounds) => [bounds.minY, bounds.maxY]),
+  ])
+  let uniformAvailableZ: number[] | undefined
+
+  for (let xIndex = 0; xIndex < xCoordinates.length - 1; xIndex++) {
+    for (let yIndex = 0; yIndex < yCoordinates.length - 1; yIndex++) {
+      const bounds = {
+        minX: xCoordinates[xIndex]!,
+        maxX: xCoordinates[xIndex + 1]!,
+        minY: yCoordinates[yIndex]!,
+        maxY: yCoordinates[yIndex + 1]!,
+      }
+      const center = {
+        x: (bounds.minX + bounds.maxX) / 2,
+        y: (bounds.minY + bounds.maxY) / 2,
+      }
+      const isBlocked = blockerBounds.some((blocker) =>
+        doesBoundsContainPoint(blocker, center),
+      )
+      if (isBlocked) return null
+
+      const accessLayers = crossLayerAccessOverlaps.flatMap((candidate) =>
+        doesBoundsContainPoint(candidate.bounds, center)
+          ? candidate.availableZ
+          : [],
+      )
+      const availableZ = getReachableLayers({ targetLayers, accessLayers })
+      if (!availableZ.some((z) => !targetLayers.includes(z))) return null
+      if (
+        uniformAvailableZ &&
+        uniformAvailableZ.join(",") !== availableZ.join(",")
+      ) {
+        return null
+      }
+      uniformAvailableZ = availableZ
+    }
+  }
+
+  return uniformAvailableZ ?? null
+}
+
 function createAccessRegion(
   bounds: Bounds,
   availableZ: number[],
@@ -232,12 +300,60 @@ function addCrossLayerAccessToTarget({
     )
     return intersection ? [intersection] : []
   })
+  const reachableZ = getUniformCrossLayerAccess({
+    targetBounds: nodeBounds,
+    crossLayerAccessOverlaps,
+    blockerBounds,
+    targetLayers: node.availableZ,
+  })
   // Free component layers prove that a via can pass through the footprint;
   // only layers with a same-net target become target-owned routing capacity.
   const targetConnectionLayers = new Set([
     ...node.availableZ,
     ...crossLayerSameNetTargets.flatMap((target) => target.availableZ),
   ])
+  if (reachableZ) {
+    const accessZ = reachableZ.filter((z) => targetConnectionLayers.has(z))
+    const targetIntersections = crossLayerSameNetTargets.flatMap((target) => {
+      const intersection = getCrossLayerAccessOverlap(node, target)
+      return intersection ? [intersection] : []
+    })
+    // Preserve the existing uniform-target behavior. Partial access below is
+    // only needed when different XY areas have different layer roles.
+    const xCoordinates = getCanonicalCoordinates([
+      nodeBounds.minX,
+      nodeBounds.maxX,
+      ...targetIntersections.flatMap((bounds) => [bounds.minX, bounds.maxX]),
+    ])
+    const slices = xCoordinates.slice(0, -1).map((minX, index) => {
+      const maxX = xCoordinates[index + 1]!
+      const width = maxX - minX
+      const centerX = (minX + maxX) / 2
+      const isCrossLayerTargetColumn = targetIntersections.some(
+        (bounds) => centerX >= bounds.minX && centerX <= bounds.maxX,
+      )
+      const availableZ =
+        !isCrossLayerTargetColumn && Math.min(width, node.height) >= viaDiameter
+          ? accessZ
+          : node.availableZ
+
+      return {
+        ...node,
+        capacityMeshNodeId: `${node.capacityMeshNodeId}:cross-layer-slice:${index}`,
+        center: { x: centerX, y: node.center.y },
+        width,
+        availableZ,
+        layer: `z${availableZ.join(",")}`,
+      }
+    })
+
+    return slices.some(
+      ({ availableZ }) => availableZ.length > node.availableZ.length,
+    )
+      ? slices
+      : [node]
+  }
+
   const regions = getAlignedCrossLayerAccessRegions({
     targetBounds: nodeBounds,
     crossLayerAccessOverlaps,

--- a/lib/solvers/TopologyMergingSolver/get-cross-layer-target-access.ts
+++ b/lib/solvers/TopologyMergingSolver/get-cross-layer-target-access.ts
@@ -5,10 +5,14 @@ import {
   getCapacityMeshNodeBounds,
 } from "../TopologyPlanningSolver/capacity-node-geometry"
 import {
+  compactTopologyMergingRegions,
   doesBoundsContainPoint,
   getCanonicalCoordinates,
 } from "./topology-merging-regions"
-import type { TopologyMergingNodeGroup } from "./topology-merging-types"
+import type {
+  TopologyMergingNodeGroup,
+  TopologyMergingRegion,
+} from "./topology-merging-types"
 
 type CrossLayerAccessOverlap = {
   bounds: Bounds
@@ -68,17 +72,35 @@ function getReachableLayers({
   return [...reachableLayers].sort((a, b) => a - b)
 }
 
-function getUniformCrossLayerAccess({
+function createAccessRegion(
+  bounds: Bounds,
+  availableZ: number[],
+): TopologyMergingRegion {
+  const topologySignature = `cross-layer-target:${availableZ.join(",")}`
+  return {
+    bounds,
+    availableZ,
+    sourceKeys: [],
+    topologyMode: "target-passthrough",
+    topologySignature,
+  }
+}
+
+function getAlignedCrossLayerAccessRegions({
   targetBounds,
   crossLayerAccessOverlaps,
   blockerBounds,
   targetLayers,
+  targetConnectionLayers,
+  viaDiameter,
 }: {
   targetBounds: Bounds
   crossLayerAccessOverlaps: CrossLayerAccessOverlap[]
   blockerBounds: Bounds[]
   targetLayers: number[]
-}): number[] | null {
+  targetConnectionLayers: ReadonlySet<number>
+  viaDiameter: number
+}): TopologyMergingRegion[] {
   const xCoordinates = getCanonicalCoordinates([
     targetBounds.minX,
     targetBounds.maxX,
@@ -97,7 +119,7 @@ function getUniformCrossLayerAccess({
     ]),
     ...blockerBounds.flatMap((bounds) => [bounds.minY, bounds.maxY]),
   ])
-  let uniformAvailableZ: number[] | undefined
+  const atomicRegions: TopologyMergingRegion[] = []
 
   for (let xIndex = 0; xIndex < xCoordinates.length - 1; xIndex++) {
     for (let yIndex = 0; yIndex < yCoordinates.length - 1; yIndex++) {
@@ -114,26 +136,42 @@ function getUniformCrossLayerAccess({
       const isBlocked = blockerBounds.some((blocker) =>
         doesBoundsContainPoint(blocker, center),
       )
-      if (isBlocked) return null
-
       const accessLayers = crossLayerAccessOverlaps.flatMap((candidate) =>
         doesBoundsContainPoint(candidate.bounds, center)
           ? candidate.availableZ
           : [],
       )
-      const availableZ = getReachableLayers({ targetLayers, accessLayers })
-      if (!availableZ.some((z) => !targetLayers.includes(z))) return null
-      if (
-        uniformAvailableZ &&
-        uniformAvailableZ.join(",") !== availableZ.join(",")
-      ) {
-        return null
-      }
-      uniformAvailableZ = availableZ
+      const reachableZ = isBlocked
+        ? targetLayers
+        : getReachableLayers({ targetLayers, accessLayers })
+      const availableZ = reachableZ.filter((z) =>
+        targetConnectionLayers.has(z),
+      )
+      atomicRegions.push(
+        createAccessRegion(
+          bounds,
+          availableZ.some((z) => !targetLayers.includes(z))
+            ? availableZ
+            : targetLayers,
+        ),
+      )
     }
   }
 
-  return uniformAvailableZ ?? null
+  const alignedRegions = compactTopologyMergingRegions(atomicRegions).map(
+    (region) => {
+      const addsLayer = region.availableZ.some(
+        (z) => !targetLayers.includes(z),
+      )
+      const width = region.bounds.maxX - region.bounds.minX
+      const height = region.bounds.maxY - region.bounds.minY
+      return addsLayer && Math.min(width, height) < viaDiameter
+        ? createAccessRegion(region.bounds, targetLayers)
+        : region
+    },
+  )
+
+  return compactTopologyMergingRegions(alignedRegions)
 }
 
 function addCrossLayerAccessToTarget({
@@ -194,58 +232,40 @@ function addCrossLayerAccessToTarget({
     )
     return intersection ? [intersection] : []
   })
-  const reachableZ = getUniformCrossLayerAccess({
+  // Free component layers prove that a via can pass through the footprint;
+  // only layers with a same-net target become target-owned routing capacity.
+  const targetConnectionLayers = new Set([
+    ...node.availableZ,
+    ...crossLayerSameNetTargets.flatMap((target) => target.availableZ),
+  ])
+  const regions = getAlignedCrossLayerAccessRegions({
     targetBounds: nodeBounds,
     crossLayerAccessOverlaps,
     blockerBounds,
     targetLayers: node.availableZ,
+    targetConnectionLayers,
+    viaDiameter,
   })
-  if (!reachableZ) return [node]
-
-  // Free component layers prove that a via can pass through the footprint;
-  // only layers with a same-net target become target-owned routing capacity.
-  const targetZ = new Set([
-    ...node.availableZ,
-    ...crossLayerSameNetTargets.flatMap((target) => target.availableZ),
-  ])
-  const accessZ = reachableZ.filter((z) => targetZ.has(z))
-  const targetIntersections = crossLayerSameNetTargets.flatMap((target) => {
-    const intersection = getCrossLayerAccessOverlap(node, target)
-    return intersection ? [intersection] : []
-  })
-  // Preserve full-height columns so a legal access strip is not fragmented by
-  // the shorter target on the other layer.
-  const xCoordinates = getCanonicalCoordinates([
-    nodeBounds.minX,
-    nodeBounds.maxX,
-    ...targetIntersections.flatMap((bounds) => [bounds.minX, bounds.maxX]),
-  ])
-  const slices = xCoordinates.slice(0, -1).map((minX, index) => {
-    const maxX = xCoordinates[index + 1]!
-    const width = maxX - minX
-    const centerX = (minX + maxX) / 2
-    const isCrossLayerTargetColumn = targetIntersections.some(
-      (bounds) => centerX >= bounds.minX && centerX <= bounds.maxX,
-    )
-    const availableZ =
-      !isCrossLayerTargetColumn && Math.min(width, node.height) >= viaDiameter
-        ? accessZ
-        : node.availableZ
-
+  const alignedNodes = regions.map((region, index) => {
+    const { bounds, availableZ } = region
     return {
       ...node,
-      capacityMeshNodeId: `${node.capacityMeshNodeId}:cross-layer-slice:${index}`,
-      center: { x: centerX, y: node.center.y },
-      width,
+      capacityMeshNodeId: `${node.capacityMeshNodeId}:cross-layer-region:${index}`,
+      center: {
+        x: (bounds.minX + bounds.maxX) / 2,
+        y: (bounds.minY + bounds.maxY) / 2,
+      },
+      width: bounds.maxX - bounds.minX,
+      height: bounds.maxY - bounds.minY,
       availableZ,
       layer: `z${availableZ.join(",")}`,
     }
   })
 
-  return slices.some(
+  return alignedNodes.some(
     ({ availableZ }) => availableZ.length > node.availableZ.length,
   )
-    ? slices
+    ? alignedNodes
     : [node]
 }
 

--- a/tests/features/srj24-sample4-selective-rerip-stall.test.ts
+++ b/tests/features/srj24-sample4-selective-rerip-stall.test.ts
@@ -1,0 +1,275 @@
+import "bun-match-svg"
+import { expect, test } from "bun:test"
+import { getSvgFromGraphicsObject } from "graphics-debug"
+import { AutoroutingPipelineSolver7_MultiGraph } from "lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph"
+import type { CapacityMeshNode } from "lib/types"
+import type { TinyHyperGraphSolver } from "tiny-hypergraph/lib/index"
+import { loadScenarioBySampleNumber } from "../../scripts/benchmark/scenarios"
+
+const PATHING_ITERATION_LIMIT = 250_000
+
+const getRegionSummary = (
+  solver: TinyHyperGraphSolver,
+  regionId: number,
+) => {
+  const metadata = solver.topology.regionMetadata?.[regionId] as
+    | Record<string, unknown>
+    | undefined
+
+  return {
+    regionId,
+    serializedRegionId:
+      metadata?.serializedRegionId ?? metadata?.capacityMeshNodeId,
+    netId: solver.problem.regionNetId[regionId],
+    availableZMask: solver.topology.regionAvailableZMask?.[regionId],
+    center: {
+      x: solver.topology.regionCenterX[regionId],
+      y: solver.topology.regionCenterY[regionId],
+    },
+    width: solver.topology.regionWidth[regionId],
+    height: solver.topology.regionHeight[regionId],
+    incidentPortCount:
+      solver.topology.regionIncidentPorts[regionId]?.length ?? 0,
+    availableZ: metadata?.availableZ,
+    containsObstacle: metadata?._containsObstacle,
+    containsTarget: metadata?._containsTarget,
+    qfpRegionType: metadata?._qfpRegionType,
+  }
+}
+
+const getPortSummary = (solver: TinyHyperGraphSolver, portId: number) => ({
+  portId,
+  serializedPortId: solver.topology.portMetadata?.[portId]?.serializedPortId,
+  x: solver.topology.portX[portId],
+  y: solver.topology.portY[portId],
+  z: solver.topology.portZ[portId],
+  routingCostX: solver.topology.portRoutingCostX?.[portId],
+  routingCostY: solver.topology.portRoutingCostY?.[portId],
+  incidentRegions: (solver.topology.incidentPortRegion[portId] ?? []).map(
+    (regionId) => getRegionSummary(solver, regionId),
+  ),
+})
+
+const getDistanceToRegion = (
+  solver: TinyHyperGraphSolver,
+  regionId: number,
+  point: { x: number; y: number },
+) => {
+  const dx = Math.max(
+    Math.abs(solver.topology.regionCenterX[regionId] - point.x) -
+      solver.topology.regionWidth[regionId] / 2,
+    0,
+  )
+  const dy = Math.max(
+    Math.abs(solver.topology.regionCenterY[regionId] - point.y) -
+      solver.topology.regionHeight[regionId] / 2,
+    0,
+  )
+  return Math.hypot(dx, dy)
+}
+
+const getCandidatePath = (solver: TinyHyperGraphSolver) => {
+  let candidate = solver.state.candidateQueue
+    .toArray()
+    .sort((left, right) => left.f - right.f)[0]
+  const path = []
+
+  while (candidate) {
+    path.unshift({
+      ...getPortSummary(solver, candidate.portId),
+      nextRegion: getRegionSummary(solver, candidate.nextRegionId),
+      f: candidate.f,
+      g: candidate.g,
+      h: candidate.h,
+    })
+    candidate = candidate.prevCandidate
+  }
+
+  return path
+}
+
+const getInputNodeSummary = ({
+  groupId,
+  isComponent,
+  node,
+}: {
+  groupId: string
+  isComponent: boolean
+  node: CapacityMeshNode
+}) => ({
+  groupId,
+  isComponent,
+  capacityMeshNodeId: node.capacityMeshNodeId,
+  center: node.center,
+  width: node.width,
+  height: node.height,
+  availableZ: node.availableZ,
+  containsObstacle: node._containsObstacle,
+  containsTarget: node._containsTarget,
+  targetConnectionName: node._targetConnectionName,
+  connectedTo: node._connectedTo,
+})
+
+const getDistanceToInputNode = (
+  node: CapacityMeshNode,
+  point: { x: number; y: number },
+) => {
+  const dx = Math.max(
+    Math.abs(node.center.x - point.x) - node.width / 2,
+    0,
+  )
+  const dy = Math.max(
+    Math.abs(node.center.y - point.y) - node.height / 2,
+    0,
+  )
+  return Math.hypot(dx, dy)
+}
+
+test("srj24 sample 4 finishes selective-rerip port pathing", async (): Promise<void> => {
+  const { scenario } = await loadScenarioBySampleNumber("srj24", 4, 1)
+  const solver = new AutoroutingPipelineSolver7_MultiGraph(scenario, {
+    effort: 1,
+    cacheProvider: null,
+  })
+
+  solver.solveUntilPhase("portPointPathingSolver")
+  solver.step()
+
+  const pathingSolver = solver.portPointPathingSolver!
+  pathingSolver.MAX_ITERATIONS = PATHING_ITERATION_LIMIT
+
+  while (
+    solver.getCurrentPhase() === "portPointPathingSolver" &&
+    !solver.failed &&
+    !solver.solved
+  ) {
+    solver.step()
+  }
+
+  const pathingStats = pathingSolver.stats as Record<string, unknown>
+  const tinySolver = pathingSolver.activeSubSolver as TinyHyperGraphSolver
+  const tinyStats = tinySolver.stats as Record<string, unknown>
+  const currentRouteId = tinySolver.state.currentRouteId
+  const currentRouteMetadata =
+    currentRouteId === undefined
+      ? undefined
+      : tinySolver.problem.routeMetadata?.[currentRouteId]
+  const startPortId =
+    currentRouteId === undefined
+      ? undefined
+      : tinySolver.problem.routeStartPort[currentRouteId]
+  const endPortId =
+    currentRouteId === undefined
+      ? undefined
+      : tinySolver.problem.routeEndPort[currentRouteId]
+  const endpointMidpoint =
+    startPortId === undefined || endPortId === undefined
+      ? undefined
+      : {
+          x:
+            (tinySolver.topology.portX[startPortId] +
+              tinySolver.topology.portX[endPortId]) /
+            2,
+          y:
+            (tinySolver.topology.portY[startPortId] +
+              tinySolver.topology.portY[endPortId]) /
+            2,
+        }
+  const nearbyRegions = endpointMidpoint
+    ? Array.from({ length: tinySolver.topology.regionCount }, (_, regionId) =>
+        getRegionSummary(tinySolver, regionId),
+      )
+        .filter(
+          ({ regionId }) =>
+            getDistanceToRegion(tinySolver, regionId, endpointMidpoint) <= 0.5,
+        )
+        .sort(
+          (left, right) =>
+            getDistanceToRegion(tinySolver, left.regionId, endpointMidpoint) -
+            getDistanceToRegion(tinySolver, right.regionId, endpointMidpoint),
+        )
+        .slice(0, 50)
+    : []
+  const nearbyTopologyInputNodes = endpointMidpoint
+    ? solver.topologyMergingSolver!.inputProblem.nodeGroups
+        .flatMap((group) =>
+          group.nodes.map((node) => ({
+            groupId: group.groupId,
+            isComponent: group.isComponent,
+            node,
+          })),
+        )
+        .filter(
+          ({ node }) =>
+            getDistanceToInputNode(node, endpointMidpoint) <= 0.5,
+        )
+        .sort(
+          (left, right) =>
+            getDistanceToInputNode(left.node, endpointMidpoint) -
+            getDistanceToInputNode(right.node, endpointMidpoint),
+        )
+        .slice(0, 100)
+        .map(getInputNodeSummary)
+    : []
+  const committedRouteIds = new Set(
+    tinySolver.state.regionSegments.flatMap((segments) =>
+      segments.map(([routeId]) => routeId),
+    ),
+  )
+  console.log(
+    "srj24 sample 4 selective-rerip stall",
+    JSON.stringify(
+      {
+        iterations: pathingSolver.iterations,
+        solved: pathingSolver.solved,
+        failed: pathingSolver.failed,
+        error: pathingSolver.error,
+        currentStage: pathingStats.currentStage,
+        tinyIterations: tinySolver.iterations,
+        regionCount: tinySolver.topology.regionCount,
+        portCount: tinySolver.topology.portCount,
+        routeCount: tinySolver.problem.routeCount,
+        committedRouteCount: committedRouteIds.size,
+        pendingRouteCount: tinySolver.state.unroutedRoutes.length,
+        currentRouteId,
+        currentRouteMetadata,
+        startPort:
+          startPortId === undefined
+            ? undefined
+            : getPortSummary(tinySolver, startPortId),
+        endPort:
+          endPortId === undefined
+            ? undefined
+            : getPortSummary(tinySolver, endPortId),
+        endpointMidpoint,
+        nearbyTopologyInputNodes,
+        nearbyRegions,
+        bestCandidatePath: getCandidatePath(tinySolver),
+        candidateQueueLength: tinySolver.state.candidateQueue.length,
+        ripCount: tinySolver.state.ripCount,
+        neverSuccessfullyRoutedRoutes:
+          tinySolver.getNeverSuccessfullyRoutedRoutes(),
+        selectiveRipCount: tinyStats.selectiveRipCount,
+        selectivelyRippedRouteCount: tinyStats.selectivelyRippedRouteCount,
+        globalReripCount: tinyStats.globalReripCount,
+        globalReripReason: tinyStats.globalReripReason,
+        maxFailedOwnerPairCount: tinyStats.maxFailedOwnerPairCount,
+        lastFailedRouteId: tinyStats.lastFailedRouteId,
+        lastDirectOwnerRouteIds: tinyStats.lastDirectOwnerRouteIds,
+        lastRepeatedOwnerRouteIds: tinyStats.lastRepeatedOwnerRouteIds,
+        lastAlternateOwnerRouteIds: tinyStats.lastAlternateOwnerRouteIds,
+        lastRippedRouteIds: tinyStats.lastRippedRouteIds,
+        neverSuccessfullyRoutedRouteCount:
+          tinyStats.neverSuccessfullyRoutedRouteCount,
+      },
+      null,
+      2,
+    ),
+  )
+
+  expect(
+    getSvgFromGraphicsObject(pathingSolver.visualize()),
+  ).toMatchSvgSnapshot(import.meta.path)
+  expect(pathingSolver.failed).toBe(false)
+  expect(pathingSolver.solved).toBe(true)
+})

--- a/tests/features/srj24-sample4-selective-rerip-stall.test.ts
+++ b/tests/features/srj24-sample4-selective-rerip-stall.test.ts
@@ -92,10 +92,12 @@ const getInputNodeSummary = ({
   groupId,
   isComponent,
   node,
+  routeRootIds,
 }: {
   groupId: string
   isComponent: boolean
   node: CapacityMeshNode
+  routeRootIds: readonly string[]
 }) => ({
   groupId,
   isComponent,
@@ -107,7 +109,12 @@ const getInputNodeSummary = ({
   containsObstacle: node._containsObstacle,
   containsTarget: node._containsTarget,
   targetConnectionName: node._targetConnectionName,
-  connectedTo: node._connectedTo,
+  connectedToCount: node._connectedTo?.length ?? 0,
+  retainedRouteRoots: routeRootIds.filter(
+    (rootId) =>
+      node._targetConnectionName === rootId ||
+      node._connectedTo?.includes(rootId),
+  ),
 })
 
 const getDistanceToInputNode = (
@@ -154,6 +161,12 @@ test("srj24 sample 4 finishes selective-rerip port pathing", async (): Promise<v
     currentRouteId === undefined
       ? undefined
       : tinySolver.problem.routeMetadata?.[currentRouteId]
+  const currentRouteRootIds =
+    (
+      currentRouteMetadata?.simpleRouteConnection as
+        | { __rootConnectionNames?: string[] }
+        | undefined
+    )?.__rootConnectionNames ?? []
   const startPortId =
     currentRouteId === undefined
       ? undefined
@@ -209,7 +222,35 @@ test("srj24 sample 4 finishes selective-rerip port pathing", async (): Promise<v
             getDistanceToInputNode(right.node, endpointMidpoint),
         )
         .slice(0, 100)
-        .map(getInputNodeSummary)
+        .map(({ groupId, isComponent, node }) =>
+          getInputNodeSummary({
+            groupId,
+            isComponent,
+            node,
+            routeRootIds: currentRouteRootIds,
+          }),
+        )
+    : []
+  const nearbyMergedNodes = endpointMidpoint
+    ? solver
+        .topologyMergingSolver!.getOutput()
+        .filter(
+          (node) => getDistanceToInputNode(node, endpointMidpoint) <= 0.5,
+        )
+        .sort(
+          (left, right) =>
+            getDistanceToInputNode(left, endpointMidpoint) -
+            getDistanceToInputNode(right, endpointMidpoint),
+        )
+        .slice(0, 100)
+        .map((node) =>
+          getInputNodeSummary({
+            groupId: "merged",
+            isComponent: node._isComponentTopologyNode === true,
+            node,
+            routeRootIds: currentRouteRootIds,
+          }),
+        )
     : []
   const committedRouteIds = new Set(
     tinySolver.state.regionSegments.flatMap((segments) =>
@@ -232,6 +273,10 @@ test("srj24 sample 4 finishes selective-rerip port pathing", async (): Promise<v
         committedRouteCount: committedRouteIds.size,
         pendingRouteCount: tinySolver.state.unroutedRoutes.length,
         currentRouteId,
+        currentRouteNetId:
+          currentRouteId === undefined
+            ? undefined
+            : tinySolver.problem.routeNet[currentRouteId],
         currentRouteMetadata,
         startPort:
           startPortId === undefined
@@ -243,6 +288,7 @@ test("srj24 sample 4 finishes selective-rerip port pathing", async (): Promise<v
             : getPortSummary(tinySolver, endPortId),
         endpointMidpoint,
         nearbyTopologyInputNodes,
+        nearbyMergedNodes,
         nearbyRegions,
         bestCandidatePath: getCandidatePath(tinySolver),
         candidateQueueLength: tinySolver.state.candidateQueue.length,

--- a/tests/features/srj24-sample4-selective-rerip-stall.test.ts
+++ b/tests/features/srj24-sample4-selective-rerip-stall.test.ts
@@ -258,6 +258,31 @@ test("srj24 sample 4 finishes selective-rerip port pathing", async (): Promise<v
     ),
   )
   console.log(
+    "srj24 sample 4 selective-rerip summary",
+    JSON.stringify({
+      regionCount: tinySolver.topology.regionCount,
+      portCount: tinySolver.topology.portCount,
+      routeCount: tinySolver.problem.routeCount,
+      committedRouteCount: committedRouteIds.size,
+      pendingRouteCount: tinySolver.state.unroutedRoutes.length,
+      currentRouteId,
+      candidateQueueLength: tinySolver.state.candidateQueue.length,
+      ripCount: tinySolver.state.ripCount,
+      selectiveRipCount: tinyStats.selectiveRipCount,
+      selectivelyRippedRouteCount: tinyStats.selectivelyRippedRouteCount,
+      globalReripCount: tinyStats.globalReripCount,
+      globalReripReason: tinyStats.globalReripReason,
+      maxFailedOwnerPairCount: tinyStats.maxFailedOwnerPairCount,
+      lastFailedRouteId: tinyStats.lastFailedRouteId,
+      lastDirectOwnerRouteIds: tinyStats.lastDirectOwnerRouteIds,
+      lastRepeatedOwnerRouteIds: tinyStats.lastRepeatedOwnerRouteIds,
+      lastAlternateOwnerRouteIds: tinyStats.lastAlternateOwnerRouteIds,
+      lastRippedRouteIds: tinyStats.lastRippedRouteIds,
+      neverSuccessfullyRoutedRouteCount:
+        tinyStats.neverSuccessfullyRoutedRouteCount,
+    }),
+  )
+  console.log(
     "srj24 sample 4 selective-rerip stall",
     JSON.stringify(
       {

--- a/tests/features/topology/fixtures/srj24-sample4-topology.fixture.ts
+++ b/tests/features/topology/fixtures/srj24-sample4-topology.fixture.ts
@@ -23,6 +23,7 @@ const BGA_TARGET_ROOT_ID = "source_trace_3"
 const GLOBAL_TARGET_ROOT_ID = "source_net_3"
 const ROUTE_CONNECTION_ID = `${BGA_TARGET_ROOT_ID}__${GLOBAL_TARGET_ROOT_ID}_mst1`
 const GRID_COORDINATES = [-1.3, -0.65, 0, 0.65, 1.3]
+export const BOTTOM_PAD_CENTER = { x: 0.17, y: -0.325 }
 
 function createPad({
   obstacleId,
@@ -129,8 +130,7 @@ export function createSrj24Sample4TopologyFixture(): Srj24Sample4TopologyFixture
   const bottomPad = createPad({
     obstacleId: "stacked-bottom-pad",
     componentId: "bottom-component",
-    x: 0.17,
-    y: 0,
+    ...BOTTOM_PAD_CENTER,
     width: 0.59,
     height: 0.64,
     layer: "bottom",
@@ -153,7 +153,11 @@ export function createSrj24Sample4TopologyFixture(): Srj24Sample4TopologyFixture
           ],
           pointsToConnect: [
             { pointId: BGA_TOP_PORT_ID, x: 0, y: 0, layer: "top" },
-            { pointId: BOTTOM_PORT_ID, x: 0.17, y: 0, layer: "bottom" },
+            {
+              pointId: BOTTOM_PORT_ID,
+              ...BOTTOM_PAD_CENTER,
+              layer: "bottom",
+            },
           ],
         },
       ],

--- a/tests/features/topology/srj24-sample4-topology-repro.test.ts
+++ b/tests/features/topology/srj24-sample4-topology-repro.test.ts
@@ -7,6 +7,7 @@ import {
   createTopologyPlanningSolverForMerging,
 } from "tests/fixtures/topology-merging-test-utils"
 import {
+  BOTTOM_PAD_CENTER,
   createSrj24Sample4TopologyFixture,
   visualizeLayerAccess,
   visualizeMixedComponent,
@@ -42,8 +43,8 @@ test("shows the srj24 sample 4 topology gap", async (): Promise<void> => {
     (node) =>
       node._containsTarget &&
       node.availableZ.includes(5) &&
-      Math.abs(node.center.x - 0.17) < 1e-6 &&
-      Math.abs(node.center.y) < 1e-6,
+      Math.abs(node.center.x - BOTTOM_PAD_CENTER.x) < 1e-6 &&
+      Math.abs(node.center.y - BOTTOM_PAD_CENTER.y) < 1e-6,
   )
   const getRetainedRouteRoots = (node: CapacityMeshNode | undefined) => {
     const aliases = new Set([
@@ -63,10 +64,10 @@ test("shows the srj24 sample 4 topology gap", async (): Promise<void> => {
   })
   topologyMergingSolver.solve()
   const bottomPadBounds = {
-    minX: 0.17 - 0.59 / 2,
-    maxX: 0.17 + 0.59 / 2,
-    minY: -0.64 / 2,
-    maxY: 0.64 / 2,
+    minX: BOTTOM_PAD_CENTER.x - 0.59 / 2,
+    maxX: BOTTOM_PAD_CENTER.x + 0.59 / 2,
+    minY: BOTTOM_PAD_CENTER.y - 0.64 / 2,
+    maxY: BOTTOM_PAD_CENTER.y + 0.64 / 2,
   }
   const crossLayerTargetAccess = topologyMergingSolver
     .getOutput()

--- a/tests/fixtures/topology-merging-test-utils.ts
+++ b/tests/fixtures/topology-merging-test-utils.ts
@@ -95,6 +95,7 @@ export function createTopologyMergingSolverFromPlanning({
   ]
   return new TopologyMergingSolver({
     layerCount: inputSrj.layerCount,
+    viaDiameter: inputSrj.minViaPadDiameter,
     nodeGroups,
   })
 }


### PR DESCRIPTION
## Stack

Stacked on #1847, which prevents the timeout fallback from accepting invalid same-layer crossings.

## Reproduction

Run the real `srj24` sample 4 pipeline until port-point pathing, then give the selective-rerip solver 250,000 iterations.

The test keeps the production topology, route ordering, costs, and constraints. The lower iteration limit makes the same search stall observable within the normal GitHub Actions test timeout.

The assertion requires port-point pathing to finish. On the reproduction commit it instead reaches the limit while repeatedly reripping blockers.

## Visualization

The test snapshots `TinyHypergraphPortPointPathingSolver.visualize()` directly. No custom colors, shapes, or synthetic topology are used.

Hosted SVG and exact rerip statistics will be added after GitHub Actions generates them.

## Validation

- GitHub-hosted reproduction run: pending
- exact sample 4 benchmark showing the full 2,000,000-iteration failure: [run 30744695751](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/30744695751)
- nothing is run locally
