### PR TITLE
Avoid duplicate pathing ports within one net

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "recharts": "^2.15.1",
     "tailwind-merge": "^3.2.0",
     "terser": "^5.43.1",
-    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#2ac358656476d25c4a938a75cac464b499d1bdbf",
+    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#058e5189b13f7832235e72281dc27c006cafeb71",
     "tiny-hypergraph-poly": "git+https://github.com/tscircuit/tiny-hypergraph.git#7b93b4c",
     "tsup": "^8.3.6",
     "typescript": "^5.9.3",


### PR DESCRIPTION
## Problem

The duplicate-port prepass sizes boundary lanes by route count. A net can have several MST route branches, but the pathing solver permits those branches to share a port because they are electrically the same net.

## Fix

Pin the upstream `tiny-hypergraph` correction:

- Reproduction: [tiny-hypergraph #141](https://github.com/tscircuit/tiny-hypergraph/pull/141)
- Fix: [tiny-hypergraph #142](https://github.com/tscircuit/tiny-hypergraph/pull/142)

The prepass now counts distinct electrical nets at each port. Different nets still receive separate physical lanes; branches of one net share one lane.

This integration changes only the exact dependency SHA. It adds no sample-specific threshold or fallback.

## Visualization

The reproduction and fix use the same real solver fixture and snapshot path.

| Before: 2 ports for one net | After: 1 shared port |
| --- | --- |
| ![Before](https://raw.githubusercontent.com/tscircuit/tiny-hypergraph/76cb1848fb7249fb5f528eeed79ba0de8e98ba75/tests/solver/__snapshots__/duplicate-congested-port-same-net-repro.snap.svg) | ![After](https://raw.githubusercontent.com/tscircuit/tiny-hypergraph/058e5189b13f7832235e72281dc27c006cafeb71/tests/solver/__snapshots__/duplicate-congested-port-same-net-repro.snap.svg) |

The upper frame is the one-port input. The lower frame is the actual duplicate-prepass output. Gray circles are topology ports; colored dashed lines are same-net route endpoint hints.

## Hosted validation

Upstream CI passes 109/109 tests.

The exact benchmark was run in GitHub Actions:

```text
/benchmark-long --dataset srj24 --sample-numbers 4 --sample-timeout 2000s --concurrency 1
```

[Hosted benchmark result](https://github.com/tscircuit/tscircuit-autorouter/pull/1849#issuecomment-5157716670): sample 4 still fails safely in selective-rerip pathing after 318.6 s. The correction reduces the graph from 76,634 to 76,334 ports, but the same route remains blocked by a separate missing local cross-layer region.

This PR is therefore a valid general correctness fix, but it is not presented as the sample 4 fix.

## Stack

Stacked on #1847. The focused sample 4 topology follow-up is separate so this dependency pin stays independently reviewable.
