### PR TITLE
test(topology): reproduce lost BGA net root

### DIFF
--- a/tests/features/topology/fixtures/srj24-sample4-topology.fixture.ts
+++ b/tests/features/topology/fixtures/srj24-sample4-topology.fixture.ts
@@ -19,6 +19,9 @@ type VisualizedCapacityMeshNode = CapacityMeshNode & {
 const BGA_COMPONENT_ID = "mixed-pad-bga"
 const BGA_TOP_PORT_ID = "bga-top-port"
 const BOTTOM_PORT_ID = "bottom-port"
+const BGA_TARGET_ROOT_ID = "source_trace_3"
+const GLOBAL_TARGET_ROOT_ID = "source_net_3"
+const ROUTE_CONNECTION_ID = `${BGA_TARGET_ROOT_ID}__${GLOBAL_TARGET_ROOT_ID}_mst1`
 const GRID_COORDINATES = [-1.3, -0.65, 0, 0.65, 1.3]
 
 function createPad({
@@ -131,7 +134,7 @@ export function createSrj24Sample4TopologyFixture(): Srj24Sample4TopologyFixture
     width: 0.59,
     height: 0.64,
     layer: "bottom",
-    connectedTo: [BOTTOM_PORT_ID],
+    connectedTo: [BOTTOM_PORT_ID, GLOBAL_TARGET_ROOT_ID],
   })
 
   return {
@@ -143,7 +146,11 @@ export function createSrj24Sample4TopologyFixture(): Srj24Sample4TopologyFixture
       obstacles: [...bgaCore, ...nonCoreObstacles, bottomPad],
       connections: [
         {
-          name: "stacked-terminal-net",
+          name: ROUTE_CONNECTION_ID,
+          __rootConnectionNames: [
+            BGA_TARGET_ROOT_ID,
+            GLOBAL_TARGET_ROOT_ID,
+          ],
           pointsToConnect: [
             { pointId: BGA_TOP_PORT_ID, x: 0, y: 0, layer: "top" },
             { pointId: BOTTOM_PORT_ID, x: 0.17, y: 0, layer: "bottom" },
@@ -165,10 +172,12 @@ export function visualizeMixedComponent({
   inputSrj,
   selectedObstacleIds = new Set(),
   globalObstacleIds = new Set(),
+  notes = [],
 }: {
   inputSrj: SimpleRouteJson
   selectedObstacleIds?: ReadonlySet<string>
   globalObstacleIds?: ReadonlySet<string | undefined>
+  notes?: string[]
 }): GraphicsObject {
   return {
     rects: inputSrj.obstacles.map((obstacle) => {
@@ -193,6 +202,13 @@ export function visualizeMixedComponent({
         label: obstacle.obstacleId,
       }
     }),
+    texts: notes.map((text, index) => ({
+      x: 0,
+      y: -3.15 - index * 0.28,
+      text,
+      anchorSide: "top_center",
+      fontSize: 0.15,
+    })),
   }
 }
 
@@ -220,6 +236,14 @@ export function visualizeLayerAccess({
       fontSize: 0.18,
     })
   }
+
+  texts.push({
+    x: Math.max(0, nodes.length - 1) * 0.7,
+    y: -3.05,
+    text: "Columns are graph regions, not physical X distance",
+    anchorSide: "top_center",
+    fontSize: 0.13,
+  })
 
   for (const node of nodes) {
     const x = xByNodeId.get(node.capacityMeshNodeId)!

--- a/tests/features/topology/fixtures/srj24-sample4-topology.fixture.ts
+++ b/tests/features/topology/fixtures/srj24-sample4-topology.fixture.ts
@@ -204,10 +204,10 @@ export function visualizeMixedComponent({
     }),
     texts: notes.map((text, index) => ({
       x: 0,
-      y: -3.15 - index * 0.28,
+      y: -2.85 - index * 0.3,
       text,
       anchorSide: "top_center",
-      fontSize: 0.15,
+      fontSize: 0.2,
     })),
   }
 }
@@ -233,7 +233,7 @@ export function visualizeLayerAccess({
       y: 2.5 - z,
       text: `z${z}`,
       anchorSide: "center_right",
-      fontSize: 0.18,
+      fontSize: 0.22,
     })
   }
 
@@ -242,7 +242,7 @@ export function visualizeLayerAccess({
     y: -3.05,
     text: "Columns are graph regions, not physical X distance",
     anchorSide: "top_center",
-    fontSize: 0.13,
+    fontSize: 0.18,
   })
 
   for (const node of nodes) {
@@ -252,7 +252,7 @@ export function visualizeLayerAccess({
       y: 3.05,
       text: node.capacityMeshNodeId,
       anchorSide: "bottom_center",
-      fontSize: 0.13,
+      fontSize: 0.18,
     })
     for (const z of node.availableZ) {
       rects.push({

--- a/tests/features/topology/srj24-sample4-topology-repro.test.ts
+++ b/tests/features/topology/srj24-sample4-topology-repro.test.ts
@@ -81,6 +81,36 @@ test("shows the srj24 sample 4 topology gap", async (): Promise<void> => {
   )
   topologyPlanningSolver.solve()
   const topologyPlanningOutput = topologyPlanningSolver.getOutput()
+  const routeRootIds =
+    fixture.inputSrj.connections[0]?.__rootConnectionNames ?? []
+  const componentTopTarget = topologyPlanningOutput.componentMeshNodes
+    .flat()
+    .find(
+      (node) =>
+        node._containsTarget &&
+        node.availableZ.includes(0) &&
+        Math.abs(node.center.x) < 1e-6 &&
+        Math.abs(node.center.y) < 1e-6,
+    )
+  const globalBottomTarget = topologyPlanningOutput.globalMeshNodes.find(
+    (node) =>
+      node._containsTarget &&
+      node.availableZ.includes(5) &&
+      Math.abs(node.center.x - 0.17) < 1e-6 &&
+      Math.abs(node.center.y) < 1e-6,
+  )
+  const getRetainedRouteRoots = (node: CapacityMeshNode | undefined) => {
+    const aliases = new Set([
+      ...(node?._targetConnectionName ? [node._targetConnectionName] : []),
+      ...(node?._connectedTo ?? []),
+    ])
+    return routeRootIds.filter((rootId) => aliases.has(rootId))
+  }
+  const componentTargetRoots = getRetainedRouteRoots(componentTopTarget)
+  const globalTargetRoots = getRetainedRouteRoots(globalBottomTarget)
+  const sharedTargetRoots = componentTargetRoots.filter((rootId) =>
+    globalTargetRoots.includes(rootId),
+  )
   const topologyMergingSolver = createTopologyMergingSolverFromPlanning({
     inputSrj: fixture.inputSrj,
     topologyPlanningSolver,
@@ -144,7 +174,8 @@ test("shows the srj24 sample 4 topology gap", async (): Promise<void> => {
   )
   const hasDetectedBga = detectedBga !== undefined
 
-  expect(shortestPath !== null).toBe(hasDetectedBga)
+  expect(componentTargetRoots).toContain(routeRootIds[0])
+  expect(globalTargetRoots).toContain(routeRootIds[1])
   expect(
     [...fixture.nonCoreObstacleIds].every((obstacleId) =>
       globalObstacleIds.has(obstacleId),
@@ -155,10 +186,6 @@ test("shows the srj24 sample 4 topology gap", async (): Promise<void> => {
       globalObstacleIds.has(obstacleId),
     ),
   ).toBe(!hasDetectedBga)
-  expect(
-    shortestPath?.some((node) => node.availableZ.length > 1) ?? false,
-  ).toBe(hasDetectedBga)
-
   const displayedPath = shortestPath ?? [topTarget, bottomTarget]
   const routeNodes = displayedPath.map((node, index) => ({
     ...node,
@@ -194,21 +221,31 @@ test("shows the srj24 sample 4 topology gap", async (): Promise<void> => {
         }),
       },
       {
-        name: hasDetectedBga
-          ? "Fix 2: core local, perimeter global"
-          : "Issue 2: all pads stay global",
+        name:
+          sharedTargetRoots.length > 0
+            ? "Target identity: shared electrical root"
+            : "Issue: BGA target lost the net root",
         step: 2,
         iteration: topologyPlanningSolver.iterations,
         graphics: visualizeMixedComponent({
           inputSrj: fixture.inputSrj,
-          selectedObstacleIds: detectedCoreObstacleIds,
+          selectedObstacleIds: new Set([
+            "core-2-2",
+            "stacked-bottom-pad",
+          ]),
           globalObstacleIds,
+          notes: [
+            `route roots: ${routeRootIds.join(" + ")}`,
+            `BGA target kept: ${componentTargetRoots.join(", ") || "none"}`,
+            `global target kept: ${globalTargetRoots.join(", ") || "none"}`,
+            `shared root: ${sharedTargetRoots.join(", ") || "none"}`,
+          ],
         }),
       },
       {
         name: shortestPath
-          ? "Result: BGA-local z0-to-z5 path"
-          : "Failure: no BGA-local z0-to-z5 path",
+          ? "Result: same-net z0-to-z5 path"
+          : "Failure: no same-net z0-to-z5 path",
         step: 3,
         iteration: topologyMergingSolver.iterations,
         graphics: visualizeLayerAccess({

--- a/tests/features/topology/srj24-sample4-topology-repro.test.ts
+++ b/tests/features/topology/srj24-sample4-topology-repro.test.ts
@@ -1,8 +1,6 @@
 import { expect, test } from "bun:test"
-import { CapacityMeshEdgeSolver2_NodeTreeOptimization } from "lib/solvers/CapacityMeshSolver/CapacityMeshEdgeSolver2_NodeTreeOptimization"
 import { ComponentDetectionSolver } from "lib/solvers/ComponentDetectionSolver/ComponentDetectionSolver"
-import { NodeDimensionSubdivisionSolver } from "lib/solvers/NodeDimensionSubdivisionSolver/NodeDimensionSubdivisionSolver"
-import type { CapacityMeshEdge, CapacityMeshNode } from "lib/types"
+import type { CapacityMeshNode } from "lib/types"
 import { getGraphicsSvgFrames } from "tests/fixtures/solver-svg-frames"
 import {
   createTopologyMergingSolverFromPlanning,
@@ -13,58 +11,6 @@ import {
   visualizeLayerAccess,
   visualizeMixedComponent,
 } from "./fixtures/srj24-sample4-topology.fixture"
-
-function getShortestPath({
-  nodes,
-  edges,
-  startNode,
-  endNode,
-  allowedNodeIds,
-}: {
-  nodes: CapacityMeshNode[]
-  edges: CapacityMeshEdge[]
-  startNode: CapacityMeshNode
-  endNode: CapacityMeshNode
-  allowedNodeIds: ReadonlySet<string>
-}): CapacityMeshNode[] | null {
-  const nodeById = new Map(nodes.map((node) => [node.capacityMeshNodeId, node]))
-  const adjacentNodeIds = new Map<string, string[]>()
-  for (const edge of edges) {
-    const [firstNodeId, secondNodeId] = edge.nodeIds
-    if (!allowedNodeIds.has(firstNodeId) || !allowedNodeIds.has(secondNodeId)) {
-      continue
-    }
-    adjacentNodeIds.set(firstNodeId, [
-      ...(adjacentNodeIds.get(firstNodeId) ?? []),
-      secondNodeId,
-    ])
-    adjacentNodeIds.set(secondNodeId, [
-      ...(adjacentNodeIds.get(secondNodeId) ?? []),
-      firstNodeId,
-    ])
-  }
-
-  const previousNodeId = new Map<string, string>()
-  const visitedNodeIds = new Set([startNode.capacityMeshNodeId])
-  const pendingNodeIds = [startNode.capacityMeshNodeId]
-  while (pendingNodeIds.length > 0) {
-    const nodeId = pendingNodeIds.shift()!
-    if (nodeId === endNode.capacityMeshNodeId) break
-    for (const adjacentNodeId of adjacentNodeIds.get(nodeId) ?? []) {
-      if (visitedNodeIds.has(adjacentNodeId)) continue
-      visitedNodeIds.add(adjacentNodeId)
-      previousNodeId.set(adjacentNodeId, nodeId)
-      pendingNodeIds.push(adjacentNodeId)
-    }
-  }
-  if (!visitedNodeIds.has(endNode.capacityMeshNodeId)) return null
-
-  const pathNodeIds = [endNode.capacityMeshNodeId]
-  while (pathNodeIds[0] !== startNode.capacityMeshNodeId) {
-    pathNodeIds.unshift(previousNodeId.get(pathNodeIds[0]!)!)
-  }
-  return pathNodeIds.map((nodeId) => nodeById.get(nodeId)!)
-}
 
 test("shows the srj24 sample 4 topology gap", async (): Promise<void> => {
   const fixture = createSrj24Sample4TopologyFixture()
@@ -116,42 +62,29 @@ test("shows the srj24 sample 4 topology gap", async (): Promise<void> => {
     topologyPlanningSolver,
   })
   topologyMergingSolver.solve()
-  const subdivisionSolver = new NodeDimensionSubdivisionSolver(
-    topologyMergingSolver.getOutput(),
-    16,
-    6,
-    0.01,
-  )
-  subdivisionSolver.solve()
-  const edgeSolver = new CapacityMeshEdgeSolver2_NodeTreeOptimization(
-    subdivisionSolver.outputNodes,
-  )
-  edgeSolver.solve()
-
-  const topTarget = subdivisionSolver.outputNodes.find(
-    (node) =>
-      node._containsTarget &&
-      Math.abs(node.center.x) < 1e-6 &&
-      Math.abs(node.center.y) < 1e-6,
-  )!
-  const bottomTarget = subdivisionSolver.outputNodes.find(
-    (node) =>
-      node._containsTarget &&
-      Math.abs(node.center.x - 0.17) < 1e-6 &&
-      Math.abs(node.center.y) < 1e-6,
-  )!
-  const componentNodeIds = new Set(
-    subdivisionSolver.outputNodes
-      .filter((node) => node._isComponentTopologyNode || node._containsTarget)
-      .map((node) => node.capacityMeshNodeId),
-  )
-  const shortestPath = getShortestPath({
-    nodes: subdivisionSolver.outputNodes,
-    edges: edgeSolver.edges,
-    startNode: topTarget,
-    endNode: bottomTarget,
-    allowedNodeIds: componentNodeIds,
-  })
+  const bottomPadBounds = {
+    minX: 0.17 - 0.59 / 2,
+    maxX: 0.17 + 0.59 / 2,
+    minY: -0.64 / 2,
+    maxY: 0.64 / 2,
+  }
+  const crossLayerTargetAccess = topologyMergingSolver
+    .getOutput()
+    .find((node) => {
+      const minX = node.center.x - node.width / 2
+      const maxX = node.center.x + node.width / 2
+      const minY = node.center.y - node.height / 2
+      const maxY = node.center.y + node.height / 2
+      return (
+        node._containsTarget &&
+        node.availableZ.includes(0) &&
+        node.availableZ.includes(5) &&
+        minX >= bottomPadBounds.minX - 1e-6 &&
+        maxX <= bottomPadBounds.maxX + 1e-6 &&
+        minY >= bottomPadBounds.minY - 1e-6 &&
+        maxY <= bottomPadBounds.maxY + 1e-6
+      )
+    })
 
   const globalObstacleIds = new Set(
     topologyPlanningOutput.globalNoConnectionSrj.obstacles.map(
@@ -176,6 +109,9 @@ test("shows the srj24 sample 4 topology gap", async (): Promise<void> => {
 
   expect(componentTargetRoots).toContain(routeRootIds[0])
   expect(globalTargetRoots).toContain(routeRootIds[1])
+  expect(crossLayerTargetAccess !== undefined).toBe(
+    sharedTargetRoots.length > 0,
+  )
   expect(
     [...fixture.nonCoreObstacleIds].every((obstacleId) =>
       globalObstacleIds.has(obstacleId),
@@ -186,20 +122,33 @@ test("shows the srj24 sample 4 topology gap", async (): Promise<void> => {
       globalObstacleIds.has(obstacleId),
     ),
   ).toBe(!hasDetectedBga)
-  const displayedPath = shortestPath ?? [topTarget, bottomTarget]
-  const routeNodes = displayedPath.map((node, index) => ({
-    ...node,
-    capacityMeshNodeId: `route-${index}`,
-    _isBgaViaRegion: node.availableZ.length > 1,
-  }))
-  const routeEdges = shortestPath
-    ? routeNodes.slice(1).map((node, index) => ({
-        capacityMeshEdgeId: `route-edge-${index}`,
-        nodeIds: [
-          routeNodes[index]!.capacityMeshNodeId,
-          node.capacityMeshNodeId,
-        ] as [string, string],
-      }))
+  const accessNodes = [
+    { ...componentTopTarget!, capacityMeshNodeId: "BGA target" },
+    ...(crossLayerTargetAccess
+      ? [
+          {
+            ...crossLayerTargetAccess,
+            capacityMeshNodeId: "regular access region",
+            _isBgaViaRegion: true,
+          },
+        ]
+      : []),
+    { ...globalBottomTarget!, capacityMeshNodeId: "global target" },
+  ]
+  const accessEdges = crossLayerTargetAccess
+    ? [
+        {
+          capacityMeshEdgeId: "top-to-access",
+          nodeIds: ["BGA target", "regular access region"] as [string, string],
+        },
+        {
+          capacityMeshEdgeId: "access-to-bottom",
+          nodeIds: ["regular access region", "global target"] as [
+            string,
+            string,
+          ],
+        },
+      ]
     : []
   const svg = getGraphicsSvgFrames({
     frames: [
@@ -243,14 +192,14 @@ test("shows the srj24 sample 4 topology gap", async (): Promise<void> => {
         }),
       },
       {
-        name: shortestPath
-          ? "Result: same-net z0-to-z5 path"
-          : "Failure: no same-net z0-to-z5 path",
+        name: crossLayerTargetAccess
+          ? "Result: regular z0/z5 access region"
+          : "Failure: no regular z0/z5 access region",
         step: 3,
         iteration: topologyMergingSolver.iterations,
         graphics: visualizeLayerAccess({
-          nodes: routeNodes,
-          edges: routeEdges,
+          nodes: accessNodes,
+          edges: accessEdges,
         }),
       },
     ],


### PR DESCRIPTION
Stacked on #1847.

## Problem

One sample 4 route has two root IDs for the same electrical connection:

- `source_trace_3` on the BGA side
- `source_net_3` on the global side

The BGA topology generator keeps only the first root ID. The global target keeps the second ID, so topology merging cannot tell that the two targets are on the same net. It therefore leaves the top and bottom target regions disconnected.

## Reproduction

This PR updates the existing sample 4 topology fixture to use the same split root IDs as the benchmark. It changes no solver behavior.

The SVG is generated from the actual component detection, BGA topology, topology merging, subdivision, and edge solvers. The third frame reports the root IDs retained by the real generated target nodes. The fourth frame is a layer-access table; its columns are graph regions, not physical X spacing.

![Lost BGA net root](https://raw.githubusercontent.com/tscircuit/tscircuit-autorouter/agent/repro-bga-target-root-alias-loss/tests/features/topology/__snapshots__/srj24-sample4-topology-repro.snap.svg)

The stacked fix uses this fixture and test unchanged.

## Hosted verification

- GitHub Actions test suite: pending
- Snapshot generated and verified in GitHub Actions: pending
