### PR TITLE
fix(topology): preserve BGA target root aliases

### DIFF
--- a/lib/solvers/BgaTopologyGeneratorSolver/InitialBgaTopologySolver.ts
+++ b/lib/solvers/BgaTopologyGeneratorSolver/InitialBgaTopologySolver.ts
@@ -11,7 +11,7 @@ import { getViaDimensions } from "lib/utils/getViaDimensions"
 import { mapLayerNameToZ } from "lib/utils/mapLayerNameToZ"
 import { BgaGrid } from "./bga-grid"
 import type { BgaGap, MissingBgaSlot } from "./bga-grid"
-import { getObstacleTargetConnectionName } from "./getObstacleTargetConnectionName"
+import { getObstacleTargetConnectionNames } from "./getObstacleTargetConnectionNames"
 
 const BGA_MULTILAYER_REGION_VIA_DIAMETER_FACTOR = 1.2
 
@@ -221,10 +221,11 @@ function createObstacleMeshNode(
     mapLayerNameToZ(layerName, srj.layerCount),
   )
   const obstacleNodeToken = getStableObstacleNodeToken(obstacle)
-  const targetConnectionName = getObstacleTargetConnectionName({
+  const targetConnectionNames = getObstacleTargetConnectionNames({
     obstacle,
     srj,
   })
+  const targetConnectionName = targetConnectionNames[0]
 
   return {
     capacityMeshNodeId: `obstacle-${componentId}-${obstacleNodeToken}-${obstacleLayers.join(",")}-${obstacle.center.x}-${obstacle.center.y}`,
@@ -233,6 +234,7 @@ function createObstacleMeshNode(
       ? {
           _containsTarget: true,
           _targetConnectionName: targetConnectionName,
+          _connectedTo: targetConnectionNames,
         }
       : {}),
     center: obstacle.center,

--- a/lib/solvers/BgaTopologyGeneratorSolver/getObstacleTargetConnectionNames.ts
+++ b/lib/solvers/BgaTopologyGeneratorSolver/getObstacleTargetConnectionNames.ts
@@ -1,10 +1,11 @@
 import type { Obstacle, SimpleRouteJson } from "lib/types"
 import { isConnectionPointOnObstacle } from "./isConnectionPointOnObstacle"
 
-export function getObstacleTargetConnectionName(input: {
+/** Returns all original root connection IDs represented by a target point. */
+export function getObstacleTargetConnectionNames(input: {
   obstacle: Obstacle
   srj: SimpleRouteJson
-}): string | undefined {
+}): string[] {
   for (const connection of input.srj.connections) {
     for (const point of connection.pointsToConnect) {
       if (
@@ -14,10 +15,12 @@ export function getObstacleTargetConnectionName(input: {
           layerCount: input.srj.layerCount,
         })
       ) {
-        return connection.__rootConnectionNames?.[0] ?? connection.name
+        return connection.__rootConnectionNames?.length
+          ? [...new Set(connection.__rootConnectionNames)]
+          : [connection.name]
       }
     }
   }
 
-  return undefined
+  return []
 }


### PR DESCRIPTION
Stacked on #1850.

## Problem

The route already says that `source_trace_3` and `source_net_3` are two roots of the same electrical connection. BGA topology generation was keeping only `source_trace_3` on each generated target node.

The overlapping global target is identified by `source_net_3`. Because the BGA node had dropped that root ID, the existing topology merger could not recognize the targets as the same net and did not create the legal local layer transition.

## Fix

Keep every `__rootConnectionNames` entry on generated BGA target nodes:

- `_targetConnectionName` remains the first root, preserving existing behavior.
- `_connectedTo` stores all roots, preserving the full electrical identity.

The existing topology merger can then match the BGA and global target through `source_net_3` and build its already-supported regular aligned regions. This adds no new region type, portal, routing fallback, or geometry exception.

## Snapshot

This uses the fixture and test from #1850 unchanged.

![Preserved BGA net roots](https://raw.githubusercontent.com/tscircuit/tscircuit-autorouter/agent/fix-bga-target-root-alias-loss/tests/features/topology/__snapshots__/srj24-sample4-topology-repro.snap.svg)

The third frame reports the root IDs retained by the actual generated target nodes. The fourth frame is the actual layer-access graph; columns are graph regions and do not represent physical X spacing.

## Hosted verification

- GitHub Actions test suite: pending
- `srj24` sample 4, Pipeline 7, effort 1: pending
