### PR TITLE
fix(topology): stabilize BGA multilayer threshold

### DIFF
--- a/lib/solvers/BgaTopologyGeneratorSolver/InitialBgaTopologySolver.ts
+++ b/lib/solvers/BgaTopologyGeneratorSolver/InitialBgaTopologySolver.ts
@@ -14,6 +14,7 @@ import type { BgaGap, MissingBgaSlot } from "./bga-grid"
 import { getObstacleTargetConnectionNames } from "./getObstacleTargetConnectionNames"
 
 const BGA_MULTILAYER_REGION_VIA_DIAMETER_FACTOR = 1.2
+const BGA_DIMENSION_EPSILON = 1e-6
 
 export type InitialBgaTopologySolverInput = {
   srj: SimpleRouteJson
@@ -94,7 +95,8 @@ function createMeshNodesFromBgaGap(input: {
 }): CapacityMeshNode[] {
   const { componentId, bgaGap, freeLayers, multiLayerThreshold } = input
   const isLargeEnoughForMultiLayer =
-    bgaGap.width > multiLayerThreshold && bgaGap.height > multiLayerThreshold
+    bgaGap.width >= multiLayerThreshold - BGA_DIMENSION_EPSILON &&
+    bgaGap.height >= multiLayerThreshold - BGA_DIMENSION_EPSILON
   let orientationKey: string = "d"
   if (bgaGap.orientation === "horizontal") orientationKey = "h"
   if (bgaGap.orientation === "vertical") orientationKey = "v"
@@ -161,8 +163,8 @@ function createMeshNodeFromMissingBgaSlot(input: {
     height: missingBgaSlot.height,
   })
   const isLargeEnoughForMultiLayer =
-    missingBgaSlot.width > multiLayerThreshold &&
-    missingBgaSlot.height > multiLayerThreshold
+    missingBgaSlot.width >= multiLayerThreshold - BGA_DIMENSION_EPSILON &&
+    missingBgaSlot.height >= multiLayerThreshold - BGA_DIMENSION_EPSILON
 
   if (!isLargeEnoughForMultiLayer) {
     return freeLayers.map((z) => ({


### PR DESCRIPTION
## Issue

The BGA topology generator decides whether a free gap can span multiple PCB layers by comparing its width and height with 1.2 times the via diameter.

In srj24 sample 4, that threshold is 0.396 mm. Neighboring gaps with the same designed size are calculated as 0.39600000000000035 mm and 0.3959999999999999 mm. The strict comparison accepts one and rejects the other, splitting the rejected gap into six isolated single-layer nodes and removing a legal layer-changing path.

## Fix

Treat dimensions within 0.000001 mm of the threshold as equal to the threshold.

This is applied in the BGA topology generator where gap and missing-slot nodes are created. It preserves the existing 1.2-times-via safety rule; it only prevents floating-point noise from changing the topology.

The production change is five added lines and three replaced lines. It does not merge general topology regions or add a routing fallback.

## Visualization

This PR is stacked on #1852, which contains the unchanged real-solver fixture. In its topology view:

- each column is one physical XY gap shown across z0-z5
- each blue box is that gap on one board layer
- a vertical bar means the boxes are owned by one multilayer capacity node

Before the fix, two equal gaps produce one node and six nodes. After the fix, both produce one multilayer node.

## Hosted validation

All tests, snapshot updates, and the srj24 sample 4 benchmark are run through GitHub Actions. Nothing is executed locally.

Benchmark command (to be posted after the snapshot check passes):

    /benchmark-long --dataset srj24 --sample-numbers 4 --sample-timeout 4000s --concurrency 1
