### PR TITLE
fix(topology): split partial BGA obstacle overlaps

### DIFF
--- a/lib/solvers/BgaTopologyGeneratorSolver/RemoveMeshNodeOverlappingSolver.ts
+++ b/lib/solvers/BgaTopologyGeneratorSolver/RemoveMeshNodeOverlappingSolver.ts
@@ -1,17 +1,73 @@
-import {
-  doBoundsOverlap,
-  getBoundFromCenteredRect,
-} from "@tscircuit/math-utils"
+import { getBoundFromCenteredRect, type Bounds } from "@tscircuit/math-utils"
 import { BaseSolver } from "@tscircuit/solver-utils"
 import type { GraphicsObject } from "graphics-debug"
 import type { CapacityMeshNode, Obstacle } from "lib/types"
 import { createRectFromCapacityNode } from "lib/utils/createRectFromCapacityNode"
 import { mapLayerNameToZ } from "lib/utils/mapLayerNameToZ"
+import {
+  getBoundsIntersection,
+  getCapacityMeshNodeBounds,
+  isValidCapacityBounds,
+} from "../TopologyPlanningSolver/capacity-node-geometry"
 
 export type RemoveMeshNodeOverlappingSolverInput = {
   meshNodes: CapacityMeshNode[]
   obstacles: Obstacle[]
   layerCount: number
+}
+
+function createNodeFromBounds({
+  node,
+  bounds,
+  availableZ,
+  suffix,
+}: {
+  node: CapacityMeshNode
+  bounds: Bounds
+  availableZ: number[]
+  suffix: string
+}): CapacityMeshNode {
+  return {
+    ...node,
+    capacityMeshNodeId: `${node.capacityMeshNodeId}:${suffix}`,
+    center: {
+      x: (bounds.minX + bounds.maxX) / 2,
+      y: (bounds.minY + bounds.maxY) / 2,
+    },
+    width: bounds.maxX - bounds.minX,
+    height: bounds.maxY - bounds.minY,
+    availableZ,
+    layer: `z${availableZ.join(",")}`,
+  }
+}
+
+function subtractBounds(bounds: Bounds, overlap: Bounds): Bounds[] {
+  return [
+    {
+      minX: bounds.minX,
+      maxX: overlap.minX,
+      minY: bounds.minY,
+      maxY: bounds.maxY,
+    },
+    {
+      minX: overlap.maxX,
+      maxX: bounds.maxX,
+      minY: bounds.minY,
+      maxY: bounds.maxY,
+    },
+    {
+      minX: overlap.minX,
+      maxX: overlap.maxX,
+      minY: bounds.minY,
+      maxY: overlap.minY,
+    },
+    {
+      minX: overlap.minX,
+      maxX: overlap.maxX,
+      minY: overlap.maxY,
+      maxY: bounds.maxY,
+    },
+  ].filter(isValidCapacityBounds)
 }
 
 export class RemoveMeshNodeOverlappingWithUnmarkedObstacle extends BaseSolver {
@@ -58,17 +114,14 @@ export class RemoveMeshNodeOverlappingWithUnmarkedObstacle extends BaseSolver {
         continue
       }
 
-      const overlapsObstacle: boolean = doBoundsOverlap(
-        getBoundFromCenteredRect(node),
+      const nodeBounds = getCapacityMeshNodeBounds(node)
+      const overlapBounds = getBoundsIntersection(
+        nodeBounds,
         getBoundFromCenteredRect(obstacle),
       )
 
-      if (!overlapsObstacle) {
+      if (!overlapBounds) {
         nextMeshNodes.push(node)
-        continue
-      }
-
-      if (node.availableZ.length === 1) {
         continue
       }
 
@@ -76,14 +129,26 @@ export class RemoveMeshNodeOverlappingWithUnmarkedObstacle extends BaseSolver {
         (z) => !obstacleAvailableZ.includes(z),
       )
 
-      for (const z of nodeFreeLayers) {
-        const nextMeshNode: CapacityMeshNode = {
-          ...node,
-          capacityMeshNodeId: `${node.capacityMeshNodeId}:z${z}`,
-          availableZ: [z],
-          layer: `z${z}`,
-        }
-        nextMeshNodes.push(nextMeshNode)
+      nextMeshNodes.push(
+        ...subtractBounds(nodeBounds, overlapBounds).map((bounds, index) =>
+          createNodeFromBounds({
+            node,
+            bounds,
+            availableZ: [...node.availableZ],
+            suffix: `outside-${this.obstacleQueueIndex}-${index}`,
+          }),
+        ),
+      )
+
+      if (nodeFreeLayers.length > 0) {
+        nextMeshNodes.push(
+          createNodeFromBounds({
+            node,
+            bounds: overlapBounds,
+            availableZ: nodeFreeLayers,
+            suffix: `under-${this.obstacleQueueIndex}`,
+          }),
+        )
       }
     }
 


### PR DESCRIPTION
Stacked on #1855, which contains the unchanged reproduction and SVG fixture.

## Issue

A BGA routing rectangle can be covered by an obstacle on only one layer and only part of its XY area.

The old removal code treated that as if the obstacle covered the entire rectangle. It removed the blocked layer everywhere and emitted one node per remaining layer. In sample 4, that turns one regular BGA gap into five isolated rectangles and discards the uncovered z5 sliver.

## Fix

Split the routing rectangle at the real obstacle boundary:

- pieces outside the obstacle keep the original layer set
- the overlapping piece keeps all layers except the obstacle layers
- each piece remains an ordinary CapacityMeshNode
- remaining layers stay grouped in one node instead of being copied into one node per layer

This models target-only, target-on-one-layer/free-on-other-layers, and free-only XY regions directly. It adds no portal, via region, via-in-pad shortcut, special edge, pathfinder exception, or pipeline stage.

## Visualization

The snapshot is the exact same test and fixture as #1855. Horizontal position and width are the real board x geometry; rows are z0-z5. Red is target capacity, blue is free capacity, and a vertical line means one ordinary node spans multiple layers.

Before the fix, the covered gap is five isolated z0-z4 nodes and z5 is removed everywhere. After the fix, the covered part is one z0-z4 node and the small uncovered part remains one z0-z5 node.

## Hosted validation

All tests, snapshots, and the srj24 sample 4 benchmark run in GitHub Actions. Nothing is executed locally.

Benchmark command after the focused snapshot check passes:

    /benchmark-long --dataset srj24 --sample-numbers 4 --sample-timeout 4000s --concurrency 1