### PR TITLE
Integrate SRJ27 power trace dataset

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@tscircuit/curvy-trace-solver": "^0.0.10",
     "@tscircuit/dataset-srj05": "git+https://github.com/tscircuit/dataset-srj05.git#9a49c126a89c083dc4d2b72cd17184735f637762",
     "@tscircuit/dataset-srj24": "git+https://github.com/tscircuit/dataset-srj24.git#0973fa8a123276ff0f5de1fc7edef31efccb9cc9",
+    "@tscircuit/dataset-srj27-power-traces": "git+https://github.com/tscircuit/dataset-srj27-power-traces.git#eb24d36",
     "@tscircuit/fixed-via-hypergraph-solver": "https://codeload.github.com/tscircuit/fixed-via-hypergraph-solver/tar.gz/bed37a6201b5dd07c9cc68b828917ecc20d6d049",
     "@tscircuit/hypergraph": "^0.0.71",
     "@tscircuit/jumper-topology-generator": "^0.0.4",

--- a/scripts/benchmark/scenarios.ts
+++ b/scripts/benchmark/scenarios.ts
@@ -16,6 +16,7 @@ export const DATASET_NAMES = [
   "srj21",
   "srj23",
   "srj24",
+  "srj27",
 ] as const
 
 export type DatasetName = (typeof DATASET_NAMES)[number]
@@ -23,7 +24,7 @@ export type DatasetName = (typeof DATASET_NAMES)[number]
 type DatasetModule = Record<string, unknown>
 
 export const DATASET_OPTIONS_LABEL =
-  "1/dataset01, zdwiel, 5/srj05, 11/srj11, 12/srj12, 13/srj13, 14/srj14, 15/srj15, 16/srj16, 18/srj18, 19/srj19, 20/srj20, 21/srj21, 23/srj23, 24/srj24"
+  "1/dataset01, zdwiel, 5/srj05, 11/srj11, 12/srj12, 13/srj13, 14/srj14, 15/srj15, 16/srj16, 18/srj18, 19/srj19, 20/srj20, 21/srj21, 23/srj23, 24/srj24, 27/srj27"
 
 const datasetAliases: Record<string, DatasetName> = {
   "1": "dataset01",
@@ -96,6 +97,11 @@ const datasetAliases: Record<string, DatasetName> = {
   srj24: "srj24",
   "dataset-srj24": "srj24",
   "@tscircuit/dataset-srj24": "srj24",
+  "27": "srj27",
+  dataset27: "srj27",
+  srj27: "srj27",
+  "dataset-srj27-power-traces": "srj27",
+  "@tscircuit/dataset-srj27-power-traces": "srj27",
   zdwiel: "zdwiel",
 }
 
@@ -219,6 +225,15 @@ const datasetLoaders: Record<DatasetName, () => Promise<DatasetModule>> = {
       ? (dataset as DatasetModule)
       : module
   },
+  srj27: async () => {
+    const module = (await import(
+      "@tscircuit/dataset-srj27-power-traces"
+    )) as DatasetModule
+    const dataset = module.dataset
+    return dataset && typeof dataset === "object"
+      ? (dataset as DatasetModule)
+      : module
+  },
 }
 
 const datasetScenarioKeyPatterns: Record<DatasetName, RegExp> = {
@@ -237,6 +252,7 @@ const datasetScenarioKeyPatterns: Record<DatasetName, RegExp> = {
   srj21: /^circuit\d{3}$/,
   srj23: /^circuit\d{3}$/,
   srj24: /^sample\d{3}$/,
+  srj27: /^sample\d{3}$/,
 }
 
 export const toSimpleRouteJson = (value: unknown): SimpleRouteJson | null => {

--- a/tests/benchmark-dataset-aliases.test.ts
+++ b/tests/benchmark-dataset-aliases.test.ts
@@ -28,4 +28,7 @@ test("benchmark dataset aliases resolve to canonical dataset names", () => {
   expect(parseDatasetName("24")).toBe("srj24")
   expect(parseDatasetName("dataset24")).toBe("srj24")
   expect(parseDatasetName("@tscircuit/dataset-srj24")).toBe("srj24")
+  expect(parseDatasetName("27")).toBe("srj27")
+  expect(parseDatasetName("dataset27")).toBe("srj27")
+  expect(parseDatasetName("dataset-srj27-power-traces")).toBe("srj27")
 })

--- a/tests/benchmark-dataset-scenarios.test.ts
+++ b/tests/benchmark-dataset-scenarios.test.ts
@@ -14,6 +14,7 @@ test("benchmark datasets load in sample order", async () => {
   const srj20Scenarios = await loadScenarios("srj20")
   const srj23Scenarios = await loadScenarios("srj23")
   const srj24Scenarios = await loadScenarios("srj24")
+  const srj27Scenarios = await loadScenarios("srj27")
 
   expect(srj11Scenarios).toHaveLength(26)
   expect(srj11Scenarios[0][0]).toBe("sample001Circuit")
@@ -60,6 +61,11 @@ test("benchmark datasets load in sample order", async () => {
   expect(srj24Scenarios[9][0]).toBe("sample010")
   expect(srj24Scenarios[0][1].connections.length).toBeGreaterThan(0)
 
+  expect(srj27Scenarios).toHaveLength(6)
+  expect(srj27Scenarios[0][0]).toBe("sample001")
+  expect(srj27Scenarios[5][0]).toBe("sample006")
+  expect(srj27Scenarios[0][1].connections.length).toBeGreaterThan(0)
+
   const sample11 = await loadScenarioBySampleNumber("srj11", 11)
   expect(sample11.scenarioName).toBe("sample011Circuit")
   expect(sample11.totalSamples).toBe(26)
@@ -87,4 +93,8 @@ test("benchmark datasets load in sample order", async () => {
   const sample24 = await loadScenarioBySampleNumber("srj24", 10)
   expect(sample24.scenarioName).toBe("sample010")
   expect(sample24.totalSamples).toBe(10)
+
+  const sample27 = await loadScenarioBySampleNumber("srj27", 6)
+  expect(sample27.scenarioName).toBe("sample006")
+  expect(sample27.totalSamples).toBe(6)
 })


### PR DESCRIPTION
## Summary

- add `@tscircuit/dataset-srj27-power-traces` as a development dataset
- register `srj27` with the benchmark and `run-sample` scenario loader
- add numeric, shorthand, and package-name aliases
- verify all six TSX-derived SRJ power samples load in deterministic order

## Why

This keeps dataset ingestion separate from the power-trace-expander pipeline integration. Follow-up solver and visual snapshot work can consume SRJ27 through the same scenario API used by the existing autorouter datasets.

## Validation

- `bun test tests/benchmark-dataset-aliases.test.ts tests/benchmark-dataset-scenarios.test.ts --timeout 9999999`
- `bunx tsc --noEmit`
- `bun run build`