### PR TITLE
experiment(pathing): prefer shorter tiny-hypergraph paths

### DIFF
--- a/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
+++ b/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
@@ -121,7 +121,7 @@ const asTinyPortMetadata = (metadata: unknown): TinyPortMetadata =>
 
 const TINY_TERMINAL_REGION_SIZE = 1e-6
 const TINY_SOLVE_GRAPH_BASE_OPTIONS: TinyHyperGraphSolverOptions = {
-  DISTANCE_TO_COST: 0.05,
+  DISTANCE_TO_COST: 0.5,
   RIP_THRESHOLD_START: 0.05,
   RIP_THRESHOLD_END: 0.8,
   RIP_CONGESTION_REGION_COST_FACTOR: 0.1,


### PR DESCRIPTION
Temporary hosted-only experiment stacked on #1856. It increases the physical-distance term for solveGraph so A* does not exhaust the local multilayer search around close cross-layer terminals. The sample 4 benchmark will decide whether this direction is valid; this PR is not part of the proposed fix stack unless the hosted result is both solved and clean.