### PR TITLE
experiment(topology): keep narrow BGA fragments single layer

### DIFF
--- a/lib/solvers/BgaTopologyGeneratorSolver/BgaTopologyGeneratorSolver.ts
+++ b/lib/solvers/BgaTopologyGeneratorSolver/BgaTopologyGeneratorSolver.ts
@@ -16,6 +16,7 @@ import {
 import type { GraphicsObject } from "graphics-debug"
 import type { CapacityMeshNode, Obstacle } from "lib/types"
 import { createRectFromCapacityNode } from "lib/utils/createRectFromCapacityNode"
+import { getViaDimensions } from "lib/utils/getViaDimensions"
 
 export class BgaTopologyGeneratorSolver extends BasePipelineSolver<TopologyGeneratorSolverParams> {
   static readonly componentKind = "bga"
@@ -43,7 +44,11 @@ export class BgaTopologyGeneratorSolver extends BasePipelineSolver<TopologyGener
             bgaTopologyGeneratorSolver.markedComponentObstacles,
           unmarkedComponentObstacles:
             bgaTopologyGeneratorSolver.unmarkedComponentObstacles,
-          viaDiameter: bgaTopologyGeneratorSolver.inputProblem.viaDiameter,
+          viaDiameter:
+            bgaTopologyGeneratorSolver.inputProblem.viaDiameter ??
+            getViaDimensions(
+              bgaTopologyGeneratorSolver.inputProblem.inputSrj,
+            ).padDiameter,
         },
       ],
     ),
@@ -57,6 +62,7 @@ export class BgaTopologyGeneratorSolver extends BasePipelineSolver<TopologyGener
           obstacles: bgaTopologyGeneratorSolver.unmarkedComponentObstacles,
           layerCount:
             bgaTopologyGeneratorSolver.inputProblem.inputSrj.layerCount,
+          viaDiameter: bgaTopologyGeneratorSolver.inputProblem.viaDiameter,
         },
       ],
     ),

--- a/lib/solvers/BgaTopologyGeneratorSolver/InitialBgaTopologySolver.ts
+++ b/lib/solvers/BgaTopologyGeneratorSolver/InitialBgaTopologySolver.ts
@@ -13,7 +13,7 @@ import { BgaGrid } from "./bga-grid"
 import type { BgaGap, MissingBgaSlot } from "./bga-grid"
 import { getObstacleTargetConnectionNames } from "./getObstacleTargetConnectionNames"
 
-const BGA_MULTILAYER_REGION_VIA_DIAMETER_FACTOR = 1.2
+export const BGA_MULTILAYER_REGION_VIA_DIAMETER_FACTOR = 1.2
 const BGA_DIMENSION_EPSILON = 1e-6
 
 export type InitialBgaTopologySolverInput = {

--- a/lib/solvers/BgaTopologyGeneratorSolver/RemoveMeshNodeOverlappingSolver.ts
+++ b/lib/solvers/BgaTopologyGeneratorSolver/RemoveMeshNodeOverlappingSolver.ts
@@ -9,11 +9,15 @@ import {
   getCapacityMeshNodeBounds,
   isValidCapacityBounds,
 } from "../TopologyPlanningSolver/capacity-node-geometry"
+import { BGA_MULTILAYER_REGION_VIA_DIAMETER_FACTOR } from "./InitialBgaTopologySolver"
+
+const BGA_DIMENSION_EPSILON = 1e-6
 
 export type RemoveMeshNodeOverlappingSolverInput = {
   meshNodes: CapacityMeshNode[]
   obstacles: Obstacle[]
   layerCount: number
+  viaDiameter: number
 }
 
 function createNodeFromBounds({
@@ -39,6 +43,42 @@ function createNodeFromBounds({
     availableZ,
     layer: `z${availableZ.join(",")}`,
   }
+}
+
+function createNodesFromBounds({
+  node,
+  bounds,
+  availableZ,
+  suffix,
+  viaDiameter,
+}: {
+  node: CapacityMeshNode
+  bounds: Bounds
+  availableZ: number[]
+  suffix: string
+  viaDiameter: number
+}): CapacityMeshNode[] {
+  const width = bounds.maxX - bounds.minX
+  const height = bounds.maxY - bounds.minY
+  const multilayerThreshold =
+    viaDiameter * BGA_MULTILAYER_REGION_VIA_DIAMETER_FACTOR
+
+  if (
+    availableZ.length <= 1 ||
+    (width >= multilayerThreshold - BGA_DIMENSION_EPSILON &&
+      height >= multilayerThreshold - BGA_DIMENSION_EPSILON)
+  ) {
+    return [createNodeFromBounds({ node, bounds, availableZ, suffix })]
+  }
+
+  return availableZ.map((z) =>
+    createNodeFromBounds({
+      node,
+      bounds,
+      availableZ: [z],
+      suffix: `${suffix}-z${z}`,
+    }),
+  )
 }
 
 function subtractBounds(bounds: Bounds, overlap: Bounds): Bounds[] {
@@ -130,23 +170,25 @@ export class RemoveMeshNodeOverlappingWithUnmarkedObstacle extends BaseSolver {
       )
 
       nextMeshNodes.push(
-        ...subtractBounds(nodeBounds, overlapBounds).map((bounds, index) =>
-          createNodeFromBounds({
+        ...subtractBounds(nodeBounds, overlapBounds).flatMap((bounds, index) =>
+          createNodesFromBounds({
             node,
             bounds,
             availableZ: [...node.availableZ],
             suffix: `outside-${this.obstacleQueueIndex}-${index}`,
+            viaDiameter: this.inputProblem.viaDiameter,
           }),
         ),
       )
 
       if (nodeFreeLayers.length > 0) {
         nextMeshNodes.push(
-          createNodeFromBounds({
+          ...createNodesFromBounds({
             node,
             bounds: overlapBounds,
             availableZ: nodeFreeLayers,
             suffix: `under-${this.obstacleQueueIndex}`,
+            viaDiameter: this.inputProblem.viaDiameter,
           }),
         )
       }

--- a/tests/features/topology/bga-topology/fixtures/partial-target-overlap.fixture.ts
+++ b/tests/features/topology/bga-topology/fixtures/partial-target-overlap.fixture.ts
@@ -242,6 +242,7 @@ export function createPartialTargetOverlapFixture() {
     meshNodes: initialNodes,
     obstacles: [bottomTarget],
     layerCount: inputSrj.layerCount,
+    viaDiameter: VIA_DIAMETER,
   })
   removalSolver.solve()
   const outputNodes = removalSolver.getOutput()


### PR DESCRIPTION
## Purpose

Temporary hosted validation for the invalid intersections and remaining srj24 sample 4 failure.

The initial BGA topology only makes a region multilayer when both dimensions can fit a via. The partial-overlap split accidentally breaks that invariant: it can create a narrow fragment but retain every layer. The pathfinder may then change layers in a region where the physical solver cannot place a via.

This experiment keeps an overlap fragment multilayer only when it still meets the existing BGA via-fit threshold. Smaller fragments become coincident ordinary single-layer regions, so traces may cross them on each legal layer but may not change layers there.

## Validation

No project code is run locally. GitHub Actions runs the fixture, test matrix, and srj24 sample benchmarks.