### PR TITLE
experiment(topology): let topology merging own foreign BGA overlaps

### DIFF
--- a/lib/solvers/BgaTopologyGeneratorSolver/BgaTopologyGeneratorSolver.ts
+++ b/lib/solvers/BgaTopologyGeneratorSolver/BgaTopologyGeneratorSolver.ts
@@ -41,8 +41,7 @@ export class BgaTopologyGeneratorSolver extends BasePipelineSolver<TopologyGener
               .componentId,
           markedComponentObstacles:
             bgaTopologyGeneratorSolver.markedComponentObstacles,
-          unmarkedComponentObstacles:
-            bgaTopologyGeneratorSolver.unmarkedComponentObstacles,
+          unmarkedComponentObstacles: [],
           viaDiameter: bgaTopologyGeneratorSolver.inputProblem.viaDiameter,
         },
       ],
@@ -54,7 +53,7 @@ export class BgaTopologyGeneratorSolver extends BasePipelineSolver<TopologyGener
         {
           meshNodes:
             bgaTopologyGeneratorSolver.initialTopologySolver.getOutput(),
-          obstacles: bgaTopologyGeneratorSolver.unmarkedComponentObstacles,
+          obstacles: [],
           layerCount:
             bgaTopologyGeneratorSolver.inputProblem.inputSrj.layerCount,
         },
@@ -67,8 +66,7 @@ export class BgaTopologyGeneratorSolver extends BasePipelineSolver<TopologyGener
         {
           meshNodes:
             bgaTopologyGeneratorSolver.removeMeshNodeOverlappingWithUnmarkedObstacle.getOutput(),
-          unmarkedComponentObstacles:
-            bgaTopologyGeneratorSolver.unmarkedComponentObstacles,
+          unmarkedComponentObstacles: [],
           layerCount:
             bgaTopologyGeneratorSolver.inputProblem.inputSrj.layerCount,
         },


### PR DESCRIPTION
Temporary hosted-validation PR stacked on #1855.\n\nThis tests one ownership rule: a component-local BGA topology contains only that component's pads. Pads from other components are preserved in their own topology group, and TopologyMergingSolver combines the groups by layer.\n\nThe change removes foreign obstacles from the three BGA-local generation inputs. It does not add fallback routing, synthetic vias, or geometry fragments.\n\nValidation is intentionally GitHub-only. First gate: srj24 sample 4 must solve and pass relaxed DRC. If that succeeds, sample 3 and regression coverage will follow.