### PR TITLE
experiment(topology): keep BGA target nodes component-owned

### DIFF
--- a/lib/solvers/BgaTopologyGeneratorSolver/BgaTopologyGeneratorSolver.ts
+++ b/lib/solvers/BgaTopologyGeneratorSolver/BgaTopologyGeneratorSolver.ts
@@ -41,8 +41,7 @@ export class BgaTopologyGeneratorSolver extends BasePipelineSolver<TopologyGener
               .componentId,
           markedComponentObstacles:
             bgaTopologyGeneratorSolver.markedComponentObstacles,
-          unmarkedComponentObstacles:
-            bgaTopologyGeneratorSolver.unmarkedComponentObstacles,
+          unmarkedComponentObstacles: [],
           viaDiameter: bgaTopologyGeneratorSolver.inputProblem.viaDiameter,
         },
       ],


### PR DESCRIPTION
Temporary hosted-validation PR stacked on #1855.\n\nThis tests one narrow invariant: the BGA-local generator creates target nodes only for pads owned by that BGA. Foreign pads are still passed to obstacle removal and gap fill, so their copper remains blocked on the correct layer; their authoritative target node comes from their own/global topology group.\n\nProduction diff: one input changes to an empty array. No fallback, synthetic via, or geometry rewrite.\n\nValidation is GitHub-only. The first gate is srj24 sample 4 solved with relaxed DRC pass; ordinary CI must also remain clean.