### PR TITLE
experiment(pathing): compare nonselective Pipeline7 routing

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -478,7 +478,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
             flags: {
               FORCE_CENTER_FIRST: true,
               RIPPING_ENABLED: true,
-              USE_SELECTIVE_RERIP_ROUTING: true,
+              USE_SELECTIVE_RERIP_ROUTING: false,
             },
             weights: {
               SHUFFLE_SEED: 0,


### PR DESCRIPTION
Temporary hosted-validation PR stacked on #1856.\n\n#1856 gives the partial BGA overlap a layer-correct geometric partition, but sample 4 still exhausts SelectiveReripTinyHyperGraphSolverWithStableInitialAssignments. This one-line experiment runs the existing nonselective tiny-hypergraph pipeline instead.\n\nThe purpose is diagnosis, not promotion: sample 4 must solve and pass relaxed DRC, and ordinary CI must remain clean. No project code was executed locally.