### PR TITLE
experiment(pathing): route layer changes first

### DIFF
--- a/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
+++ b/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
@@ -219,6 +219,45 @@ const getRouteConnectionName = (routeMetadata: RouteMetadata) =>
 const getTinyRouteConnectionNetId = (connection: TinyRouteConnection): string =>
   connection.mutuallyConnectedNetworkId
 
+const requiresLayerChange = (connection: TinyRouteConnection): boolean => {
+  const [start, end] = connection.simpleRouteConnection.pointsToConnect
+  if (!start || !end) return false
+
+  const endLayers = new Set(getConnectionPointLayers(end))
+  return getConnectionPointLayers(start).every(
+    (layer) => !endLayers.has(layer),
+  )
+}
+
+const orderSelectiveReripConnections = (
+  connections: TinyRouteConnection[],
+): TinyRouteConnection[] => {
+  const orderedByNetSize = orderConnectionsByNetCardinality(
+    connections,
+    getTinyRouteConnectionNetId,
+  )
+  const connectionsByNet = new Map<string, TinyRouteConnection[]>()
+
+  for (const connection of orderedByNetSize) {
+    const netId = getTinyRouteConnectionNetId(connection)
+    const netConnections = connectionsByNet.get(netId) ?? []
+    netConnections.push(connection)
+    connectionsByNet.set(netId, netConnections)
+  }
+
+  return [...connectionsByNet.values()].flatMap((netConnections) =>
+    netConnections
+      .map((connection, index) => ({ connection, index }))
+      .sort(
+        (left, right) =>
+          Number(requiresLayerChange(right.connection)) -
+            Number(requiresLayerChange(left.connection)) ||
+          left.index - right.index,
+      )
+      .map(({ connection }) => connection),
+  )
+}
+
 const getRoutePoint = (routeMetadata: RouteMetadata, endpointIndex: 0 | 1) =>
   routeMetadata.simpleRouteConnection?.pointsToConnect[endpointIndex]
 
@@ -902,10 +941,7 @@ export class TinyHypergraphPortPointPathingSolver extends BaseSolver {
       params.connections,
     )
     const connections = params.flags.USE_SELECTIVE_RERIP_ROUTING
-      ? orderConnectionsByNetCardinality(
-          tinyRouteConnections,
-          getTinyRouteConnectionNetId,
-        )
+      ? orderSelectiveReripConnections(tinyRouteConnections)
       : tinyRouteConnections
     this.rootConnectionNameByConnectionId = new Map(
       connections.map((connection) => [


### PR DESCRIPTION
Temporary hosted diagnostic stacked on #1856.

Selective routing already schedules larger nets first, but preserves each net’s original edge order. In srj24 sample 4 that commits 24 same-layer edges before attempting the first constrained cross-layer edge.

This experiment keeps the same net-priority policy and only orders cross-layer edges before same-layer edges within each net. It does not change topology, DRC constraints, via permissions, geometry, or acceptance rules.

Validation is GitHub Actions only; no project command is run locally.

Hosted benchmark:

    /benchmark-long --dataset srj24 --sample-numbers 4 --sample-timeout 4000s --concurrency 1