### PR TITLE
fix(pathing): pin layer-aware cross-layer heuristic

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "recharts": "^2.15.1",
     "tailwind-merge": "^3.2.0",
     "terser": "^5.43.1",
-    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#2ac358656476d25c4a938a75cac464b499d1bdbf",
+    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#788d124bc39fa4fdccad2c1e5181d3b7e780bc97",
     "tiny-hypergraph-poly": "git+https://github.com/tscircuit/tiny-hypergraph.git#7b93b4c",
     "tsup": "^8.3.6",
     "typescript": "^5.9.3",


### PR DESCRIPTION
## Problem

After #1856 makes the sample-4 BGA topology reachable, the path search can still exhaust its iterations. Its heuristic sees a cross-layer goal as close in XY even while the route is on the wrong layer, so it explores nearby wrong-layer space instead of moving toward an existing ordinary region where the layer change is legal.

## Change

This PR only updates the `tiny-hypergraph` pin to the stacked upstream fix:

- tscircuit/tiny-hypergraph#143 — bounded visual reproduction
- tscircuit/tiny-hypergraph#144 — layer-aware search ordering

The upstream fix changes A* ordering only. It does not add topology, permit vias, or weaken collision checks.

![Layer-aware cross-layer route](https://raw.githubusercontent.com/tscircuit/tiny-hypergraph/agent/fix-cross-layer-heuristic-detour/tests/solver/__snapshots__/cross-layer-heuristic-detour.snap.svg)

## Hosted verification

- upstream formatter check: passed
- upstream full TypeScript check: passed
- upstream full tests: 109 passed
- `srj24` sample 4 Pipeline7 benchmark: pending

All tests, snapshots, and benchmarks run in GitHub Actions. No project command was run locally.
