### PR TITLE
fix(pathing): use directed graph guidance for cross-layer routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "recharts": "^2.15.1",
     "tailwind-merge": "^3.2.0",
     "terser": "^5.43.1",
-    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#9971a86ad7dfdf554d916f78ccbfc495ca0d0726",
+    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#f24160f638dfc6473ace9bca2fb1b42b64ba7412",
     "tiny-hypergraph-poly": "git+https://github.com/tscircuit/tiny-hypergraph.git#7b93b4c",
     "tsup": "^8.3.6",
     "typescript": "^5.9.3",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "recharts": "^2.15.1",
     "tailwind-merge": "^3.2.0",
     "terser": "^5.43.1",
-    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#2ac358656476d25c4a938a75cac464b499d1bdbf",
+    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#9971a86ad7dfdf554d916f78ccbfc495ca0d0726",
     "tiny-hypergraph-poly": "git+https://github.com/tscircuit/tiny-hypergraph.git#7b93b4c",
     "tsup": "^8.3.6",
     "typescript": "^5.9.3",


### PR DESCRIPTION
## Change

Pins tscircuit/tiny-hypergraph#146.

For a cross-layer route, the tiny solver now distinguishes a port entering a useful region from the same port entering a dead end. While the route remains on its start layer, A* uses remaining directed graph hops together with the existing XY estimate.

This integration changes only the dependency SHA. It does not include the broad BGA overlap splitting from #1856 and does not alter autorouter topology.

## Validation

- upstream full tests and SVG snapshot: passed in GitHub Actions
- upstream formatter and TypeScript checks: passed in GitHub Actions
- srj24 sample 4 benchmark: pending in this PR

Nothing is run locally.