### PR TITLE
Diagnostic: inspect sample 4 after aligned BGA topology

### DIFF
--- a/lib/solvers/TopologyMergingSolver/get-cross-layer-target-access.ts
+++ b/lib/solvers/TopologyMergingSolver/get-cross-layer-target-access.ts
@@ -299,6 +299,24 @@ function addCrossLayerAccessToTarget({
     targetConnectionLayers,
     viaDiameter,
   })
+  if (node.capacityMeshNodeId === "cmn_1672") {
+    console.error(
+      "SRJ24_SAMPLE4_TARGET_ACCESS",
+      JSON.stringify({
+        viaDiameter,
+        targetLayers: node.availableZ,
+        targetConnectionLayers: [...targetConnectionLayers],
+        sameNetTargets: crossLayerSameNetTargets.map((target) => ({
+          id: target.capacityMeshNodeId,
+          bounds: getCapacityMeshNodeBounds(target),
+          availableZ: target.availableZ,
+        })),
+        freeAccessOverlaps,
+        blockerBounds,
+        regions,
+      }),
+    )
+  }
   const alignedNodes = regions.map((region, index) => {
     const { bounds, availableZ } = region
     return {

--- a/tests/features/srj24-sample4-directed-hop-stall.test.ts
+++ b/tests/features/srj24-sample4-directed-hop-stall.test.ts
@@ -1,9 +1,39 @@
 import { expect, test } from "bun:test"
 import { AutoroutingPipelineSolver7_MultiGraph } from "lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph"
+import { getTopologyMergingNodesWithCrossLayerTargetAccess } from "lib/solvers/TopologyMergingSolver/get-cross-layer-target-access"
+import { getCapacityMeshNodeBounds } from "lib/solvers/TopologyPlanningSolver/capacity-node-geometry"
+import type { CapacityMeshNode } from "lib/types"
 import type { TinyHyperGraphSolver } from "tiny-hypergraph/lib/index"
 import { loadScenarioBySampleNumber } from "../../scripts/benchmark/scenarios"
 
 const PATHING_ITERATION_LIMIT = 250_000
+
+const END_TARGET_BOUNDS = {
+  minX: 1.27 - 0.59 / 2,
+  maxX: 1.27 + 0.59 / 2,
+  minY: -2.9 - 0.64 / 2,
+  maxY: -2.9 + 0.64 / 2,
+}
+
+const overlapsEndTarget = (node: CapacityMeshNode): boolean => {
+  const bounds = getCapacityMeshNodeBounds(node)
+  return !(
+    bounds.maxX <= END_TARGET_BOUNDS.minX ||
+    bounds.minX >= END_TARGET_BOUNDS.maxX ||
+    bounds.maxY <= END_TARGET_BOUNDS.minY ||
+    bounds.minY >= END_TARGET_BOUNDS.maxY
+  )
+}
+
+const summarizeNode = (node: CapacityMeshNode) => ({
+  id: node.capacityMeshNodeId,
+  bounds: getCapacityMeshNodeBounds(node),
+  availableZ: node.availableZ,
+  containsObstacle: node._containsObstacle,
+  containsTarget: node._containsTarget,
+  targetConnectionName: node._targetConnectionName,
+  connectedTo: node._connectedTo,
+})
 
 const summarizePort = (solver: TinyHyperGraphSolver, portId: number) => ({
   portId,
@@ -44,6 +74,36 @@ test("diagnose sample 4 topology at the stalled route", async () => {
   ) {
     solver.step()
   }
+
+  const mergingInput = solver.topologyMergingSolver!.inputProblem
+  const preparedAccess = getTopologyMergingNodesWithCrossLayerTargetAccess({
+    nodeGroups: mergingInput.nodeGroups,
+    viaDiameter: mergingInput.viaDiameter,
+  })
+  console.error(
+    "SRJ24_SAMPLE4_MERGING_INPUT",
+    JSON.stringify(
+      mergingInput.nodeGroups.flatMap((group) =>
+        group.nodes
+          .filter(overlapsEndTarget)
+          .map((node) => ({
+            groupId: group.groupId,
+            isComponent: group.isComponent,
+            ...summarizeNode(node),
+            prepared: preparedAccess.get(node)!.map(summarizeNode),
+          })),
+      ),
+    ),
+  )
+  console.error(
+    "SRJ24_SAMPLE4_MERGING_OUTPUT",
+    JSON.stringify(
+      solver.topologyMergingSolver!
+        .getOutput()
+        .filter(overlapsEndTarget)
+        .map(summarizeNode),
+    ),
+  )
 
   const tinySolver = pathingSolver.activeSubSolver as TinyHyperGraphSolver
   const routeId = tinySolver.state.currentRouteId!

--- a/tests/features/srj24-sample4-directed-hop-stall.test.ts
+++ b/tests/features/srj24-sample4-directed-hop-stall.test.ts
@@ -67,7 +67,7 @@ test("diagnose sample 4 topology at the stalled route", async () => {
 
   const pathingSolver = solver.portPointPathingSolver!
   while (
-    pathingSolver.activeSubSolver === null &&
+    !pathingSolver.activeSubSolver &&
     !solver.failed &&
     !solver.solved
   ) {

--- a/tests/features/srj24-sample4-directed-hop-stall.test.ts
+++ b/tests/features/srj24-sample4-directed-hop-stall.test.ts
@@ -66,6 +66,7 @@ test("diagnose sample 4 topology at the stalled route", async () => {
   solver.step()
 
   const pathingSolver = solver.portPointPathingSolver!
+  const tinySolver = pathingSolver.activeSubSolver as TinyHyperGraphSolver
 
   while (
     solver.getCurrentPhase() === "portPointPathingSolver" &&
@@ -105,7 +106,6 @@ test("diagnose sample 4 topology at the stalled route", async () => {
     ),
   )
 
-  const tinySolver = pathingSolver.activeSubSolver as TinyHyperGraphSolver
   const routeId = tinySolver.state.currentRouteId!
   const startPortId = tinySolver.problem.routeStartPort[routeId]!
   const endPortId = tinySolver.problem.routeEndPort[routeId]!
@@ -147,8 +147,16 @@ test("diagnose sample 4 topology at the stalled route", async () => {
   console.error(
     "SRJ24_SAMPLE4_STATE",
     JSON.stringify({
+      pathingSolved: pathingSolver.solved,
+      pathingFailed: pathingSolver.failed,
+      pathingError: pathingSolver.error?.message,
       pathingIterations: pathingSolver.iterations,
+      tinySolved: tinySolver.solved,
+      tinyFailed: tinySolver.failed,
+      tinyError: tinySolver.error?.message,
       tinyIterations: tinySolver.iterations,
+      tinyMaxIterations: tinySolver.MAX_ITERATIONS,
+      tinyStats: tinySolver.stats,
       committedRouteCount: committedRouteIds.size,
       pendingRouteCount: tinySolver.state.unroutedRoutes.length,
       routeId,

--- a/tests/features/srj24-sample4-directed-hop-stall.test.ts
+++ b/tests/features/srj24-sample4-directed-hop-stall.test.ts
@@ -74,13 +74,37 @@ test("diagnose sample 4 topology at the stalled route", async () => {
     solver.step()
   }
   const tinySolver = pathingSolver.activeSubSolver as TinyHyperGraphSolver
+  const routeExpansionCount = new Map<number, number>()
+  const routeAttemptCount = new Map<number, number>()
+  let lastActiveRouteId: number | undefined
 
   while (
     solver.getCurrentPhase() === "portPointPathingSolver" &&
     !solver.failed &&
     !solver.solved
   ) {
+    const routeIdBeforeStep = tinySolver.state.currentRouteId
+    const tinyIterationsBeforeStep = tinySolver.iterations
     solver.step()
+    const routeIdAfterStep = tinySolver.state.currentRouteId
+    const attributedRouteId = routeIdBeforeStep ?? routeIdAfterStep
+    if (attributedRouteId !== undefined) {
+      routeExpansionCount.set(
+        attributedRouteId,
+        (routeExpansionCount.get(attributedRouteId) ?? 0) +
+          (tinySolver.iterations - tinyIterationsBeforeStep),
+      )
+    }
+    if (
+      routeIdAfterStep !== undefined &&
+      routeIdAfterStep !== lastActiveRouteId
+    ) {
+      routeAttemptCount.set(
+        routeIdAfterStep,
+        (routeAttemptCount.get(routeIdAfterStep) ?? 0) + 1,
+      )
+    }
+    lastActiveRouteId = routeIdAfterStep
   }
 
   const mergingInput = solver.topologyMergingSolver!.inputProblem
@@ -171,6 +195,17 @@ test("diagnose sample 4 topology at the stalled route", async () => {
       ).length,
       committedRouteCount: committedRouteIds.size,
       pendingRouteCount: tinySolver.state.unroutedRoutes.length,
+      candidateQueueSize: tinySolver.state.candidateQueue.length,
+      topRouteSearches: [...routeExpansionCount]
+        .map(([expandedRouteId, expansions]) => ({
+          routeId: expandedRouteId,
+          expansions,
+          attempts: routeAttemptCount.get(expandedRouteId) ?? 0,
+          connectionId:
+            tinySolver.problem.routeMetadata?.[expandedRouteId]?.connectionId,
+        }))
+        .sort((left, right) => right.expansions - left.expansions)
+        .slice(0, 20),
       routeId,
       routeNetId: tinySolver.problem.routeNet[routeId],
       routeMetadata: tinySolver.problem.routeMetadata?.[routeId],

--- a/tests/features/srj24-sample4-directed-hop-stall.test.ts
+++ b/tests/features/srj24-sample4-directed-hop-stall.test.ts
@@ -1,0 +1,146 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver7_MultiGraph } from "lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph"
+import type {
+  Candidate,
+  TinyHyperGraphSolver,
+} from "tiny-hypergraph/lib/index"
+import { loadScenarioBySampleNumber } from "../../scripts/benchmark/scenarios"
+
+const PATHING_ITERATION_LIMIT = 250_000
+
+const getDirectedHopCount = (
+  solver: TinyHyperGraphSolver,
+  routeId: number,
+  portId: number,
+  nextRegionId: number,
+) => {
+  const hopCounts =
+    solver.problemSetup.directedHopCountToEndByRoute[routeId]
+  if (!hopCounts) return undefined
+
+  const incidentRegions = solver.topology.incidentPortRegion[portId] ?? []
+  const side =
+    incidentRegions[0] === nextRegionId
+      ? 0
+      : incidentRegions[1] === nextRegionId
+        ? 1
+        : undefined
+
+  return side === undefined ? undefined : hopCounts[portId * 2 + side]
+}
+
+const summarizeCandidate = (
+  solver: TinyHyperGraphSolver,
+  routeId: number,
+  candidate: Candidate,
+) => ({
+  portId: candidate.portId,
+  nextRegionId: candidate.nextRegionId,
+  z: solver.topology.portZ[candidate.portId],
+  x: solver.topology.portX[candidate.portId],
+  y: solver.topology.portY[candidate.portId],
+  directedHopCount: getDirectedHopCount(
+    solver,
+    routeId,
+    candidate.portId,
+    candidate.nextRegionId,
+  ),
+  g: candidate.g,
+  h: candidate.h,
+  f: candidate.f,
+})
+
+const getCandidatePathTail = (
+  solver: TinyHyperGraphSolver,
+  routeId: number,
+  candidate: Candidate | undefined,
+) => {
+  const path = []
+  let currentCandidate = candidate
+
+  while (currentCandidate) {
+    path.unshift(summarizeCandidate(solver, routeId, currentCandidate))
+    currentCandidate = currentCandidate.prevCandidate
+  }
+
+  return path.slice(-20)
+}
+
+test("diagnose srj24 sample 4 directed-hop pathing stall", async () => {
+  const { scenario } = await loadScenarioBySampleNumber("srj24", 4, 1)
+  const solver = new AutoroutingPipelineSolver7_MultiGraph(scenario, {
+    effort: 1,
+    cacheProvider: null,
+  })
+
+  solver.solveUntilPhase("portPointPathingSolver")
+  solver.step()
+
+  const pathingSolver = solver.portPointPathingSolver!
+  pathingSolver.MAX_ITERATIONS = PATHING_ITERATION_LIMIT
+
+  while (
+    solver.getCurrentPhase() === "portPointPathingSolver" &&
+    !solver.failed &&
+    !solver.solved
+  ) {
+    solver.step()
+  }
+
+  const tinySolver = pathingSolver.activeSubSolver as TinyHyperGraphSolver
+  const routeId = tinySolver.state.currentRouteId!
+  const startPortId = tinySolver.problem.routeStartPort[routeId]!
+  const endPortId = tinySolver.problem.routeEndPort[routeId]!
+  const queuedCandidates = tinySolver.state.candidateQueue
+    .toArray()
+    .sort((left, right) => left.f - right.f)
+  const bestCandidate = queuedCandidates[0]
+  const directedHopCounts =
+    tinySolver.problemSetup.directedHopCountToEndByRoute[routeId]
+  const finiteHopCounts = directedHopCounts
+    ? Array.from(directedHopCounts).filter((hopCount) => hopCount >= 0)
+    : []
+  const committedRouteIds = new Set(
+    tinySolver.state.regionSegments.flatMap((segments) =>
+      segments.map(([committedRouteId]) => committedRouteId),
+    ),
+  )
+
+  console.log(
+    "srj24 sample 4 directed-hop diagnostic",
+    JSON.stringify(
+      {
+        pathingIterations: pathingSolver.iterations,
+        tinyIterations: tinySolver.iterations,
+        committedRouteCount: committedRouteIds.size,
+        pendingRouteCount: tinySolver.state.unroutedRoutes.length,
+        routeId,
+        startPortId,
+        endPortId,
+        startZ: tinySolver.topology.portZ[startPortId],
+        endZ: tinySolver.topology.portZ[endPortId],
+        directedHopHeuristicPresent: directedHopCounts !== undefined,
+        reachableDirectedHopCount: finiteHopCounts.length,
+        minDirectedHopCount:
+          finiteHopCounts.length === 0 ? undefined : Math.min(...finiteHopCounts),
+        maxDirectedHopCount:
+          finiteHopCounts.length === 0 ? undefined : Math.max(...finiteHopCounts),
+        candidateQueueLength: queuedCandidates.length,
+        bestQueuedCandidates: queuedCandidates
+          .slice(0, 20)
+          .map((candidate) =>
+            summarizeCandidate(tinySolver, routeId, candidate),
+          ),
+        bestCandidatePathTail: getCandidatePathTail(
+          tinySolver,
+          routeId,
+          bestCandidate,
+        ),
+      },
+      null,
+      2,
+    ),
+  )
+
+  expect(pathingSolver.solved).toBe(true)
+})

--- a/tests/features/srj24-sample4-directed-hop-stall.test.ts
+++ b/tests/features/srj24-sample4-directed-hop-stall.test.ts
@@ -66,6 +66,13 @@ test("diagnose sample 4 topology at the stalled route", async () => {
   solver.step()
 
   const pathingSolver = solver.portPointPathingSolver!
+  while (
+    pathingSolver.activeSubSolver === null &&
+    !solver.failed &&
+    !solver.solved
+  ) {
+    solver.step()
+  }
   const tinySolver = pathingSolver.activeSubSolver as TinyHyperGraphSolver
 
   while (
@@ -77,6 +84,7 @@ test("diagnose sample 4 topology at the stalled route", async () => {
   }
 
   const mergingInput = solver.topologyMergingSolver!.inputProblem
+  const mergingOutput = solver.topologyMergingSolver!.getOutput()
   const preparedAccess = getTopologyMergingNodesWithCrossLayerTargetAccess({
     nodeGroups: mergingInput.nodeGroups,
     viaDiameter: mergingInput.viaDiameter,
@@ -99,10 +107,7 @@ test("diagnose sample 4 topology at the stalled route", async () => {
   console.error(
     "SRJ24_SAMPLE4_MERGING_OUTPUT",
     JSON.stringify(
-      solver.topologyMergingSolver!
-        .getOutput()
-        .filter(overlapsEndTarget)
-        .map(summarizeNode),
+      mergingOutput.filter(overlapsEndTarget).map(summarizeNode),
     ),
   )
 
@@ -157,6 +162,13 @@ test("diagnose sample 4 topology at the stalled route", async () => {
       tinyIterations: tinySolver.iterations,
       tinyMaxIterations: tinySolver.MAX_ITERATIONS,
       tinyStats: tinySolver.stats,
+      graphRegionCount: tinySolver.topology.regionCount,
+      graphPortCount: tinySolver.topology.portCount,
+      graphRouteCount: tinySolver.problem.routeCount,
+      mergedRegionCount: mergingOutput.length,
+      crossLayerTargetRegionCount: mergingOutput.filter(
+        (node) => node._containsTarget && node.availableZ.length > 1,
+      ).length,
       committedRouteCount: committedRouteIds.size,
       pendingRouteCount: tinySolver.state.unroutedRoutes.length,
       routeId,

--- a/tests/features/srj24-sample4-directed-hop-stall.test.ts
+++ b/tests/features/srj24-sample4-directed-hop-stall.test.ts
@@ -32,7 +32,10 @@ const summarizeNode = (node: CapacityMeshNode) => ({
   containsObstacle: node._containsObstacle,
   containsTarget: node._containsTarget,
   targetConnectionName: node._targetConnectionName,
-  connectedTo: node._connectedTo,
+  rootAliases: node._connectedTo?.filter((alias) =>
+    alias.startsWith("source_"),
+  ),
+  connectedToCount: node._connectedTo?.length ?? 0,
 })
 
 const summarizePort = (solver: TinyHyperGraphSolver, portId: number) => ({

--- a/tests/features/srj24-sample4-directed-hop-stall.test.ts
+++ b/tests/features/srj24-sample4-directed-hop-stall.test.ts
@@ -8,6 +8,31 @@ import { loadScenarioBySampleNumber } from "../../scripts/benchmark/scenarios"
 
 const PATHING_ITERATION_LIMIT = 250_000
 
+const summarizePort = (solver: TinyHyperGraphSolver, portId: number) => ({
+  portId,
+  x: solver.topology.portX[portId],
+  y: solver.topology.portY[portId],
+  routingCostX:
+    solver.topology.portRoutingCostX?.[portId] ??
+    solver.topology.portX[portId],
+  routingCostY:
+    solver.topology.portRoutingCostY?.[portId] ??
+    solver.topology.portY[portId],
+  z: solver.topology.portZ[portId],
+  incidentRegions: solver.topology.incidentPortRegion[portId].map(
+    (regionId) => ({
+      regionId,
+      center: {
+        x: solver.topology.regionCenterX[regionId],
+        y: solver.topology.regionCenterY[regionId],
+      },
+      availableZMask: solver.topology.regionAvailableZMask?.[regionId],
+      metadata: solver.topology.regionMetadata?.[regionId],
+    }),
+  ),
+  metadata: solver.topology.portMetadata?.[portId],
+})
+
 const getDirectedHopCount = (
   solver: TinyHyperGraphSolver,
   routeId: number,
@@ -115,10 +140,14 @@ test("diagnose srj24 sample 4 directed-hop pathing stall", async () => {
         committedRouteCount: committedRouteIds.size,
         pendingRouteCount: tinySolver.state.unroutedRoutes.length,
         routeId,
+        routeNetId: tinySolver.problem.routeNet[routeId],
+        routeMetadata: tinySolver.problem.routeMetadata?.[routeId],
         startPortId,
         endPortId,
         startZ: tinySolver.topology.portZ[startPortId],
         endZ: tinySolver.topology.portZ[endPortId],
+        startPort: summarizePort(tinySolver, startPortId),
+        endPort: summarizePort(tinySolver, endPortId),
         directedHopHeuristicPresent: directedHopCounts !== undefined,
         reachableDirectedHopCount: finiteHopCounts.length,
         minDirectedHopCount:

--- a/tests/features/srj24-sample4-directed-hop-stall.test.ts
+++ b/tests/features/srj24-sample4-directed-hop-stall.test.ts
@@ -1,9 +1,6 @@
 import { expect, test } from "bun:test"
 import { AutoroutingPipelineSolver7_MultiGraph } from "lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph"
-import type {
-  Candidate,
-  TinyHyperGraphSolver,
-} from "tiny-hypergraph/lib/index"
+import type { TinyHyperGraphSolver } from "tiny-hypergraph/lib/index"
 import { loadScenarioBySampleNumber } from "../../scripts/benchmark/scenarios"
 
 const PATHING_ITERATION_LIMIT = 250_000
@@ -12,12 +9,6 @@ const summarizePort = (solver: TinyHyperGraphSolver, portId: number) => ({
   portId,
   x: solver.topology.portX[portId],
   y: solver.topology.portY[portId],
-  routingCostX:
-    solver.topology.portRoutingCostX?.[portId] ??
-    solver.topology.portX[portId],
-  routingCostY:
-    solver.topology.portRoutingCostY?.[portId] ??
-    solver.topology.portY[portId],
   z: solver.topology.portZ[portId],
   incidentRegions: solver.topology.incidentPortRegion[portId].map(
     (regionId) => ({
@@ -33,65 +24,7 @@ const summarizePort = (solver: TinyHyperGraphSolver, portId: number) => ({
   metadata: solver.topology.portMetadata?.[portId],
 })
 
-const getDirectedHopCount = (
-  solver: TinyHyperGraphSolver,
-  routeId: number,
-  portId: number,
-  nextRegionId: number,
-) => {
-  const hopCounts =
-    solver.problemSetup.directedHopCountToEndByRoute[routeId]
-  if (!hopCounts) return undefined
-
-  const incidentRegions = solver.topology.incidentPortRegion[portId] ?? []
-  const side =
-    incidentRegions[0] === nextRegionId
-      ? 0
-      : incidentRegions[1] === nextRegionId
-        ? 1
-        : undefined
-
-  return side === undefined ? undefined : hopCounts[portId * 2 + side]
-}
-
-const summarizeCandidate = (
-  solver: TinyHyperGraphSolver,
-  routeId: number,
-  candidate: Candidate,
-) => ({
-  portId: candidate.portId,
-  nextRegionId: candidate.nextRegionId,
-  z: solver.topology.portZ[candidate.portId],
-  x: solver.topology.portX[candidate.portId],
-  y: solver.topology.portY[candidate.portId],
-  directedHopCount: getDirectedHopCount(
-    solver,
-    routeId,
-    candidate.portId,
-    candidate.nextRegionId,
-  ),
-  g: candidate.g,
-  h: candidate.h,
-  f: candidate.f,
-})
-
-const getCandidatePathTail = (
-  solver: TinyHyperGraphSolver,
-  routeId: number,
-  candidate: Candidate | undefined,
-) => {
-  const path = []
-  let currentCandidate = candidate
-
-  while (currentCandidate) {
-    path.unshift(summarizeCandidate(solver, routeId, currentCandidate))
-    currentCandidate = currentCandidate.prevCandidate
-  }
-
-  return path.slice(-20)
-}
-
-test("diagnose srj24 sample 4 directed-hop pathing stall", async () => {
+test("diagnose sample 4 topology at the stalled route", async () => {
   const { scenario } = await loadScenarioBySampleNumber("srj24", 4, 1)
   const solver = new AutoroutingPipelineSolver7_MultiGraph(scenario, {
     effort: 1,
@@ -116,59 +49,72 @@ test("diagnose srj24 sample 4 directed-hop pathing stall", async () => {
   const routeId = tinySolver.state.currentRouteId!
   const startPortId = tinySolver.problem.routeStartPort[routeId]!
   const endPortId = tinySolver.problem.routeEndPort[routeId]!
-  const queuedCandidates = tinySolver.state.candidateQueue
+  const endRegionId = tinySolver.topology.incidentPortRegion[endPortId][0]!
+  const endBoundaryPorts = (
+    tinySolver.topology.regionIncidentPorts[endRegionId] ?? []
+  ).map((portId) => ({
+    portId,
+    x: tinySolver.topology.portX[portId],
+    y: tinySolver.topology.portY[portId],
+    z: tinySolver.topology.portZ[portId],
+    incidentRegions: tinySolver.topology.incidentPortRegion[portId].map(
+      (regionId) => ({
+        regionId,
+        metadata: tinySolver.topology.regionMetadata?.[regionId],
+      }),
+    ),
+  }))
+  const bestCandidates = tinySolver.state.candidateQueue
     .toArray()
     .sort((left, right) => left.f - right.f)
-  const bestCandidate = queuedCandidates[0]
-  const directedHopCounts =
-    tinySolver.problemSetup.directedHopCountToEndByRoute[routeId]
-  const finiteHopCounts = directedHopCounts
-    ? Array.from(directedHopCounts).filter((hopCount) => hopCount >= 0)
-    : []
+    .slice(0, 5)
+    .map((candidate) => ({
+      portId: candidate.portId,
+      nextRegionId: candidate.nextRegionId,
+      x: tinySolver.topology.portX[candidate.portId],
+      y: tinySolver.topology.portY[candidate.portId],
+      z: tinySolver.topology.portZ[candidate.portId],
+      g: candidate.g,
+      h: candidate.h,
+      f: candidate.f,
+    }))
   const committedRouteIds = new Set(
     tinySolver.state.regionSegments.flatMap((segments) =>
       segments.map(([committedRouteId]) => committedRouteId),
     ),
   )
 
-  console.log(
-    "srj24 sample 4 directed-hop diagnostic",
-    JSON.stringify(
-      {
-        pathingIterations: pathingSolver.iterations,
-        tinyIterations: tinySolver.iterations,
-        committedRouteCount: committedRouteIds.size,
-        pendingRouteCount: tinySolver.state.unroutedRoutes.length,
-        routeId,
-        routeNetId: tinySolver.problem.routeNet[routeId],
-        routeMetadata: tinySolver.problem.routeMetadata?.[routeId],
-        startPortId,
-        endPortId,
-        startZ: tinySolver.topology.portZ[startPortId],
-        endZ: tinySolver.topology.portZ[endPortId],
-        startPort: summarizePort(tinySolver, startPortId),
-        endPort: summarizePort(tinySolver, endPortId),
-        directedHopHeuristicPresent: directedHopCounts !== undefined,
-        reachableDirectedHopCount: finiteHopCounts.length,
-        minDirectedHopCount:
-          finiteHopCounts.length === 0 ? undefined : Math.min(...finiteHopCounts),
-        maxDirectedHopCount:
-          finiteHopCounts.length === 0 ? undefined : Math.max(...finiteHopCounts),
-        candidateQueueLength: queuedCandidates.length,
-        bestQueuedCandidates: queuedCandidates
-          .slice(0, 20)
-          .map((candidate) =>
-            summarizeCandidate(tinySolver, routeId, candidate),
-          ),
-        bestCandidatePathTail: getCandidatePathTail(
-          tinySolver,
-          routeId,
-          bestCandidate,
-        ),
-      },
-      null,
-      2,
-    ),
+  console.error(
+    "SRJ24_SAMPLE4_STATE",
+    JSON.stringify({
+      pathingIterations: pathingSolver.iterations,
+      tinyIterations: tinySolver.iterations,
+      committedRouteCount: committedRouteIds.size,
+      pendingRouteCount: tinySolver.state.unroutedRoutes.length,
+      routeId,
+      routeNetId: tinySolver.problem.routeNet[routeId],
+      routeMetadata: tinySolver.problem.routeMetadata?.[routeId],
+    }),
+  )
+  console.error(
+    "SRJ24_SAMPLE4_START_PORT",
+    JSON.stringify(summarizePort(tinySolver, startPortId)),
+  )
+  console.error(
+    "SRJ24_SAMPLE4_END_PORT",
+    JSON.stringify(summarizePort(tinySolver, endPortId)),
+  )
+  console.error(
+    "SRJ24_SAMPLE4_END_REGION",
+    JSON.stringify({
+      endRegionId,
+      occupancy: tinySolver.state.regionSegments[endRegionId],
+      boundaryPorts: endBoundaryPorts,
+    }),
+  )
+  console.error(
+    "SRJ24_SAMPLE4_CANDIDATES",
+    JSON.stringify(bestCandidates),
   )
 
   expect(pathingSolver.solved).toBe(true)

--- a/tests/features/srj24-sample4-directed-hop-stall.test.ts
+++ b/tests/features/srj24-sample4-directed-hop-stall.test.ts
@@ -6,8 +6,6 @@ import type { CapacityMeshNode } from "lib/types"
 import type { TinyHyperGraphSolver } from "tiny-hypergraph/lib/index"
 import { loadScenarioBySampleNumber } from "../../scripts/benchmark/scenarios"
 
-const PATHING_ITERATION_LIMIT = 250_000
-
 const END_TARGET_BOUNDS = {
   minX: 1.27 - 0.59 / 2,
   maxX: 1.27 + 0.59 / 2,
@@ -68,7 +66,6 @@ test("diagnose sample 4 topology at the stalled route", async () => {
   solver.step()
 
   const pathingSolver = solver.portPointPathingSolver!
-  pathingSolver.MAX_ITERATIONS = PATHING_ITERATION_LIMIT
 
   while (
     solver.getCurrentPhase() === "portPointPathingSolver" &&


### PR DESCRIPTION
## Purpose

Temporary hosted diagnostic for #1875. Do not merge.

The topology fix now represents the partially covered BGA cell as ordinary aligned regions, but the exact `srj24` sample 4 benchmark still exhausts selective-rerip iterations after 432.3s.

This PR adds one diagnostic test on the exact #1875 head. It stops pathing after 250,000 iterations and prints:

- the currently stalled route and source connection metadata;
- its start and end PCB terminals, coordinates, layers, and incident regions;
- committed and pending route counts;
- directed reachability statistics;
- the best queued candidates and the tail of the best candidate path.

It makes no production solver or topology changes. The final assertion intentionally fails when pathing remains unsolved so GitHub Actions preserves the diagnostic log.

## Validation

GitHub Actions only; nothing is run locally.
