### PR TITLE
experiment(pathing): combine layer-aware point pairs with directed guidance

### DIFF
--- a/lib/solvers/NetToPointPairsSolver/NetToPointPairsSolver.ts
+++ b/lib/solvers/NetToPointPairsSolver/NetToPointPairsSolver.ts
@@ -4,7 +4,7 @@ import {
   SimpleRouteJson,
 } from "lib/types"
 import { BaseSolver } from "../BaseSolver"
-import { buildMinimumSpanningTree } from "./buildMinimumSpanningTree"
+import { buildLayerAwareMinimumSpanningTree } from "./buildLayerAwareMinimumSpanningTree"
 import { GraphicsObject } from "graphics-debug"
 import { mergeConnections } from "./mergeConnections"
 import { seededRandom } from "lib/utils/cloneAndShuffleArray"
@@ -172,9 +172,10 @@ export class NetToPointPairsSolver extends BaseSolver {
       return
     }
 
-    const edges = buildMinimumSpanningTree(connection.pointsToConnect, {
-      extraEdges: zeroWeightEdges,
-    })
+    const edges = buildLayerAwareMinimumSpanningTree(
+      connection.pointsToConnect,
+      zeroWeightEdges,
+    )
 
     let mstIdx = 0
     for (const edge of edges) {

--- a/lib/solvers/NetToPointPairsSolver/buildLayerAwareMinimumSpanningTree.ts
+++ b/lib/solvers/NetToPointPairsSolver/buildLayerAwareMinimumSpanningTree.ts
@@ -1,0 +1,102 @@
+import type { ConnectionPoint } from "lib/types"
+import { getConnectionPointLayers } from "lib/utils/connection-point-utils"
+import {
+  buildMinimumSpanningTree,
+  type Edge,
+} from "./buildMinimumSpanningTree"
+
+const getPlanarDistance = (a: ConnectionPoint, b: ConnectionPoint) =>
+  Math.hypot(a.x - b.x, a.y - b.y)
+
+export const connectionPointsShareLayer = (
+  a: ConnectionPoint,
+  b: ConnectionPoint,
+) => {
+  const bLayers = new Set(getConnectionPointLayers(b))
+  return getConnectionPointLayers(a).some((layer) => bLayers.has(layer))
+}
+
+export const getLayerChangePenalty = (points: ConnectionPoint[]) => {
+  if (points.length <= 1) return 1
+
+  const xs = points.map((point) => point.x)
+  const ys = points.map((point) => point.y)
+  const diagonal = Math.hypot(
+    Math.max(...xs) - Math.min(...xs),
+    Math.max(...ys) - Math.min(...ys),
+  )
+
+  // A layer change must sort after every possible same-layer edge.
+  return Math.max(diagonal, 1) * 2
+}
+
+export const getLayerAwareConnectionPointWeight = (
+  a: ConnectionPoint,
+  b: ConnectionPoint,
+  layerChangePenalty: number,
+) =>
+  getPlanarDistance(a, b) +
+  (connectionPointsShareLayer(a, b) ? 0 : layerChangePenalty)
+
+/**
+ * Builds one planar tree per copper layer before joining those trees together.
+ * This avoids turning a staggered top/bottom pad field into a sequence of
+ * unnecessary layer changes merely because opposite-layer pads are close in XY.
+ */
+export const buildLayerAwareMinimumSpanningTree = (
+  points: ConnectionPoint[],
+  extraEdges: Edge<ConnectionPoint>[] = [],
+): Edge<ConnectionPoint>[] => {
+  const layerChangePenalty = getLayerChangePenalty(points)
+  const pointsByLayer = new Map<string, ConnectionPoint[]>()
+
+  for (const point of points) {
+    for (const layer of new Set(getConnectionPointLayers(point))) {
+      const layerPoints = pointsByLayer.get(layer) ?? []
+      layerPoints.push(point)
+      pointsByLayer.set(layer, layerPoints)
+    }
+  }
+
+  const sameLayerEdges = [...pointsByLayer.values()].flatMap((layerPoints) =>
+    buildMinimumSpanningTree(layerPoints),
+  )
+
+  // Ensure the sparse global graph has a candidate between every pair of
+  // otherwise separate layer trees, even when each point's nearest XY
+  // neighbors all happen to be on its own layer.
+  const crossLayerEdges: Edge<ConnectionPoint>[] = []
+  const layerGroups = [...pointsByLayer.values()]
+  for (let i = 0; i < layerGroups.length; i++) {
+    for (let j = i + 1; j < layerGroups.length; j++) {
+      let closestPair: [ConnectionPoint, ConnectionPoint] | undefined
+      let closestDistance = Infinity
+
+      for (const a of layerGroups[i]!) {
+        for (const b of layerGroups[j]!) {
+          if (a === b || connectionPointsShareLayer(a, b)) continue
+          const distance = getPlanarDistance(a, b)
+          if (distance < closestDistance) {
+            closestDistance = distance
+            closestPair = [a, b]
+          }
+        }
+      }
+
+      if (closestPair) {
+        crossLayerEdges.push({
+          from: closestPair[0],
+          to: closestPair[1],
+          weight: closestDistance + layerChangePenalty,
+        })
+      }
+    }
+  }
+
+  return buildMinimumSpanningTree(points, {
+    extraEdges: [...extraEdges, ...sameLayerEdges, ...crossLayerEdges],
+    getEdgeWeight: (from, to, planarDistance) =>
+      planarDistance +
+      (connectionPointsShareLayer(from, to) ? 0 : layerChangePenalty),
+  })
+}

--- a/lib/solvers/NetToPointPairsSolver/buildMinimumSpanningTree.ts
+++ b/lib/solvers/NetToPointPairsSolver/buildMinimumSpanningTree.ts
@@ -177,35 +177,31 @@ class KDTree {
 
 // Disjoint Set (Union-Find) data structure for Kruskal's algorithm
 export class DisjointSet {
-  private parent: Map<string, string> = new Map()
-  private rank: Map<string, number> = new Map()
+  private parent: Map<Point, Point> = new Map()
+  private rank: Map<Point, number> = new Map()
 
   constructor(points: Point[]) {
     // Initialize each point as a separate set
     for (const point of points) {
-      const key = this.pointToKey(point)
-      this.parent.set(key, key)
-      this.rank.set(key, 0)
+      this.parent.set(point, point)
+      this.rank.set(point, 0)
     }
   }
 
-  private pointToKey(point: Point): string {
-    return `${point.x},${point.y}`
-  }
-
-  find(point: Point): string {
-    const key = this.pointToKey(point)
-    if (!this.parent.has(key)) {
-      throw new Error(`Point ${key} not found in DisjointSet`)
+  find(point: Point): Point {
+    if (!this.parent.has(point)) {
+      throw new Error(
+        `Point (${point.x}, ${point.y}) not found in DisjointSet`,
+      )
     }
 
-    let root = key
+    let root = point
     while (root !== this.parent.get(root)) {
       root = this.parent.get(root)!
     }
 
     // Path compression
-    let current = key
+    let current = point
     while (current !== root) {
       const next = this.parent.get(current)!
       this.parent.set(current, root)
@@ -241,7 +237,7 @@ export class DisjointSet {
 }
 
 // Edge representation for Kruskal's algorithm
-interface Edge<T extends Point> {
+export interface Edge<T extends Point> {
   from: T
   to: T
   weight: number
@@ -249,6 +245,7 @@ interface Edge<T extends Point> {
 
 interface BuildMinimumSpanningTreeOptions<T extends Point> {
   extraEdges?: Edge<T>[]
+  getEdgeWeight?: (from: T, to: T, planarDistance: number) => number
 }
 
 // Main function to build a minimum spanning tree using Kruskal's algorithm
@@ -275,8 +272,8 @@ export function buildMinimumSpanningTree<T extends Point>(
     const neighbors = kdTree.findKNearestNeighbors(point, k + 1) // +1 because it includes the point itself
 
     for (const neighbor of neighbors) {
-      // Skip self
-      if (point.x === neighbor.x && point.y === neighbor.y) {
+      // Skip the same point, but keep distinct terminals at identical x/y.
+      if (point === neighbor) {
         continue
       }
 
@@ -287,7 +284,7 @@ export function buildMinimumSpanningTree<T extends Point>(
       edges.push({
         from: point,
         to: neighbor as T,
-        weight: distance,
+        weight: opts.getEdgeWeight?.(point, neighbor as T, distance) ?? distance,
       })
     }
   }

--- a/lib/solvers/NetToPointPairsSolver2_OffBoardConnection/NetToPointPairsSolver2_OffBoardConnection.ts
+++ b/lib/solvers/NetToPointPairsSolver2_OffBoardConnection/NetToPointPairsSolver2_OffBoardConnection.ts
@@ -9,7 +9,11 @@ import {
   getExternalConnectionState,
   NetToPointPairsSolver,
 } from "../NetToPointPairsSolver/NetToPointPairsSolver"
-import { buildMinimumSpanningTree } from "../NetToPointPairsSolver/buildMinimumSpanningTree"
+import {
+  buildLayerAwareMinimumSpanningTree,
+  getLayerAwareConnectionPointWeight,
+  getLayerChangePenalty,
+} from "../NetToPointPairsSolver/buildLayerAwareMinimumSpanningTree"
 
 /**
  * Extends the base NetToPointPairsSolver with an optimization that utilizes
@@ -83,6 +87,7 @@ export class NetToPointPairsSolver2_OffBoardConnection extends NetToPointPairsSo
   _findBestConnectionPointsFromDisjointSets(
     sourcePoint: ConnectionPoint,
     targetPoint: ConnectionPoint,
+    layerChangePenalty = 0,
   ): {
     pointsToConnect: [ConnectionPoint, ConnectionPoint]
   } {
@@ -102,9 +107,10 @@ export class NetToPointPairsSolver2_OffBoardConnection extends NetToPointPairsSo
 
     for (const currentSourceCandidate of sourcePointEquivalenceGroup) {
       for (const currentTargetCandidate of targetPointEquivalenceGroup) {
-        const distance = Math.sqrt(
-          Math.pow(currentSourceCandidate.x - currentTargetCandidate.x, 2) +
-            Math.pow(currentSourceCandidate.y - currentTargetCandidate.y, 2),
+        const distance = getLayerAwareConnectionPointWeight(
+          currentSourceCandidate,
+          currentTargetCandidate,
+          layerChangePenalty,
         )
         if (distance < minimumDistance) {
           minimumDistance = distance
@@ -122,6 +128,9 @@ export class NetToPointPairsSolver2_OffBoardConnection extends NetToPointPairsSo
       return
     }
     const currentConnection = this.unprocessedConnections.pop()!
+    const layerChangePenalty = getLayerChangePenalty(
+      currentConnection.pointsToConnect,
+    )
 
     // This logic is copied from the parent class
     const { pointIdToGroup, zeroWeightEdges } = getExternalConnectionState(
@@ -143,6 +152,7 @@ export class NetToPointPairsSolver2_OffBoardConnection extends NetToPointPairsSo
         this._findBestConnectionPointsFromDisjointSets(
           currentConnection.pointsToConnect[0],
           currentConnection.pointsToConnect[1],
+          layerChangePenalty,
         )
       this.newConnections.push({
         ...currentConnection,
@@ -154,9 +164,9 @@ export class NetToPointPairsSolver2_OffBoardConnection extends NetToPointPairsSo
       return
     }
 
-    const minimumSpanningTreeEdges = buildMinimumSpanningTree(
+    const minimumSpanningTreeEdges = buildLayerAwareMinimumSpanningTree(
       currentConnection.pointsToConnect,
-      { extraEdges: zeroWeightEdges },
+      zeroWeightEdges,
     )
 
     let mstEdgeIndex = 0
@@ -168,6 +178,7 @@ export class NetToPointPairsSolver2_OffBoardConnection extends NetToPointPairsSo
       const optimizedMstEdge = this._findBestConnectionPointsFromDisjointSets(
         mstEdge.from,
         mstEdge.to,
+        layerChangePenalty,
       )
 
       this.newConnections.push({

--- a/tests/features/srj24-sample4-layer-aware-mst-diagnostic.test.ts
+++ b/tests/features/srj24-sample4-layer-aware-mst-diagnostic.test.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver7_MultiGraph } from "lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph"
+import type { ConnectionPoint } from "lib/types"
+import { getConnectionPointLayers } from "lib/utils/connection-point-utils"
+import type { TinyHyperGraphSolver } from "tiny-hypergraph/lib/index"
+import { loadScenarioBySampleNumber } from "../../scripts/benchmark/scenarios"
+
+const pointsShareLayer = (a: ConnectionPoint, b: ConnectionPoint) => {
+  const bLayers = new Set(getConnectionPointLayers(b))
+  return getConnectionPointLayers(a).some((layer) => bLayers.has(layer))
+}
+
+test("diagnose srj24 sample 4 after layer-aware point pairing", async () => {
+  const { scenario } = await loadScenarioBySampleNumber("srj24", 4, 1)
+  const solver = new AutoroutingPipelineSolver7_MultiGraph(scenario, {
+    effort: 1,
+    cacheProvider: null,
+  })
+
+  solver.solveUntilPhase("portPointPathingSolver")
+  solver.step()
+
+  const pointPairs = solver.netToPointPairsSolver!.newConnections
+  const crossLayerPairs = pointPairs.filter(
+    (connection) =>
+      connection.pointsToConnect.length === 2 &&
+      !pointsShareLayer(
+        connection.pointsToConnect[0]!,
+        connection.pointsToConnect[1]!,
+      ),
+  )
+
+  const pathingSolver = solver.portPointPathingSolver!
+  pathingSolver.MAX_ITERATIONS = 100_000
+  while (
+    solver.getCurrentPhase() === "portPointPathingSolver" &&
+    !solver.failed &&
+    !solver.solved
+  ) {
+    solver.step()
+  }
+
+  const tinySolver = pathingSolver.activeSubSolver as TinyHyperGraphSolver
+  const currentRouteId = tinySolver.state.currentRouteId
+  const startPortId =
+    currentRouteId === undefined
+      ? undefined
+      : tinySolver.problem.routeStartPort[currentRouteId]
+  const endPortId =
+    currentRouteId === undefined
+      ? undefined
+      : tinySolver.problem.routeEndPort[currentRouteId]
+  const getPort = (portId: number | undefined) =>
+    portId === undefined
+      ? undefined
+      : {
+          x: tinySolver.topology.portX[portId],
+          y: tinySolver.topology.portY[portId],
+          z: tinySolver.topology.portZ[portId],
+          serializedPortId:
+            tinySolver.topology.portMetadata?.[portId]?.serializedPortId,
+        }
+
+  console.log(
+    "srj24 sample 4 layer-aware point-pair diagnostic",
+    JSON.stringify({
+      pointPairCount: pointPairs.length,
+      crossLayerPairCount: crossLayerPairs.length,
+      crossLayerPairs: crossLayerPairs.slice(0, 20).map((connection) => ({
+        name: connection.name,
+        points: connection.pointsToConnect.map((point) => ({
+          x: point.x,
+          y: point.y,
+          layers: getConnectionPointLayers(point),
+          pcbPortId: point.pcb_port_id,
+        })),
+      })),
+      pathingIterations: pathingSolver.iterations,
+      pathingSolved: pathingSolver.solved,
+      pathingFailed: pathingSolver.failed,
+      currentRouteId,
+      currentRouteMetadata:
+        currentRouteId === undefined
+          ? undefined
+          : tinySolver.problem.routeMetadata?.[currentRouteId],
+      startPort: getPort(startPortId),
+      endPort: getPort(endPortId),
+      committedRouteCount: new Set(
+        tinySolver.state.regionSegments.flatMap((segments) =>
+          segments.map(([routeId]) => routeId),
+        ),
+      ).size,
+      pendingRouteCount: tinySolver.state.unroutedRoutes.length,
+      candidateQueueLength: tinySolver.state.candidateQueue.length,
+    }),
+  )
+
+  expect(pathingSolver.solved).toBe(true)
+})


### PR DESCRIPTION
## Purpose

Temporary hosted-only validation for srj24 sample 4.

The current point-pair tree uses XY distance alone. In a staggered top/bottom pad field, that creates many avoidable cross-layer connections. The tiny-hypergraph solver then spends most of its iteration budget finding layer transitions instead of routing the board.

This experiment first connects points that share a layer, then adds only the cross-layer edges needed to join those layer groups. It is stacked on the directed tiny-hypergraph guidance in #1870. Neither change relaxes collision checks or accepts invalid geometry.

The diagnostic records connection counts and progress after 100,000 hosted iterations. The acceptance test is the hosted srj24 sample 4 benchmark: the sample must solve, pass relaxed DRC, and produce credible geometry.

No project test or benchmark is run locally.