### PR TITLE
test(topology): reproduce missing 2D target access

### DIFF
--- a/tests/features/topology/bga-topology/fixtures/partial-target-overlap.fixture.ts
+++ b/tests/features/topology/bga-topology/fixtures/partial-target-overlap.fixture.ts
@@ -3,13 +3,13 @@ import type { GraphicsObject } from "graphics-debug"
 import { BgaTopologyGeneratorSolver } from "lib/solvers/BgaTopologyGeneratorSolver/BgaTopologyGeneratorSolver"
 import type { CapacityMeshNode, Obstacle, SimpleRouteJson } from "lib/types"
 
-const COMPONENT_ID = "sample4-bga"
-const CONNECTION_NAME = "source_trace_3__source_net_3_mst25"
+const COMPONENT_ID = "pcb_component_9"
+const CONNECTION_NAME = "source_trace_3__source_net_3_mst24"
 const ROOT_CONNECTION_NAMES = ["source_trace_3", "source_net_3"]
 const PAD_SIZE = 0.254
 const VIA_DIAMETER = 0.33
 const X_COORDINATES = [-3.45, -2.8, -2.15]
-const Y_COORDINATES = [-7.45, -6.8]
+const Y_COORDINATES = [-6.15, -5.5]
 const TARGET_GAP_NODE_PREFIX = `cmn_d_${COMPONENT_ID}_0_1_`
 
 function createMarkedPads(): Obstacle[] {
@@ -23,7 +23,7 @@ function createMarkedPads(): Obstacle[] {
       width: PAD_SIZE,
       height: PAD_SIZE,
       connectedTo:
-        x === -2.8 && y === -6.8 ? ["pcb_port_310"] : [],
+        x === -2.8 && y === -6.15 ? ["pcb_port_309"] : [],
     })),
   )
 }
@@ -34,10 +34,10 @@ function createBottomTarget(): Obstacle {
     componentId: "other-component",
     type: "rect",
     layers: ["bottom"],
-    center: { x: -2.63, y: -6.8 },
+    center: { x: -2.63, y: -5.825 },
     width: 0.59,
     height: 0.64,
-    connectedTo: ["pcb_port_1063"],
+    connectedTo: ["pcb_port_775"],
   }
 }
 
@@ -65,7 +65,7 @@ function getInputGraphics({
   targetGap: CapacityMeshNode
 }): GraphicsObject {
   const topTarget = markedPads.find(
-    (pad) => pad.center.x === -2.8 && pad.center.y === -6.8,
+    (pad) => pad.center.x === -2.8 && pad.center.y === -6.15,
   )!
 
   return {
@@ -98,14 +98,14 @@ function getInputGraphics({
     texts: [
       {
         x: -2.475,
-        y: -6.58,
+        y: -5.3,
         text: "Real board geometry (mm)",
         anchorSide: "bottom_center",
         fontSize: 0.08,
       },
       {
         x: -2.475,
-        y: -7.57,
+        y: -6.5,
         text: "The bottom pad covers only part of the blue gap on z5",
         anchorSide: "top_center",
         fontSize: 0.07,
@@ -218,20 +218,20 @@ export function createPartialTargetOverlapFixture() {
         pointsToConnect: [
           {
             x: -2.8,
-            y: -6.8,
+            y: -6.15,
             layer: "top",
-            pointId: "pcb_port_310",
+            pointId: "pcb_port_309",
           },
           {
             x: -2.63,
-            y: -7.125,
+            y: -5.825,
             layer: "bottom",
-            pointId: "pcb_port_1063",
+            pointId: "pcb_port_775",
           },
         ],
       },
     ],
-    bounds: { minX: -3.9, maxX: -1.8, minY: -7.9, maxY: -6.3 },
+    bounds: { minX: -3.9, maxX: -1.8, minY: -6.6, maxY: -5.2 },
   }
   const bgaSolver = new BgaTopologyGeneratorSolver({
     inputSrj,

--- a/tests/features/topology/bga-topology/fixtures/partial-target-overlap.fixture.ts
+++ b/tests/features/topology/bga-topology/fixtures/partial-target-overlap.fixture.ts
@@ -1,0 +1,255 @@
+import { getBoundFromCenteredRect, type Bounds } from "@tscircuit/math-utils"
+import type { GraphicsObject } from "graphics-debug"
+import { InitialBgaTopologySolver } from "lib/solvers/BgaTopologyGeneratorSolver/InitialBgaTopologySolver"
+import { RemoveMeshNodeOverlappingWithUnmarkedObstacle } from "lib/solvers/BgaTopologyGeneratorSolver/RemoveMeshNodeOverlappingSolver"
+import type { CapacityMeshNode, Obstacle, SimpleRouteJson } from "lib/types"
+
+const COMPONENT_ID = "sample4-bga"
+const CONNECTION_NAME = "source_trace_3__source_net_3_mst25"
+const ROOT_CONNECTION_NAMES = ["source_trace_3", "source_net_3"]
+const PAD_SIZE = 0.254
+const VIA_DIAMETER = 0.33
+const X_COORDINATES = [-3.45, -2.8, -2.15]
+const Y_COORDINATES = [-7.45, -6.8]
+const TARGET_GAP_NODE_PREFIX = `cmn_d_${COMPONENT_ID}_0_1_`
+
+function createMarkedPads(): Obstacle[] {
+  return Y_COORDINATES.flatMap((y, row) =>
+    X_COORDINATES.map((x, col) => ({
+      obstacleId: `bga-pad-${row}-${col}`,
+      componentId: COMPONENT_ID,
+      type: "rect" as const,
+      layers: ["top"],
+      center: { x, y },
+      width: PAD_SIZE,
+      height: PAD_SIZE,
+      connectedTo:
+        x === -2.8 && y === -6.8 ? ["pcb_port_310"] : [],
+    })),
+  )
+}
+
+function createBottomTarget(): Obstacle {
+  return {
+    obstacleId: "bottom-target",
+    componentId: "other-component",
+    type: "rect",
+    layers: ["bottom"],
+    center: { x: -2.63, y: -7.125 },
+    width: 0.59,
+    height: 0.64,
+    connectedTo: ["pcb_port_1063"],
+  }
+}
+
+function isTargetGapNode(node: CapacityMeshNode): boolean {
+  return node.capacityMeshNodeId.startsWith(TARGET_GAP_NODE_PREFIX)
+}
+
+function isConnectionTarget(node: CapacityMeshNode): boolean {
+  return (
+    node._targetConnectionName !== undefined &&
+    ROOT_CONNECTION_NAMES.some(
+      (name) =>
+        node._targetConnectionName === name || node._connectedTo?.includes(name),
+    )
+  )
+}
+
+function getInputGraphics({
+  markedPads,
+  bottomTarget,
+  targetGap,
+}: {
+  markedPads: Obstacle[]
+  bottomTarget: Obstacle
+  targetGap: CapacityMeshNode
+}): GraphicsObject {
+  const topTarget = markedPads.find(
+    (pad) => pad.center.x === -2.8 && pad.center.y === -6.8,
+  )!
+
+  return {
+    rects: [
+      {
+        center: targetGap.center,
+        width: targetGap.width,
+        height: targetGap.height,
+        fill: "rgba(35,145,205,0.16)",
+        stroke: "rgba(20,105,165,0.9)",
+        label: "BGA routing gap",
+      },
+      {
+        center: topTarget.center,
+        width: topTarget.width,
+        height: topTarget.height,
+        fill: "rgba(225,45,45,0.28)",
+        stroke: "rgba(175,20,20,0.9)",
+        label: "same-net top target (z0)",
+      },
+      {
+        center: bottomTarget.center,
+        width: bottomTarget.width,
+        height: bottomTarget.height,
+        fill: "rgba(225,45,45,0.18)",
+        stroke: "rgba(175,20,20,0.9)",
+        label: "same-net bottom target (z5)",
+      },
+    ],
+    texts: [
+      {
+        x: -2.475,
+        y: -6.58,
+        text: "Real XY geometry (millimetres)",
+        anchorSide: "bottom_center",
+        fontSize: 0.08,
+      },
+      {
+        x: -2.475,
+        y: -7.57,
+        text: "The blue gap overlaps the bottom target on z5",
+        anchorSide: "top_center",
+        fontSize: 0.07,
+      },
+    ],
+  }
+}
+
+function getLayerRowGraphics(nodes: CapacityMeshNode[]): GraphicsObject {
+  const relevantNodes = nodes.filter(
+    (node) => isTargetGapNode(node) || isConnectionTarget(node),
+  )
+  const rects: NonNullable<GraphicsObject["rects"]> = []
+  const lines: NonNullable<GraphicsObject["lines"]> = []
+  const texts: NonNullable<GraphicsObject["texts"]> = []
+
+  for (let z = 0; z < 6; z++) {
+    const rowY = 2.5 - z
+    texts.push({
+      x: -3.82,
+      y: rowY,
+      text: `z${z}`,
+      anchorSide: "center_right",
+      fontSize: 0.11,
+    })
+    lines.push({
+      points: [
+        { x: -3.72, y: rowY - 0.24 },
+        { x: -1.85, y: rowY - 0.24 },
+      ],
+      strokeColor: "rgba(40,40,40,0.14)",
+      strokeWidth: 0.008,
+    })
+  }
+
+  for (const node of relevantNodes) {
+    const bounds: Bounds = getBoundFromCenteredRect(node)
+    for (const z of node.availableZ) {
+      rects.push({
+        center: { x: node.center.x, y: 2.5 - z },
+        width: node.width,
+        height: 0.42,
+        fill: node._containsTarget
+          ? "rgba(225,45,45,0.25)"
+          : "rgba(35,145,205,0.2)",
+        stroke: node._containsTarget
+          ? "rgba(175,20,20,0.9)"
+          : "rgba(20,105,165,0.9)",
+        label: `${node.capacityMeshNodeId}\navailableZ: ${node.availableZ.join(",")}`,
+      })
+    }
+
+    if (node.availableZ.length > 1) {
+      const minZ = Math.min(...node.availableZ)
+      const maxZ = Math.max(...node.availableZ)
+      lines.push({
+        points: [
+          { x: bounds.maxX - 0.025, y: 2.5 - minZ },
+          { x: bounds.maxX - 0.025, y: 2.5 - maxZ },
+        ],
+        strokeColor: node._containsTarget
+          ? "rgba(175,20,20,0.95)"
+          : "rgba(20,105,165,0.95)",
+        strokeWidth: 0.04,
+        label: `one node on z${node.availableZ.join(",z")}`,
+      })
+    }
+  }
+
+  texts.push(
+    {
+      x: -2.78,
+      y: 3.08,
+      text: "x position and width are the real board geometry",
+      anchorSide: "bottom_center",
+      fontSize: 0.11,
+    },
+    {
+      x: -2.78,
+      y: -3.05,
+      text: "Red = target capacity; blue = free capacity",
+      anchorSide: "top_center",
+      fontSize: 0.1,
+    },
+  )
+
+  return { rects, lines, texts }
+}
+
+export function createPartialTargetOverlapFixture() {
+  const markedPads = createMarkedPads()
+  const bottomTarget = createBottomTarget()
+  const inputSrj: SimpleRouteJson = {
+    layerCount: 6,
+    minTraceWidth: 0.1,
+    minViaPadDiameter: VIA_DIAMETER,
+    minViaHoleDiameter: 0.15,
+    obstacles: [...markedPads, bottomTarget],
+    connections: [
+      {
+        name: CONNECTION_NAME,
+        __rootConnectionNames: ROOT_CONNECTION_NAMES,
+        pointsToConnect: [
+          {
+            x: -2.8,
+            y: -6.8,
+            layer: "top",
+            pointId: "pcb_port_310",
+          },
+          {
+            x: -2.63,
+            y: -7.125,
+            layer: "bottom",
+            pointId: "pcb_port_1063",
+          },
+        ],
+      },
+    ],
+    bounds: { minX: -3.9, maxX: -1.8, minY: -7.9, maxY: -6.3 },
+  }
+  const initialSolver = new InitialBgaTopologySolver({
+    srj: inputSrj,
+    componentBounds: inputSrj.bounds,
+    componentId: COMPONENT_ID,
+    markedComponentObstacles: markedPads,
+    unmarkedComponentObstacles: [bottomTarget],
+    viaDiameter: VIA_DIAMETER,
+  })
+  initialSolver.solve()
+  const initialNodes = initialSolver.getOutput()
+  const targetGap = initialNodes.find(isTargetGapNode)!
+  const removalSolver = new RemoveMeshNodeOverlappingWithUnmarkedObstacle({
+    meshNodes: initialNodes,
+    obstacles: [bottomTarget],
+    layerCount: inputSrj.layerCount,
+  })
+  removalSolver.solve()
+  const outputNodes = removalSolver.getOutput()
+
+  return {
+    initialTargetGap: targetGap,
+    outputTargetGapNodes: outputNodes.filter(isTargetGapNode),
+    inputGraphics: getInputGraphics({ markedPads, bottomTarget, targetGap }),
+    outputGraphics: getLayerRowGraphics(outputNodes),
+  }
+}

--- a/tests/features/topology/bga-topology/fixtures/partial-target-overlap.fixture.ts
+++ b/tests/features/topology/bga-topology/fixtures/partial-target-overlap.fixture.ts
@@ -1,7 +1,6 @@
 import { getBoundFromCenteredRect, type Bounds } from "@tscircuit/math-utils"
 import type { GraphicsObject } from "graphics-debug"
-import { InitialBgaTopologySolver } from "lib/solvers/BgaTopologyGeneratorSolver/InitialBgaTopologySolver"
-import { RemoveMeshNodeOverlappingWithUnmarkedObstacle } from "lib/solvers/BgaTopologyGeneratorSolver/RemoveMeshNodeOverlappingSolver"
+import { BgaTopologyGeneratorSolver } from "lib/solvers/BgaTopologyGeneratorSolver/BgaTopologyGeneratorSolver"
 import type { CapacityMeshNode, Obstacle, SimpleRouteJson } from "lib/types"
 
 const COMPONENT_ID = "sample4-bga"
@@ -43,7 +42,7 @@ function createBottomTarget(): Obstacle {
 }
 
 function isTargetGapNode(node: CapacityMeshNode): boolean {
-  return node.capacityMeshNodeId.startsWith(TARGET_GAP_NODE_PREFIX)
+  return node.capacityMeshNodeId.includes(TARGET_GAP_NODE_PREFIX)
 }
 
 function isConnectionTarget(node: CapacityMeshNode): boolean {
@@ -234,24 +233,19 @@ export function createPartialTargetOverlapFixture() {
     ],
     bounds: { minX: -3.9, maxX: -1.8, minY: -7.9, maxY: -6.3 },
   }
-  const initialSolver = new InitialBgaTopologySolver({
-    srj: inputSrj,
-    componentBounds: inputSrj.bounds,
-    componentId: COMPONENT_ID,
-    markedComponentObstacles: markedPads,
-    unmarkedComponentObstacles: [bottomTarget],
+  const bgaSolver = new BgaTopologyGeneratorSolver({
+    inputSrj,
+    detectedComponent: {
+      componentId: COMPONENT_ID,
+      componentKind: "bga",
+      bounds: { ...inputSrj.bounds, __type: "rect" },
+    },
     viaDiameter: VIA_DIAMETER,
   })
-  initialSolver.solve()
-  const initialNodes = initialSolver.getOutput()
+  bgaSolver.solve()
+  const initialNodes = bgaSolver.initialTopologySolver.getOutput()
   const targetGap = initialNodes.find(isTargetGapNode)!
-  const removalSolver = new RemoveMeshNodeOverlappingWithUnmarkedObstacle({
-    meshNodes: initialNodes,
-    obstacles: [bottomTarget],
-    layerCount: inputSrj.layerCount,
-  })
-  removalSolver.solve()
-  const outputNodes = removalSolver.getOutput()
+  const outputNodes = bgaSolver.getOutput().routingRegions
 
   return {
     initialTargetGap: targetGap,

--- a/tests/features/topology/bga-topology/fixtures/partial-target-overlap.fixture.ts
+++ b/tests/features/topology/bga-topology/fixtures/partial-target-overlap.fixture.ts
@@ -35,7 +35,7 @@ function createBottomTarget(): Obstacle {
     componentId: "other-component",
     type: "rect",
     layers: ["bottom"],
-    center: { x: -2.63, y: -7.125 },
+    center: { x: -2.63, y: -6.8 },
     width: 0.59,
     height: 0.64,
     connectedTo: ["pcb_port_1063"],

--- a/tests/features/topology/bga-topology/fixtures/partial-target-overlap.fixture.ts
+++ b/tests/features/topology/bga-topology/fixtures/partial-target-overlap.fixture.ts
@@ -100,14 +100,14 @@ function getInputGraphics({
       {
         x: -2.475,
         y: -6.58,
-        text: "Real XY geometry (millimetres)",
+        text: "Real board geometry (mm)",
         anchorSide: "bottom_center",
         fontSize: 0.08,
       },
       {
         x: -2.475,
         y: -7.57,
-        text: "The blue gap overlaps the bottom target on z5",
+        text: "The bottom pad covers only part of the blue gap on z5",
         anchorSide: "top_center",
         fontSize: 0.07,
       },
@@ -128,7 +128,7 @@ function getLayerRowGraphics(nodes: CapacityMeshNode[]): GraphicsObject {
     texts.push({
       x: -3.82,
       y: rowY,
-      text: `z${z}`,
+      text: z === 0 ? "z0 top" : z === 5 ? "z5 bottom" : `z${z}`,
       anchorSide: "center_right",
       fontSize: 0.11,
     })
@@ -171,7 +171,7 @@ function getLayerRowGraphics(nodes: CapacityMeshNode[]): GraphicsObject {
           ? "rgba(175,20,20,0.95)"
           : "rgba(20,105,165,0.95)",
         strokeWidth: 0.04,
-        label: `one node on z${node.availableZ.join(",z")}`,
+        label: `one regular region on z${node.availableZ.join(",z")}; not a trace`,
       })
     }
   }
@@ -180,16 +180,23 @@ function getLayerRowGraphics(nodes: CapacityMeshNode[]): GraphicsObject {
     {
       x: -2.78,
       y: 3.08,
-      text: "x position and width are the real board geometry",
+      text: "Box x-position and width use the real board geometry",
       anchorSide: "bottom_center",
       fontSize: 0.11,
     },
     {
       x: -2.78,
-      y: -3.05,
-      text: "Red = target capacity; blue = free capacity",
+      y: -2.93,
+      text: "Blue boxes = ordinary free regions; red boxes = target regions",
       anchorSide: "top_center",
-      fontSize: 0.1,
+      fontSize: 0.085,
+    },
+    {
+      x: -2.78,
+      y: -3.14,
+      text: "Vertical blue bar = one region shared across layers (not a trace)",
+      anchorSide: "top_center",
+      fontSize: 0.078,
     },
   )
 

--- a/tests/features/topology/bga-topology/fixtures/partial-target-overlap.fixture.ts
+++ b/tests/features/topology/bga-topology/fixtures/partial-target-overlap.fixture.ts
@@ -194,16 +194,16 @@ function createInputGraphics(): GraphicsObject {
       {
         x: 1.27,
         y: -2.36,
-        text: "Exact stalled mst8 target geometry (mm)",
+        text: "Same physical XY scale (mm)",
         anchorSide: "bottom_center",
-        fontSize: 0.035,
+        fontSize: 0.055,
       },
       {
         x: 1.27,
         y: -3.45,
-        text: "Red: z0 target · Blue: z5 target · Cyan: component-free cells",
+        text: "Red z0 · blue z5 · cyan free z0-z4",
         anchorSide: "top_center",
-        fontSize: 0.03,
+        fontSize: 0.05,
       },
     ],
   }
@@ -284,19 +284,19 @@ function createOutputGraphics({
       {
         x: 1.27,
         y: -2.36,
-        text: "Merged regions at the same XY scale",
+        text: "Same physical XY scale (mm)",
         anchorSide: "bottom_center",
-        fontSize: 0.035,
+        fontSize: 0.055,
       },
       {
         x: 1.27,
         y: -3.45,
         text:
           accessRegions.length > 0
-            ? "Green: ordinary z0/z5 region · Circle: real via diameter"
-            : "Issue: horizontal compaction cuts the legal vertical strip into short rows",
+            ? "Green z0/z5 region · circle Ø0.33 via"
+            : "Missing: no Ø0.33 z0/z5 region",
         anchorSide: "top_center",
-        fontSize: 0.03,
+        fontSize: 0.05,
       },
     ],
   }

--- a/tests/features/topology/bga-topology/fixtures/partial-target-overlap.fixture.ts
+++ b/tests/features/topology/bga-topology/fixtures/partial-target-overlap.fixture.ts
@@ -1,16 +1,42 @@
-import { getBoundFromCenteredRect, type Bounds } from "@tscircuit/math-utils"
+import {
+  getBoundFromCenteredRect,
+  type Bounds,
+} from "@tscircuit/math-utils"
 import type { GraphicsObject } from "graphics-debug"
 import { BgaTopologyGeneratorSolver } from "lib/solvers/BgaTopologyGeneratorSolver/BgaTopologyGeneratorSolver"
+import {
+  getBoundsIntersection,
+  getCapacityMeshNodeBounds,
+} from "lib/solvers/TopologyPlanningSolver/capacity-node-geometry"
+import { TopologyMergingSolver } from "lib/solvers/TopologyMergingSolver/TopologyMergingSolver"
 import type { CapacityMeshNode, Obstacle, SimpleRouteJson } from "lib/types"
 
 const COMPONENT_ID = "pcb_component_9"
-const CONNECTION_NAME = "source_trace_3__source_net_3_mst24"
+const CONNECTION_NAME = "source_trace_3__source_net_3_mst25"
 const ROOT_CONNECTION_NAMES = ["source_trace_3", "source_net_3"]
+const TARGET_ALIASES = [CONNECTION_NAME, ...ROOT_CONNECTION_NAMES]
 const PAD_SIZE = 0.254
 const VIA_DIAMETER = 0.33
 const X_COORDINATES = [-3.45, -2.8, -2.15]
-const Y_COORDINATES = [-6.15, -5.5]
-const TARGET_GAP_NODE_PREFIX = `cmn_d_${COMPONENT_ID}_0_1_`
+const Y_COORDINATES = [-7.45, -6.8]
+const COMPONENT_BOUNDS = {
+  minX: -3.9,
+  maxX: -1.8,
+  minY: -7.9,
+  maxY: -6.35,
+}
+
+const COLORS = {
+  component: "rgba(45,45,45,0.65)",
+  freeFill: "rgba(35,145,205,0.16)",
+  freeStroke: "rgba(20,105,165,0.72)",
+  targetFill: "rgba(225,45,45,0.24)",
+  targetStroke: "rgba(175,20,20,0.88)",
+  accessFill: "rgba(35,175,90,0.28)",
+  accessStroke: "rgba(15,125,60,0.95)",
+  otherPadFill: "rgba(115,125,140,0.16)",
+  otherPadStroke: "rgba(80,90,105,0.55)",
+}
 
 function createMarkedPads(): Obstacle[] {
   return Y_COORDINATES.flatMap((y, row) =>
@@ -23,7 +49,7 @@ function createMarkedPads(): Obstacle[] {
       width: PAD_SIZE,
       height: PAD_SIZE,
       connectedTo:
-        x === -2.8 && y === -6.15 ? ["pcb_port_309"] : [],
+        x === -2.8 && y === -6.8 ? ["pcb_port_310"] : [],
     })),
   )
 }
@@ -34,172 +60,196 @@ function createBottomTarget(): Obstacle {
     componentId: "other-component",
     type: "rect",
     layers: ["bottom"],
-    center: { x: -2.63, y: -5.825 },
+    center: { x: -2.63, y: -7.125 },
     width: 0.59,
     height: 0.64,
-    connectedTo: ["pcb_port_775"],
+    connectedTo: ["pcb_port_1063"],
   }
 }
 
-function isTargetGapNode(node: CapacityMeshNode): boolean {
-  return node.capacityMeshNodeId.includes(TARGET_GAP_NODE_PREFIX)
-}
-
-function isConnectionTarget(node: CapacityMeshNode): boolean {
-  return (
-    node._targetConnectionName !== undefined &&
-    ROOT_CONNECTION_NAMES.some(
-      (name) =>
-        node._targetConnectionName === name || node._connectedTo?.includes(name),
-    )
+function hasTargetAlias(node: CapacityMeshNode): boolean {
+  return TARGET_ALIASES.some(
+    (alias) =>
+      node._targetConnectionName === alias ||
+      node._connectedTo?.includes(alias),
   )
 }
 
-function getInputGraphics({
+function createGlobalTargetNode(bottomTarget: Obstacle): CapacityMeshNode {
+  return {
+    capacityMeshNodeId: "global-bottom-target",
+    center: bottomTarget.center,
+    width: bottomTarget.width,
+    height: bottomTarget.height,
+    layer: "z5",
+    availableZ: [5],
+    _containsObstacle: true,
+    _containsTarget: true,
+    _targetConnectionName: CONNECTION_NAME,
+    _connectedTo: [...TARGET_ALIASES],
+  }
+}
+
+function isInsideBounds(node: CapacityMeshNode, bounds: Bounds): boolean {
+  const nodeBounds = getCapacityMeshNodeBounds(node)
+  return (
+    nodeBounds.minX >= bounds.minX - 1e-6 &&
+    nodeBounds.maxX <= bounds.maxX + 1e-6 &&
+    nodeBounds.minY >= bounds.minY - 1e-6 &&
+    nodeBounds.maxY <= bounds.maxY + 1e-6
+  )
+}
+
+function getComponentOutline() {
+  return {
+    center: {
+      x: (COMPONENT_BOUNDS.minX + COMPONENT_BOUNDS.maxX) / 2,
+      y: (COMPONENT_BOUNDS.minY + COMPONENT_BOUNDS.maxY) / 2,
+    },
+    width: COMPONENT_BOUNDS.maxX - COMPONENT_BOUNDS.minX,
+    height: COMPONENT_BOUNDS.maxY - COMPONENT_BOUNDS.minY,
+    fill: "rgba(0,0,0,0)",
+    stroke: COLORS.component,
+    label: "BGA local topology bounds",
+  }
+}
+
+function createInputGraphics({
   markedPads,
   bottomTarget,
-  targetGap,
 }: {
   markedPads: Obstacle[]
   bottomTarget: Obstacle
-  targetGap: CapacityMeshNode
 }): GraphicsObject {
-  const topTarget = markedPads.find(
-    (pad) => pad.center.x === -2.8 && pad.center.y === -6.15,
-  )!
-
   return {
     rects: [
-      {
-        center: targetGap.center,
-        width: targetGap.width,
-        height: targetGap.height,
-        fill: "rgba(35,145,205,0.16)",
-        stroke: "rgba(20,105,165,0.9)",
-        label: "BGA routing gap",
-      },
-      {
-        center: topTarget.center,
-        width: topTarget.width,
-        height: topTarget.height,
-        fill: "rgba(225,45,45,0.28)",
-        stroke: "rgba(175,20,20,0.9)",
-        label: "same-net top target (z0)",
-      },
+      getComponentOutline(),
+      ...markedPads.map((pad) => {
+        const isTopTarget = pad.connectedTo.includes("pcb_port_310")
+        return {
+          center: pad.center,
+          width: pad.width,
+          height: pad.height,
+          fill: isTopTarget ? COLORS.targetFill : COLORS.otherPadFill,
+          stroke: isTopTarget ? COLORS.targetStroke : COLORS.otherPadStroke,
+          label: isTopTarget ? "top target z0" : "top BGA pad",
+        }
+      }),
       {
         center: bottomTarget.center,
         width: bottomTarget.width,
         height: bottomTarget.height,
-        fill: "rgba(225,45,45,0.18)",
-        stroke: "rgba(175,20,20,0.9)",
-        label: "same-net bottom target (z5)",
+        fill: COLORS.targetFill,
+        stroke: COLORS.targetStroke,
+        label: "bottom target z5",
       },
     ],
     texts: [
       {
-        x: -2.475,
-        y: -5.3,
-        text: "Real board geometry (mm)",
+        x: -2.85,
+        y: -6.22,
+        text: "Exact mst25 board geometry (mm)",
         anchorSide: "bottom_center",
-        fontSize: 0.08,
+        fontSize: 0.07,
       },
       {
-        x: -2.475,
-        y: -6.5,
-        text: "The bottom pad covers only part of the blue gap on z5",
+        x: -2.85,
+        y: -8.02,
+        text: "Red = physical targets; gray = other top-layer pads",
         anchorSide: "top_center",
-        fontSize: 0.07,
+        fontSize: 0.06,
       },
     ],
   }
 }
 
-function getLayerRowGraphics(nodes: CapacityMeshNode[]): GraphicsObject {
-  const relevantNodes = nodes.filter(
-    (node) => isTargetGapNode(node) || isConnectionTarget(node),
+function createOutputGraphics({
+  outputNodes,
+  bottomTarget,
+  accessRegions,
+}: {
+  outputNodes: CapacityMeshNode[]
+  bottomTarget: Obstacle
+  accessRegions: CapacityMeshNode[]
+}): GraphicsObject {
+  const bottomTargetBounds = getBoundFromCenteredRect(bottomTarget)
+  const accessRegionIds = new Set(
+    accessRegions.map((node) => node.capacityMeshNodeId),
   )
-  const rects: NonNullable<GraphicsObject["rects"]> = []
-  const lines: NonNullable<GraphicsObject["lines"]> = []
-  const texts: NonNullable<GraphicsObject["texts"]> = []
-
-  for (let z = 0; z < 6; z++) {
-    const rowY = 2.5 - z
-    texts.push({
-      x: -3.82,
-      y: rowY,
-      text: z === 0 ? "z0 top" : z === 5 ? "z5 bottom" : `z${z}`,
-      anchorSide: "center_right",
-      fontSize: 0.11,
-    })
-    lines.push({
-      points: [
-        { x: -3.72, y: rowY - 0.24 },
-        { x: -1.85, y: rowY - 0.24 },
-      ],
-      strokeColor: "rgba(40,40,40,0.14)",
-      strokeWidth: 0.008,
-    })
-  }
-
-  for (const node of relevantNodes) {
-    const bounds: Bounds = getBoundFromCenteredRect(node)
-    for (const z of node.availableZ) {
-      rects.push({
-        center: { x: node.center.x, y: 2.5 - z },
-        width: node.width,
-        height: 0.42,
-        fill: node._containsTarget
-          ? "rgba(225,45,45,0.25)"
-          : "rgba(35,145,205,0.2)",
-        stroke: node._containsTarget
-          ? "rgba(175,20,20,0.9)"
-          : "rgba(20,105,165,0.9)",
-        label: `${node.capacityMeshNodeId}\navailableZ: ${node.availableZ.join(",")}`,
-      })
-    }
-
-    if (node.availableZ.length > 1) {
-      const minZ = Math.min(...node.availableZ)
-      const maxZ = Math.max(...node.availableZ)
-      lines.push({
-        points: [
-          { x: bounds.maxX - 0.025, y: 2.5 - minZ },
-          { x: bounds.maxX - 0.025, y: 2.5 - maxZ },
-        ],
-        strokeColor: node._containsTarget
-          ? "rgba(175,20,20,0.95)"
-          : "rgba(20,105,165,0.95)",
-        strokeWidth: 0.04,
-        label: `one regular region on z${node.availableZ.join(",z")}; not a trace`,
-      })
-    }
-  }
-
-  texts.push(
-    {
-      x: -2.78,
-      y: 3.08,
-      text: "Box x-position and width use the real board geometry",
-      anchorSide: "bottom_center",
-      fontSize: 0.11,
-    },
-    {
-      x: -2.78,
-      y: -2.93,
-      text: "Blue boxes = ordinary free regions; red boxes = target regions",
-      anchorSide: "top_center",
-      fontSize: 0.085,
-    },
-    {
-      x: -2.78,
-      y: -3.14,
-      text: "Vertical blue bar = one region shared across layers (not a trace)",
-      anchorSide: "top_center",
-      fontSize: 0.078,
-    },
+  const relevantNodes = outputNodes.filter(
+    (node) =>
+      getBoundsIntersection(
+        getCapacityMeshNodeBounds(node),
+        bottomTargetBounds,
+      ) !== null,
+  )
+  const orderedNodes = [...relevantNodes].sort(
+    (left, right) =>
+      Number(left._containsTarget) - Number(right._containsTarget) ||
+      left.availableZ.length - right.availableZ.length,
   )
 
-  return { rects, lines, texts }
+  return {
+    rects: [
+      getComponentOutline(),
+      ...orderedNodes.map((node) => {
+        const isAccess = accessRegionIds.has(node.capacityMeshNodeId)
+        const isTarget = node._containsTarget === true
+        return {
+          center: node.center,
+          width: node.width,
+          height: node.height,
+          fill: isAccess
+            ? COLORS.accessFill
+            : isTarget
+              ? COLORS.targetFill
+              : COLORS.freeFill,
+          stroke: isAccess
+            ? COLORS.accessStroke
+            : isTarget
+              ? COLORS.targetStroke
+              : COLORS.freeStroke,
+          strokeWidth: isAccess ? 0.025 : 0.01,
+          label: `${node.capacityMeshNodeId}\navailableZ: ${node.availableZ.join(",")}`,
+        }
+      }),
+      {
+        center: bottomTarget.center,
+        width: bottomTarget.width,
+        height: bottomTarget.height,
+        fill: "rgba(0,0,0,0)",
+        stroke: COLORS.targetStroke,
+        strokeWidth: 0.018,
+        label: "physical bottom target boundary",
+      },
+    ],
+    circles: accessRegions.map((node) => ({
+      center: node.center,
+      radius: VIA_DIAMETER / 2,
+      fill: "rgba(35,175,90,0.08)",
+      stroke: COLORS.accessStroke,
+      label: `${VIA_DIAMETER.toFixed(2)} mm via fits`,
+    })),
+    texts: [
+      {
+        x: -2.85,
+        y: -6.22,
+        text: "Merged capacity regions at the same XY scale",
+        anchorSide: "bottom_center",
+        fontSize: 0.07,
+      },
+      {
+        x: -2.85,
+        y: -8.02,
+        text:
+          accessRegions.length > 0
+            ? "Green = legal z0↔z5 access; circle = real via diameter"
+            : "Issue: no via-sized z0↔z5 region inside the target",
+        anchorSide: "top_center",
+        fontSize: 0.06,
+      },
+    ],
+  }
 }
 
 export function createPartialTargetOverlapFixture() {
@@ -218,39 +268,73 @@ export function createPartialTargetOverlapFixture() {
         pointsToConnect: [
           {
             x: -2.8,
-            y: -6.15,
+            y: -6.8,
             layer: "top",
-            pointId: "pcb_port_309",
+            pointId: "pcb_port_310",
           },
           {
             x: -2.63,
-            y: -5.825,
+            y: -7.125,
             layer: "bottom",
-            pointId: "pcb_port_775",
+            pointId: "pcb_port_1063",
           },
         ],
       },
     ],
-    bounds: { minX: -3.9, maxX: -1.8, minY: -6.6, maxY: -5.2 },
+    bounds: COMPONENT_BOUNDS,
   }
   const bgaSolver = new BgaTopologyGeneratorSolver({
     inputSrj,
     detectedComponent: {
       componentId: COMPONENT_ID,
       componentKind: "bga",
-      bounds: { ...inputSrj.bounds, __type: "rect" },
+      bounds: { ...COMPONENT_BOUNDS, __type: "rect" },
     },
     viaDiameter: VIA_DIAMETER,
   })
   bgaSolver.solve()
-  const initialNodes = bgaSolver.initialTopologySolver.getOutput()
-  const targetGap = initialNodes.find(isTargetGapNode)!
-  const outputNodes = bgaSolver.getOutput().routingRegions
+
+  const topologySolver = new TopologyMergingSolver({
+    layerCount: inputSrj.layerCount,
+    viaDiameter: VIA_DIAMETER,
+    nodeGroups: [
+      {
+        groupId: "global",
+        isComponent: false,
+        nodes: [createGlobalTargetNode(bottomTarget)],
+      },
+      {
+        groupId: COMPONENT_ID,
+        isComponent: true,
+        nodes: bgaSolver.getOutput().routingRegions,
+      },
+    ],
+  })
+  topologySolver.solve()
+  if (topologySolver.failed) {
+    throw new Error(topologySolver.error ?? "Topology merging failed")
+  }
+
+  const bottomTargetBounds = getBoundFromCenteredRect(bottomTarget)
+  const outputNodes = topologySolver.getOutput()
+  const accessRegions = outputNodes.filter(
+    (node) =>
+      node._containsTarget === true &&
+      hasTargetAlias(node) &&
+      node.availableZ.includes(0) &&
+      node.availableZ.includes(5) &&
+      node.width >= VIA_DIAMETER - 1e-6 &&
+      node.height >= VIA_DIAMETER - 1e-6 &&
+      isInsideBounds(node, bottomTargetBounds),
+  )
 
   return {
-    initialTargetGap: targetGap,
-    outputTargetGapNodes: outputNodes.filter(isTargetGapNode),
-    inputGraphics: getInputGraphics({ markedPads, bottomTarget, targetGap }),
-    outputGraphics: getLayerRowGraphics(outputNodes),
+    accessRegions,
+    inputGraphics: createInputGraphics({ markedPads, bottomTarget }),
+    outputGraphics: createOutputGraphics({
+      outputNodes,
+      bottomTarget,
+      accessRegions,
+    }),
   }
 }

--- a/tests/features/topology/bga-topology/fixtures/partial-target-overlap.fixture.ts
+++ b/tests/features/topology/bga-topology/fixtures/partial-target-overlap.fixture.ts
@@ -1,163 +1,209 @@
-import {
-  getBoundFromCenteredRect,
-  type Bounds,
-} from "@tscircuit/math-utils"
+import type { Bounds } from "@tscircuit/math-utils"
 import type { GraphicsObject } from "graphics-debug"
-import { BgaTopologyGeneratorSolver } from "lib/solvers/BgaTopologyGeneratorSolver/BgaTopologyGeneratorSolver"
 import {
   getBoundsIntersection,
   getCapacityMeshNodeBounds,
 } from "lib/solvers/TopologyPlanningSolver/capacity-node-geometry"
 import { TopologyMergingSolver } from "lib/solvers/TopologyMergingSolver/TopologyMergingSolver"
-import type { CapacityMeshNode, Obstacle, SimpleRouteJson } from "lib/types"
+import type { CapacityMeshNode } from "lib/types"
 
-const COMPONENT_ID = "pcb_component_9"
-const CONNECTION_NAME = "source_trace_3__source_net_3_mst25"
+const CONNECTION_NAME = "source_trace_3__source_net_3_mst8"
 const ROOT_CONNECTION_NAMES = ["source_trace_3", "source_net_3"]
-const TARGET_ALIASES = [CONNECTION_NAME, ...ROOT_CONNECTION_NAMES]
-const PAD_SIZE = 0.254
 const VIA_DIAMETER = 0.33
-const X_COORDINATES = [-3.45, -2.8, -2.15]
-const Y_COORDINATES = [-7.45, -6.8]
-const COMPONENT_BOUNDS = {
-  minX: -3.9,
-  maxX: -1.8,
-  minY: -7.9,
-  maxY: -6.35,
+const TOP_TARGET_BOUNDS = {
+  minX: 0.973,
+  maxX: 1.227,
+  minY: -3.027,
+  maxY: -2.773,
 }
+const BOTTOM_TARGET_BOUNDS = {
+  minX: 0.975,
+  maxX: 1.565,
+  minY: -3.22,
+  maxY: -2.58,
+}
+const LOCAL_VIEW_BOUNDS = {
+  minX: 0.82,
+  maxX: 1.72,
+  minY: -3.37,
+  maxY: -2.43,
+}
+const COMPONENT_FREE_BOUNDS = [
+  {
+    minX: 1.227,
+    maxX: 1.623,
+    minY: -3.027,
+    maxY: -2.773,
+  },
+  {
+    minX: 0.973,
+    maxX: 1.227,
+    minY: -3.423,
+    maxY: -3.027,
+  },
+  {
+    minX: 0.973,
+    maxX: 1.227,
+    minY: -2.773,
+    maxY: -2.377,
+  },
+  {
+    minX: 1.227,
+    maxX: 1.623,
+    minY: -3.423,
+    maxY: -3.027,
+  },
+  {
+    minX: 1.227,
+    maxX: 1.623,
+    minY: -2.773,
+    maxY: -2.377,
+  },
+]
 
 const COLORS = {
-  component: "rgba(45,45,45,0.65)",
-  freeFill: "rgba(35,145,205,0.16)",
-  freeStroke: "rgba(20,105,165,0.72)",
-  targetFill: "rgba(225,45,45,0.24)",
-  targetStroke: "rgba(175,20,20,0.88)",
-  accessFill: "rgba(35,175,90,0.28)",
-  accessStroke: "rgba(15,125,60,0.95)",
-  otherPadFill: "rgba(115,125,140,0.16)",
-  otherPadStroke: "rgba(80,90,105,0.55)",
+  backgroundFill: "rgba(90,100,115,0.06)",
+  backgroundStroke: "rgba(80,90,105,0.42)",
+  componentFreeFill: "rgba(40,155,210,0.14)",
+  componentFreeStroke: "rgba(20,110,170,0.62)",
+  topFill: "rgba(225,45,45,0.28)",
+  topStroke: "rgba(175,20,20,0.92)",
+  bottomFill: "rgba(55,95,220,0.22)",
+  bottomStroke: "rgba(35,65,175,0.88)",
+  accessFill: "rgba(35,175,90,0.3)",
+  accessStroke: "rgba(15,125,60,0.96)",
 }
 
-function createMarkedPads(): Obstacle[] {
-  return Y_COORDINATES.flatMap((y, row) =>
-    X_COORDINATES.map((x, col) => ({
-      obstacleId: `bga-pad-${row}-${col}`,
-      componentId: COMPONENT_ID,
-      type: "rect" as const,
-      layers: ["top"],
-      center: { x, y },
-      width: PAD_SIZE,
-      height: PAD_SIZE,
-      connectedTo:
-        x === -2.8 && y === -6.8 ? ["pcb_port_310"] : [],
-    })),
-  )
-}
-
-function createBottomTarget(): Obstacle {
-  return {
-    obstacleId: "bottom-target",
-    componentId: "other-component",
-    type: "rect",
-    layers: ["bottom"],
-    center: { x: -2.63, y: -7.125 },
-    width: 0.59,
-    height: 0.64,
-    connectedTo: ["pcb_port_1063"],
-  }
-}
-
-function hasTargetAlias(node: CapacityMeshNode): boolean {
-  return TARGET_ALIASES.some(
-    (alias) =>
-      node._targetConnectionName === alias ||
-      node._connectedTo?.includes(alias),
-  )
-}
-
-function createGlobalTargetNode(bottomTarget: Obstacle): CapacityMeshNode {
-  return {
-    capacityMeshNodeId: "global-bottom-target",
-    center: bottomTarget.center,
-    width: bottomTarget.width,
-    height: bottomTarget.height,
-    layer: "z5",
-    availableZ: [5],
-    _containsObstacle: true,
-    _containsTarget: true,
-    _targetConnectionName: CONNECTION_NAME,
-    _connectedTo: [...TARGET_ALIASES],
-  }
-}
-
-function isInsideBounds(node: CapacityMeshNode, bounds: Bounds): boolean {
-  const nodeBounds = getCapacityMeshNodeBounds(node)
-  return (
-    nodeBounds.minX >= bounds.minX - 1e-6 &&
-    nodeBounds.maxX <= bounds.maxX + 1e-6 &&
-    nodeBounds.minY >= bounds.minY - 1e-6 &&
-    nodeBounds.maxY <= bounds.maxY + 1e-6
-  )
-}
-
-function getComponentOutline() {
-  return {
-    center: {
-      x: (COMPONENT_BOUNDS.minX + COMPONENT_BOUNDS.maxX) / 2,
-      y: (COMPONENT_BOUNDS.minY + COMPONENT_BOUNDS.maxY) / 2,
-    },
-    width: COMPONENT_BOUNDS.maxX - COMPONENT_BOUNDS.minX,
-    height: COMPONENT_BOUNDS.maxY - COMPONENT_BOUNDS.minY,
-    fill: "rgba(0,0,0,0)",
-    stroke: COLORS.component,
-    label: "BGA local topology bounds",
-  }
-}
-
-function createInputGraphics({
-  markedPads,
-  bottomTarget,
+function createNodeFromBounds({
+  id,
+  bounds,
+  availableZ,
+  metadata = {},
 }: {
-  markedPads: Obstacle[]
-  bottomTarget: Obstacle
-}): GraphicsObject {
+  id: string
+  bounds: Bounds
+  availableZ: number[]
+  metadata?: Partial<CapacityMeshNode>
+}): CapacityMeshNode {
+  return {
+    capacityMeshNodeId: id,
+    center: {
+      x: (bounds.minX + bounds.maxX) / 2,
+      y: (bounds.minY + bounds.maxY) / 2,
+    },
+    width: bounds.maxX - bounds.minX,
+    height: bounds.maxY - bounds.minY,
+    availableZ,
+    layer: `z${availableZ.join(",")}`,
+    ...metadata,
+  }
+}
+
+function createGlobalNodes(): CapacityMeshNode[] {
+  return [
+    createNodeFromBounds({
+      id: "cmn_2022",
+      bounds: {
+        minX: -4.227,
+        maxX: 3.827,
+        minY: -8.877,
+        maxY: -0.823,
+      },
+      availableZ: [0, 1, 2, 3, 4, 5],
+    }),
+    createNodeFromBounds({
+      id: "cmn_1672",
+      bounds: BOTTOM_TARGET_BOUNDS,
+      availableZ: [5],
+      metadata: {
+        _containsObstacle: true,
+        _containsTarget: true,
+        _targetConnectionName: CONNECTION_NAME,
+        _connectedTo: [...ROOT_CONNECTION_NAMES],
+      },
+    }),
+  ]
+}
+
+function createComponentNodes(): CapacityMeshNode[] {
+  const freeNodes = COMPONENT_FREE_BOUNDS.flatMap((bounds, boundsIndex) =>
+    [0, 1, 2, 3, 4].map((z) =>
+      createNodeFromBounds({
+        id: `component-free-${boundsIndex}-z${z}`,
+        bounds,
+        availableZ: [z],
+      }),
+    ),
+  )
+  return [
+    ...freeNodes,
+    createNodeFromBounds({
+      id: "obstacle-pcb_component_9-port-190",
+      bounds: TOP_TARGET_BOUNDS,
+      availableZ: [0],
+      metadata: {
+        _containsObstacle: true,
+        _containsTarget: true,
+        _targetConnectionName: ROOT_CONNECTION_NAMES[0],
+        _connectedTo: [...ROOT_CONNECTION_NAMES],
+      },
+    }),
+  ]
+}
+
+function createInputGraphics(): GraphicsObject {
   return {
     rects: [
-      getComponentOutline(),
-      ...markedPads.map((pad) => {
-        const isTopTarget = pad.connectedTo.includes("pcb_port_310")
-        return {
-          center: pad.center,
-          width: pad.width,
-          height: pad.height,
-          fill: isTopTarget ? COLORS.targetFill : COLORS.otherPadFill,
-          stroke: isTopTarget ? COLORS.targetStroke : COLORS.otherPadStroke,
-          label: isTopTarget ? "top target z0" : "top BGA pad",
-        }
-      }),
       {
-        center: bottomTarget.center,
-        width: bottomTarget.width,
-        height: bottomTarget.height,
-        fill: COLORS.targetFill,
-        stroke: COLORS.targetStroke,
+        center: { x: 1.27, y: -2.9 },
+        width: LOCAL_VIEW_BOUNDS.maxX - LOCAL_VIEW_BOUNDS.minX,
+        height: LOCAL_VIEW_BOUNDS.maxY - LOCAL_VIEW_BOUNDS.minY,
+        fill: COLORS.backgroundFill,
+        stroke: COLORS.backgroundStroke,
+        label: "global free background z0-z5 (local view)",
+      },
+      ...COMPONENT_FREE_BOUNDS.map((bounds) => ({
+        center: {
+          x: (bounds.minX + bounds.maxX) / 2,
+          y: (bounds.minY + bounds.maxY) / 2,
+        },
+        width: bounds.maxX - bounds.minX,
+        height: bounds.maxY - bounds.minY,
+        fill: COLORS.componentFreeFill,
+        stroke: COLORS.componentFreeStroke,
+        label: "component free corridor z0-z4",
+      })),
+      {
+        center: { x: 1.27, y: -2.9 },
+        width: 0.59,
+        height: 0.64,
+        fill: COLORS.bottomFill,
+        stroke: COLORS.bottomStroke,
         label: "bottom target z5",
+      },
+      {
+        center: { x: 1.1, y: -2.9 },
+        width: 0.254,
+        height: 0.254,
+        fill: COLORS.topFill,
+        stroke: COLORS.topStroke,
+        label: "top target z0",
       },
     ],
     texts: [
       {
-        x: -2.85,
-        y: -6.22,
-        text: "Exact mst25 board geometry (mm)",
+        x: 1.27,
+        y: -2.36,
+        text: "Exact stalled mst8 target geometry (mm)",
         anchorSide: "bottom_center",
-        fontSize: 0.07,
+        fontSize: 0.035,
       },
       {
-        x: -2.85,
-        y: -8.02,
-        text: "Red = physical targets; gray = other top-layer pads",
+        x: 1.27,
+        y: -3.45,
+        text: "Red: z0 target · Blue: z5 target · Cyan: component-free cells",
         anchorSide: "top_center",
-        fontSize: 0.06,
+        fontSize: 0.03,
       },
     ],
   }
@@ -165,61 +211,65 @@ function createInputGraphics({
 
 function createOutputGraphics({
   outputNodes,
-  bottomTarget,
   accessRegions,
 }: {
   outputNodes: CapacityMeshNode[]
-  bottomTarget: Obstacle
   accessRegions: CapacityMeshNode[]
 }): GraphicsObject {
-  const bottomTargetBounds = getBoundFromCenteredRect(bottomTarget)
   const accessRegionIds = new Set(
     accessRegions.map((node) => node.capacityMeshNodeId),
   )
-  const relevantNodes = outputNodes.filter(
-    (node) =>
-      getBoundsIntersection(
-        getCapacityMeshNodeBounds(node),
-        bottomTargetBounds,
-      ) !== null,
-  )
-  const orderedNodes = [...relevantNodes].sort(
-    (left, right) =>
-      Number(left._containsTarget) - Number(right._containsTarget) ||
-      left.availableZ.length - right.availableZ.length,
-  )
+  const relevantNodes = outputNodes
+    .filter(
+      (node) =>
+        getBoundsIntersection(
+          getCapacityMeshNodeBounds(node),
+          BOTTOM_TARGET_BOUNDS,
+        ) !== null,
+    )
+    .sort(
+      (left, right) =>
+        Number(left._containsTarget) - Number(right._containsTarget) ||
+        left.availableZ.length - right.availableZ.length,
+    )
 
   return {
     rects: [
-      getComponentOutline(),
-      ...orderedNodes.map((node) => {
+      ...relevantNodes.map((node) => {
         const isAccess = accessRegionIds.has(node.capacityMeshNodeId)
-        const isTarget = node._containsTarget === true
+        const isTopTarget =
+          node._containsTarget === true && node.availableZ.includes(0)
+        const isBottomTarget =
+          node._containsTarget === true && node.availableZ.includes(5)
         return {
           center: node.center,
           width: node.width,
           height: node.height,
           fill: isAccess
             ? COLORS.accessFill
-            : isTarget
-              ? COLORS.targetFill
-              : COLORS.freeFill,
+            : isTopTarget
+              ? COLORS.topFill
+              : isBottomTarget
+                ? COLORS.bottomFill
+                : COLORS.componentFreeFill,
           stroke: isAccess
             ? COLORS.accessStroke
-            : isTarget
-              ? COLORS.targetStroke
-              : COLORS.freeStroke,
-          strokeWidth: isAccess ? 0.025 : 0.01,
+            : isTopTarget
+              ? COLORS.topStroke
+              : isBottomTarget
+                ? COLORS.bottomStroke
+                : COLORS.componentFreeStroke,
+          strokeWidth: isAccess ? 0.012 : 0.006,
           label: `${node.capacityMeshNodeId}\navailableZ: ${node.availableZ.join(",")}`,
         }
       }),
       {
-        center: bottomTarget.center,
-        width: bottomTarget.width,
-        height: bottomTarget.height,
+        center: { x: 1.27, y: -2.9 },
+        width: 0.59,
+        height: 0.64,
         fill: "rgba(0,0,0,0)",
-        stroke: COLORS.targetStroke,
-        strokeWidth: 0.018,
+        stroke: COLORS.bottomStroke,
+        strokeWidth: 0.01,
         label: "physical bottom target boundary",
       },
     ],
@@ -232,81 +282,40 @@ function createOutputGraphics({
     })),
     texts: [
       {
-        x: -2.85,
-        y: -6.22,
-        text: "Merged capacity regions at the same XY scale",
+        x: 1.27,
+        y: -2.36,
+        text: "Merged regions at the same XY scale",
         anchorSide: "bottom_center",
-        fontSize: 0.07,
+        fontSize: 0.035,
       },
       {
-        x: -2.85,
-        y: -8.02,
+        x: 1.27,
+        y: -3.45,
         text:
           accessRegions.length > 0
-            ? "Green = legal z0↔z5 access; circle = real via diameter"
-            : "Issue: no via-sized z0↔z5 region inside the target",
+            ? "Green: ordinary z0/z5 region · Circle: real via diameter"
+            : "Issue: horizontal compaction cuts the legal vertical strip into short rows",
         anchorSide: "top_center",
-        fontSize: 0.06,
+        fontSize: 0.03,
       },
     ],
   }
 }
 
 export function createPartialTargetOverlapFixture() {
-  const markedPads = createMarkedPads()
-  const bottomTarget = createBottomTarget()
-  const inputSrj: SimpleRouteJson = {
-    layerCount: 6,
-    minTraceWidth: 0.1,
-    minViaPadDiameter: VIA_DIAMETER,
-    minViaHoleDiameter: 0.15,
-    obstacles: [...markedPads, bottomTarget],
-    connections: [
-      {
-        name: CONNECTION_NAME,
-        __rootConnectionNames: ROOT_CONNECTION_NAMES,
-        pointsToConnect: [
-          {
-            x: -2.8,
-            y: -6.8,
-            layer: "top",
-            pointId: "pcb_port_310",
-          },
-          {
-            x: -2.63,
-            y: -7.125,
-            layer: "bottom",
-            pointId: "pcb_port_1063",
-          },
-        ],
-      },
-    ],
-    bounds: COMPONENT_BOUNDS,
-  }
-  const bgaSolver = new BgaTopologyGeneratorSolver({
-    inputSrj,
-    detectedComponent: {
-      componentId: COMPONENT_ID,
-      componentKind: "bga",
-      bounds: { ...COMPONENT_BOUNDS, __type: "rect" },
-    },
-    viaDiameter: VIA_DIAMETER,
-  })
-  bgaSolver.solve()
-
   const topologySolver = new TopologyMergingSolver({
-    layerCount: inputSrj.layerCount,
+    layerCount: 6,
     viaDiameter: VIA_DIAMETER,
     nodeGroups: [
       {
         groupId: "global",
         isComponent: false,
-        nodes: [createGlobalTargetNode(bottomTarget)],
+        nodes: createGlobalNodes(),
       },
       {
-        groupId: COMPONENT_ID,
+        groupId: "component-3",
         isComponent: true,
-        nodes: bgaSolver.getOutput().routingRegions,
+        nodes: createComponentNodes(),
       },
     ],
   })
@@ -315,26 +324,23 @@ export function createPartialTargetOverlapFixture() {
     throw new Error(topologySolver.error ?? "Topology merging failed")
   }
 
-  const bottomTargetBounds = getBoundFromCenteredRect(bottomTarget)
   const outputNodes = topologySolver.getOutput()
   const accessRegions = outputNodes.filter(
     (node) =>
       node._containsTarget === true &&
-      hasTargetAlias(node) &&
       node.availableZ.includes(0) &&
       node.availableZ.includes(5) &&
       node.width >= VIA_DIAMETER - 1e-6 &&
       node.height >= VIA_DIAMETER - 1e-6 &&
-      isInsideBounds(node, bottomTargetBounds),
+      getBoundsIntersection(
+        getCapacityMeshNodeBounds(node),
+        BOTTOM_TARGET_BOUNDS,
+      ) !== null,
   )
 
   return {
     accessRegions,
-    inputGraphics: createInputGraphics({ markedPads, bottomTarget }),
-    outputGraphics: createOutputGraphics({
-      outputNodes,
-      bottomTarget,
-      accessRegions,
-    }),
+    inputGraphics: createInputGraphics(),
+    outputGraphics: createOutputGraphics({ outputNodes, accessRegions }),
   }
 }

--- a/tests/features/topology/bga-topology/partial-target-overlap.test.ts
+++ b/tests/features/topology/bga-topology/partial-target-overlap.test.ts
@@ -2,29 +2,27 @@ import { expect, test } from "bun:test"
 import { getGraphicsSvgFrames } from "tests/fixtures/solver-svg-frames"
 import { createPartialTargetOverlapFixture } from "./fixtures/partial-target-overlap.fixture"
 
-test("shows a BGA gap partially covered by a target on one layer", async () => {
+test("provides via-sized cross-layer access inside a partially covered target", async () => {
   const fixture = createPartialTargetOverlapFixture()
-
-  expect(fixture.initialTargetGap.availableZ).toEqual([0, 1, 2, 3, 4, 5])
-  expect(fixture.outputTargetGapNodes.length).toBeGreaterThan(0)
 
   const svg = getGraphicsSvgFrames({
     frames: [
       {
-        name: "Input: real XY overlap",
+        name: "Input: exact mst25 geometry",
         step: 0,
         graphics: fixture.inputGraphics,
       },
       {
-        name: "Output: topology regions by layer",
+        name: "Output: merged regions",
         step: 1,
         graphics: fixture.outputGraphics,
       },
     ],
     columns: 2,
     cellWidth: 2.4,
-    cellHeight: 6.6,
+    cellHeight: 2,
   })
 
   await expect(svg).toMatchSvgSnapshot(import.meta.path, { scale: 2 })
+  expect(fixture.accessRegions.length).toBeGreaterThan(0)
 })

--- a/tests/features/topology/bga-topology/partial-target-overlap.test.ts
+++ b/tests/features/topology/bga-topology/partial-target-overlap.test.ts
@@ -8,12 +8,12 @@ test("provides via-sized cross-layer access inside a partially covered target", 
   const svg = getGraphicsSvgFrames({
     frames: [
       {
-        name: "Input: exact mst25 geometry",
+        name: "Input: exact sample 4 mst8 target",
         step: 0,
         graphics: fixture.inputGraphics,
       },
       {
-        name: "Output: merged regions",
+        name: "Output: ordinary merged regions",
         step: 1,
         graphics: fixture.outputGraphics,
       },

--- a/tests/features/topology/bga-topology/partial-target-overlap.test.ts
+++ b/tests/features/topology/bga-topology/partial-target-overlap.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test"
+import { getGraphicsSvgFrames } from "tests/fixtures/solver-svg-frames"
+import { createPartialTargetOverlapFixture } from "./fixtures/partial-target-overlap.fixture"
+
+test("shows a BGA gap partially covered by a target on one layer", async () => {
+  const fixture = createPartialTargetOverlapFixture()
+
+  expect(fixture.initialTargetGap.availableZ).toEqual([0, 1, 2, 3, 4, 5])
+  expect(fixture.outputTargetGapNodes.length).toBeGreaterThan(0)
+
+  const svg = getGraphicsSvgFrames({
+    frames: [
+      {
+        name: "Physical input: BGA gap and two targets",
+        step: 0,
+        graphics: fixture.inputGraphics,
+      },
+      {
+        name: "BGA topology after partial target overlap",
+        step: 1,
+        graphics: fixture.outputGraphics,
+      },
+    ],
+    columns: 2,
+    cellWidth: 2.4,
+    cellHeight: 6.6,
+  })
+
+  await expect(svg).toMatchSvgSnapshot(import.meta.path, { scale: 2 })
+})

--- a/tests/features/topology/bga-topology/partial-target-overlap.test.ts
+++ b/tests/features/topology/bga-topology/partial-target-overlap.test.ts
@@ -11,12 +11,12 @@ test("shows a BGA gap partially covered by a target on one layer", async () => {
   const svg = getGraphicsSvgFrames({
     frames: [
       {
-        name: "Physical input: BGA gap and two targets",
+        name: "Input: real XY overlap",
         step: 0,
         graphics: fixture.inputGraphics,
       },
       {
-        name: "BGA topology after partial target overlap",
+        name: "Output: topology regions by layer",
         step: 1,
         graphics: fixture.outputGraphics,
       },


### PR DESCRIPTION
## What this reproduces

Sample 4 contains an ordinary BGA routing region that is only partly covered by a bottom-layer target pad.

The current obstacle-removal step treats that partial overlap as if the pad covered the whole region. It replaces the complete six-layer region with separate single-layer copies on z0-z4. This removes the layer continuity from the physically uncovered part of the region.

This PR adds a focused fixture using the real sample-4 coordinates and the actual BGA topology solvers. It does not change solver behavior.

## How to read the snapshot

- Left: the real XY overlap. The bottom pad covers only part of the blue routing region on z5.
- Right: the topology regions produced on each layer.
- Blue boxes are ordinary free regions; red boxes are target regions.
- A vertical blue bar means one ordinary region is shared across layers. It is topology membership, not a routed trace.

In the broken output, the full-width blue region is copied separately onto z0-z4 and disappears on z5. There is no shared multilayer region for the physically uncovered space.

## Validation

Hosted GitHub Actions only. The snapshot will be generated by the repository snapshot workflow.
