### PR TITLE
fix(pathing): scale search budget with route count

### DIFF
--- a/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
+++ b/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
@@ -142,6 +142,7 @@ const DUPLICATE_PORT_TRAVERSAL_PENALTY = 150
 const DEFAULT_CRAMPED_PORT_TRAVERSAL_PENALTY = 150
 export const MAX_CONNECTIONS_FOR_DUPLICATE_CONGESTED_PORT_PREPASS = 1_000
 const MIN_SOLVE_GRAPH_ITERATIONS = 2_000_000
+const SOLVE_GRAPH_ITERATIONS_PER_CONNECTION = 5_000
 
 export const shouldRunDuplicateCongestedPortPrepass = ({
   hasPreloadedTraceOccupancy,
@@ -157,10 +158,17 @@ const getEffortScale = (effort: number) => Math.max(effort, 1e-2)
 
 export const getTinyHyperGraphSolveGraphMaxIterations = ({
   effort,
+  connectionCount,
 }: {
   effort: number
   connectionCount: number
-}) => Math.ceil(MIN_SOLVE_GRAPH_ITERATIONS * getEffortScale(effort))
+}) =>
+  Math.ceil(
+    Math.max(
+      MIN_SOLVE_GRAPH_ITERATIONS,
+      connectionCount * SOLVE_GRAPH_ITERATIONS_PER_CONNECTION,
+    ) * getEffortScale(effort),
+  )
 
 const getTinyViaSizeOptions = (
   minViaPadDiameter?: number,


### PR DESCRIPTION
## Problem

Tiny solveGraph has a fixed 2,000,000-iteration allowance. That is enough for ordinary boards, but the hosted sample 4 diagnostic shows the 841-route graph is still making progress when the allowance ends: route 619 is active, 222 routes remain pending, and 8,296 candidates remain queued.

## Fix

Keep the existing 2M minimum for normal graphs. For larger graphs, allow 5,000 candidate expansions per route, multiplied by the existing effort value.

At effort 1:

- graphs up to 400 routes stay at 2M, exactly as before
- sample 4 receives 4.205M for its 841 routes

This changes only how long the existing collision-aware search may continue. It does not change route cost, heuristic weight, topology, via legality, intersection rules, or output geometry.

## Snapshot

This PR uses the reproduction test unchanged. The blue line is the real production MAX_ITERATIONS function. The sample 4 point moves from the flat 2M limit to the graph-sized 4.205M allowance.

![Graph-sized search budget](https://raw.githubusercontent.com/tscircuit/tscircuit-autorouter/agent/fix-sample4-size-scaled-search/tests/features/port-point-pathing/__snapshots__/tiny-solve-graph-budget.snap.svg)

## Hosted verification

- full test and snapshot suite: running
- srj24 sample 4, Pipeline7, effort 1: running
- final trace and relaxed DRC inspection: pending benchmark artifact

No project command was run locally.

## Stack

1. #1853 stabilizes dense-component detection.
2. #1874 reproduces the missing ordinary cross-layer target region.
3. #1875 restores that legal region.
4. #1880 reproduces the fixed search-budget exhaustion.
5. This PR applies the route-count-scaled allowance.