### PR TITLE
Rename length matching post-processing stage

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -229,7 +229,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
   strawSolver?: StrawSolver
   deadEndSolver?: DeadEndSolver
   traceSimplificationSolver?: TraceSimplificationSolver
-  postProcessingSolver?: PostProcessingSolver
+  lengthMatchingPostProcessingSolver?: PostProcessingSolver
   powerTraceExpansionSolver?: PowerTraceExpansionSolver
   availableSegmentPointSolver?: AvailableSegmentPointSolver
   portPointPathingSolver?: TinyHypergraphPortPointPathingSolver
@@ -690,11 +690,11 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
         ]
       },
     ),
-    definePipelineStep("postProcessingSolver", PostProcessingSolver, (cms) => {
+    definePipelineStep("lengthMatchingPostProcessingSolver", PostProcessingSolver, (cms) => {
       const netToPointPairsSolver = cms.netToPointPairsSolver
       if (!netToPointPairsSolver)
         throw new Error(
-          "Pipeline7: post-processing requires NetToPointPairsSolver output",
+          "Pipeline7: length-matching post-processing requires NetToPointPairsSolver output",
         )
       const connections = netToPointPairsSolver.newConnections
       const finalHdConnectionNames = new Map<string, string>()
@@ -848,7 +848,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
     // @ts-ignore
     this.activeSubSolver = new pipelineStepDef.solverClass(...constructorParams)
     if (
-      pipelineStepDef.solverName === "postProcessingSolver" ||
+      pipelineStepDef.solverName === "lengthMatchingPostProcessingSolver" ||
       pipelineStepDef.solverName === "powerTraceExpansionSolver"
     )
       this.MAX_ITERATIONS = Math.max(
@@ -900,7 +900,8 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
     const highDensityRepairViz = this.highDensityRepairSolver?.visualize()
     const highDensityStitchViz = this.highDensityStitchSolver?.visualize()
     const traceSimplificationViz = this.traceSimplificationSolver?.visualize()
-    const postProcessingViz = this.postProcessingSolver?.visualize()
+    const lengthMatchingPostProcessingViz =
+      this.lengthMatchingPostProcessingSolver?.visualize()
     const traceWidthViz = this.traceWidthSolver?.visualize()
     const necessaryCrampedPortPointSolverViz =
       this.necessaryCrampedPortPointSolver?.visualize()
@@ -1026,7 +1027,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
       traceWidthViz,
       globalDrcForceImproveViz,
       exactGeometryDrcForceImproveViz,
-      postProcessingViz,
+      lengthMatchingPostProcessingViz,
       this.solved
         ? combineVisualizations(
             { lines: problemLines },
@@ -1104,7 +1105,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
 
   _getOutputHdRoutes(): HighDensityRoute[] {
     return (
-      this.postProcessingSolver?.getOutput().hdRoutes ??
+      this.lengthMatchingPostProcessingSolver?.getOutput().hdRoutes ??
       this.exactGeometryDrcForceImproveSolver?.getOutput() ??
       this.globalDrcForceImproveSolver?.getOutput() ??
       this.traceWidthSolver?.getHdRoutesWithWidths() ??

--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -690,61 +690,67 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
         ]
       },
     ),
-    definePipelineStep("lengthMatchingPostProcessingSolver", PostProcessingSolver, (cms) => {
-      const netToPointPairsSolver = cms.netToPointPairsSolver
-      if (!netToPointPairsSolver)
-        throw new Error(
-          "Pipeline7: length-matching post-processing requires NetToPointPairsSolver output",
-        )
-      const connections = netToPointPairsSolver.newConnections
-      const finalHdConnectionNames = new Map<string, string>()
-      for (const pair of cms.srj.differentialPairs ?? []) {
-        for (const connectionName of pair.connectionNames) {
-          const matchingConnections = connections.filter(
-            (connection) =>
-              connection.name === connectionName ||
-              connection.__rootConnectionNames?.includes(connectionName) ||
-              connection.__netConnectionName === connectionName,
+    definePipelineStep(
+      "lengthMatchingPostProcessingSolver",
+      PostProcessingSolver,
+      (cms) => {
+        const netToPointPairsSolver = cms.netToPointPairsSolver
+        if (!netToPointPairsSolver)
+          throw new Error(
+            "Pipeline7: length-matching post-processing requires NetToPointPairsSolver output",
           )
-          if (matchingConnections.length !== 1)
-            throw new Error(
-              `Pipeline7: differential pair connection "${connectionName}" must resolve to exactly one final point-pair connection, got ${matchingConnections.length}`,
+        const connections = netToPointPairsSolver.newConnections
+        const finalHdConnectionNames = new Map<string, string>()
+        for (const pair of cms.srj.differentialPairs ?? []) {
+          for (const connectionName of pair.connectionNames) {
+            const matchingConnections = connections.filter(
+              (connection) =>
+                connection.name === connectionName ||
+                connection.__rootConnectionNames?.includes(connectionName) ||
+                connection.__netConnectionName === connectionName,
             )
-          finalHdConnectionNames.set(
-            connectionName,
-            matchingConnections[0]!.name,
-          )
-        }
-      }
-      const differentialPairs = (cms.srj.differentialPairs ?? []).map(
-        (pair) => {
-          const connectionNames = pair.connectionNames.map((connectionName) => {
-            const finalHdConnectionName =
-              finalHdConnectionNames.get(connectionName)
-            if (!finalHdConnectionName)
+            if (matchingConnections.length !== 1)
               throw new Error(
-                `Pipeline7: differential pair connection "${connectionName}" is missing from final routed output`,
+                `Pipeline7: differential pair connection "${connectionName}" must resolve to exactly one final point-pair connection, got ${matchingConnections.length}`,
               )
-            return finalHdConnectionName
-          }) as [string, string]
-          if (connectionNames[0] === connectionNames[1])
-            throw new Error(
-              `Pipeline7: differential pair ${pair.connectionNames.join("/")} resolves both members to "${connectionNames[0]}"`,
+            finalHdConnectionNames.set(
+              connectionName,
+              matchingConnections[0]!.name,
             )
-          return { ...pair, connectionNames }
-        },
-      )
-      return [
-        {
-          hdRoutes: cms.exactGeometryDrcForceImproveSolver!.getOutput(),
-          differentialPairs,
-          obstacles: cms.srj.obstacles,
-          bounds: cms.srj.bounds,
-          layerCount: cms.srj.layerCount,
-          allowViaInPad: cms.originalSrj.allowViaInPad ?? false,
-        },
-      ]
-    }),
+          }
+        }
+        const differentialPairs = (cms.srj.differentialPairs ?? []).map(
+          (pair) => {
+            const connectionNames = pair.connectionNames.map(
+              (connectionName) => {
+                const finalHdConnectionName =
+                  finalHdConnectionNames.get(connectionName)
+                if (!finalHdConnectionName)
+                  throw new Error(
+                    `Pipeline7: differential pair connection "${connectionName}" is missing from final routed output`,
+                  )
+                return finalHdConnectionName
+              },
+            ) as [string, string]
+            if (connectionNames[0] === connectionNames[1])
+              throw new Error(
+                `Pipeline7: differential pair ${pair.connectionNames.join("/")} resolves both members to "${connectionNames[0]}"`,
+              )
+            return { ...pair, connectionNames }
+          },
+        )
+        return [
+          {
+            hdRoutes: cms.exactGeometryDrcForceImproveSolver!.getOutput(),
+            differentialPairs,
+            obstacles: cms.srj.obstacles,
+            bounds: cms.srj.bounds,
+            layerCount: cms.srj.layerCount,
+            allowViaInPad: cms.originalSrj.allowViaInPad ?? false,
+          },
+        ]
+      },
+    ),
     definePipelineStep(
       "powerTraceExpansionSolver",
       PowerTraceExpansionSolver,

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph.ts
@@ -714,61 +714,67 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
         ]
       },
     ),
-    definePipelineStep("lengthMatchingPostProcessingSolver", PostProcessingSolver, (cms) => {
-      const netToPointPairsSolver = cms.netToPointPairsSolver
-      if (!netToPointPairsSolver)
-        throw new Error(
-          "Pipeline9: length-matching post-processing requires NetToPointPairsSolver output",
-        )
-      const connections = netToPointPairsSolver.newConnections
-      const finalHdConnectionNames = new Map<string, string>()
-      for (const pair of cms.srj.differentialPairs ?? []) {
-        for (const connectionName of pair.connectionNames) {
-          const matchingConnections = connections.filter(
-            (connection) =>
-              connection.name === connectionName ||
-              connection.__rootConnectionNames?.includes(connectionName) ||
-              connection.__netConnectionName === connectionName,
+    definePipelineStep(
+      "lengthMatchingPostProcessingSolver",
+      PostProcessingSolver,
+      (cms) => {
+        const netToPointPairsSolver = cms.netToPointPairsSolver
+        if (!netToPointPairsSolver)
+          throw new Error(
+            "Pipeline9: length-matching post-processing requires NetToPointPairsSolver output",
           )
-          if (matchingConnections.length !== 1)
-            throw new Error(
-              `Pipeline9: differential pair connection "${connectionName}" must resolve to exactly one final point-pair connection, got ${matchingConnections.length}`,
+        const connections = netToPointPairsSolver.newConnections
+        const finalHdConnectionNames = new Map<string, string>()
+        for (const pair of cms.srj.differentialPairs ?? []) {
+          for (const connectionName of pair.connectionNames) {
+            const matchingConnections = connections.filter(
+              (connection) =>
+                connection.name === connectionName ||
+                connection.__rootConnectionNames?.includes(connectionName) ||
+                connection.__netConnectionName === connectionName,
             )
-          finalHdConnectionNames.set(
-            connectionName,
-            matchingConnections[0]!.name,
-          )
-        }
-      }
-      const differentialPairs = (cms.srj.differentialPairs ?? []).map(
-        (pair) => {
-          const connectionNames = pair.connectionNames.map((connectionName) => {
-            const finalHdConnectionName =
-              finalHdConnectionNames.get(connectionName)
-            if (!finalHdConnectionName)
+            if (matchingConnections.length !== 1)
               throw new Error(
-                `Pipeline9: differential pair connection "${connectionName}" is missing from final routed output`,
+                `Pipeline9: differential pair connection "${connectionName}" must resolve to exactly one final point-pair connection, got ${matchingConnections.length}`,
               )
-            return finalHdConnectionName
-          }) as [string, string]
-          if (connectionNames[0] === connectionNames[1])
-            throw new Error(
-              `Pipeline9: differential pair ${pair.connectionNames.join("/")} resolves both members to "${connectionNames[0]}"`,
+            finalHdConnectionNames.set(
+              connectionName,
+              matchingConnections[0]!.name,
             )
-          return { ...pair, connectionNames }
-        },
-      )
-      return [
-        {
-          hdRoutes: cms.exactGeometryDrcForceImproveSolver!.getOutput(),
-          differentialPairs,
-          obstacles: cms.srj.obstacles,
-          bounds: cms.srj.bounds,
-          layerCount: cms.srj.layerCount,
-          allowViaInPad: cms.originalSrj.allowViaInPad ?? false,
-        },
-      ]
-    }),
+          }
+        }
+        const differentialPairs = (cms.srj.differentialPairs ?? []).map(
+          (pair) => {
+            const connectionNames = pair.connectionNames.map(
+              (connectionName) => {
+                const finalHdConnectionName =
+                  finalHdConnectionNames.get(connectionName)
+                if (!finalHdConnectionName)
+                  throw new Error(
+                    `Pipeline9: differential pair connection "${connectionName}" is missing from final routed output`,
+                  )
+                return finalHdConnectionName
+              },
+            ) as [string, string]
+            if (connectionNames[0] === connectionNames[1])
+              throw new Error(
+                `Pipeline9: differential pair ${pair.connectionNames.join("/")} resolves both members to "${connectionNames[0]}"`,
+              )
+            return { ...pair, connectionNames }
+          },
+        )
+        return [
+          {
+            hdRoutes: cms.exactGeometryDrcForceImproveSolver!.getOutput(),
+            differentialPairs,
+            obstacles: cms.srj.obstacles,
+            bounds: cms.srj.bounds,
+            layerCount: cms.srj.layerCount,
+            allowViaInPad: cms.originalSrj.allowViaInPad ?? false,
+          },
+        ]
+      },
+    ),
   ]
 
   constructor(

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph.ts
@@ -232,7 +232,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
   strawSolver?: StrawSolver
   deadEndSolver?: DeadEndSolver
   traceSimplificationSolver?: TraceSimplificationSolver
-  postProcessingSolver?: PostProcessingSolver
+  lengthMatchingPostProcessingSolver?: PostProcessingSolver
   availableSegmentPointSolver?: AvailableSegmentPointSolver
   portPointPathingSolver?: TinyHypergraphPortPointPathingSolver
   multiSectionPortPointOptimizer?: MultiSectionPortPointOptimizer
@@ -714,11 +714,11 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
         ]
       },
     ),
-    definePipelineStep("postProcessingSolver", PostProcessingSolver, (cms) => {
+    definePipelineStep("lengthMatchingPostProcessingSolver", PostProcessingSolver, (cms) => {
       const netToPointPairsSolver = cms.netToPointPairsSolver
       if (!netToPointPairsSolver)
         throw new Error(
-          "Pipeline9: post-processing requires NetToPointPairsSolver output",
+          "Pipeline9: length-matching post-processing requires NetToPointPairsSolver output",
         )
       const connections = netToPointPairsSolver.newConnections
       const finalHdConnectionNames = new Map<string, string>()
@@ -856,7 +856,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
     const constructorParams = pipelineStepDef.getConstructorParams(this)
     // @ts-ignore
     this.activeSubSolver = new pipelineStepDef.solverClass(...constructorParams)
-    if (pipelineStepDef.solverName === "postProcessingSolver")
+    if (pipelineStepDef.solverName === "lengthMatchingPostProcessingSolver")
       this.MAX_ITERATIONS = Math.max(
         this.MAX_ITERATIONS,
         this.iterations + this.activeSubSolver.MAX_ITERATIONS + 1,
@@ -906,7 +906,8 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
     const highDensityRepairViz = this.highDensityRepairSolver?.visualize()
     const highDensityStitchViz = this.highDensityStitchSolver?.visualize()
     const traceSimplificationViz = this.traceSimplificationSolver?.visualize()
-    const postProcessingViz = this.postProcessingSolver?.visualize()
+    const lengthMatchingPostProcessingViz =
+      this.lengthMatchingPostProcessingSolver?.visualize()
     const traceWidthViz = this.traceWidthSolver?.visualize()
     const necessaryCrampedPortPointSolverViz =
       this.necessaryCrampedPortPointSolver?.visualize()
@@ -1032,7 +1033,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
       traceWidthViz,
       globalDrcForceImproveViz,
       exactGeometryDrcForceImproveViz,
-      postProcessingViz,
+      lengthMatchingPostProcessingViz,
       this.solved
         ? combineVisualizations(
             { lines: problemLines },
@@ -1110,7 +1111,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
 
   _getOutputHdRoutes(): HighDensityRoute[] {
     return (
-      this.postProcessingSolver?.getOutput().hdRoutes ??
+      this.lengthMatchingPostProcessingSolver?.getOutput().hdRoutes ??
       this.exactGeometryDrcForceImproveSolver?.getOutput() ??
       this.globalDrcForceImproveSolver?.getOutput() ??
       this.traceWidthSolver?.getHdRoutesWithWidths() ??

--- a/tests/pipeline7-post-processing-ambiguous-differential-pair.test.ts
+++ b/tests/pipeline7-post-processing-ambiguous-differential-pair.test.ts
@@ -28,12 +28,12 @@ test("Pipeline7 rejects a differential pair member split across final routes", (
       },
     ],
   })
-  const postProcessingStep = solver.pipelineDef.find(
-    (step) => step.solverName === "postProcessingSolver",
+  const lengthMatchingPostProcessingStep = solver.pipelineDef.find(
+    (step) => step.solverName === "lengthMatchingPostProcessingSolver",
   )!
 
   expect(() =>
-    postProcessingStep.getConstructorParams({
+    lengthMatchingPostProcessingStep.getConstructorParams({
       ...solver,
       netToPointPairsSolver: {
         newConnections: [

--- a/tests/pipeline7-post-processing-before-power-expansion.test.ts
+++ b/tests/pipeline7-post-processing-before-power-expansion.test.ts
@@ -31,9 +31,11 @@ test("Pipeline7 runs post-processing before default power expansion", () => {
     ],
   })
   const powerTraceExpansionStep = solver.pipelineDef.at(-1)
-  const postProcessingStep = solver.pipelineDef.at(-2)
+  const lengthMatchingPostProcessingStep = solver.pipelineDef.at(-2)
   expect(powerTraceExpansionStep?.solverName).toBe("powerTraceExpansionSolver")
-  expect(postProcessingStep?.solverName).toBe("postProcessingSolver")
+  expect(lengthMatchingPostProcessingStep?.solverName).toBe(
+    "lengthMatchingPostProcessingSolver",
+  )
 
   const powerTraceParams = powerTraceExpansionStep!.getConstructorParams({
     ...solver,
@@ -43,7 +45,7 @@ test("Pipeline7 runs post-processing before default power expansion", () => {
   expect((powerTraceParams[0] as any).fixedTraces).toEqual([])
   expect(powerTraceParams[1]).toEqual({ allowNewVias: false })
 
-  const [params] = postProcessingStep!.getConstructorParams({
+  const [params] = lengthMatchingPostProcessingStep!.getConstructorParams({
     ...solver,
     netToPointPairsSolver: {
       newConnections: solver.srj.connections.map((connection) => ({
@@ -78,8 +80,8 @@ test("Pipeline7 runs post-processing before default power expansion", () => {
     },
   } as any)
 
-  const postProcessingParams = params as any
-  expect(Object.keys(postProcessingParams).sort()).toEqual(
+  const lengthMatchingPostProcessingParams = params as any
+  expect(Object.keys(lengthMatchingPostProcessingParams).sort()).toEqual(
     [
       "allowViaInPad",
       "bounds",
@@ -89,22 +91,24 @@ test("Pipeline7 runs post-processing before default power expansion", () => {
       "obstacles",
     ].sort(),
   )
-  expect(postProcessingParams.differentialPairs).toEqual([
+  expect(lengthMatchingPostProcessingParams.differentialPairs).toEqual([
     {
       connectionNames: ["PAIR_P_mst0", "PAIR_N_mst0"],
       lengthTolerance: 0.01,
     },
   ])
   expect(
-    postProcessingParams.hdRoutes.map((route: any) => route.connectionName),
+    lengthMatchingPostProcessingParams.hdRoutes.map(
+      (route: any) => route.connectionName,
+    ),
   ).toEqual(["PAIR_P_mst0", "PAIR_N_mst0"])
 
-  const postProcessingSolver = new (postProcessingStep!.solverClass as any)(
-    postProcessingParams,
-  )
-  postProcessingSolver.solve()
+  const lengthMatchingPostProcessingSolver = new (
+    lengthMatchingPostProcessingStep!.solverClass as any
+  )(lengthMatchingPostProcessingParams)
+  lengthMatchingPostProcessingSolver.solve()
   expect(
-    postProcessingSolver
+    lengthMatchingPostProcessingSolver
       .getOutput()
       .hdRoutes.map((route: any) => route.connectionName),
   ).toEqual(["PAIR_P_mst0", "PAIR_N_mst0"])


### PR DESCRIPTION
## Summary

- rename the Pipeline 7 and Pipeline 9 post-processing phase to `lengthMatchingPostProcessingSolver`
- update the pipeline-owned solver fields, visualization references, and diagnostics
- update focused Pipeline 7 regression tests for the new phase identifier

## Why

The generic `postProcessingSolver` name did not describe the stage's role. The new name makes it explicit that this phase performs length-matching post-processing.

## Impact

Consumers that inspect pipeline phase names should use `lengthMatchingPostProcessingSolver`.

## Validation

- `bun test --timeout 9999999 tests/pipeline7-post-processing-ambiguous-differential-pair.test.ts tests/pipeline7-post-processing-before-power-expansion.test.ts`
- `bun run build`
- `git diff --check`