### PR TITLE
Add resolved DDR constraints to SimpleRouteJson

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,24 @@ interface SimpleRouteBus {
   busId: string
   connectionNames: string[] // Ordered SimpleRouteConnection names
   maxLengthSkew?: number // Maximum routed-length difference in millimeters
+  traceWidth?: number // Resolved copper width in millimeters
+  allowedLayers?: string[] // Legal routing layers, including terminal layers
+}
+
+interface DifferentialPair {
+  connectionNames: [string, string]
+  lengthTolerance: number // Maximum pair skew in millimeters
+  traceGap?: number // Resolved edge-to-edge copper gap in millimeters
+  maxUncoupledLength?: number // Maximum uncoupled length in millimeters
 }
 ```
 
 `maxLengthSkew` records the maximum permitted routed-length difference for the
 bus. Bus metadata is preserved in the output so routing implementations can
 apply the constraint without losing the original membership or ordering.
+`traceWidth`, `traceGap`, and `allowedLayers` are resolved routing geometry;
+stackup-aware impedance targets should be converted to these dimensions before
+creating SimpleRouteJson.
 
 Via-in-pad repair is disabled by default because it generally requires filled
 and capped vias. Set `allowViaInPad: true` only when the fabrication process

--- a/lib/types/srj-types.ts
+++ b/lib/types/srj-types.ts
@@ -76,7 +76,12 @@ export interface SimpleRouteJson {
 
 export interface DifferentialPair {
   connectionNames: [string, string]
+  /** Maximum permitted routed-length difference in millimeters. */
   lengthTolerance: number
+  /** Resolved edge-to-edge copper gap in millimeters. */
+  traceGap?: number
+  /** Maximum permitted length routed without pair coupling, in millimeters. */
+  maxUncoupledLength?: number
 }
 
 export interface SimpleRouteBus {
@@ -85,6 +90,10 @@ export interface SimpleRouteBus {
   connectionNames: string[]
   /** Maximum permitted routed-length difference in millimeters. */
   maxLengthSkew?: number
+  /** Resolved copper width in millimeters for members without an override. */
+  traceWidth?: number
+  /** Layers on which this bus may be routed, including its terminal layers. */
+  allowedLayers?: string[]
 }
 
 export interface Obstacle {

--- a/tests/features/simple-route-json-bus-types.test.ts
+++ b/tests/features/simple-route-json-bus-types.test.ts
@@ -28,6 +28,16 @@ test("preserves SimpleRouteJson bus metadata during preprocessing", () => {
         busId: "data",
         connectionNames: ["data0", "data1"],
         maxLengthSkew: 0.1,
+        traceWidth: 0.12,
+        allowedLayers: ["top"],
+      },
+    ],
+    differentialPairs: [
+      {
+        connectionNames: ["data0", "data1"],
+        lengthTolerance: 0.05,
+        traceGap: 0.1,
+        maxUncoupledLength: 0.5,
       },
     ],
     bounds: { minX: -2, minY: -2, maxX: 2, maxY: 2 },
@@ -37,4 +47,7 @@ test("preserves SimpleRouteJson bus metadata during preprocessing", () => {
   solver.solve()
 
   expect(solver.getOutputSimpleRouteJson().buses).toEqual(srj.buses)
+  expect(solver.getOutputSimpleRouteJson().differentialPairs).toEqual(
+    srj.differentialPairs,
+  )
 })


### PR DESCRIPTION
## Summary

- add resolved bus `traceWidth` and `allowedLayers` fields to `SimpleRouteBus`
- add resolved `traceGap` and `maxUncoupledLength` fields to `DifferentialPair`
- document that impedance targets are converted by a stackup-aware resolver before SimpleRouteJson is created
- verify preprocessing preserves all new fields

These are autorouter-native constraints only. This does not add source-component props or routing-phase metadata to SimpleRouteJson.

## Validation

- `bun test tests/features/simple-route-json-bus-types.test.ts --timeout 9999999`
- `bun run build`
- `git diff --check`

## Stack

- source props: tscircuit/props#779
- first consumer: tscircuit/bus-tracer#4
- core emission follows after the props and SimpleRouteJson releases are available.