### PR TITLE
Use cached repair03 DRC evaluator

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "zdwiel-dataset": "git+https://github.com/dwiel/tscircuit-benchmark.git#be36518b5bf51755dae92c230061ab3cf4e3e063",
     "high-density-repair01": "git+https://github.com/tscircuit/high-density-repair01.git#cefc7be547ff727bd31573ac096b850da847af46",
     "high-density-repair02": "https://codeload.github.com/tscircuit/high-density-repair02/tar.gz/2afc0cbba3bf2f7eb6b9cd33615d21e9ad9352d4",
-    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#99ccf2776b2bc37e1ac9d2c6ab754f9d8ba25025",
+    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#846ce5041a447107af091d1c79afef883f408a59",
     "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- pin `high-density-repair03` to commit `846ce5041a447107af091d1c79afef883f408a59` from [tscircuit/high-density-repair03#48](https://github.com/tscircuit/high-density-repair03/pull/48)
- resolve the pin from canonical `tscircuit/high-density-repair03`, not a fork URL

## Performance

Repair03’s isolated SRJ18 benchmark for this exact commit reports 69.43s total versus 92.74s on repair03 main (25.1% faster), with matching per-sample and aggregate final DRC counts. See [the repair03 benchmark result](https://github.com/tscircuit/high-density-repair03/pull/48#issuecomment-5171512521).

That result does **not** transfer to the end-to-end autorouter benchmark: the initial SRJ18 run on this PR reported Pipeline7 P50 123.8s versus 118.5s on main (4.5% slower), with the same 75.0% completion and 12.5% relaxed-DRC-pass rates. See [the autorouter SRJ18 result](https://github.com/tscircuit/tscircuit-autorouter/pull/1897#issuecomment-5171635776). An explicit rerun is queued for confirmation.

## Validation

- verified commit fetches from canonical repair03 PR ref `refs/pull/48/head`
- `bun test tests/features/safe-trace-layer-repair-visual.test.ts --timeout 9999999`

The full local autorouter build remains blocked by unrelated missing/mismatched dependencies in the inherited install (`tiny-hypergraph`, `@tscircuit/power-trace-expander`, and an existing `length-matching-solver` type mismatch).