### PR TITLE
test: reproduce real six-layer routing timeout

### DIFF
--- a/tests/features/__snapshots__/pipeline7-srj18-sample006-iteration-budget.snap.svg
+++ b/tests/features/__snapshots__/pipeline7-srj18-sample006-iteration-budget.snap.svg
@@ -1,0 +1,62 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="17.622999,-15.699 14.824999,-3.85" data-type="line" data-label="source_trace_150__source_net_150
+z: 0" points="385.56531927357946,597.6567076742824 254.43468072642065,42.34329232571761" fill="none" stroke="hsla(265, 70%, 50%, 0.8)" stroke-width="1px" stroke-dasharray="3 3"/></g><circle data-type="circle" data-label="" data-x="17.622999" data-y="-15.699" cx="385.56531927357946" cy="597.6567076742824" r="2.3432923257176337" fill="rgba(128, 128, 128, 0.5)" stroke="black" stroke-width="0.0213375"/><circle data-type="circle" data-label="" data-x="14.824999" data-y="-3.85" cx="254.43468072642065" cy="42.34329232571761" r="2.3432923257176337" fill="rgba(128, 128, 128, 0.5)" stroke="black" stroke-width="0.0213375"/><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+net: 27
+endpoint: start
+port: tiny-terminal:start-port:source_trace_150__source_net_150
+z: 0" data-x="17.622999" data-y="-15.699" cx="385.56531927357946" cy="597.6567076742824" r="3" fill="hsla(265, 70%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+net: 27
+endpoint: end
+port: tiny-terminal:end-port:source_trace_150__source_net_150
+z: 0" data-x="14.824999" data-y="-3.85" cx="254.43468072642065" cy="42.34329232571761" r="3" fill="hsla(265, 70%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="source_trace_150__source_net_150
+z: 0" data-x="16.223999" data-y="-9.7745" cx="320" cy="320" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+net: 27
+endpoint: start
+port: tiny-terminal:start-port:source_trace_150__source_net_150
+z: 0" data-x="17.622999" data-y="-15.699" cx="385.56531927357946" cy="597.6567076742824" r="3" fill="hsla(265, 70%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+net: 27
+endpoint: end
+port: tiny-terminal:end-port:source_trace_150__source_net_150
+z: 0" data-x="14.824999" data-y="-3.85" cx="254.43468072642065" cy="42.34329232571761" r="3" fill="hsla(265, 70%, 50%, 0.8)"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":46.86584651435267,"c":0,"e":-440.3514469830111,"b":0,"d":-46.86584651435267,"f":-138.09021675454017};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/features/pipeline7-srj18-sample006-iteration-budget.test.ts
+++ b/tests/features/pipeline7-srj18-sample006-iteration-budget.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "bun:test"
+import type { GraphicsObject } from "graphics-debug"
+import { AutoroutingPipelineSolver7_MultiGraph } from "lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph"
+import { loadScenarioBySampleNumber } from "../../scripts/benchmark/scenarios"
+import { getLastStepGraphicsObject } from "../fixtures/getLastStepGraphicsObject"
+
+const FAILED_CONNECTION_ID = "source_trace_150__source_net_150"
+
+const getConnectionGraphics = (
+  solver: AutoroutingPipelineSolver7_MultiGraph,
+): GraphicsObject => {
+  const graphics = getLastStepGraphicsObject(solver.visualize())
+  return {
+    lines:
+      graphics.lines?.filter((line) =>
+        line.label?.includes(FAILED_CONNECTION_ID),
+      ) ?? [],
+    points:
+      graphics.points?.filter((point) =>
+        point.label?.includes(FAILED_CONNECTION_ID),
+      ) ?? [],
+    circles:
+      graphics.circles?.filter((circle) =>
+        circle.label?.includes(FAILED_CONNECTION_ID),
+      ) ?? [],
+  }
+}
+
+test("repro: six-layer SRJ18 sample006 exhausts tiny-hypergraph iterations", async (): Promise<void> => {
+  const { scenario } = await loadScenarioBySampleNumber("srj18", 6)
+  const solver = new AutoroutingPipelineSolver7_MultiGraph(scenario, {
+    cacheProvider: null,
+    effort: 0.7,
+  })
+
+  solver.solveUntilPhase("portPointPathingSolver")
+  while (
+    solver.getCurrentPhase() === "portPointPathingSolver" &&
+    !solver.failed &&
+    !solver.solved
+  ) {
+    solver.step()
+  }
+
+  expect(scenario.layerCount).toBe(6)
+  expect(scenario.connections).toHaveLength(290)
+  expect(solver.portPointPathingSolver?.solved).toBe(false)
+  expect(solver.portPointPathingSolver?.failed).toBe(true)
+  expect(solver.portPointPathingSolver?.error).toContain(
+    "ran out of iterations",
+  )
+  expect(getConnectionGraphics(solver)).toMatchGraphicsSvg(import.meta.path)
+})


### PR DESCRIPTION
## What

- Runs the pinned SRJ18 sample006 circuit through Pipeline 7 at effort `0.7`.
- Uses the real six-layer board input with 290 source connections and 481 obstacles.
- Captures the existing failure at the tiny-hypergraph port-point stage.
- Adds a focused SVG snapshot for `source_trace_150__source_net_150`; the baseline contains only its unresolved dashed airwire.

## Why

The previous version generated duplicate synthetic connections and only compared numeric budgets. This replacement is a real circuit-routing failure: current main reaches the 1,400,000-iteration solve cap with 42 connections still unrouted.

## Impact

Test-only. This is PR 1 of the stack and intentionally characterizes the current unsolved output. The snapshot is limited to one representative failed net, keeping the visual fixture small while showing the missing route directly.

## Checks

- `bun test tests/features/pipeline7-srj18-sample006-iteration-budget.test.ts --timeout 9999999` (passes in about 41 seconds while asserting the expected timeout)

## Stack

The follow-up PR #1904 raises the size-aware budget, changes the assertions to a successful solve, and replaces the airwire snapshot with the actual multilayer path.