### PR TITLE
fix: scale tiny-hypergraph budget with route count

### DIFF
--- a/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
+++ b/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
@@ -154,6 +154,7 @@ const getTinyViaSizeOptions = (
 const getTinyHyperGraphSolveGraphOptions = (
   effort: number,
   minViaPadDiameter?: number,
+  connectionCountScale = 1,
 ): TinyHyperGraphSolverOptions => {
   const effortScale = getEffortScale(effort)
   return {
@@ -161,13 +162,16 @@ const getTinyHyperGraphSolveGraphOptions = (
     ...getTinyViaSizeOptions(minViaPadDiameter),
     USE_SPARSE_CANDIDATE_STORAGE: true,
     RIP_THRESHOLD_RAMP_ATTEMPTS: Math.ceil(10 * effortScale),
-    MAX_ITERATIONS: Math.ceil(2_000_000 * effortScale),
+    MAX_ITERATIONS: Math.ceil(
+      2_000_000 * effortScale * connectionCountScale,
+    ),
   }
 }
 
 const getTinyHyperGraphSectionSolverOptions = (
   effort: number,
   minViaPadDiameter?: number,
+  connectionCountScale = 1,
 ): TinyHyperGraphSectionSolverOptions => {
   const effortScale = getEffortScale(effort)
   return {
@@ -175,7 +179,9 @@ const getTinyHyperGraphSectionSolverOptions = (
     ...getTinyViaSizeOptions(minViaPadDiameter),
     USE_SPARSE_CANDIDATE_STORAGE: true,
     RIP_THRESHOLD_RAMP_ATTEMPTS: Math.ceil(16 * effortScale),
-    MAX_ITERATIONS: Math.ceil(1_000_000 * effortScale),
+    MAX_ITERATIONS: Math.ceil(
+      1_000_000 * effortScale * connectionCountScale,
+    ),
   }
 }
 
@@ -183,18 +189,27 @@ const getTinyHyperGraphPipelineInput = (
   serializedHyperGraph: SerializedHyperGraph,
   effort: number,
   minViaPadDiameter?: number,
-): TinyHyperGraphSectionPipelineInput => ({
-  serializedHyperGraph,
-  createSectionMask: ({ topology }) => new Int8Array(topology.portCount),
-  solveGraphOptions: getTinyHyperGraphSolveGraphOptions(
-    effort,
-    minViaPadDiameter,
-  ),
-  sectionSolverOptions: getTinyHyperGraphSectionSolverOptions(
-    effort,
-    minViaPadDiameter,
-  ),
-})
+): TinyHyperGraphSectionPipelineInput => {
+  const connectionCount = serializedHyperGraph.connections?.length ?? 0
+  const connectionCountScale = Math.max(
+    1,
+    connectionCount / MAX_CONNECTIONS_FOR_DUPLICATE_CONGESTED_PORT_PREPASS,
+  )
+  return {
+    serializedHyperGraph,
+    createSectionMask: ({ topology }) => new Int8Array(topology.portCount),
+    solveGraphOptions: getTinyHyperGraphSolveGraphOptions(
+      effort,
+      minViaPadDiameter,
+      connectionCountScale,
+    ),
+    sectionSolverOptions: getTinyHyperGraphSectionSolverOptions(
+      effort,
+      minViaPadDiameter,
+      connectionCountScale,
+    ),
+  }
+}
 
 const getTinyHyperGraphPipelineMaxIterations = (
   inputProblem: TinyHyperGraphSectionPipelineInput,

--- a/tests/features/__snapshots__/pipeline7-srj18-sample006-iteration-budget.snap.svg
+++ b/tests/features/__snapshots__/pipeline7-srj18-sample006-iteration-budget.snap.svg
@@ -1,22 +1,296 @@
 <svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="17.622999,-15.699 14.824999,-3.85" data-type="line" data-label="source_trace_150__source_net_150
-z: 0" points="385.56531927357946,597.6567076742824 254.43468072642065,42.34329232571761" fill="none" stroke="hsla(265, 70%, 50%, 0.8)" stroke-width="1px" stroke-dasharray="3 3"/></g><circle data-type="circle" data-label="" data-x="17.622999" data-y="-15.699" cx="385.56531927357946" cy="597.6567076742824" r="2.3432923257176337" fill="rgba(128, 128, 128, 0.5)" stroke="black" stroke-width="0.0213375"/><circle data-type="circle" data-label="" data-x="14.824999" data-y="-3.85" cx="254.43468072642065" cy="42.34329232571761" r="2.3432923257176337" fill="rgba(128, 128, 128, 0.5)" stroke="black" stroke-width="0.0213375"/><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+z: 0" points="397.74317380947696,597.7951453826013 274.35950941984765,75.28869815146567" fill="none" stroke="hsla(265, 70%, 50%, 0.8)" stroke-width="1px" stroke-dasharray="3 3"/></g><g><polyline data-points="14.271998999999997,-3.83 14.046999,-3.605" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8460
+z: 4" points="249.97381735141823,74.40675630450622 240.05197157312443,64.48491052621222" fill="none" stroke="rgba(52, 152, 219, 0.95)" stroke-width="1px" stroke-dasharray="3 2"/></g><g><polyline data-points="14.046999,-3.605 14.046999,-3.25475" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8467
+z: 4" points="240.05197157312443,64.48491052621222 240.05197157312443,49.03990393133458" fill="none" stroke="rgba(52, 152, 219, 0.95)" stroke-width="1px" stroke-dasharray="3 2"/></g><g><polyline data-points="14.046999,-3.25475 14.251998999999998,-3.04975" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8469
+z: 4 -&gt; 0" points="240.05197157312443,49.03990393133458 249.0918755044588,40.00000000000003" fill="none" stroke="rgba(22, 160, 133, 0.95)" stroke-width="1px" stroke-dasharray="2 4 2"/></g><g><polyline data-points="16.764999,-11.484166875000001 16.199999,-8.905000000000001" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8572
+z: 4" points="359.9078685749158,411.9332598381795 334.99301139831084,298.19949997047075" fill="none" stroke="rgba(52, 152, 219, 0.95)" stroke-width="1px" stroke-dasharray="3 2"/></g><g><polyline data-points="16.199999,-8.905000000000001 16.764999,-7.5425" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8577
+z: 4" points="334.99301139831084,298.19949997047075 359.9078685749158,238.11721164635713" fill="none" stroke="rgba(52, 152, 219, 0.95)" stroke-width="1px" stroke-dasharray="3 2"/></g><g><polyline data-points="16.764999,-7.147500000000001 15.644999,-6.454000000000001" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8582
+z: 4" points="359.9078685749158,220.6988601689077 310.51912514518574,190.1175266255882" fill="none" stroke="rgba(52, 152, 219, 0.95)" stroke-width="1px" stroke-dasharray="3 2"/></g><g><polyline data-points="14.619998999999996,-3.83 14.271998999999997,-3.83" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8651
+z: 4" points="265.31960548851293,74.40675630450622 249.97381735141823,74.40675630450622" fill="none" stroke="rgba(52, 152, 219, 0.95)" stroke-width="1px" stroke-dasharray="3 2"/></g><g><polyline data-points="14.251998999999998,-3.04975 14.599998999999997,-3.04975" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8659
+z: 0" points="249.0918755044588,40.00000000000003 264.4376636415535,40.00000000000003" fill="none" stroke="hsla(265, 70%, 50%, 0.8)" stroke-width="1px"/></g><g><polyline data-points="15.069999,-6.229000000000001 14.844998999999998,-6.004000000000001" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8796
+z: 4" points="285.1632970451011,180.19568084729423 275.24145126680696,170.2738350690002" fill="none" stroke="rgba(52, 152, 219, 0.95)" stroke-width="1px" stroke-dasharray="3 2"/></g><g><polyline data-points="14.844998999999998,-6.004000000000001 14.844998999999998,-5.655" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8801
+z: 4" points="275.24145126680696,170.2738350690002 275.24145126680696,154.8839498395575" fill="none" stroke="rgba(52, 152, 219, 0.95)" stroke-width="1px" stroke-dasharray="3 2"/></g><g><polyline data-points="14.844998999999998,-5.655 14.844998999999998,-5.205000000000001" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8805
+z: 4" points="275.24145126680696,154.8839498395575 275.24145126680696,135.04025828296955" fill="none" stroke="rgba(52, 152, 219, 0.95)" stroke-width="1px" stroke-dasharray="3 2"/></g><g><polyline data-points="14.844998999999998,-5.205000000000001 14.844998999999998,-4.853" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8810
+z: 4" points="275.24145126680696,135.04025828296955 275.24145126680696,119.51808177648289" fill="none" stroke="rgba(52, 152, 219, 0.95)" stroke-width="1px" stroke-dasharray="3 2"/></g><g><polyline data-points="14.844998999999998,-4.853 14.844998999999998,-4.4030000000000005" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8814
+z: 4" points="275.24145126680696,119.51808177648289 275.24145126680696,99.67439021989492" fill="none" stroke="rgba(52, 152, 219, 0.95)" stroke-width="1px" stroke-dasharray="3 2"/></g><g><polyline data-points="14.844998999999998,-4.4030000000000005 14.844998999999998,-4.0550000000000015" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8820
+z: 4" points="275.24145126680696,99.67439021989492 275.24145126680696,84.32860208280027" fill="none" stroke="rgba(52, 152, 219, 0.95)" stroke-width="1px" stroke-dasharray="3 2"/></g><g><polyline data-points="14.844998999999998,-4.0550000000000015 14.619998999999996,-3.83" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8825
+z: 4" points="275.24145126680696,84.32860208280027 265.31960548851293,74.40675630450622" fill="none" stroke="rgba(52, 152, 219, 0.95)" stroke-width="1px" stroke-dasharray="3 2"/></g><g><polyline data-points="15.049999,-3.449875 14.824999,-3.625" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8827
+z: 0" points="284.28135519814157,57.64434907573286 274.35950941984765,65.36685237317167" fill="none" stroke="hsla(265, 70%, 50%, 0.8)" stroke-width="1px"/></g><g><polyline data-points="14.599998999999997,-3.04975 15.049999,-3.04975" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8833
+z: 0" points="264.4376636415535,40.00000000000003 284.28135519814157,40.00000000000003" fill="none" stroke="hsla(265, 70%, 50%, 0.8)" stroke-width="1px"/></g><g><polyline data-points="14.824999,-3.625 14.824999,-3.85" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8898
+z: 0" points="274.35950941984765,65.36685237317167 274.35950941984765,75.28869815146567" fill="none" stroke="hsla(265, 70%, 50%, 0.8)" stroke-width="1px"/></g><g><polyline data-points="15.419999,-6.229000000000001 15.069999,-6.229000000000001" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8987
+z: 4" points="300.5972793668918,180.19568084729423 285.1632970451011,180.19568084729423" fill="none" stroke="rgba(52, 152, 219, 0.95)" stroke-width="1px" stroke-dasharray="3 2"/></g><g><polyline data-points="15.224999,-3.27475 15.049999,-3.449875" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-9025
+z: 0" points="291.998346359037,49.92184577829403 284.28135519814157,57.64434907573286" fill="none" stroke="hsla(265, 70%, 50%, 0.8)" stroke-width="1px"/></g><g><polyline data-points="15.049999,-3.04975 15.224999,-3.27475" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-9031
+z: 0" points="284.28135519814157,40.00000000000003 291.998346359037,49.92184577829403" fill="none" stroke="hsla(265, 70%, 50%, 0.8)" stroke-width="1px"/></g><g><polyline data-points="15.644999,-6.454000000000001 15.419999,-6.229000000000001" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-9142
+z: 4" points="310.51912514518574,190.1175266255882 300.5972793668918,180.19568084729423" fill="none" stroke="rgba(52, 152, 219, 0.95)" stroke-width="1px" stroke-dasharray="3 2"/></g><g><polyline data-points="17.622999,-14.449 16.764999,-11.484166875000001" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-9875
+z: 0 -&gt; 4" points="397.74317380947696,542.6737799476347 359.9078685749158,411.9332598381795" fill="none" stroke="rgba(22, 160, 133, 0.95)" stroke-width="1px" stroke-dasharray="2 4 2"/></g><g><polyline data-points="16.764999,-7.5425 16.764999,-7.147500000000001" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-9875
+z: 4" points="359.9078685749158,238.11721164635713 359.9078685749158,220.6988601689077" fill="none" stroke="rgba(52, 152, 219, 0.95)" stroke-width="1px" stroke-dasharray="3 2"/></g><g><polyline data-points="17.622999,-15.699 17.622999,-15.698999999999998" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-10134
+z: 0" points="397.74317380947696,597.7951453826013 397.74317380947696,597.7951453826013" fill="none" stroke="hsla(265, 70%, 50%, 0.8)" stroke-width="1px"/></g><g><polyline data-points="17.622999,-15.698999999999998 17.622999,-14.449" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-10135
+z: 0" points="397.74317380947696,597.7951453826013 397.74317380947696,542.6737799476347" fill="none" stroke="hsla(265, 70%, 50%, 0.8)" stroke-width="1px"/></g><g><polyline data-points="14.271998999999997,-3.83 14.046999,-3.605" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8460
+z: 4" points="249.97381735141823,74.40675630450622 240.05197157312443,64.48491052621222" fill="none" stroke="rgba(52, 152, 219, 0.95)" stroke-width="1px" stroke-dasharray="3 2"/></g><g><polyline data-points="14.046999,-3.605 14.046999,-3.25475" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8467
+z: 4" points="240.05197157312443,64.48491052621222 240.05197157312443,49.03990393133458" fill="none" stroke="rgba(52, 152, 219, 0.95)" stroke-width="1px" stroke-dasharray="3 2"/></g><g><polyline data-points="14.046999,-3.25475 14.251998999999998,-3.04975" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8469
+z: 4 -&gt; 0" points="240.05197157312443,49.03990393133458 249.0918755044588,40.00000000000003" fill="none" stroke="rgba(22, 160, 133, 0.95)" stroke-width="1px" stroke-dasharray="2 4 2"/></g><g><polyline data-points="16.764999,-11.484166875000001 16.199999,-8.905000000000001" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8572
+z: 4" points="359.9078685749158,411.9332598381795 334.99301139831084,298.19949997047075" fill="none" stroke="rgba(52, 152, 219, 0.95)" stroke-width="1px" stroke-dasharray="3 2"/></g><g><polyline data-points="16.199999,-8.905000000000001 16.764999,-7.5425" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8577
+z: 4" points="334.99301139831084,298.19949997047075 359.9078685749158,238.11721164635713" fill="none" stroke="rgba(52, 152, 219, 0.95)" stroke-width="1px" stroke-dasharray="3 2"/></g><g><polyline data-points="16.764999,-7.147500000000001 15.644999,-6.454000000000001" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8582
+z: 4" points="359.9078685749158,220.6988601689077 310.51912514518574,190.1175266255882" fill="none" stroke="rgba(52, 152, 219, 0.95)" stroke-width="1px" stroke-dasharray="3 2"/></g><g><polyline data-points="14.619998999999996,-3.83 14.271998999999997,-3.83" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8651
+z: 4" points="265.31960548851293,74.40675630450622 249.97381735141823,74.40675630450622" fill="none" stroke="rgba(52, 152, 219, 0.95)" stroke-width="1px" stroke-dasharray="3 2"/></g><g><polyline data-points="14.251998999999998,-3.04975 14.599998999999997,-3.04975" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8659
+z: 0" points="249.0918755044588,40.00000000000003 264.4376636415535,40.00000000000003" fill="none" stroke="hsla(265, 70%, 50%, 0.8)" stroke-width="1px"/></g><g><polyline data-points="15.069999,-6.229000000000001 14.844998999999998,-6.004000000000001" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8796
+z: 4" points="285.1632970451011,180.19568084729423 275.24145126680696,170.2738350690002" fill="none" stroke="rgba(52, 152, 219, 0.95)" stroke-width="1px" stroke-dasharray="3 2"/></g><g><polyline data-points="14.844998999999998,-6.004000000000001 14.844998999999998,-5.655" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8801
+z: 4" points="275.24145126680696,170.2738350690002 275.24145126680696,154.8839498395575" fill="none" stroke="rgba(52, 152, 219, 0.95)" stroke-width="1px" stroke-dasharray="3 2"/></g><g><polyline data-points="14.844998999999998,-5.655 14.844998999999998,-5.205000000000001" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8805
+z: 4" points="275.24145126680696,154.8839498395575 275.24145126680696,135.04025828296955" fill="none" stroke="rgba(52, 152, 219, 0.95)" stroke-width="1px" stroke-dasharray="3 2"/></g><g><polyline data-points="14.844998999999998,-5.205000000000001 14.844998999999998,-4.853" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8810
+z: 4" points="275.24145126680696,135.04025828296955 275.24145126680696,119.51808177648289" fill="none" stroke="rgba(52, 152, 219, 0.95)" stroke-width="1px" stroke-dasharray="3 2"/></g><g><polyline data-points="14.844998999999998,-4.853 14.844998999999998,-4.4030000000000005" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8814
+z: 4" points="275.24145126680696,119.51808177648289 275.24145126680696,99.67439021989492" fill="none" stroke="rgba(52, 152, 219, 0.95)" stroke-width="1px" stroke-dasharray="3 2"/></g><g><polyline data-points="14.844998999999998,-4.4030000000000005 14.844998999999998,-4.0550000000000015" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8820
+z: 4" points="275.24145126680696,99.67439021989492 275.24145126680696,84.32860208280027" fill="none" stroke="rgba(52, 152, 219, 0.95)" stroke-width="1px" stroke-dasharray="3 2"/></g><g><polyline data-points="14.844998999999998,-4.0550000000000015 14.619998999999996,-3.83" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8825
+z: 4" points="275.24145126680696,84.32860208280027 265.31960548851293,74.40675630450622" fill="none" stroke="rgba(52, 152, 219, 0.95)" stroke-width="1px" stroke-dasharray="3 2"/></g><g><polyline data-points="15.049999,-3.449875 14.824999,-3.625" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8827
+z: 0" points="284.28135519814157,57.64434907573286 274.35950941984765,65.36685237317167" fill="none" stroke="hsla(265, 70%, 50%, 0.8)" stroke-width="1px"/></g><g><polyline data-points="14.599998999999997,-3.04975 15.049999,-3.04975" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8833
+z: 0" points="264.4376636415535,40.00000000000003 284.28135519814157,40.00000000000003" fill="none" stroke="hsla(265, 70%, 50%, 0.8)" stroke-width="1px"/></g><g><polyline data-points="14.824999,-3.625 14.824999,-3.85" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8898
+z: 0" points="274.35950941984765,65.36685237317167 274.35950941984765,75.28869815146567" fill="none" stroke="hsla(265, 70%, 50%, 0.8)" stroke-width="1px"/></g><g><polyline data-points="15.419999,-6.229000000000001 15.069999,-6.229000000000001" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-8987
+z: 4" points="300.5972793668918,180.19568084729423 285.1632970451011,180.19568084729423" fill="none" stroke="rgba(52, 152, 219, 0.95)" stroke-width="1px" stroke-dasharray="3 2"/></g><g><polyline data-points="15.224999,-3.27475 15.049999,-3.449875" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-9025
+z: 0" points="291.998346359037,49.92184577829403 284.28135519814157,57.64434907573286" fill="none" stroke="hsla(265, 70%, 50%, 0.8)" stroke-width="1px"/></g><g><polyline data-points="15.049999,-3.04975 15.224999,-3.27475" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-9031
+z: 0" points="284.28135519814157,40.00000000000003 291.998346359037,49.92184577829403" fill="none" stroke="hsla(265, 70%, 50%, 0.8)" stroke-width="1px"/></g><g><polyline data-points="15.644999,-6.454000000000001 15.419999,-6.229000000000001" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-9142
+z: 4" points="310.51912514518574,190.1175266255882 300.5972793668918,180.19568084729423" fill="none" stroke="rgba(52, 152, 219, 0.95)" stroke-width="1px" stroke-dasharray="3 2"/></g><g><polyline data-points="17.622999,-14.449 16.764999,-11.484166875000001" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-9875
+z: 0 -&gt; 4" points="397.74317380947696,542.6737799476347 359.9078685749158,411.9332598381795" fill="none" stroke="rgba(22, 160, 133, 0.95)" stroke-width="1px" stroke-dasharray="2 4 2"/></g><g><polyline data-points="16.764999,-7.5425 16.764999,-7.147500000000001" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-9875
+z: 4" points="359.9078685749158,238.11721164635713 359.9078685749158,220.6988601689077" fill="none" stroke="rgba(52, 152, 219, 0.95)" stroke-width="1px" stroke-dasharray="3 2"/></g><g><polyline data-points="17.622999,-15.699 17.622999,-15.698999999999998" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-10134
+z: 0" points="397.74317380947696,597.7951453826013 397.74317380947696,597.7951453826013" fill="none" stroke="hsla(265, 70%, 50%, 0.8)" stroke-width="1px"/></g><g><polyline data-points="17.622999,-15.698999999999998 17.622999,-14.449" data-type="line" data-label="route: source_trace_150__source_net_150
+region: region-10135
+z: 0" points="397.74317380947696,597.7951453826013 397.74317380947696,542.6737799476347" fill="none" stroke="hsla(265, 70%, 50%, 0.8)" stroke-width="1px"/></g><circle data-type="circle" data-label="" data-x="17.622999" data-y="-15.699" cx="397.74317380947696" cy="597.7951453826013" r="2.204854617398665" fill="rgba(128, 128, 128, 0.5)" stroke="black" stroke-width="0.022677232142857145"/><circle data-type="circle" data-label="" data-x="14.824999" data-y="-3.85" cx="274.35950941984765" cy="75.28869815146567" r="2.204854617398665" fill="rgba(128, 128, 128, 0.5)" stroke="black" stroke-width="0.022677232142857145"/><circle data-type="circle" data-label="" data-x="17.622999" data-y="-15.699" cx="397.74317380947696" cy="597.7951453826013" r="2.204854617398665" fill="rgba(128, 128, 128, 0.5)" stroke="black" stroke-width="0.022677232142857145"/><circle data-type="circle" data-label="" data-x="14.824999" data-y="-3.85" cx="274.35950941984765" cy="75.28869815146567" r="2.204854617398665" fill="rgba(128, 128, 128, 0.5)" stroke="black" stroke-width="0.022677232142857145"/><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
 net: 27
 endpoint: start
 port: tiny-terminal:start-port:source_trace_150__source_net_150
-z: 0" data-x="17.622999" data-y="-15.699" cx="385.56531927357946" cy="597.6567076742824" r="3" fill="hsla(265, 70%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+z: 0" data-x="17.622999" data-y="-15.699" cx="397.74317380947696" cy="597.7951453826013" r="3" fill="hsla(265, 70%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
 net: 27
 endpoint: end
 port: tiny-terminal:end-port:source_trace_150__source_net_150
-z: 0" data-x="14.824999" data-y="-3.85" cx="254.43468072642065" cy="42.34329232571761" r="3" fill="hsla(265, 70%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="source_trace_150__source_net_150
-z: 0" data-x="16.223999" data-y="-9.7745" cx="320" cy="320" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+z: 0" data-x="14.824999" data-y="-3.85" cx="274.35950941984765" cy="75.28869815146567" r="3" fill="hsla(265, 70%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="source_trace_150__source_net_150
+z: 0" data-x="16.223999" data-y="-9.7745" cx="336.0513416146622" cy="336.5419217670335" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
 net: 27
 endpoint: start
 port: tiny-terminal:start-port:source_trace_150__source_net_150
-z: 0" data-x="17.622999" data-y="-15.699" cx="385.56531927357946" cy="597.6567076742824" r="3" fill="hsla(265, 70%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+z: 0" data-x="17.622999" data-y="-15.699" cx="397.74317380947696" cy="597.7951453826013" r="3" fill="hsla(265, 70%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
 net: 27
 endpoint: end
 port: tiny-terminal:end-port:source_trace_150__source_net_150
-z: 0" data-x="14.824999" data-y="-3.85" cx="254.43468072642065" cy="42.34329232571761" r="3" fill="hsla(265, 70%, 50%, 0.8)"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+z: 0" data-x="14.824999" data-y="-3.85" cx="274.35950941984765" cy="75.28869815146567" r="3" fill="hsla(265, 70%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce24173_pp0_z4::4
+net: 27
+z: 4" data-x="14.271998999999997" data-y="-3.83" cx="249.97381735141823" cy="74.40675630450622" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce24172_pp0_z4::4
+net: 27
+z: 4" data-x="14.046999" data-y="-3.605" cx="240.05197157312443" cy="64.48491052621222" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce24186_pp0_z4::4
+net: 27
+z: 4" data-x="14.046999" data-y="-3.25475" cx="240.05197157312443" cy="49.03990393133458" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce24196_pp0_z0::0
+net: 27
+z: 0" data-x="14.251998999999998" data-y="-3.04975" cx="249.0918755044588" cy="40.00000000000003" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce24447_pp3_z4::4
+net: 27
+z: 4" data-x="16.764999" data-y="-11.484166875000001" cx="359.9078685749158" cy="411.9332598381795" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce24440_pp5_z4::4
+net: 27
+z: 4" data-x="16.199999" data-y="-8.905000000000001" cx="334.99301139831084" cy="298.19949997047075" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce24457_pp4_z4::4
+net: 27
+z: 4" data-x="16.764999" data-y="-7.5425" cx="359.9078685749158" cy="238.11721164635713" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce24505_pp0_z4::4
+net: 27
+z: 4" data-x="16.764999" data-y="-7.147500000000001" cx="359.9078685749158" cy="220.6988601689077" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce24495_pp0_z4::4
+net: 27
+z: 4" data-x="15.644999" data-y="-6.454000000000001" cx="310.51912514518574" cy="190.1175266255882" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce24657_pp0_z4::4
+net: 27
+z: 4" data-x="14.619998999999996" data-y="-3.83" cx="265.31960548851293" cy="74.40675630450622" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce24673_pp0_z0::0
+net: 27
+z: 0" data-x="14.599998999999997" data-y="-3.04975" cx="264.4376636415535" cy="40.00000000000003" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce24973_pp0_z4::4
+net: 27
+z: 4" data-x="15.069999" data-y="-6.229000000000001" cx="285.1632970451011" cy="180.19568084729423" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce24972_pp0_z4::4
+net: 27
+z: 4" data-x="14.844998999999998" data-y="-6.004000000000001" cx="275.24145126680696" cy="170.2738350690002" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce24982_pp0_z4::4
+net: 27
+z: 4" data-x="14.844998999999998" data-y="-5.655" cx="275.24145126680696" cy="154.8839498395575" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce24990_pp0_z4::4
+net: 27
+z: 4" data-x="14.844998999999998" data-y="-5.205000000000001" cx="275.24145126680696" cy="135.04025828296955" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce25001_pp0_z4::4
+net: 27
+z: 4" data-x="14.844998999999998" data-y="-4.853" cx="275.24145126680696" cy="119.51808177648289" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce25009_pp0_z4::4
+net: 27
+z: 4" data-x="14.844998999999998" data-y="-4.4030000000000005" cx="275.24145126680696" cy="99.67439021989492" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce25023_pp0_z4::4
+net: 27
+z: 4" data-x="14.844998999999998" data-y="-4.0550000000000015" cx="275.24145126680696" cy="84.32860208280027" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce25039_pp0_z0_cramped::0
+net: 27
+z: 0" data-x="15.049999" data-y="-3.449875" cx="284.28135519814157" cy="57.64434907573286" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce25037_pp0_z0::0
+net: 27
+z: 0" data-x="14.824999" data-y="-3.625" cx="274.35950941984765" cy="65.36685237317167" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce25056_pp0_z0::0
+net: 27
+z: 0" data-x="15.049999" data-y="-3.04975" cx="284.28135519814157" cy="40.00000000000003" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: tiny-terminal:end-port:source_trace_150__source_net_150
+net: 27
+z: 0" data-x="14.824999" data-y="-3.85" cx="274.35950941984765" cy="75.28869815146567" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce25458_pp0_z4::4
+net: 27
+z: 4" data-x="15.419999" data-y="-6.229000000000001" cx="300.5972793668918" cy="180.19568084729423" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce25537_pp0_z0_cramped::0
+net: 27
+z: 0" data-x="15.224999" data-y="-3.27475" cx="291.998346359037" cy="49.92184577829403" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce27529_pp0_z0::0
+net: 27
+z: 0" data-x="17.622999" data-y="-14.449" cx="397.74317380947696" cy="542.6737799476347" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: tiny-terminal:start-port:source_trace_150__source_net_150
+net: 27
+z: 0" data-x="17.622999" data-y="-15.699" cx="397.74317380947696" cy="597.7951453826013" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce28808_pp0_z0::0
+net: 27
+z: 0" data-x="17.622999" data-y="-15.698999999999998" cx="397.74317380947696" cy="597.7951453826013" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+net: 27
+endpoint: start
+port: tiny-terminal:start-port:source_trace_150__source_net_150
+z: 0" data-x="17.622999" data-y="-15.699" cx="397.74317380947696" cy="597.7951453826013" r="3" fill="hsla(265, 70%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+net: 27
+endpoint: end
+port: tiny-terminal:end-port:source_trace_150__source_net_150
+z: 0" data-x="14.824999" data-y="-3.85" cx="274.35950941984765" cy="75.28869815146567" r="3" fill="hsla(265, 70%, 50%, 0.8)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce24173_pp0_z4::4
+net: 27
+z: 4" data-x="14.271998999999997" data-y="-3.83" cx="249.97381735141823" cy="74.40675630450622" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce24172_pp0_z4::4
+net: 27
+z: 4" data-x="14.046999" data-y="-3.605" cx="240.05197157312443" cy="64.48491052621222" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce24186_pp0_z4::4
+net: 27
+z: 4" data-x="14.046999" data-y="-3.25475" cx="240.05197157312443" cy="49.03990393133458" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce24196_pp0_z0::0
+net: 27
+z: 0" data-x="14.251998999999998" data-y="-3.04975" cx="249.0918755044588" cy="40.00000000000003" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce24447_pp3_z4::4
+net: 27
+z: 4" data-x="16.764999" data-y="-11.484166875000001" cx="359.9078685749158" cy="411.9332598381795" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce24440_pp5_z4::4
+net: 27
+z: 4" data-x="16.199999" data-y="-8.905000000000001" cx="334.99301139831084" cy="298.19949997047075" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce24457_pp4_z4::4
+net: 27
+z: 4" data-x="16.764999" data-y="-7.5425" cx="359.9078685749158" cy="238.11721164635713" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce24505_pp0_z4::4
+net: 27
+z: 4" data-x="16.764999" data-y="-7.147500000000001" cx="359.9078685749158" cy="220.6988601689077" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce24495_pp0_z4::4
+net: 27
+z: 4" data-x="15.644999" data-y="-6.454000000000001" cx="310.51912514518574" cy="190.1175266255882" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce24657_pp0_z4::4
+net: 27
+z: 4" data-x="14.619998999999996" data-y="-3.83" cx="265.31960548851293" cy="74.40675630450622" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce24673_pp0_z0::0
+net: 27
+z: 0" data-x="14.599998999999997" data-y="-3.04975" cx="264.4376636415535" cy="40.00000000000003" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce24973_pp0_z4::4
+net: 27
+z: 4" data-x="15.069999" data-y="-6.229000000000001" cx="285.1632970451011" cy="180.19568084729423" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce24972_pp0_z4::4
+net: 27
+z: 4" data-x="14.844998999999998" data-y="-6.004000000000001" cx="275.24145126680696" cy="170.2738350690002" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce24982_pp0_z4::4
+net: 27
+z: 4" data-x="14.844998999999998" data-y="-5.655" cx="275.24145126680696" cy="154.8839498395575" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce24990_pp0_z4::4
+net: 27
+z: 4" data-x="14.844998999999998" data-y="-5.205000000000001" cx="275.24145126680696" cy="135.04025828296955" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce25001_pp0_z4::4
+net: 27
+z: 4" data-x="14.844998999999998" data-y="-4.853" cx="275.24145126680696" cy="119.51808177648289" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce25009_pp0_z4::4
+net: 27
+z: 4" data-x="14.844998999999998" data-y="-4.4030000000000005" cx="275.24145126680696" cy="99.67439021989492" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce25023_pp0_z4::4
+net: 27
+z: 4" data-x="14.844998999999998" data-y="-4.0550000000000015" cx="275.24145126680696" cy="84.32860208280027" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce25039_pp0_z0_cramped::0
+net: 27
+z: 0" data-x="15.049999" data-y="-3.449875" cx="284.28135519814157" cy="57.64434907573286" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce25037_pp0_z0::0
+net: 27
+z: 0" data-x="14.824999" data-y="-3.625" cx="274.35950941984765" cy="65.36685237317167" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce25056_pp0_z0::0
+net: 27
+z: 0" data-x="15.049999" data-y="-3.04975" cx="284.28135519814157" cy="40.00000000000003" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: tiny-terminal:end-port:source_trace_150__source_net_150
+net: 27
+z: 0" data-x="14.824999" data-y="-3.85" cx="274.35950941984765" cy="75.28869815146567" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce25458_pp0_z4::4
+net: 27
+z: 4" data-x="15.419999" data-y="-6.229000000000001" cx="300.5972793668918" cy="180.19568084729423" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce25537_pp0_z0_cramped::0
+net: 27
+z: 0" data-x="15.224999" data-y="-3.27475" cx="291.998346359037" cy="49.92184577829403" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce27529_pp0_z0::0
+net: 27
+z: 0" data-x="17.622999" data-y="-14.449" cx="397.74317380947696" cy="542.6737799476347" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: tiny-terminal:start-port:source_trace_150__source_net_150
+net: 27
+z: 0" data-x="17.622999" data-y="-15.699" cx="397.74317380947696" cy="597.7951453826013" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g><circle data-type="point" data-label="route: source_trace_150__source_net_150
+port: ce28808_pp0_z0::0
+net: 27
+z: 0" data-x="17.622999" data-y="-15.698999999999998" cx="397.74317380947696" cy="597.7951453826013" r="3" fill="hsla(265, 70%, 50%, 1)"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
               document.currentScript.parentElement.addEventListener('mousemove', (e) => {
                 const svg = e.currentTarget;
                 const rect = svg.getBoundingClientRect();
@@ -38,7 +312,7 @@ z: 0" data-x="14.824999" data-y="-3.85" cx="254.43468072642065" cy="42.343292325
                 v.setAttribute('y2', '640');
 
                 // Calculate real coordinates using inverse transformation
-                const matrix = {"a":46.86584651435267,"c":0,"e":-440.3514469830111,"b":0,"d":-46.86584651435267,"f":-138.09021675454017};
+                const matrix = {"a":44.0970923479733,"c":0,"e":-379.3798405417642,"b":0,"d":-44.0970923479733,"f":-94.48510738823154};
                 // Manually invert and apply the affine transform
                 // Since we only use translate and scale, we can directly compute:
                 // x' = (x - tx) / sx

--- a/tests/features/pipeline7-srj18-sample006-iteration-budget.test.ts
+++ b/tests/features/pipeline7-srj18-sample006-iteration-budget.test.ts
@@ -26,7 +26,7 @@ const getConnectionGraphics = (
   }
 }
 
-test("repro: six-layer SRJ18 sample006 exhausts tiny-hypergraph iterations", async (): Promise<void> => {
+test("six-layer SRJ18 sample006 routes with a scaled tiny-hypergraph budget", async (): Promise<void> => {
   const { scenario } = await loadScenarioBySampleNumber("srj18", 6)
   const solver = new AutoroutingPipelineSolver7_MultiGraph(scenario, {
     cacheProvider: null,
@@ -44,10 +44,8 @@ test("repro: six-layer SRJ18 sample006 exhausts tiny-hypergraph iterations", asy
 
   expect(scenario.layerCount).toBe(6)
   expect(scenario.connections).toHaveLength(290)
-  expect(solver.portPointPathingSolver?.solved).toBe(false)
-  expect(solver.portPointPathingSolver?.failed).toBe(true)
-  expect(solver.portPointPathingSolver?.error).toContain(
-    "ran out of iterations",
-  )
+  expect(solver.portPointPathingSolver?.solved).toBe(true)
+  expect(solver.portPointPathingSolver?.failed).toBe(false)
+  expect(solver.portPointPathingSolver?.error).toBeNull()
   expect(getConnectionGraphics(solver)).toMatchGraphicsSvg(import.meta.path)
 })


### PR DESCRIPTION
## What

- Scales the tiny-hypergraph solve and section iteration caps once the serialized graph exceeds the existing 180-connection prepass boundary.
- Converts the real six-layer SRJ18 sample006 reproduction from an expected timeout into a successful port-point solve.
- Updates the focused SVG snapshot from a single unresolved airwire to the actual routed path, including its `z0`/`z4` layer transitions.

## Why

This is PR 2 of the stack on top of #1903. On the same real board and effort, current main stops at 1,400,000 solve iterations with 42 routes missing. The size-aware cap allows the solver to complete at 1,983,338 port-point iterations.

## Impact

- Problems at or below 180 serialized connections retain their existing budget.
- Larger boards receive work proportional to connection count instead of inheriting a small-board ceiling.
- The proof is behavioral and visual: the same previously missing net has a complete multilayer route in the SVG diff.

## Root cause

Both tiny-hypergraph iteration caps multiplied fixed constants by `effort` only. Once a board exceeded the point where the duplicate-congested-port prepass is skipped, its size was not represented in the solver work budget.

## Checks

- `bun test tests/features/pipeline7-srj18-sample006-iteration-budget.test.ts --timeout 9999999` (passes without snapshot-update mode in about 70 seconds)
- `bun run build`

## Stack

Base reproduction: #1903