### PR TITLE
Forward trace clearance to differential pair length matching

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -772,6 +772,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
             obstacles: cms.srj.obstacles,
             bounds: cms.srj.bounds,
             layerCount: cms.srj.layerCount,
+            obstacleMargin: cms.srj.minTraceToPadEdgeClearance ?? 0.15,
             allowViaInPad: cms.originalSrj.allowViaInPad ?? false,
           },
         ]

--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/differential-pair-post-processing-solver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/differential-pair-post-processing-solver.ts
@@ -7,6 +7,10 @@ import {
 import type { GraphicsObject } from "graphics-debug"
 import { BaseSolver } from "../../solvers/BaseSolver"
 
+type DifferentialPairPostProcessingSolverParams = PostProcessingSolverParams & {
+  obstacleMargin?: number
+}
+
 /** Applies the post-processing algorithm implied by each pair's constraints. */
 export class DifferentialPairPostProcessingSolver extends BaseSolver {
   readonly lengthMatchingSolver?: LengthMatchingSolver
@@ -16,7 +20,9 @@ export class DifferentialPairPostProcessingSolver extends BaseSolver {
   private phase: "length-matching" | "coupled-rerouting" | "complete"
   private outputHdRoutes?: PostProcessingSolverParams["hdRoutes"]
 
-  constructor(public readonly inputProblem: PostProcessingSolverParams) {
+  constructor(
+    public readonly inputProblem: DifferentialPairPostProcessingSolverParams,
+  ) {
     super()
     this.lengthOnlyPairs = inputProblem.differentialPairs.filter(
       (pair) =>
@@ -61,10 +67,7 @@ export class DifferentialPairPostProcessingSolver extends BaseSolver {
         obstacles: inputProblem.obstacles,
         bounds: inputProblem.bounds,
         layerCount: inputProblem.layerCount,
-        obstacleMargin: Math.max(
-          0,
-          ...inputProblem.hdRoutes.map((route) => route.traceThickness),
-        ),
+        obstacleMargin: inputProblem.obstacleMargin,
       })
       this.phase = "length-matching"
       this.MAX_ITERATIONS = this.lengthMatchingSolver.MAX_ITERATIONS + 2
@@ -125,7 +128,9 @@ export class DifferentialPairPostProcessingSolver extends BaseSolver {
     }
   }
 
-  override getConstructorParams(): [PostProcessingSolverParams] {
+  override getConstructorParams(): [
+    DifferentialPairPostProcessingSolverParams,
+  ] {
     return [this.inputProblem]
   }
 

--- a/tests/pipeline7-post-processing-before-power-expansion.test.ts
+++ b/tests/pipeline7-post-processing-before-power-expansion.test.ts
@@ -5,6 +5,7 @@ test("Pipeline7 runs post-processing before default power expansion", () => {
   const solver = new AutoroutingPipelineSolver7_MultiGraph({
     layerCount: 2,
     minTraceWidth: 0.15,
+    minTraceToPadEdgeClearance: 0.1,
     minViaPadDiameter: 0.3,
     bounds: { minX: 0, minY: 0, maxX: 20, maxY: 10 },
     obstacles: [],
@@ -91,9 +92,11 @@ test("Pipeline7 runs post-processing before default power expansion", () => {
       "differentialPairs",
       "hdRoutes",
       "layerCount",
+      "obstacleMargin",
       "obstacles",
     ].sort(),
   )
+  expect(lengthMatchingPostProcessingParams.obstacleMargin).toBe(0.1)
   expect(lengthMatchingPostProcessingParams.differentialPairs).toEqual([
     {
       connectionNames: ["PAIR_P_mst0", "PAIR_N_mst0"],

--- a/tests/pipeline7-post-processing-mixed-connection-length-matching.test.ts
+++ b/tests/pipeline7-post-processing-mixed-connection-length-matching.test.ts
@@ -1,0 +1,159 @@
+import { expect, test } from "bun:test"
+import { DifferentialPairPostProcessingSolver } from "lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/differential-pair-post-processing-solver"
+
+const getRouteLength = (route: Array<{ x: number; y: number }>): number => {
+  let length = 0
+  for (let index = 1; index < route.length; index++) {
+    const previous = route[index - 1]!
+    const point = route[index]!
+    length += Math.hypot(point.x - previous.x, point.y - previous.y)
+  }
+  return length
+}
+
+test("Pipeline7 length matches the mixed-selector Core fixture", () => {
+  const createPad = (
+    x: number,
+    y: number,
+    connectedTo: string[] = [],
+  ) => ({
+    type: "rect" as const,
+    layers: ["top"],
+    center: { x, y },
+    width: 0.54,
+    height: 0.64,
+    connectedTo,
+  })
+  const params = {
+    hdRoutes: [
+      {
+        connectionName: "source_trace_1",
+        rootConnectionName: "source_trace_1",
+        traceThickness: 0.15,
+        viaDiameter: 0.3,
+        route: [
+          {
+            x: 5.49,
+            y: 2,
+            z: 0,
+            traceThickness: 0.15,
+            pcb_port_id: "pcb_port_6",
+          },
+          {
+            x: 4.959882004456018,
+            y: 1.4698820044560181,
+            z: 0,
+            traceThickness: 0.15,
+          },
+          {
+            x: -3.979882004456018,
+            y: 1.4698820044560181,
+            z: 0,
+            traceThickness: 0.15,
+          },
+          {
+            x: -3.979882004456018,
+            y: 1.4698820044560184,
+            z: 0,
+            traceThickness: 0.15,
+          },
+          {
+            x: -4.51,
+            y: 2,
+            z: 0,
+            traceThickness: 0.15,
+            pcb_port_id: "pcb_port_2",
+          },
+        ],
+        vias: [],
+        jumpers: [],
+      },
+      {
+        connectionName: "source_trace_0",
+        rootConnectionName: "source_trace_0",
+        traceThickness: 0.15,
+        viaDiameter: 0.3,
+        route: [
+          {
+            x: 5.49,
+            y: -2,
+            z: 0,
+            traceThickness: 0.15,
+            pcb_port_id: "pcb_port_4",
+          },
+          {
+            x: 4.929664934965422,
+            y: -1.4396649349654222,
+            z: 0,
+            traceThickness: 0.15,
+          },
+          {
+            x: -5.949664934965422,
+            y: -1.4396649349654222,
+            z: 0,
+            traceThickness: 0.15,
+          },
+          {
+            x: -5.949664934965422,
+            y: -1.4396649349654222,
+            z: 0,
+            traceThickness: 0.15,
+          },
+          {
+            x: -6.51,
+            y: -2,
+            z: 0,
+            traceThickness: 0.15,
+            pcb_port_id: "pcb_port_0",
+          },
+        ],
+        vias: [],
+        jumpers: [],
+      },
+    ],
+    differentialPairs: [
+      {
+        connectionNames: ["source_trace_0", "source_trace_1"] as [
+          string,
+          string,
+        ],
+        lengthTolerance: 0.05,
+      },
+    ],
+    obstacles: [
+      createPad(-6.51, -2, ["source_trace_0"]),
+      createPad(-5.49, -2),
+      createPad(-4.51, 2, ["source_trace_1"]),
+      createPad(-3.49, 2),
+      createPad(5.49, -2, ["source_trace_0"]),
+      createPad(6.51, -2),
+      createPad(5.49, 2, ["source_trace_1"]),
+      createPad(6.51, 2),
+    ],
+    bounds: { minX: -10, maxX: 10, minY: -5, maxY: 5 },
+    layerCount: 2,
+    obstacleMargin: 0.1,
+  }
+  const originalRoutes = structuredClone(params.hdRoutes)
+  const solver = new DifferentialPairPostProcessingSolver(params)
+
+  solver.solve()
+
+  expect(solver.failed).toBe(false)
+  expect(solver.solved).toBe(true)
+  const outputRoutes = solver.getOutput().hdRoutes
+  const routesByName = new Map(
+    outputRoutes.map((route) => [route.connectionName, route]),
+  )
+  const first = routesByName.get("source_trace_0")!
+  const second = routesByName.get("source_trace_1")!
+
+  expect(first.route[0]).toEqual(originalRoutes[1]!.route[0])
+  expect(first.route.at(-1)).toEqual(originalRoutes[1]!.route.at(-1))
+  expect(second.route[0]).toEqual(originalRoutes[0]!.route[0])
+  expect(second.route.at(-1)).toEqual(originalRoutes[0]!.route.at(-1))
+  expect(
+    Math.abs(getRouteLength(first.route) - getRouteLength(second.route)),
+  ).toBeLessThanOrEqual(0.05)
+  expect(outputRoutes).not.toEqual(originalRoutes)
+})

--- a/tests/pipeline7-post-processing-mixed-connection-length-matching.test.ts
+++ b/tests/pipeline7-post-processing-mixed-connection-length-matching.test.ts
@@ -12,11 +12,7 @@ const getRouteLength = (route: Array<{ x: number; y: number }>): number => {
 }
 
 test("Pipeline7 length matches the mixed-selector Core fixture", () => {
-  const createPad = (
-    x: number,
-    y: number,
-    connectedTo: string[] = [],
-  ) => ({
+  const createPad = (x: number, y: number, connectedTo: string[] = []) => ({
     type: "rect" as const,
     layers: ["top"],
     center: { x, y },


### PR DESCRIPTION
## Summary

- forward Pipeline 7's `minTraceToPadEdgeClearance` into differential-pair length matching
- stop substituting trace width for the board's requested pad-clearance rule
- add a Core-derived reproduction that preserves all endpoints and matches skew within 0.05 mm

## Root cause

The Pipeline 7 adapter discarded the SRJ board clearance and passed the maximum routed trace width as `obstacleMargin`. In Core's mixed-selector differential-pair fixture, the routed trace has 0.135 mm edge clearance from a neighboring pad, which satisfies the board's 0.1 mm rule but not the substituted 0.15 mm value. The length matcher therefore rejected every candidate and surfaced an exhaustion error.

## Validation

- `bun test tests/pipeline7-post-processing-mixed-connection-length-matching.test.ts --timeout 9999999`
- `bun test tests/pipeline7-post-processing-asymmetric-terminals.test.ts --timeout 9999999`
- `bunx tsc --noEmit`
- `bun run build`
- linked Core mixed-selector, exact routing-phase, and QFP pin-topology tests pass (with the mixed-selector snapshot updated to show the restored meander)
