### PR TITLE
Resolve bugreport 80 dual meanders

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@tscircuit/hypergraph": "^0.0.71",
     "@tscircuit/jumper-topology-generator": "^0.0.4",
     "@tscircuit/krt-wasm": "^0.1.0",
-    "@tscircuit/length-matching-solver": "git+https://github.com/tscircuit/length-matching-solver.git#8a18980f652ac75718a7a9e3d64760514604bdad",
+    "@tscircuit/length-matching-solver": "git+https://github.com/tscircuit/length-matching-solver.git#6c8731d6466436a8b4a818e09665eb2b2262dc5a",
     "@tscircuit/math-utils": "^0.0.36",
     "@tscircuit/power-trace-expander": "git+https://github.com/tscircuit/power-trace-expander.git#2ebc65792485c6154c237204abd75a5ea0c52be0",
     "@tscircuit/rectdiff": "git+https://github.com/tscircuit/rectdiff.git#ba0f5e0356fa95572c44b2c5539b1a159bd6c7b6",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@tscircuit/hypergraph": "^0.0.71",
     "@tscircuit/jumper-topology-generator": "^0.0.4",
     "@tscircuit/krt-wasm": "^0.1.0",
-    "@tscircuit/length-matching-solver": "git+https://github.com/tscircuit/length-matching-solver.git#c1575da7944fedd9eb8dd0b3e5aeeaa7ed443b41",
+    "@tscircuit/length-matching-solver": "git+https://github.com/tscircuit/length-matching-solver.git#84a4088b958ecdf8e6665abd11b37e30398a9216",
     "@tscircuit/math-utils": "^0.0.36",
     "@tscircuit/power-trace-expander": "git+https://github.com/tscircuit/power-trace-expander.git#2ebc65792485c6154c237204abd75a5ea0c52be0",
     "@tscircuit/rectdiff": "git+https://github.com/tscircuit/rectdiff.git#ba0f5e0356fa95572c44b2c5539b1a159bd6c7b6",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@tscircuit/hypergraph": "^0.0.71",
     "@tscircuit/jumper-topology-generator": "^0.0.4",
     "@tscircuit/krt-wasm": "^0.1.0",
-    "@tscircuit/length-matching-solver": "git+https://github.com/tscircuit/length-matching-solver.git#84a4088b958ecdf8e6665abd11b37e30398a9216",
+    "@tscircuit/length-matching-solver": "git+https://github.com/tscircuit/length-matching-solver.git#8a18980f652ac75718a7a9e3d64760514604bdad",
     "@tscircuit/math-utils": "^0.0.36",
     "@tscircuit/power-trace-expander": "git+https://github.com/tscircuit/power-trace-expander.git#2ebc65792485c6154c237204abd75a5ea0c52be0",
     "@tscircuit/rectdiff": "git+https://github.com/tscircuit/rectdiff.git#ba0f5e0356fa95572c44b2c5539b1a159bd6c7b6",

--- a/tests/bugs/bugreport80-75ab58.test.ts
+++ b/tests/bugs/bugreport80-75ab58.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test"
 import { AutoroutingPipelineSolver } from "lib"
 import type { SimpleRouteJson } from "lib/types"
+import { getLastStepSvg } from "../fixtures/getLastStepSvg"
 import bugReport from "../../fixtures/bug-reports/bugreport80-75ab58/bugreport80-75ab58.json" with {
   type: "json",
 }
@@ -12,5 +13,7 @@ test("bugreport80-75ab58.json", () => {
   solver.solve()
 
   expect(solver.failed).toBe(false)
-  expect(solver.visualize()).toMatchGraphicsSvg(import.meta.path)
+  expect(getLastStepSvg(solver.visualize())).toMatchSvgSnapshot(
+    import.meta.path,
+  )
 })

--- a/tests/bugs/bugreport80-75ab58.test.ts
+++ b/tests/bugs/bugreport80-75ab58.test.ts
@@ -9,7 +9,8 @@ const srj = bugReport.simple_route_json as SimpleRouteJson
 
 test("bugreport80-75ab58.json", () => {
   const solver = new AutoroutingPipelineSolver(srj)
-  expect(() => solver.solve()).toThrow(
-    'LengthMatchingSolver: no same-layer straight segment can tune connection "source_trace_13"',
-  )
+  solver.solve()
+
+  expect(solver.failed).toBe(false)
+  expect(solver.visualize()).toMatchGraphicsSvg(import.meta.path)
 })


### PR DESCRIPTION
## Summary

- pin the length-matching solver fix from tscircuit/length-matching-solver#38
- convert bugreport 80 from an expected exception into a successful routing regression
- snapshot the completed solver visualization

## Root cause

The short differential-pair routes had no eligible one-tooth candidates, and rounded meander geometry was subsequently rejected when it briefly overlapped its own connected terminal pads. The dependency fix admits the physical one-tooth footprint and treats only endpoint-containing connected obstacles as terminal copper.

## Validation

- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/bugs/bugreport80-75ab58.test.ts --timeout 9999999`
- generated solver visualization inspected as PNG

Depends on https://github.com/tscircuit/length-matching-solver/pull/38