### PR TITLE
Add autorouter benchmark dashboard link

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,3 +179,7 @@ bun test
 # Build the library
 bun run build
 ```
+
+## Maintainer resources
+
+Track routing performance and benchmark results in the [Autorouter Benchmark Dashboard](https://autorouter-benchmark-dashboard.vercel.app/).


### PR DESCRIPTION
## Summary

- add a small maintainer resources section to the README
- link the Autorouter Benchmark Dashboard for tracking routing performance and benchmark results

## Why

The repository did not expose the benchmark dashboard in its maintainer or development documentation. The README is the best location because the only internal documentation files are agent-specific instruction files (`AGENTS.md` and `CLAUDE.md`).

## Impact

Maintainers and contributors can discover benchmark results directly from the repository documentation. There is no runtime or package behavior change.

## Validation

- confirmed the dashboard returns HTTP 200
- ran `git diff --check`
- tests not run (documentation-only change)