### PR TITLE
Reduce Final-Route Vias with Transactional DRC-Safe Layer Collapsing

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -797,8 +797,8 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
         }
         return [
           {
-            hdRoutes: cms.lengthMatchingPostProcessingSolver!.getOutput()
-              .hdRoutes,
+            hdRoutes:
+              cms.lengthMatchingPostProcessingSolver!.getOutput().hdRoutes,
             originalSrj: cms.originalSrj,
             obstacles: cms.srj.obstacles,
             layerCount: cms.srj.layerCount,

--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -65,11 +65,13 @@ import { SingleLayerNodeMergerSolver } from "../../solvers/SingleLayerNodeMerger
 import { StrawSolver } from "../../solvers/StrawSolver/StrawSolver"
 import { TraceSimplificationSolver } from "../../solvers/TraceSimplificationSolver/TraceSimplificationSolver"
 import { TraceWidthSolver } from "../../solvers/TraceWidthSolver/TraceWidthSolver"
+import { FinalViaOptimizationSolver } from "../../solvers/FinalViaOptimizationSolver/FinalViaOptimizationSolver"
 import { PreprocessSimpleRouteJsonSolver } from "../AutoroutingPipeline4_TinyHypergraph/PreprocessSimpleRouteJsonSolver"
 import { MergedComponentTopologyView } from "./MergedComponentTopologyView"
 import { PowerTraceExpansionSolver } from "./PowerTraceExpansionSolver"
 import { convertPipeline7HdRoutesToSimplifiedPcbTraces } from "./convertPipeline7HdRoutesToSimplifiedPcbTraces"
 import { createPipeline7AutoroutingDrcEvaluator } from "./create-pipeline7-autorouting-drc-evaluator"
+import { createPipeline7RelaxedDrcEvaluator } from "./create-pipeline7-relaxed-drc-evaluator"
 import { DifferentialPairPostProcessingSolver } from "./differential-pair-post-processing-solver"
 import { getPowerTraceExpansionConnectionNames } from "./getPowerTraceExpansionConnectionNames"
 import { lockHdRouteTerminals } from "./lock-hd-route-terminals"
@@ -231,6 +233,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
   deadEndSolver?: DeadEndSolver
   traceSimplificationSolver?: TraceSimplificationSolver
   lengthMatchingPostProcessingSolver?: DifferentialPairPostProcessingSolver
+  finalViaOptimizationSolver?: FinalViaOptimizationSolver
   powerTraceExpansionSolver?: PowerTraceExpansionSolver
   availableSegmentPointSolver?: AvailableSegmentPointSolver
   portPointPathingSolver?: TinyHypergraphPortPointPathingSolver
@@ -779,6 +782,41 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
       },
     ),
     definePipelineStep(
+      "finalViaOptimizationSolver",
+      FinalViaOptimizationSolver,
+      (cms) => {
+        const conversionOptions = {
+          connections: cms.netToPointPairsSolver?.newConnections ?? [],
+          originalConnections: cms.originalSrj.connections,
+          layerCount: cms.srj.layerCount,
+          obstacles: cms.srj.obstacles,
+          defaultViaHoleDiameter: cms.viaHoleDiameter,
+          connMap: cms.connMap,
+          srjWithPointPairs: cms.srjWithPointPairs!,
+          originalSrj: cms.originalSrj,
+        }
+        return [
+          {
+            hdRoutes: cms.lengthMatchingPostProcessingSolver!.getOutput()
+              .hdRoutes,
+            originalSrj: cms.originalSrj,
+            obstacles: cms.srj.obstacles,
+            layerCount: cms.srj.layerCount,
+            connMap: cms.connMap,
+            convert: (hdRoutes: HighDensityRoute[]) =>
+              convertPipeline7HdRoutesToSimplifiedPcbTraces({
+                ...conversionOptions,
+                hdRoutes,
+              }),
+            productionDrcEvaluator:
+              createPipeline7AutoroutingDrcEvaluator(conversionOptions),
+            relaxedDrcEvaluator:
+              createPipeline7RelaxedDrcEvaluator(conversionOptions),
+          },
+        ]
+      },
+    ),
+    definePipelineStep(
       "powerTraceExpansionSolver",
       PowerTraceExpansionSolver,
       (cms) => {
@@ -889,6 +927,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
     this.activeSubSolver = new pipelineStepDef.solverClass(...constructorParams)
     if (
       pipelineStepDef.solverName === "lengthMatchingPostProcessingSolver" ||
+      pipelineStepDef.solverName === "finalViaOptimizationSolver" ||
       pipelineStepDef.solverName === "powerTraceExpansionSolver"
     )
       this.MAX_ITERATIONS = Math.max(
@@ -1145,6 +1184,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
 
   _getOutputHdRoutes(): HighDensityRoute[] {
     return (
+      this.finalViaOptimizationSolver?.getOutput() ??
       this.lengthMatchingPostProcessingSolver?.getOutput().hdRoutes ??
       this.exactGeometryDrcForceImproveSolver?.getOutput() ??
       this.globalDrcForceImproveSolver?.getOutput() ??

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph.ts
@@ -65,12 +65,14 @@ import { SingleLayerNodeMergerSolver } from "../../solvers/SingleLayerNodeMerger
 import { StrawSolver } from "../../solvers/StrawSolver/StrawSolver"
 import { TraceSimplificationSolver } from "../../solvers/TraceSimplificationSolver/TraceSimplificationSolver"
 import { TraceWidthSolver } from "../../solvers/TraceWidthSolver/TraceWidthSolver"
+import { FinalViaOptimizationSolver } from "../../solvers/FinalViaOptimizationSolver/FinalViaOptimizationSolver"
 import { convertPreloadedTraceToHdRoutes } from "./convert-preloaded-traces-to-hd-routes"
 import { PreloadedTraceGraphSolver } from "./preloaded-trace-graph-solver"
 import { PreprocessSimpleRouteJsonWithoutTraceObstaclesSolver } from "./preprocess-simple-route-json-without-trace-obstacles-solver"
 import { MergedComponentTopologyView } from "../AutoroutingPipeline7_MultiGraph/MergedComponentTopologyView"
 import { convertPipeline7HdRoutesToSimplifiedPcbTraces } from "../AutoroutingPipeline7_MultiGraph/convertPipeline7HdRoutesToSimplifiedPcbTraces"
 import { createPipeline7RelaxedDrcEvaluator } from "../AutoroutingPipeline7_MultiGraph/create-pipeline7-relaxed-drc-evaluator"
+import { createPipeline7AutoroutingDrcEvaluator } from "../AutoroutingPipeline7_MultiGraph/create-pipeline7-autorouting-drc-evaluator"
 import { lockHdRouteTerminals } from "../AutoroutingPipeline7_MultiGraph/lock-hd-route-terminals"
 
 interface CapacityMeshSolverOptions {
@@ -233,6 +235,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
   deadEndSolver?: DeadEndSolver
   traceSimplificationSolver?: TraceSimplificationSolver
   lengthMatchingPostProcessingSolver?: PostProcessingSolver
+  finalViaOptimizationSolver?: FinalViaOptimizationSolver
   availableSegmentPointSolver?: AvailableSegmentPointSolver
   portPointPathingSolver?: TinyHypergraphPortPointPathingSolver
   multiSectionPortPointOptimizer?: MultiSectionPortPointOptimizer
@@ -775,6 +778,41 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
         ]
       },
     ),
+    definePipelineStep(
+      "finalViaOptimizationSolver",
+      FinalViaOptimizationSolver,
+      (cms) => {
+        const conversionOptions = {
+          connections: cms.netToPointPairsSolver?.newConnections ?? [],
+          originalConnections: cms.originalSrj.connections,
+          layerCount: cms.srj.layerCount,
+          obstacles: cms.srj.obstacles,
+          defaultViaHoleDiameter: cms.viaHoleDiameter,
+          connMap: cms.connMap,
+          srjWithPointPairs: cms.srjWithPointPairs!,
+          originalSrj: cms.originalSrj,
+        }
+        return [
+          {
+            hdRoutes:
+              cms.lengthMatchingPostProcessingSolver!.getOutput().hdRoutes,
+            originalSrj: cms.originalSrj,
+            obstacles: cms.srj.obstacles,
+            layerCount: cms.srj.layerCount,
+            connMap: cms.connMap,
+            convert: (hdRoutes: HighDensityRoute[]) =>
+              convertPipeline7HdRoutesToSimplifiedPcbTraces({
+                ...conversionOptions,
+                hdRoutes,
+              }),
+            productionDrcEvaluator:
+              createPipeline7AutoroutingDrcEvaluator(conversionOptions),
+            relaxedDrcEvaluator:
+              createPipeline7RelaxedDrcEvaluator(conversionOptions),
+          },
+        ]
+      },
+    ),
   ]
 
   constructor(
@@ -862,7 +900,10 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
     const constructorParams = pipelineStepDef.getConstructorParams(this)
     // @ts-ignore
     this.activeSubSolver = new pipelineStepDef.solverClass(...constructorParams)
-    if (pipelineStepDef.solverName === "lengthMatchingPostProcessingSolver")
+    if (
+      pipelineStepDef.solverName === "lengthMatchingPostProcessingSolver" ||
+      pipelineStepDef.solverName === "finalViaOptimizationSolver"
+    )
       this.MAX_ITERATIONS = Math.max(
         this.MAX_ITERATIONS,
         this.iterations + this.activeSubSolver.MAX_ITERATIONS + 1,
@@ -1117,6 +1158,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
 
   _getOutputHdRoutes(): HighDensityRoute[] {
     return (
+      this.finalViaOptimizationSolver?.getOutput() ??
       this.lengthMatchingPostProcessingSolver?.getOutput().hdRoutes ??
       this.exactGeometryDrcForceImproveSolver?.getOutput() ??
       this.globalDrcForceImproveSolver?.getOutput() ??

--- a/lib/solvers/FinalViaOptimizationSolver/FinalViaOptimizationSolver.ts
+++ b/lib/solvers/FinalViaOptimizationSolver/FinalViaOptimizationSolver.ts
@@ -14,6 +14,10 @@ import { getProtectedConnectionNames } from "./get-protected-connection-names"
 import { getSameLayerSpanCollapseCandidates } from "./try-collapse-same-layer-span"
 
 const MAX_CANDIDATE_ATTEMPTS = 32
+// Geometry-only discovery must also be bounded: some pathological boards have
+// thousands of post-processed routes. Routes with the most layer transitions
+// are scanned first, so this limit preserves the highest-value opportunities.
+const MAX_INITIAL_ROUTE_SCANS = 512
 
 type PendingCandidate = {
   connectionName: string
@@ -91,6 +95,7 @@ export class FinalViaOptimizationSolver extends BaseSolver {
   private readonly acceptedRouteRescanQueue: string[] = []
   private readonly protectedConnectionNames: Set<string>
   private readonly obstacleSHI: ObstacleSpatialHashIndex
+  private hdRouteSHI: HighDensityRouteSpatialIndex
   private initialRouteScanIndex = 0
   private candidateEvaluations = 0
   private quality: RouteQualitySnapshot
@@ -117,9 +122,14 @@ export class FinalViaOptimizationSolver extends BaseSolver {
       "flatbush",
       createObjectsWithZLayers(input.obstacles, input.layerCount),
     )
+    this.hdRouteSHI = new HighDensityRouteSpatialIndex(this.hdRoutes)
     this.eligibleConnectionNames = this.hdRoutes
       .filter(
         (route) =>
+          route.route.filter(
+            (point, index) =>
+              index > 0 && point.z !== route.route[index - 1]!.z,
+          ).length >= 2 &&
           !isProtectedRoute(
             route,
             this.protectedConnectionNames,
@@ -127,8 +137,17 @@ export class FinalViaOptimizationSolver extends BaseSolver {
             input.connMap,
           ),
       )
+      .sort((a, b) => {
+        const transitionCount = (route: HighDensityRoute) =>
+          route.route.filter(
+            (point, index) =>
+              index > 0 && point.z !== route.route[index - 1]!.z,
+          ).length
+        const transitionDelta = transitionCount(b) - transitionCount(a)
+        if (transitionDelta !== 0) return transitionDelta
+        return a.connectionName.localeCompare(b.connectionName)
+      })
       .map((route) => route.connectionName)
-      .sort()
     this.quality = createRouteQualitySnapshot({
       hdRoutes: this.hdRoutes,
       srj: input.originalSrj,
@@ -144,6 +163,7 @@ export class FinalViaOptimizationSolver extends BaseSolver {
       scannedEligibleRouteCount: 0,
       rescannedAcceptedRouteCount: 0,
       candidateEvaluationBudget: MAX_CANDIDATE_ATTEMPTS,
+      initialRouteScanBudget: MAX_INITIAL_ROUTE_SCANS,
       candidateEvaluationCount: 0,
       acceptedCandidateCount: 0,
       rejectedByCollisionCount: 0,
@@ -168,7 +188,7 @@ export class FinalViaOptimizationSolver extends BaseSolver {
       throw new Error("FinalViaOptimizationSolver route index is invalid")
     const candidates = getSameLayerSpanCollapseCandidates({
       route: structuredClone(route),
-      hdRouteSHI: new HighDensityRouteSpatialIndex(this.hdRoutes),
+      hdRouteSHI: this.hdRouteSHI,
       obstacleSHI: this.obstacleSHI,
       connMap: this.input.connMap,
       outline: this.input.originalSrj.outline,
@@ -272,7 +292,10 @@ export class FinalViaOptimizationSolver extends BaseSolver {
   }
 
   _step(): void {
-    if (this.initialRouteScanIndex < this.eligibleConnectionNames.length) {
+    if (
+      this.initialRouteScanIndex < this.eligibleConnectionNames.length &&
+      this.initialRouteScanIndex < MAX_INITIAL_ROUTE_SCANS
+    ) {
       const connectionName =
         this.eligibleConnectionNames[this.initialRouteScanIndex++]!
       this.scanRoute(connectionName, false)
@@ -349,6 +372,9 @@ export class FinalViaOptimizationSolver extends BaseSolver {
     }
 
     this.hdRoutes = candidateRoutes
+    // The collision index is immutable, so refresh it only after an accepted
+    // mutation (at most MAX_CANDIDATE_ATTEMPTS times), never once per scan.
+    this.hdRouteSHI = new HighDensityRouteSpatialIndex(this.hdRoutes)
     this.quality = candidateQuality
     this.stats.acceptedCandidateCount++
     this.removeStaleCandidates(candidate.connectionName)

--- a/lib/solvers/FinalViaOptimizationSolver/FinalViaOptimizationSolver.ts
+++ b/lib/solvers/FinalViaOptimizationSolver/FinalViaOptimizationSolver.ts
@@ -8,7 +8,7 @@ import type { HighDensityRoute } from "lib/types/high-density-types"
 import { createObjectsWithZLayers } from "lib/utils/createObjectsWithZLayers"
 import { createRouteQualitySnapshot, type RouteQualitySnapshot } from "./create-route-quality-snapshot"
 import { getProtectedConnectionNames } from "./get-protected-connection-names"
-import { tryCollapseSameLayerSpan } from "./try-collapse-same-layer-span"
+import { getSameLayerSpanCollapseCandidates } from "./try-collapse-same-layer-span"
 
 const MAX_CANDIDATE_ATTEMPTS = 32
 
@@ -79,10 +79,10 @@ export class FinalViaOptimizationSolver extends BaseSolver {
   }
 
   hdRoutes: HighDensityRoute[]
-  private readonly candidateConnectionNames: string[]
+  private readonly candidateConnectionQueue: string[]
+  private readonly rejectedCandidateKeys = new Map<string, Set<string>>()
   private readonly protectedConnectionNames: Set<string>
   private readonly obstacleSHI: ObstacleSpatialHashIndex
-  private candidateIndex = 0
   private attempts = 0
   private quality: RouteQualitySnapshot
 
@@ -108,7 +108,7 @@ export class FinalViaOptimizationSolver extends BaseSolver {
       "flatbush",
       createObjectsWithZLayers(input.obstacles, input.layerCount),
     )
-    this.candidateConnectionNames = this.hdRoutes
+    this.candidateConnectionQueue = this.hdRoutes
       .filter(
         (route) =>
           !isProtectedRoute(
@@ -141,21 +141,45 @@ export class FinalViaOptimizationSolver extends BaseSolver {
     }
   }
 
-  private getCandidateRoutes(routeIndex: number): HighDensityRoute[] | null {
+  private getCandidateRoutes(
+    routeIndex: number,
+  ): Array<{ routes: HighDensityRoute[]; key: string }> {
     const route = this.hdRoutes[routeIndex]
     if (!route)
       throw new Error("FinalViaOptimizationSolver route index is invalid")
-    const candidateRoute = tryCollapseSameLayerSpan({
+    const rejectedKeys = this.rejectedCandidateKeys.get(route.connectionName)
+    const candidates = getSameLayerSpanCollapseCandidates({
       route: structuredClone(route),
       hdRouteSHI: new HighDensityRouteSpatialIndex(this.hdRoutes),
       obstacleSHI: this.obstacleSHI,
       connMap: this.input.connMap,
       outline: this.input.originalSrj.outline,
     })
-    if (!candidateRoute) return null
-    const candidateRoutes = structuredClone(this.hdRoutes)
-    candidateRoutes[routeIndex] = candidateRoute
-    return candidateRoutes
+    return candidates
+      .map(({ route: candidateRoute }) => {
+        const routes = structuredClone(this.hdRoutes)
+        routes[routeIndex] = candidateRoute
+        return {
+          routes,
+          key: candidateRoute.route
+            .map((point) => `${point.x}:${point.y}:${point.z}`)
+            .join("|"),
+        }
+      })
+      .filter(({ key }) => !rejectedKeys?.has(key))
+  }
+
+  private queueAnotherCandidate(connectionName: string): void {
+    if (!this.candidateConnectionQueue.includes(connectionName)) {
+      this.candidateConnectionQueue.push(connectionName)
+    }
+  }
+
+  private rejectCandidate(connectionName: string, key: string): void {
+    const rejectedKeys = this.rejectedCandidateKeys.get(connectionName)
+    if (rejectedKeys) rejectedKeys.add(key)
+    else this.rejectedCandidateKeys.set(connectionName, new Set([key]))
+    this.queueAnotherCandidate(connectionName)
   }
 
   private hasValidRollbackInvariant(candidateRoutes: HighDensityRoute[]): boolean {
@@ -177,7 +201,7 @@ export class FinalViaOptimizationSolver extends BaseSolver {
 
   _step(): void {
     if (
-      this.candidateIndex >= this.candidateConnectionNames.length ||
+      this.candidateConnectionQueue.length === 0 ||
       this.attempts >= MAX_CANDIDATE_ATTEMPTS
     ) {
       this.stats.finalOutputViaCount = this.quality.outputViaCount
@@ -187,7 +211,7 @@ export class FinalViaOptimizationSolver extends BaseSolver {
       return
     }
 
-    const connectionName = this.candidateConnectionNames[this.candidateIndex++]!
+    const connectionName = this.candidateConnectionQueue.shift()!
     const routeIndex = this.hdRoutes.findIndex(
       (route) => route.connectionName === connectionName,
     )
@@ -197,18 +221,32 @@ export class FinalViaOptimizationSolver extends BaseSolver {
       )
     this.attempts++
     this.stats.attemptedCandidateCount++
-    const candidateRoutes = this.getCandidateRoutes(routeIndex)
-    if (!candidateRoutes) {
+    const candidate = this.getCandidateRoutes(routeIndex)[0]
+    if (!candidate) {
       this.stats.rejectedByCollisionCount++
       return
     }
-    if (!this.hasValidRollbackInvariant(candidateRoutes)) {
+    if (!this.hasValidRollbackInvariant(candidate.routes)) {
       this.stats.rejectedByConnectivityCount++
+      this.rejectCandidate(connectionName, candidate.key)
+      return
+    }
+
+    const convertedCandidate = this.input.convert(candidate.routes)
+    const convertedCandidateViaCount = convertedCandidate.reduce(
+      (count, trace) =>
+        count +
+        trace.route.filter((segment) => segment.route_type === "via").length,
+      0,
+    )
+    if (convertedCandidateViaCount >= this.quality.outputViaCount) {
+      this.stats.rejectedByMetadataCount++
+      this.rejectCandidate(connectionName, candidate.key)
       return
     }
 
     const candidateQuality = createRouteQualitySnapshot({
-      hdRoutes: candidateRoutes,
+      hdRoutes: candidate.routes,
       convert: this.input.convert,
       productionDrcEvaluator: this.input.productionDrcEvaluator,
       relaxedDrcEvaluator: this.input.relaxedDrcEvaluator,
@@ -220,6 +258,7 @@ export class FinalViaOptimizationSolver extends BaseSolver {
         this.quality.productionDrcIssueScore
     ) {
       this.stats.rejectedByProductionDrcCount++
+      this.rejectCandidate(connectionName, candidate.key)
       return
     }
     if (
@@ -227,22 +266,27 @@ export class FinalViaOptimizationSolver extends BaseSolver {
       this.quality.relaxedDrcErrorCount
     ) {
       this.stats.rejectedByRelaxedDrcCount++
+      this.rejectCandidate(connectionName, candidate.key)
       return
     }
     if (candidateQuality.outputViaCount >= this.quality.outputViaCount) {
       this.stats.rejectedByMetadataCount++
+      this.rejectCandidate(connectionName, candidate.key)
       return
     }
     if (
       candidateQuality.totalTraceLength > this.quality.totalTraceLength + 1e-6
     ) {
       this.stats.rejectedByTraceLengthCount++
+      this.rejectCandidate(connectionName, candidate.key)
       return
     }
 
-    this.hdRoutes = candidateRoutes
+    this.hdRoutes = candidate.routes
     this.quality = candidateQuality
     this.stats.acceptedCandidateCount++
+    this.rejectedCandidateKeys.delete(connectionName)
+    this.queueAnotherCandidate(connectionName)
   }
 
   getOutput(): HighDensityRoute[] {

--- a/lib/solvers/FinalViaOptimizationSolver/FinalViaOptimizationSolver.ts
+++ b/lib/solvers/FinalViaOptimizationSolver/FinalViaOptimizationSolver.ts
@@ -1,0 +1,253 @@
+import type { DrcEvaluator } from "high-density-repair03/lib"
+import type { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { ObstacleSpatialHashIndex } from "lib/data-structures/ObstacleTree"
+import { HighDensityRouteSpatialIndex } from "lib/data-structures/HighDensityRouteSpatialIndex"
+import { BaseSolver } from "lib/solvers/BaseSolver"
+import type { Obstacle, SimpleRouteJson, SimplifiedPcbTraces } from "lib/types"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+import { createObjectsWithZLayers } from "lib/utils/createObjectsWithZLayers"
+import { createRouteQualitySnapshot, type RouteQualitySnapshot } from "./create-route-quality-snapshot"
+import { getProtectedConnectionNames } from "./get-protected-connection-names"
+import { tryCollapseSameLayerSpan } from "./try-collapse-same-layer-span"
+
+const MAX_CANDIDATE_ATTEMPTS = 32
+
+const structurallyEqual = (a: unknown, b: unknown): boolean =>
+  JSON.stringify(a) === JSON.stringify(b)
+
+const isProtectedRoute = (
+  route: HighDensityRoute,
+  protectedConnectionNames: ReadonlySet<string>,
+  obstacles: ReadonlyArray<Obstacle>,
+  connMap: ConnectivityMap,
+): boolean =>
+  protectedConnectionNames.has(route.connectionName) ||
+  protectedConnectionNames.has(route.rootConnectionName ?? "") ||
+  Boolean(route.jumpers?.length) ||
+  route.route.some(
+    (point, index) =>
+      point.insideJumperPad ||
+      point.toNextSegmentType === "through_obstacle" ||
+      (index > 0 && index < route.route.length - 1 && point.pcb_port_id),
+  ) ||
+  route.vias.some((via) =>
+    obstacles.some(
+      (obstacle) =>
+        Math.abs(via.x - obstacle.center.x) <= obstacle.width / 2 + 1e-6 &&
+        Math.abs(via.y - obstacle.center.y) <= obstacle.height / 2 + 1e-6 &&
+        obstacle.connectedTo.some(
+          (id) =>
+            id === route.connectionName ||
+            id === route.rootConnectionName ||
+            connMap.areIdsConnected(id, route.connectionName) ||
+            (route.rootConnectionName !== undefined &&
+              connMap.areIdsConnected(id, route.rootConnectionName)),
+        ),
+    ),
+  )
+
+const hasSameIdentityAndTerminals = (
+  baseline: HighDensityRoute,
+  candidate: HighDensityRoute,
+): boolean => {
+  const baselineStart = baseline.route[0]
+  const baselineEnd = baseline.route[baseline.route.length - 1]
+  const candidateStart = candidate.route[0]
+  const candidateEnd = candidate.route[candidate.route.length - 1]
+  return Boolean(
+    baselineStart &&
+      baselineEnd &&
+      candidateStart &&
+      candidateEnd &&
+      baseline.connectionName === candidate.connectionName &&
+      baseline.rootConnectionName === candidate.rootConnectionName &&
+      baseline.startPcbPortId === candidate.startPcbPortId &&
+      baseline.endPcbPortId === candidate.endPcbPortId &&
+      baselineStart.x === candidateStart.x &&
+      baselineStart.y === candidateStart.y &&
+      baselineEnd.x === candidateEnd.x &&
+      baselineEnd.y === candidateEnd.y &&
+      baselineStart.pcb_port_id === candidateStart.pcb_port_id &&
+      baselineEnd.pcb_port_id === candidateEnd.pcb_port_id,
+  )
+}
+
+/** Final, transactional via reduction after all DRC and pair post-processing. */
+export class FinalViaOptimizationSolver extends BaseSolver {
+  override getSolverName(): string {
+    return "FinalViaOptimizationSolver"
+  }
+
+  hdRoutes: HighDensityRoute[]
+  private readonly candidateConnectionNames: string[]
+  private readonly protectedConnectionNames: Set<string>
+  private readonly obstacleSHI: ObstacleSpatialHashIndex
+  private candidateIndex = 0
+  private attempts = 0
+  private quality: RouteQualitySnapshot
+
+  constructor(
+    private readonly input: {
+      hdRoutes: HighDensityRoute[]
+      originalSrj: SimpleRouteJson
+      obstacles: Obstacle[]
+      layerCount: number
+      connMap: ConnectivityMap
+      convert: (routes: HighDensityRoute[]) => SimplifiedPcbTraces
+      productionDrcEvaluator: DrcEvaluator
+      relaxedDrcEvaluator: DrcEvaluator
+    },
+  ) {
+    super()
+    this.hdRoutes = structuredClone(input.hdRoutes)
+    this.protectedConnectionNames = getProtectedConnectionNames({
+      originalSrj: input.originalSrj,
+      hdRoutes: input.hdRoutes,
+    })
+    this.obstacleSHI = new ObstacleSpatialHashIndex(
+      "flatbush",
+      createObjectsWithZLayers(input.obstacles, input.layerCount),
+    )
+    this.candidateConnectionNames = this.hdRoutes
+      .filter(
+        (route) =>
+          !isProtectedRoute(
+            route,
+            this.protectedConnectionNames,
+            input.obstacles,
+            input.connMap,
+          ),
+      )
+      .map((route) => route.connectionName)
+      .sort()
+    this.quality = createRouteQualitySnapshot({
+      hdRoutes: this.hdRoutes,
+      convert: input.convert,
+      productionDrcEvaluator: input.productionDrcEvaluator,
+      relaxedDrcEvaluator: input.relaxedDrcEvaluator,
+    })
+    this.stats = {
+      initialOutputViaCount: this.quality.outputViaCount,
+      finalOutputViaCount: this.quality.outputViaCount,
+      removedViaCount: 0,
+      attemptedCandidateCount: 0,
+      acceptedCandidateCount: 0,
+      rejectedByCollisionCount: 0,
+      rejectedByConnectivityCount: 0,
+      rejectedByMetadataCount: 0,
+      rejectedByProductionDrcCount: 0,
+      rejectedByRelaxedDrcCount: 0,
+      rejectedByTraceLengthCount: 0,
+    }
+  }
+
+  private getCandidateRoutes(routeIndex: number): HighDensityRoute[] | null {
+    const route = this.hdRoutes[routeIndex]
+    if (!route)
+      throw new Error("FinalViaOptimizationSolver route index is invalid")
+    const candidateRoute = tryCollapseSameLayerSpan({
+      route: structuredClone(route),
+      hdRouteSHI: new HighDensityRouteSpatialIndex(this.hdRoutes),
+      obstacleSHI: this.obstacleSHI,
+      connMap: this.input.connMap,
+      outline: this.input.originalSrj.outline,
+    })
+    if (!candidateRoute) return null
+    const candidateRoutes = structuredClone(this.hdRoutes)
+    candidateRoutes[routeIndex] = candidateRoute
+    return candidateRoutes
+  }
+
+  private hasValidRollbackInvariant(candidateRoutes: HighDensityRoute[]): boolean {
+    if (candidateRoutes.length !== this.hdRoutes.length) return false
+    return candidateRoutes.every((route, index) => {
+      const acceptedRoute = this.hdRoutes[index]
+      if (!acceptedRoute || !hasSameIdentityAndTerminals(acceptedRoute, route)) {
+        return false
+      }
+      return !isProtectedRoute(
+        acceptedRoute,
+        this.protectedConnectionNames,
+        this.input.obstacles,
+        this.input.connMap,
+      ) ||
+        structurallyEqual(acceptedRoute, route)
+    })
+  }
+
+  _step(): void {
+    if (
+      this.candidateIndex >= this.candidateConnectionNames.length ||
+      this.attempts >= MAX_CANDIDATE_ATTEMPTS
+    ) {
+      this.stats.finalOutputViaCount = this.quality.outputViaCount
+      this.stats.removedViaCount =
+        this.stats.initialOutputViaCount - this.quality.outputViaCount
+      this.solved = true
+      return
+    }
+
+    const connectionName = this.candidateConnectionNames[this.candidateIndex++]!
+    const routeIndex = this.hdRoutes.findIndex(
+      (route) => route.connectionName === connectionName,
+    )
+    if (routeIndex < 0)
+      throw new Error(
+        `FinalViaOptimizationSolver lost route "${connectionName}"`,
+      )
+    this.attempts++
+    this.stats.attemptedCandidateCount++
+    const candidateRoutes = this.getCandidateRoutes(routeIndex)
+    if (!candidateRoutes) {
+      this.stats.rejectedByCollisionCount++
+      return
+    }
+    if (!this.hasValidRollbackInvariant(candidateRoutes)) {
+      this.stats.rejectedByConnectivityCount++
+      return
+    }
+
+    const candidateQuality = createRouteQualitySnapshot({
+      hdRoutes: candidateRoutes,
+      convert: this.input.convert,
+      productionDrcEvaluator: this.input.productionDrcEvaluator,
+      relaxedDrcEvaluator: this.input.relaxedDrcEvaluator,
+    })
+    if (
+      candidateQuality.productionDrcErrorCount >
+        this.quality.productionDrcErrorCount ||
+      candidateQuality.productionDrcIssueScore >
+        this.quality.productionDrcIssueScore
+    ) {
+      this.stats.rejectedByProductionDrcCount++
+      return
+    }
+    if (
+      candidateQuality.relaxedDrcErrorCount >
+      this.quality.relaxedDrcErrorCount
+    ) {
+      this.stats.rejectedByRelaxedDrcCount++
+      return
+    }
+    if (candidateQuality.outputViaCount >= this.quality.outputViaCount) {
+      this.stats.rejectedByMetadataCount++
+      return
+    }
+    if (
+      candidateQuality.totalTraceLength > this.quality.totalTraceLength + 1e-6
+    ) {
+      this.stats.rejectedByTraceLengthCount++
+      return
+    }
+
+    this.hdRoutes = candidateRoutes
+    this.quality = candidateQuality
+    this.stats.acceptedCandidateCount++
+  }
+
+  getOutput(): HighDensityRoute[] {
+    if (!this.solved)
+      throw new Error("FinalViaOptimizationSolver output requested before solve")
+    return this.hdRoutes
+  }
+}

--- a/lib/solvers/FinalViaOptimizationSolver/FinalViaOptimizationSolver.ts
+++ b/lib/solvers/FinalViaOptimizationSolver/FinalViaOptimizationSolver.ts
@@ -6,11 +6,22 @@ import { BaseSolver } from "lib/solvers/BaseSolver"
 import type { Obstacle, SimpleRouteJson, SimplifiedPcbTraces } from "lib/types"
 import type { HighDensityRoute } from "lib/types/high-density-types"
 import { createObjectsWithZLayers } from "lib/utils/createObjectsWithZLayers"
-import { createRouteQualitySnapshot, type RouteQualitySnapshot } from "./create-route-quality-snapshot"
+import {
+  createRouteQualitySnapshot,
+  type RouteQualitySnapshot,
+} from "./create-route-quality-snapshot"
 import { getProtectedConnectionNames } from "./get-protected-connection-names"
 import { getSameLayerSpanCollapseCandidates } from "./try-collapse-same-layer-span"
 
 const MAX_CANDIDATE_ATTEMPTS = 32
+
+type PendingCandidate = {
+  connectionName: string
+  route: HighDensityRoute
+  key: string
+  removedTransitionCount: number
+  lengthSaved: number
+}
 
 const structurallyEqual = (a: unknown, b: unknown): boolean =>
   JSON.stringify(a) === JSON.stringify(b)
@@ -46,7 +57,7 @@ const isProtectedRoute = (
     ),
   )
 
-const hasSameIdentityAndTerminals = (
+export const hasSameIdentityAndTerminals = (
   baseline: HighDensityRoute,
   candidate: HighDensityRoute,
 ): boolean => {
@@ -63,12 +74,8 @@ const hasSameIdentityAndTerminals = (
       baseline.rootConnectionName === candidate.rootConnectionName &&
       baseline.startPcbPortId === candidate.startPcbPortId &&
       baseline.endPcbPortId === candidate.endPcbPortId &&
-      baselineStart.x === candidateStart.x &&
-      baselineStart.y === candidateStart.y &&
-      baselineEnd.x === candidateEnd.x &&
-      baselineEnd.y === candidateEnd.y &&
-      baselineStart.pcb_port_id === candidateStart.pcb_port_id &&
-      baselineEnd.pcb_port_id === candidateEnd.pcb_port_id,
+      structurallyEqual(baselineStart, candidateStart) &&
+      structurallyEqual(baselineEnd, candidateEnd),
   )
 }
 
@@ -79,11 +86,13 @@ export class FinalViaOptimizationSolver extends BaseSolver {
   }
 
   hdRoutes: HighDensityRoute[]
-  private readonly candidateConnectionQueue: string[]
-  private readonly rejectedCandidateKeys = new Map<string, Set<string>>()
+  private readonly eligibleConnectionNames: string[]
+  private readonly pendingCandidates: PendingCandidate[] = []
+  private readonly acceptedRouteRescanQueue: string[] = []
   private readonly protectedConnectionNames: Set<string>
   private readonly obstacleSHI: ObstacleSpatialHashIndex
-  private attempts = 0
+  private initialRouteScanIndex = 0
+  private candidateEvaluations = 0
   private quality: RouteQualitySnapshot
 
   constructor(
@@ -108,7 +117,7 @@ export class FinalViaOptimizationSolver extends BaseSolver {
       "flatbush",
       createObjectsWithZLayers(input.obstacles, input.layerCount),
     )
-    this.candidateConnectionQueue = this.hdRoutes
+    this.eligibleConnectionNames = this.hdRoutes
       .filter(
         (route) =>
           !isProtectedRoute(
@@ -122,6 +131,7 @@ export class FinalViaOptimizationSolver extends BaseSolver {
       .sort()
     this.quality = createRouteQualitySnapshot({
       hdRoutes: this.hdRoutes,
+      srj: input.originalSrj,
       convert: input.convert,
       productionDrcEvaluator: input.productionDrcEvaluator,
       relaxedDrcEvaluator: input.relaxedDrcEvaluator,
@@ -131,6 +141,10 @@ export class FinalViaOptimizationSolver extends BaseSolver {
       finalOutputViaCount: this.quality.outputViaCount,
       removedViaCount: 0,
       attemptedCandidateCount: 0,
+      scannedEligibleRouteCount: 0,
+      rescannedAcceptedRouteCount: 0,
+      candidateEvaluationBudget: MAX_CANDIDATE_ATTEMPTS,
+      candidateEvaluationCount: 0,
       acceptedCandidateCount: 0,
       rejectedByCollisionCount: 0,
       rejectedByConnectivityCount: 0,
@@ -141,77 +155,7 @@ export class FinalViaOptimizationSolver extends BaseSolver {
     }
   }
 
-  private getCandidateRoutes(
-    routeIndex: number,
-  ): Array<{ routes: HighDensityRoute[]; key: string }> {
-    const route = this.hdRoutes[routeIndex]
-    if (!route)
-      throw new Error("FinalViaOptimizationSolver route index is invalid")
-    const rejectedKeys = this.rejectedCandidateKeys.get(route.connectionName)
-    const candidates = getSameLayerSpanCollapseCandidates({
-      route: structuredClone(route),
-      hdRouteSHI: new HighDensityRouteSpatialIndex(this.hdRoutes),
-      obstacleSHI: this.obstacleSHI,
-      connMap: this.input.connMap,
-      outline: this.input.originalSrj.outline,
-    })
-    return candidates
-      .map(({ route: candidateRoute }) => {
-        const routes = structuredClone(this.hdRoutes)
-        routes[routeIndex] = candidateRoute
-        return {
-          routes,
-          key: candidateRoute.route
-            .map((point) => `${point.x}:${point.y}:${point.z}`)
-            .join("|"),
-        }
-      })
-      .filter(({ key }) => !rejectedKeys?.has(key))
-  }
-
-  private queueAnotherCandidate(connectionName: string): void {
-    if (!this.candidateConnectionQueue.includes(connectionName)) {
-      this.candidateConnectionQueue.push(connectionName)
-    }
-  }
-
-  private rejectCandidate(connectionName: string, key: string): void {
-    const rejectedKeys = this.rejectedCandidateKeys.get(connectionName)
-    if (rejectedKeys) rejectedKeys.add(key)
-    else this.rejectedCandidateKeys.set(connectionName, new Set([key]))
-    this.queueAnotherCandidate(connectionName)
-  }
-
-  private hasValidRollbackInvariant(candidateRoutes: HighDensityRoute[]): boolean {
-    if (candidateRoutes.length !== this.hdRoutes.length) return false
-    return candidateRoutes.every((route, index) => {
-      const acceptedRoute = this.hdRoutes[index]
-      if (!acceptedRoute || !hasSameIdentityAndTerminals(acceptedRoute, route)) {
-        return false
-      }
-      return !isProtectedRoute(
-        acceptedRoute,
-        this.protectedConnectionNames,
-        this.input.obstacles,
-        this.input.connMap,
-      ) ||
-        structurallyEqual(acceptedRoute, route)
-    })
-  }
-
-  _step(): void {
-    if (
-      this.candidateConnectionQueue.length === 0 ||
-      this.attempts >= MAX_CANDIDATE_ATTEMPTS
-    ) {
-      this.stats.finalOutputViaCount = this.quality.outputViaCount
-      this.stats.removedViaCount =
-        this.stats.initialOutputViaCount - this.quality.outputViaCount
-      this.solved = true
-      return
-    }
-
-    const connectionName = this.candidateConnectionQueue.shift()!
+  private scanRoute(connectionName: string, isRescan: boolean): void {
     const routeIndex = this.hdRoutes.findIndex(
       (route) => route.connectionName === connectionName,
     )
@@ -219,34 +163,158 @@ export class FinalViaOptimizationSolver extends BaseSolver {
       throw new Error(
         `FinalViaOptimizationSolver lost route "${connectionName}"`,
       )
-    this.attempts++
-    this.stats.attemptedCandidateCount++
-    const candidate = this.getCandidateRoutes(routeIndex)[0]
-    if (!candidate) {
+    const route = this.hdRoutes[routeIndex]
+    if (!route)
+      throw new Error("FinalViaOptimizationSolver route index is invalid")
+    const candidates = getSameLayerSpanCollapseCandidates({
+      route: structuredClone(route),
+      hdRouteSHI: new HighDensityRouteSpatialIndex(this.hdRoutes),
+      obstacleSHI: this.obstacleSHI,
+      connMap: this.input.connMap,
+      outline: this.input.originalSrj.outline,
+    })
+    if (isRescan) this.stats.rescannedAcceptedRouteCount++
+    else this.stats.scannedEligibleRouteCount++
+    if (candidates.length === 0) {
       this.stats.rejectedByCollisionCount++
       return
     }
-    if (!this.hasValidRollbackInvariant(candidate.routes)) {
-      this.stats.rejectedByConnectivityCount++
-      this.rejectCandidate(connectionName, candidate.key)
+    for (const candidate of candidates) {
+      const key = candidate.route.route
+        .map((point) => `${point.x}:${point.y}:${point.z}`)
+        .join("|")
+      this.pendingCandidates.push({
+        connectionName,
+        route: candidate.route,
+        key,
+        removedTransitionCount: candidate.removedTransitionCount,
+        lengthSaved: candidate.lengthSaved,
+      })
+    }
+    this.pendingCandidates.sort((a, b) => {
+      if (b.removedTransitionCount !== a.removedTransitionCount) {
+        return b.removedTransitionCount - a.removedTransitionCount
+      }
+      if (b.lengthSaved !== a.lengthSaved) return b.lengthSaved - a.lengthSaved
+      if (a.connectionName !== b.connectionName) {
+        return a.connectionName.localeCompare(b.connectionName)
+      }
+      return a.key.localeCompare(b.key)
+    })
+  }
+
+  private getCandidateRoutes(candidate: PendingCandidate): HighDensityRoute[] {
+    const routeIndex = this.hdRoutes.findIndex(
+      (route) => route.connectionName === candidate.connectionName,
+    )
+    if (routeIndex < 0)
+      throw new Error(
+        `FinalViaOptimizationSolver lost route "${candidate.connectionName}"`,
+      )
+    const routes = structuredClone(this.hdRoutes)
+    routes[routeIndex] = structuredClone(candidate.route)
+    return routes
+  }
+
+  private finish(): void {
+    this.stats.finalOutputViaCount = this.quality.outputViaCount
+    this.stats.removedViaCount =
+      this.stats.initialOutputViaCount - this.quality.outputViaCount
+    this.solved = true
+  }
+
+  private queueAcceptedRouteForRescan(connectionName: string): void {
+    if (!this.acceptedRouteRescanQueue.includes(connectionName)) {
+      this.acceptedRouteRescanQueue.push(connectionName)
+    }
+  }
+
+  private removeStaleCandidates(connectionName: string): void {
+    for (let index = this.pendingCandidates.length - 1; index >= 0; index--) {
+      if (this.pendingCandidates[index]?.connectionName === connectionName) {
+        this.pendingCandidates.splice(index, 1)
+      }
+    }
+  }
+
+  private getConvertedViaCount(routes: HighDensityRoute[]): number {
+    return this.input
+      .convert(routes)
+      .reduce(
+        (count, trace) =>
+          count +
+          trace.route.filter((segment) => segment.route_type === "via").length,
+        0,
+      )
+  }
+
+  private hasValidRollbackInvariant(
+    candidateRoutes: HighDensityRoute[],
+  ): boolean {
+    if (candidateRoutes.length !== this.hdRoutes.length) return false
+    return candidateRoutes.every((route, index) => {
+      const acceptedRoute = this.hdRoutes[index]
+      if (
+        !acceptedRoute ||
+        !hasSameIdentityAndTerminals(acceptedRoute, route)
+      ) {
+        return false
+      }
+      return (
+        !isProtectedRoute(
+          acceptedRoute,
+          this.protectedConnectionNames,
+          this.input.obstacles,
+          this.input.connMap,
+        ) || structurallyEqual(acceptedRoute, route)
+      )
+    })
+  }
+
+  _step(): void {
+    if (this.initialRouteScanIndex < this.eligibleConnectionNames.length) {
+      const connectionName =
+        this.eligibleConnectionNames[this.initialRouteScanIndex++]!
+      this.scanRoute(connectionName, false)
+      return
+    }
+    if (this.pendingCandidates.length === 0) {
+      const connectionName = this.acceptedRouteRescanQueue.shift()
+      if (
+        connectionName &&
+        this.candidateEvaluations < MAX_CANDIDATE_ATTEMPTS
+      ) {
+        this.scanRoute(connectionName, true)
+        return
+      }
+      this.finish()
+      return
+    }
+    if (this.candidateEvaluations >= MAX_CANDIDATE_ATTEMPTS) {
+      this.finish()
       return
     }
 
-    const convertedCandidate = this.input.convert(candidate.routes)
-    const convertedCandidateViaCount = convertedCandidate.reduce(
-      (count, trace) =>
-        count +
-        trace.route.filter((segment) => segment.route_type === "via").length,
-      0,
-    )
+    const candidate = this.pendingCandidates.shift()!
+    const candidateRoutes = this.getCandidateRoutes(candidate)
+    if (!this.hasValidRollbackInvariant(candidateRoutes)) {
+      this.stats.rejectedByConnectivityCount++
+      return
+    }
+
+    this.candidateEvaluations++
+    this.stats.candidateEvaluationCount++
+    this.stats.attemptedCandidateCount++
+    const convertedCandidateViaCount =
+      this.getConvertedViaCount(candidateRoutes)
     if (convertedCandidateViaCount >= this.quality.outputViaCount) {
       this.stats.rejectedByMetadataCount++
-      this.rejectCandidate(connectionName, candidate.key)
       return
     }
 
     const candidateQuality = createRouteQualitySnapshot({
-      hdRoutes: candidate.routes,
+      hdRoutes: candidateRoutes,
+      srj: this.input.originalSrj,
       convert: this.input.convert,
       productionDrcEvaluator: this.input.productionDrcEvaluator,
       relaxedDrcEvaluator: this.input.relaxedDrcEvaluator,
@@ -254,44 +322,44 @@ export class FinalViaOptimizationSolver extends BaseSolver {
     if (
       candidateQuality.productionDrcErrorCount >
         this.quality.productionDrcErrorCount ||
-      candidateQuality.productionDrcIssueScore >
-        this.quality.productionDrcIssueScore
+      (candidateQuality.productionDrcErrorCount ===
+        this.quality.productionDrcErrorCount &&
+        candidateQuality.productionDrcIssueScore >
+          this.quality.productionDrcIssueScore)
     ) {
       this.stats.rejectedByProductionDrcCount++
-      this.rejectCandidate(connectionName, candidate.key)
       return
     }
     if (
-      candidateQuality.relaxedDrcErrorCount >
-      this.quality.relaxedDrcErrorCount
+      candidateQuality.relaxedDrcErrorCount > this.quality.relaxedDrcErrorCount
     ) {
       this.stats.rejectedByRelaxedDrcCount++
-      this.rejectCandidate(connectionName, candidate.key)
       return
     }
     if (candidateQuality.outputViaCount >= this.quality.outputViaCount) {
       this.stats.rejectedByMetadataCount++
-      this.rejectCandidate(connectionName, candidate.key)
       return
     }
     if (
-      candidateQuality.totalTraceLength > this.quality.totalTraceLength + 1e-6
+      candidateQuality.totalTraceLength >
+      this.quality.totalTraceLength + 1e-6
     ) {
       this.stats.rejectedByTraceLengthCount++
-      this.rejectCandidate(connectionName, candidate.key)
       return
     }
 
-    this.hdRoutes = candidate.routes
+    this.hdRoutes = candidateRoutes
     this.quality = candidateQuality
     this.stats.acceptedCandidateCount++
-    this.rejectedCandidateKeys.delete(connectionName)
-    this.queueAnotherCandidate(connectionName)
+    this.removeStaleCandidates(candidate.connectionName)
+    this.queueAcceptedRouteForRescan(candidate.connectionName)
   }
 
   getOutput(): HighDensityRoute[] {
     if (!this.solved)
-      throw new Error("FinalViaOptimizationSolver output requested before solve")
+      throw new Error(
+        "FinalViaOptimizationSolver output requested before solve",
+      )
     return this.hdRoutes
   }
 }

--- a/lib/solvers/FinalViaOptimizationSolver/create-route-quality-snapshot.ts
+++ b/lib/solvers/FinalViaOptimizationSolver/create-route-quality-snapshot.ts
@@ -1,10 +1,7 @@
 import type { DrcEvaluator } from "high-density-repair03/lib"
-import type { SimplifiedPcbTraces } from "lib/types"
+import { getDrcSnapshot } from "high-density-repair03/lib/solvers/GlobalDrcForceImproveSolver/solverHelpers"
+import type { SimpleRouteJson, SimplifiedPcbTraces } from "lib/types"
 import type { HighDensityRoute } from "lib/types/high-density-types"
-
-type DrcResult =
-  | Array<Record<string, unknown>>
-  | { errors: Array<Record<string, unknown>> }
 
 export type RouteQualitySnapshot = {
   productionDrcErrorCount: number
@@ -14,22 +11,10 @@ export type RouteQualitySnapshot = {
   totalTraceLength: number
 }
 
-const getErrors = (result: DrcResult): Array<Record<string, unknown>> =>
-  Array.isArray(result) ? result : result.errors
-
-const getIssueSeverity = (error: Record<string, unknown>): number => {
-  if (typeof error.severity === "number") return error.severity
-  if (error.severity === "error") return 3
-  if (error.severity === "warning") return 2
-  return 1
-}
-
 const getTraceLength = (traces: SimplifiedPcbTraces): number => {
   let length = 0
   for (const trace of traces) {
-    let previousWire:
-      | { x: number; y: number; layer: string }
-      | undefined
+    let previousWire: { x: number; y: number; layer: string } | undefined
     for (const segment of trace.route) {
       if (segment.route_type !== "wire") {
         previousWire = undefined
@@ -50,30 +35,33 @@ const getTraceLength = (traces: SimplifiedPcbTraces): number => {
 /** Creates the production-output quality tuple used for transactional acceptance. */
 export const createRouteQualitySnapshot = ({
   hdRoutes,
+  srj,
   convert,
   productionDrcEvaluator,
   relaxedDrcEvaluator,
 }: {
   hdRoutes: HighDensityRoute[]
+  srj: SimpleRouteJson
   convert: (routes: HighDensityRoute[]) => SimplifiedPcbTraces
   productionDrcEvaluator: DrcEvaluator
   relaxedDrcEvaluator: DrcEvaluator
 }): RouteQualitySnapshot => {
   const traces = convert(hdRoutes)
-  const productionErrors = getErrors(
-    productionDrcEvaluator({ traces: traces as any, routes: hdRoutes }) as DrcResult,
+  const productionSnapshot = getDrcSnapshot(
+    srj as any,
+    hdRoutes as any,
+    productionDrcEvaluator as any,
   )
-  const relaxedErrors = getErrors(
-    relaxedDrcEvaluator({ traces: traces as any, routes: hdRoutes }) as DrcResult,
+  const relaxedSnapshot = getDrcSnapshot(
+    srj as any,
+    hdRoutes as any,
+    relaxedDrcEvaluator as any,
   )
 
   return {
-    productionDrcErrorCount: productionErrors.length,
-    productionDrcIssueScore: productionErrors.reduce(
-      (score, error) => score + getIssueSeverity(error),
-      0,
-    ),
-    relaxedDrcErrorCount: relaxedErrors.length,
+    productionDrcErrorCount: productionSnapshot.count,
+    productionDrcIssueScore: productionSnapshot.issueScore,
+    relaxedDrcErrorCount: relaxedSnapshot.count,
     outputViaCount: traces.reduce(
       (count, trace) =>
         count +

--- a/lib/solvers/FinalViaOptimizationSolver/create-route-quality-snapshot.ts
+++ b/lib/solvers/FinalViaOptimizationSolver/create-route-quality-snapshot.ts
@@ -1,0 +1,85 @@
+import type { DrcEvaluator } from "high-density-repair03/lib"
+import type { SimplifiedPcbTraces } from "lib/types"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+
+type DrcResult =
+  | Array<Record<string, unknown>>
+  | { errors: Array<Record<string, unknown>> }
+
+export type RouteQualitySnapshot = {
+  productionDrcErrorCount: number
+  productionDrcIssueScore: number
+  relaxedDrcErrorCount: number
+  outputViaCount: number
+  totalTraceLength: number
+}
+
+const getErrors = (result: DrcResult): Array<Record<string, unknown>> =>
+  Array.isArray(result) ? result : result.errors
+
+const getIssueSeverity = (error: Record<string, unknown>): number => {
+  if (typeof error.severity === "number") return error.severity
+  if (error.severity === "error") return 3
+  if (error.severity === "warning") return 2
+  return 1
+}
+
+const getTraceLength = (traces: SimplifiedPcbTraces): number => {
+  let length = 0
+  for (const trace of traces) {
+    let previousWire:
+      | { x: number; y: number; layer: string }
+      | undefined
+    for (const segment of trace.route) {
+      if (segment.route_type !== "wire") {
+        previousWire = undefined
+        continue
+      }
+      if (previousWire && previousWire.layer === segment.layer) {
+        length += Math.hypot(
+          segment.x - previousWire.x,
+          segment.y - previousWire.y,
+        )
+      }
+      previousWire = segment
+    }
+  }
+  return length
+}
+
+/** Creates the production-output quality tuple used for transactional acceptance. */
+export const createRouteQualitySnapshot = ({
+  hdRoutes,
+  convert,
+  productionDrcEvaluator,
+  relaxedDrcEvaluator,
+}: {
+  hdRoutes: HighDensityRoute[]
+  convert: (routes: HighDensityRoute[]) => SimplifiedPcbTraces
+  productionDrcEvaluator: DrcEvaluator
+  relaxedDrcEvaluator: DrcEvaluator
+}): RouteQualitySnapshot => {
+  const traces = convert(hdRoutes)
+  const productionErrors = getErrors(
+    productionDrcEvaluator({ traces: traces as any, routes: hdRoutes }) as DrcResult,
+  )
+  const relaxedErrors = getErrors(
+    relaxedDrcEvaluator({ traces: traces as any, routes: hdRoutes }) as DrcResult,
+  )
+
+  return {
+    productionDrcErrorCount: productionErrors.length,
+    productionDrcIssueScore: productionErrors.reduce(
+      (score, error) => score + getIssueSeverity(error),
+      0,
+    ),
+    relaxedDrcErrorCount: relaxedErrors.length,
+    outputViaCount: traces.reduce(
+      (count, trace) =>
+        count +
+        trace.route.filter((segment) => segment.route_type === "via").length,
+      0,
+    ),
+    totalTraceLength: getTraceLength(traces),
+  }
+}

--- a/lib/solvers/FinalViaOptimizationSolver/get-protected-connection-names.ts
+++ b/lib/solvers/FinalViaOptimizationSolver/get-protected-connection-names.ts
@@ -1,0 +1,77 @@
+import type { SimpleRouteJson } from "lib/types"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+import { getPowerTraceExpansionConnectionNames } from "lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/getPowerTraceExpansionConnectionNames"
+
+const resolveFinalConnectionNames = (
+  connectionName: string,
+  finalConnectionNames: ReadonlySet<string>,
+  finalRoutes: ReadonlyArray<HighDensityRoute>,
+): string[] =>
+  [...finalConnectionNames].filter(
+    (name) =>
+      name === connectionName ||
+      finalRoutes.some(
+        (route) =>
+          route.connectionName === name &&
+          (route.rootConnectionName === connectionName ||
+            route.connectionName === connectionName),
+      ),
+  )
+
+/** Returns connections that the first final optimization pass must leave inert. */
+export const getProtectedConnectionNames = ({
+  originalSrj,
+  hdRoutes,
+}: {
+  originalSrj: SimpleRouteJson
+  hdRoutes: ReadonlyArray<HighDensityRoute>
+}): Set<string> => {
+  const finalConnectionNames = new Set(
+    hdRoutes.map((route) => route.connectionName),
+  )
+  const protectedNames = new Set<string>()
+
+  for (const pair of originalSrj.differentialPairs ?? []) {
+    for (const connectionName of pair.connectionNames) {
+      for (const name of resolveFinalConnectionNames(
+        connectionName,
+        finalConnectionNames,
+        hdRoutes,
+      )) {
+        protectedNames.add(name)
+      }
+    }
+  }
+  for (const connection of originalSrj.connections) {
+    if (!connection.pointsToConnect.some((point) => "terminalVia" in point)) {
+      continue
+    }
+    for (const name of resolveFinalConnectionNames(
+      connection.name,
+      finalConnectionNames,
+      hdRoutes,
+    )) {
+      protectedNames.add(name)
+    }
+  }
+  for (const connectionName of getPowerTraceExpansionConnectionNames(originalSrj)) {
+    for (const name of resolveFinalConnectionNames(
+      connectionName,
+      finalConnectionNames,
+      hdRoutes,
+    )) {
+      protectedNames.add(name)
+    }
+  }
+  for (const trace of originalSrj.traces ?? []) {
+    for (const name of resolveFinalConnectionNames(
+      trace.connection_name,
+      finalConnectionNames,
+      hdRoutes,
+    )) {
+      protectedNames.add(name)
+    }
+  }
+
+  return protectedNames
+}

--- a/lib/solvers/FinalViaOptimizationSolver/get-protected-connection-names.ts
+++ b/lib/solvers/FinalViaOptimizationSolver/get-protected-connection-names.ts
@@ -54,7 +54,9 @@ export const getProtectedConnectionNames = ({
       protectedNames.add(name)
     }
   }
-  for (const connectionName of getPowerTraceExpansionConnectionNames(originalSrj)) {
+  for (const connectionName of getPowerTraceExpansionConnectionNames(
+    originalSrj,
+  )) {
     for (const name of resolveFinalConnectionNames(
       connectionName,
       finalConnectionNames,

--- a/lib/solvers/FinalViaOptimizationSolver/rebuild-and-validate-route-vias.ts
+++ b/lib/solvers/FinalViaOptimizationSolver/rebuild-and-validate-route-vias.ts
@@ -1,0 +1,27 @@
+import type { HighDensityRoute } from "lib/types/high-density-types"
+
+const samePoint = (
+  a: { x: number; y: number },
+  b: { x: number; y: number },
+): boolean => Math.abs(a.x - b.x) < 1e-9 && Math.abs(a.y - b.y) < 1e-9
+
+/** Rebuilds ordinary via metadata and rejects transitions with no legal location. */
+export const rebuildAndValidateRouteVias = (
+  route: HighDensityRoute,
+): HighDensityRoute | null => {
+  if (route.route.length < 2) return null
+
+  const vias: HighDensityRoute["vias"] = []
+  for (let index = 1; index < route.route.length; index++) {
+    const previous = route.route[index - 1]!
+    const current = route.route[index]!
+    if (previous.z === current.z) continue
+    if (previous.toNextSegmentType === "through_obstacle") return null
+    if (!samePoint(previous, current)) return null
+    if (!vias.some((via) => samePoint(via, current))) {
+      vias.push({ x: current.x, y: current.y })
+    }
+  }
+
+  return { ...route, vias }
+}

--- a/lib/solvers/FinalViaOptimizationSolver/try-collapse-same-layer-span.ts
+++ b/lib/solvers/FinalViaOptimizationSolver/try-collapse-same-layer-span.ts
@@ -1,0 +1,99 @@
+import { calculate45DegreePaths } from "lib/utils/calculate45DegreePaths"
+import { doesSegmentCrossPolygonBoundary } from "lib/utils/polygonContainment"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+import type { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { HighDensityRouteSpatialIndex } from "lib/data-structures/HighDensityRouteSpatialIndex"
+import { ObstacleSpatialHashIndex } from "lib/data-structures/ObstacleTree"
+import { breakRouteIntoSections } from "lib/solvers/UselessViaRemovalSolver/break-route-into-sections"
+import { canSectionMoveToLayer } from "lib/solvers/UselessViaRemovalSolver/can-section-move-to-layer"
+import { rebuildAndValidateRouteVias } from "./rebuild-and-validate-route-vias"
+
+const pathLength = (points: HighDensityRoute["route"]): number =>
+  points.slice(1).reduce(
+    (length, point, index) =>
+      length + Math.hypot(point.x - points[index]!.x, point.y - points[index]!.y),
+    0,
+  )
+
+const crossesOutline = (
+  points: HighDensityRoute["route"],
+  outline: ReadonlyArray<{ x: number; y: number }> | undefined,
+): boolean =>
+  Boolean(
+    outline &&
+      outline.length >= 3 &&
+      points.slice(1).some((point, index) =>
+        doesSegmentCrossPolygonBoundary({
+          start: points[index]!,
+          end: point,
+          polygon: [...outline],
+        }),
+      ),
+  )
+
+/** Finds one maximal A→…→A excursion that can safely become same-layer copper. */
+export const tryCollapseSameLayerSpan = ({
+  route,
+  hdRouteSHI,
+  obstacleSHI,
+  connMap,
+  outline,
+}: {
+  route: HighDensityRoute
+  hdRouteSHI: HighDensityRouteSpatialIndex
+  obstacleSHI: ObstacleSpatialHashIndex
+  connMap: ConnectivityMap
+  outline?: ReadonlyArray<{ x: number; y: number }>
+}): HighDensityRoute | null => {
+  const sections = breakRouteIntoSections(route)
+  for (let startSectionIndex = 0; startSectionIndex < sections.length - 2; startSectionIndex++) {
+    const startSection = sections[startSectionIndex]!
+    for (let endSectionIndex = sections.length - 1; endSectionIndex >= startSectionIndex + 2; endSectionIndex--) {
+      const endSection = sections[endSectionIndex]!
+      if (startSection.z !== endSection.z) continue
+      const start = startSection.points[startSection.points.length - 1]!
+      const end = endSection.points[0]!
+      const removed = route.route.slice(startSection.endIndex, endSection.startIndex + 1)
+      if (removed.some((point) => point.insideJumperPad || point.toNextSegmentType)) continue
+
+      for (const candidatePath of calculate45DegreePaths(start, end)) {
+        const replacement = candidatePath.map((point, index) =>
+          index === 0
+            ? { ...start }
+            : index === candidatePath.length - 1
+              ? { ...end }
+              : { x: point.x, y: point.y, z: start.z },
+        )
+        if (pathLength(replacement) > pathLength(removed) + 1e-6) continue
+        if (crossesOutline(replacement, outline)) continue
+        if (!canSectionMoveToLayer({
+          currentSection: {
+            startIndex: startSection.endIndex,
+            endIndex: endSection.startIndex,
+            z: start.z,
+            points: replacement,
+          },
+          targetZ: start.z,
+          route,
+          hdRouteSHI,
+          obstacleSHI,
+          connMap,
+          defaultTraceThickness: route.traceThickness,
+          obstacleMargin: 0.15,
+          traceMargin: 0.1,
+        })) continue
+
+        const candidate = rebuildAndValidateRouteVias({
+          ...route,
+          route: [
+            ...route.route.slice(0, startSection.endIndex),
+            ...replacement,
+            ...route.route.slice(endSection.startIndex + 1),
+          ],
+        })
+        if (candidate) return candidate
+      }
+    }
+  }
+  return null
+}

--- a/lib/solvers/FinalViaOptimizationSolver/try-collapse-same-layer-span.ts
+++ b/lib/solvers/FinalViaOptimizationSolver/try-collapse-same-layer-span.ts
@@ -9,11 +9,14 @@ import { canSectionMoveToLayer } from "lib/solvers/UselessViaRemovalSolver/can-s
 import { rebuildAndValidateRouteVias } from "./rebuild-and-validate-route-vias"
 
 const pathLength = (points: HighDensityRoute["route"]): number =>
-  points.slice(1).reduce(
-    (length, point, index) =>
-      length + Math.hypot(point.x - points[index]!.x, point.y - points[index]!.y),
-    0,
-  )
+  points
+    .slice(1)
+    .reduce(
+      (length, point, index) =>
+        length +
+        Math.hypot(point.x - points[index]!.x, point.y - points[index]!.y),
+      0,
+    )
 
 const crossesOutline = (
   points: HighDensityRoute["route"],
@@ -32,8 +35,9 @@ const crossesOutline = (
   )
 
 const getLayerTransitionCount = (route: HighDensityRoute): number =>
-  route.route.slice(1).filter((point, index) => point.z !== route.route[index]!.z)
-    .length
+  route.route
+    .slice(1)
+    .filter((point, index) => point.z !== route.route[index]!.z).length
 
 export type SameLayerSpanCollapseCandidate = {
   route: HighDensityRoute
@@ -61,15 +65,31 @@ export const getSameLayerSpanCollapseCandidates = ({
   const candidates: SameLayerSpanCollapseCandidate[] = []
   const candidateKeys = new Set<string>()
   const originalTransitionCount = getLayerTransitionCount(route)
-  for (let startSectionIndex = 0; startSectionIndex < sections.length - 2; startSectionIndex++) {
+  for (
+    let startSectionIndex = 0;
+    startSectionIndex < sections.length - 2;
+    startSectionIndex++
+  ) {
     const startSection = sections[startSectionIndex]!
-    for (let endSectionIndex = sections.length - 1; endSectionIndex >= startSectionIndex + 2; endSectionIndex--) {
+    for (
+      let endSectionIndex = sections.length - 1;
+      endSectionIndex >= startSectionIndex + 2;
+      endSectionIndex--
+    ) {
       const endSection = sections[endSectionIndex]!
       if (startSection.z !== endSection.z) continue
       const start = startSection.points[startSection.points.length - 1]!
       const end = endSection.points[0]!
-      const removed = route.route.slice(startSection.endIndex, endSection.startIndex + 1)
-      if (removed.some((point) => point.insideJumperPad || point.toNextSegmentType)) continue
+      const removed = route.route.slice(
+        startSection.endIndex,
+        endSection.startIndex + 1,
+      )
+      if (
+        removed.some(
+          (point) => point.insideJumperPad || point.toNextSegmentType,
+        )
+      )
+        continue
 
       for (const candidatePath of calculate45DegreePaths(start, end)) {
         const replacement = candidatePath.map((point, index) =>
@@ -81,22 +101,25 @@ export const getSameLayerSpanCollapseCandidates = ({
         )
         if (pathLength(replacement) > pathLength(removed) + 1e-6) continue
         if (crossesOutline(replacement, outline)) continue
-        if (!canSectionMoveToLayer({
-          currentSection: {
-            startIndex: startSection.endIndex,
-            endIndex: endSection.startIndex,
-            z: start.z,
-            points: replacement,
-          },
-          targetZ: start.z,
-          route,
-          hdRouteSHI,
-          obstacleSHI,
-          connMap,
-          defaultTraceThickness: route.traceThickness,
-          obstacleMargin: 0.15,
-          traceMargin: 0.1,
-        })) continue
+        if (
+          !canSectionMoveToLayer({
+            currentSection: {
+              startIndex: startSection.endIndex,
+              endIndex: endSection.startIndex,
+              z: start.z,
+              points: replacement,
+            },
+            targetZ: start.z,
+            route,
+            hdRouteSHI,
+            obstacleSHI,
+            connMap,
+            defaultTraceThickness: route.traceThickness,
+            obstacleMargin: 0.15,
+            traceMargin: 0.1,
+          })
+        )
+          continue
 
         const candidate = rebuildAndValidateRouteVias({
           ...route,

--- a/lib/solvers/FinalViaOptimizationSolver/try-collapse-same-layer-span.ts
+++ b/lib/solvers/FinalViaOptimizationSolver/try-collapse-same-layer-span.ts
@@ -31,21 +31,36 @@ const crossesOutline = (
       ),
   )
 
-/** Finds one maximal A→…→A excursion that can safely become same-layer copper. */
-export const tryCollapseSameLayerSpan = ({
+const getLayerTransitionCount = (route: HighDensityRoute): number =>
+  route.route.slice(1).filter((point, index) => point.z !== route.route[index]!.z)
+    .length
+
+export type SameLayerSpanCollapseCandidate = {
+  route: HighDensityRoute
+  removedTransitionCount: number
+  lengthSaved: number
+}
+
+/** Enumerates a small deterministic shortlist of maximal A→…→A collapses. */
+export const getSameLayerSpanCollapseCandidates = ({
   route,
   hdRouteSHI,
   obstacleSHI,
   connMap,
   outline,
+  maxCandidates = 4,
 }: {
   route: HighDensityRoute
   hdRouteSHI: HighDensityRouteSpatialIndex
   obstacleSHI: ObstacleSpatialHashIndex
   connMap: ConnectivityMap
   outline?: ReadonlyArray<{ x: number; y: number }>
-}): HighDensityRoute | null => {
+  maxCandidates?: number
+}): SameLayerSpanCollapseCandidate[] => {
   const sections = breakRouteIntoSections(route)
+  const candidates: SameLayerSpanCollapseCandidate[] = []
+  const candidateKeys = new Set<string>()
+  const originalTransitionCount = getLayerTransitionCount(route)
   for (let startSectionIndex = 0; startSectionIndex < sections.length - 2; startSectionIndex++) {
     const startSection = sections[startSectionIndex]!
     for (let endSectionIndex = sections.length - 1; endSectionIndex >= startSectionIndex + 2; endSectionIndex--) {
@@ -91,9 +106,35 @@ export const tryCollapseSameLayerSpan = ({
             ...route.route.slice(endSection.startIndex + 1),
           ],
         })
-        if (candidate) return candidate
+        if (!candidate) continue
+        const removedTransitionCount =
+          originalTransitionCount - getLayerTransitionCount(candidate)
+        if (removedTransitionCount <= 0) continue
+        const key = candidate.route
+          .map((point) => `${point.x}:${point.y}:${point.z}`)
+          .join("|")
+        if (candidateKeys.has(key)) continue
+        candidateKeys.add(key)
+        candidates.push({
+          route: candidate,
+          removedTransitionCount,
+          lengthSaved: pathLength(removed) - pathLength(replacement),
+        })
       }
     }
   }
-  return null
+  return candidates
+    .sort((a, b) => {
+      if (b.removedTransitionCount !== a.removedTransitionCount) {
+        return b.removedTransitionCount - a.removedTransitionCount
+      }
+      return b.lengthSaved - a.lengthSaved
+    })
+    .slice(0, maxCandidates)
 }
+
+/** Finds the strongest same-layer excursion candidate for existing callers. */
+export const tryCollapseSameLayerSpan = (
+  input: Parameters<typeof getSameLayerSpanCollapseCandidates>[0],
+): HighDensityRoute | null =>
+  getSameLayerSpanCollapseCandidates(input)[0]?.route ?? null

--- a/tests/features/pipeline9-minimal-preloaded-trace-graph.test.ts
+++ b/tests/features/pipeline9-minimal-preloaded-trace-graph.test.ts
@@ -80,6 +80,7 @@ test("Pipeline9 owns copied stages with minimal preloaded-trace changes", () => 
     "highDensityStitchSolver",
     "globalDrcForceImproveSolver",
     "exactGeometryDrcForceImproveSolver",
+    "finalViaOptimizationSolver",
   ]) {
     expect(
       solver.pipelineDef.find((step) => step.solverName === stageName)

--- a/tests/final-via-optimization-collapses-maximal-multilayer-excursion.test.ts
+++ b/tests/final-via-optimization-collapses-maximal-multilayer-excursion.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "bun:test"
+import { HighDensityRouteSpatialIndex } from "lib/data-structures/HighDensityRouteSpatialIndex"
+import { ObstacleSpatialHashIndex } from "lib/data-structures/ObstacleTree"
+import { getSameLayerSpanCollapseCandidates } from "lib/solvers/FinalViaOptimizationSolver/try-collapse-same-layer-span"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
+
+test("final via optimization collapses a maximal multilayer same-layer excursion", () => {
+  const srj = {
+    layerCount: 3,
+    minTraceWidth: 0.1,
+    bounds: { minX: -3, minY: -2, maxX: 3, maxY: 2 },
+    obstacles: [],
+    connections: [
+      {
+        name: "trace",
+        pointsToConnect: [
+          { x: -2, y: 0, layer: "top", pointId: "start" },
+          { x: 2, y: 0, layer: "top", pointId: "end" },
+        ],
+      },
+    ],
+  }
+  const route: HighDensityRoute = {
+    connectionName: "trace",
+    traceThickness: 0.1,
+    viaDiameter: 0.3,
+    vias: [
+      { x: -1, y: 0 },
+      { x: -0.25, y: 0 },
+      { x: 0.25, y: 0 },
+      { x: 1, y: 0 },
+    ],
+    route: [
+      { x: -2, y: 0, z: 0 },
+      { x: -1, y: 0, z: 0 },
+      { x: -1, y: 0, z: 1 },
+      { x: -0.25, y: 0, z: 1 },
+      { x: -0.25, y: 0, z: 2 },
+      { x: 0.25, y: 0, z: 2 },
+      { x: 0.25, y: 0, z: 1 },
+      { x: 1, y: 0, z: 1 },
+      { x: 1, y: 0, z: 0 },
+      { x: 2, y: 0, z: 0 },
+    ],
+  }
+
+  const candidates = getSameLayerSpanCollapseCandidates({
+    route,
+    hdRouteSHI: new HighDensityRouteSpatialIndex([route]),
+    obstacleSHI: new ObstacleSpatialHashIndex("flatbush", []),
+    connMap: getConnectivityMapFromSimpleRouteJson(srj),
+  })
+
+  expect(candidates[0]?.removedTransitionCount).toBe(4)
+  expect(candidates[0]?.route.vias).toEqual([])
+})

--- a/tests/final-via-optimization-collapses-same-layer-excursion.test.ts
+++ b/tests/final-via-optimization-collapses-same-layer-excursion.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "bun:test"
+import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
+import { ObstacleSpatialHashIndex } from "lib/data-structures/ObstacleTree"
+import { HighDensityRouteSpatialIndex } from "lib/data-structures/HighDensityRouteSpatialIndex"
+import { tryCollapseSameLayerSpan } from "lib/solvers/FinalViaOptimizationSolver/try-collapse-same-layer-span"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+
+test("final via optimization collapses a clear top-bottom-top excursion", () => {
+  const srj = {
+    layerCount: 2,
+    minTraceWidth: 0.1,
+    bounds: { minX: -2, minY: -2, maxX: 2, maxY: 2 },
+    obstacles: [],
+    connections: [
+      {
+        name: "trace",
+        pointsToConnect: [
+          { x: -1, y: 0, layer: "top", pointId: "start" },
+          { x: 1, y: 0, layer: "top", pointId: "end" },
+        ],
+      },
+    ],
+  }
+  const route: HighDensityRoute = {
+    connectionName: "trace",
+    traceThickness: 0.1,
+    viaDiameter: 0.3,
+    vias: [
+      { x: -0.5, y: 0 },
+      { x: 0.5, y: 0 },
+    ],
+    route: [
+      { x: -1, y: 0, z: 0 },
+      { x: -0.5, y: 0, z: 0 },
+      { x: -0.5, y: 0, z: 1 },
+      { x: 0.5, y: 0, z: 1 },
+      { x: 0.5, y: 0, z: 0 },
+      { x: 1, y: 0, z: 0 },
+    ],
+  }
+
+  const collapsed = tryCollapseSameLayerSpan({
+    route,
+    hdRouteSHI: new HighDensityRouteSpatialIndex([route]),
+    obstacleSHI: new ObstacleSpatialHashIndex("flatbush", []),
+    connMap: getConnectivityMapFromSimpleRouteJson(srj),
+  })
+
+  expect(collapsed?.vias).toEqual([])
+  expect(collapsed?.route.every((point) => point.z === 0)).toBe(true)
+})

--- a/tests/final-via-optimization-rejection-gates.test.ts
+++ b/tests/final-via-optimization-rejection-gates.test.ts
@@ -1,0 +1,109 @@
+import { expect, test } from "bun:test"
+import type { DrcEvaluator } from "high-density-repair03/lib"
+import { FinalViaOptimizationSolver } from "lib/solvers/FinalViaOptimizationSolver/FinalViaOptimizationSolver"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
+
+test("final via optimization rejects DRC and converted-output regressions", () => {
+  const srj = {
+    layerCount: 2,
+    minTraceWidth: 0.1,
+    bounds: { minX: -2, minY: -2, maxX: 2, maxY: 2 },
+    obstacles: [],
+    connections: [
+      {
+        name: "trace",
+        pointsToConnect: [
+          { x: -1, y: 0, layer: "top", pointId: "start" },
+          { x: 1, y: 0, layer: "top", pointId: "end" },
+        ],
+      },
+    ],
+  }
+  const route: HighDensityRoute = {
+    connectionName: "trace",
+    traceThickness: 0.1,
+    viaDiameter: 0.3,
+    vias: [
+      { x: -0.5, y: 0 },
+      { x: 0.5, y: 0 },
+    ],
+    route: [
+      { x: -1, y: 0, z: 0 },
+      { x: -0.5, y: 0, z: 0 },
+      { x: -0.5, y: 0, z: 1 },
+      { x: 0.5, y: 0, z: 1 },
+      { x: 0.5, y: 0, z: 0 },
+      { x: 1, y: 0, z: 0 },
+    ],
+  }
+  const getSolver = ({
+    productionDrcEvaluator,
+    convertKeepsVias = false,
+  }: {
+    productionDrcEvaluator: DrcEvaluator
+    convertKeepsVias?: boolean
+  }) =>
+    new FinalViaOptimizationSolver({
+      hdRoutes: [structuredClone(route)],
+      originalSrj: srj,
+      obstacles: [],
+      layerCount: 2,
+      connMap: getConnectivityMapFromSimpleRouteJson(srj),
+      productionDrcEvaluator,
+      relaxedDrcEvaluator: (() => ({ errors: [] })) as DrcEvaluator,
+      convert: (routes) => {
+        const vias = convertKeepsVias
+          ? route.vias
+          : routes.flatMap((candidateRoute) => candidateRoute.vias)
+        return [
+          {
+            type: "pcb_trace" as const,
+            pcb_trace_id: "trace",
+            connection_name: "trace",
+            route: vias.map((via) => ({
+              route_type: "via" as const,
+              x: via.x,
+              y: via.y,
+              from_layer: "top",
+              to_layer: "bottom",
+            })),
+          },
+        ]
+      },
+    })
+  const countRegression = getSolver({
+    productionDrcEvaluator: (({ routes }) => ({
+      errors: routes?.[0]?.vias.length === 0 ? [{ message: "new error" }] : [],
+    })) as DrcEvaluator,
+  })
+  const severityRegression = getSolver({
+    productionDrcEvaluator: (({ routes }) => ({
+      errors: [
+        {
+          message:
+            routes?.[0]?.vias.length === 0
+              ? "gap: 0mm required: 0.1mm"
+              : "gap: 0.09mm required: 0.1mm",
+        },
+      ],
+    })) as DrcEvaluator,
+  })
+  const noConvertedViaReduction = getSolver({
+    productionDrcEvaluator: (() => ({ errors: [] })) as DrcEvaluator,
+    convertKeepsVias: true,
+  })
+
+  countRegression.solve()
+  severityRegression.solve()
+  noConvertedViaReduction.solve()
+
+  expect(countRegression.stats.rejectedByProductionDrcCount).toBeGreaterThan(0)
+  expect(severityRegression.stats.rejectedByProductionDrcCount).toBeGreaterThan(
+    0,
+  )
+  expect(noConvertedViaReduction.stats.rejectedByMetadataCount).toBeGreaterThan(
+    0,
+  )
+  expect(countRegression.getOutput()[0]?.vias).toHaveLength(2)
+})

--- a/tests/final-via-optimization-repeated-collapses.test.ts
+++ b/tests/final-via-optimization-repeated-collapses.test.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "bun:test"
+import type { DrcEvaluator } from "high-density-repair03/lib"
+import { FinalViaOptimizationSolver } from "lib/solvers/FinalViaOptimizationSolver/FinalViaOptimizationSolver"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
+
+test("final via optimization rescans an accepted route for another collapse", () => {
+  const srj = {
+    layerCount: 2,
+    minTraceWidth: 0.1,
+    bounds: { minX: -5, minY: -2, maxX: 5, maxY: 2 },
+    obstacles: [
+      {
+        type: "rect" as const,
+        layers: ["top"],
+        center: { x: 0, y: 0 },
+        width: 0.4,
+        height: 0.4,
+        connectedTo: ["foreign"],
+      },
+    ],
+    connections: [
+      {
+        name: "trace",
+        pointsToConnect: [
+          { x: -4, y: 0, layer: "top", pointId: "start" },
+          { x: 4, y: 0, layer: "top", pointId: "end" },
+        ],
+      },
+    ],
+  }
+  const route: HighDensityRoute = {
+    connectionName: "trace",
+    traceThickness: 0.1,
+    viaDiameter: 0.3,
+    vias: [
+      { x: -3, y: 0 },
+      { x: -1, y: 0 },
+      { x: 1, y: 0 },
+      { x: 3, y: 0 },
+    ],
+    route: [
+      { x: -4, y: 0, z: 0 },
+      { x: -3, y: 0, z: 0 },
+      { x: -3, y: 0, z: 1 },
+      { x: -1, y: 0, z: 1 },
+      { x: -1, y: 0, z: 0 },
+      { x: -0.5, y: 1, z: 0 },
+      { x: 0.5, y: 1, z: 0 },
+      { x: 1, y: 0, z: 0 },
+      { x: 1, y: 0, z: 1 },
+      { x: 3, y: 0, z: 1 },
+      { x: 3, y: 0, z: 0 },
+      { x: 4, y: 0, z: 0 },
+    ],
+  }
+  const noErrors = (() => ({ errors: [] })) as DrcEvaluator
+  const solver = new FinalViaOptimizationSolver({
+    hdRoutes: [route],
+    originalSrj: srj,
+    obstacles: srj.obstacles,
+    layerCount: 2,
+    connMap: getConnectivityMapFromSimpleRouteJson(srj),
+    productionDrcEvaluator: noErrors,
+    relaxedDrcEvaluator: noErrors,
+    convert: (routes) =>
+      routes.map((candidate) => ({
+        type: "pcb_trace" as const,
+        pcb_trace_id: candidate.connectionName,
+        connection_name: candidate.connectionName,
+        route: candidate.vias.map((via) => ({
+          route_type: "via" as const,
+          x: via.x,
+          y: via.y,
+          from_layer: "top",
+          to_layer: "bottom",
+        })),
+      })),
+  })
+
+  solver.solve()
+
+  expect(solver.stats.acceptedCandidateCount).toBe(2)
+  expect(solver.stats.rescannedAcceptedRouteCount).toBe(2)
+  expect(solver.getOutput()[0]?.vias).toEqual([])
+})

--- a/tests/final-via-optimization-route-invariants.test.ts
+++ b/tests/final-via-optimization-route-invariants.test.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "bun:test"
+import type { DrcEvaluator } from "high-density-repair03/lib"
+import {
+  FinalViaOptimizationSolver,
+  hasSameIdentityAndTerminals,
+} from "lib/solvers/FinalViaOptimizationSolver/FinalViaOptimizationSolver"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
+
+test("final via optimization preserves endpoint metadata and protected routes", () => {
+  const srj = {
+    layerCount: 2,
+    minTraceWidth: 0.1,
+    bounds: { minX: -2, minY: -2, maxX: 2, maxY: 2 },
+    obstacles: [],
+    differentialPairs: [
+      {
+        connectionNames: ["protected", "other"] as [string, string],
+        lengthTolerance: 0.1,
+      },
+    ],
+    connections: [
+      {
+        name: "protected",
+        pointsToConnect: [
+          { x: -1, y: 0, layer: "top", pointId: "protected_start" },
+          { x: 1, y: 0, layer: "top", pointId: "protected_end" },
+        ],
+      },
+      {
+        name: "other",
+        pointsToConnect: [
+          { x: -1, y: 1, layer: "top", pointId: "other_start" },
+          { x: 1, y: 1, layer: "top", pointId: "other_end" },
+        ],
+      },
+    ],
+  }
+  const protectedRoute: HighDensityRoute = {
+    connectionName: "protected",
+    rootConnectionName: "protected",
+    startPcbPortId: "pcb_port_start",
+    endPcbPortId: "pcb_port_end",
+    traceThickness: 0.1,
+    viaDiameter: 0.3,
+    vias: [
+      { x: -0.5, y: 0 },
+      { x: 0.5, y: 0 },
+    ],
+    route: [
+      { x: -1, y: 0, z: 0, pcb_port_id: "pcb_port_start" },
+      { x: -0.5, y: 0, z: 0 },
+      { x: -0.5, y: 0, z: 1 },
+      { x: 0.5, y: 0, z: 1 },
+      { x: 0.5, y: 0, z: 0 },
+      { x: 1, y: 0, z: 0, pcb_port_id: "pcb_port_end" },
+    ],
+  }
+  const endpointLayerChanged: HighDensityRoute = {
+    ...structuredClone(protectedRoute),
+    route: protectedRoute.route.map((point, index) =>
+      index === 0 ? { ...point, z: 1 } : point,
+    ),
+  }
+  const noErrors = (() => ({ errors: [] })) as DrcEvaluator
+  const solver = new FinalViaOptimizationSolver({
+    hdRoutes: [protectedRoute],
+    originalSrj: srj,
+    obstacles: [],
+    layerCount: 2,
+    connMap: getConnectivityMapFromSimpleRouteJson(srj),
+    convert: () => [],
+    productionDrcEvaluator: noErrors,
+    relaxedDrcEvaluator: noErrors,
+  })
+
+  solver.solve()
+
+  expect(
+    hasSameIdentityAndTerminals(protectedRoute, endpointLayerChanged),
+  ).toBe(false)
+  expect(solver.getOutput()).toEqual([protectedRoute])
+  expect(solver.stats.scannedEligibleRouteCount).toBe(0)
+})

--- a/tests/final-via-optimization-scan-and-budget.test.ts
+++ b/tests/final-via-optimization-scan-and-budget.test.ts
@@ -4,9 +4,9 @@ import { FinalViaOptimizationSolver } from "lib/solvers/FinalViaOptimizationSolv
 import type { HighDensityRoute } from "lib/types/high-density-types"
 import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
 
-test("final via optimization scans every route while bounding converted DRC candidates", () => {
+const createSolver = (routeCount: number) => {
   const connectionNames = Array.from(
-    { length: 40 },
+    { length: routeCount },
     (_, index) => `trace_${String(index).padStart(2, "0")}`,
   )
   const srj = {
@@ -42,7 +42,7 @@ test("final via optimization scans every route while bounding converted DRC cand
     }),
   )
   const noErrors = (() => ({ errors: [] })) as DrcEvaluator
-  const solver = new FinalViaOptimizationSolver({
+  return new FinalViaOptimizationSolver({
     hdRoutes,
     originalSrj: srj,
     obstacles: [],
@@ -64,10 +64,24 @@ test("final via optimization scans every route while bounding converted DRC cand
         })),
       })),
   })
+}
+
+test("final via optimization scans every eligible route while bounding converted DRC candidates", () => {
+  const solver = createSolver(40)
 
   solver.solve()
 
   expect(solver.stats.scannedEligibleRouteCount).toBe(40)
   expect(solver.stats.candidateEvaluationCount).toBe(32)
   expect(solver.stats.acceptedCandidateCount).toBe(32)
+})
+
+test("final via optimization bounds initial geometry discovery on very large boards", () => {
+  const solver = createSolver(513)
+
+  solver.solve()
+
+  expect(solver.stats.initialRouteScanBudget).toBe(512)
+  expect(solver.stats.scannedEligibleRouteCount).toBe(512)
+  expect(solver.stats.candidateEvaluationCount).toBe(32)
 })

--- a/tests/final-via-optimization-scan-and-budget.test.ts
+++ b/tests/final-via-optimization-scan-and-budget.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "bun:test"
+import type { DrcEvaluator } from "high-density-repair03/lib"
+import { FinalViaOptimizationSolver } from "lib/solvers/FinalViaOptimizationSolver/FinalViaOptimizationSolver"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
+
+test("final via optimization scans every route while bounding converted DRC candidates", () => {
+  const connectionNames = Array.from(
+    { length: 40 },
+    (_, index) => `trace_${String(index).padStart(2, "0")}`,
+  )
+  const srj = {
+    layerCount: 2,
+    minTraceWidth: 0.1,
+    bounds: { minX: -2, minY: -50, maxX: 2, maxY: 50 },
+    obstacles: [],
+    connections: connectionNames.map((name, index) => ({
+      name,
+      pointsToConnect: [
+        { x: -1, y: index, layer: "top", pointId: `${name}_start` },
+        { x: 1, y: index, layer: "top", pointId: `${name}_end` },
+      ],
+    })),
+  }
+  const hdRoutes: HighDensityRoute[] = connectionNames.map(
+    (connectionName, y) => ({
+      connectionName,
+      traceThickness: 0.1,
+      viaDiameter: 0.3,
+      vias: [
+        { x: -0.5, y },
+        { x: 0.5, y },
+      ],
+      route: [
+        { x: -1, y, z: 0 },
+        { x: -0.5, y, z: 0 },
+        { x: -0.5, y, z: 1 },
+        { x: 0.5, y, z: 1 },
+        { x: 0.5, y, z: 0 },
+        { x: 1, y, z: 0 },
+      ],
+    }),
+  )
+  const noErrors = (() => ({ errors: [] })) as DrcEvaluator
+  const solver = new FinalViaOptimizationSolver({
+    hdRoutes,
+    originalSrj: srj,
+    obstacles: [],
+    layerCount: 2,
+    connMap: getConnectivityMapFromSimpleRouteJson(srj),
+    productionDrcEvaluator: noErrors,
+    relaxedDrcEvaluator: noErrors,
+    convert: (routes) =>
+      routes.map((route) => ({
+        type: "pcb_trace" as const,
+        pcb_trace_id: route.connectionName,
+        connection_name: route.connectionName,
+        route: route.vias.map((via) => ({
+          route_type: "via" as const,
+          x: via.x,
+          y: via.y,
+          from_layer: "top",
+          to_layer: "bottom",
+        })),
+      })),
+  })
+
+  solver.solve()
+
+  expect(solver.stats.scannedEligibleRouteCount).toBe(40)
+  expect(solver.stats.candidateEvaluationCount).toBe(32)
+  expect(solver.stats.acceptedCandidateCount).toBe(32)
+})

--- a/tests/final-via-optimization-transactional-acceptance.test.ts
+++ b/tests/final-via-optimization-transactional-acceptance.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "bun:test"
+import type { DrcEvaluator } from "high-density-repair03/lib"
+import { FinalViaOptimizationSolver } from "lib/solvers/FinalViaOptimizationSolver/FinalViaOptimizationSolver"
+import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+
+test("final via optimization accepts only a DRC-safe converted via reduction", () => {
+  const srj = {
+    layerCount: 2,
+    minTraceWidth: 0.1,
+    bounds: { minX: -2, minY: -2, maxX: 2, maxY: 2 },
+    obstacles: [],
+    connections: [
+      {
+        name: "trace",
+        pointsToConnect: [
+          { x: -1, y: 0, layer: "top", pointId: "start" },
+          { x: 1, y: 0, layer: "top", pointId: "end" },
+        ],
+      },
+    ],
+  }
+  const hdRoutes: HighDensityRoute[] = [
+    {
+      connectionName: "trace",
+      traceThickness: 0.1,
+      viaDiameter: 0.3,
+      vias: [
+        { x: -0.5, y: 0 },
+        { x: 0.5, y: 0 },
+      ],
+      route: [
+        { x: -1, y: 0, z: 0 },
+        { x: -0.5, y: 0, z: 0 },
+        { x: -0.5, y: 0, z: 1 },
+        { x: 0.5, y: 0, z: 1 },
+        { x: 0.5, y: 0, z: 0 },
+        { x: 1, y: 0, z: 0 },
+      ],
+    },
+  ]
+  const noErrors = (() => ({ errors: [] })) as DrcEvaluator
+  const solver = new FinalViaOptimizationSolver({
+    hdRoutes,
+    originalSrj: srj,
+    obstacles: [],
+    layerCount: 2,
+    connMap: getConnectivityMapFromSimpleRouteJson(srj),
+    productionDrcEvaluator: noErrors,
+    relaxedDrcEvaluator: noErrors,
+    convert: (routes) =>
+      routes.map((route) => ({
+        type: "pcb_trace" as const,
+        pcb_trace_id: route.connectionName,
+        connection_name: route.connectionName,
+        route: route.vias.map((via) => ({
+          route_type: "via" as const,
+          x: via.x,
+          y: via.y,
+          from_layer: "top",
+          to_layer: "bottom",
+        })),
+      })),
+  })
+
+  solver.solve()
+
+  expect(solver.getOutput()[0]?.vias).toEqual([])
+  expect(solver.stats.removedViaCount).toBe(2)
+  expect(hdRoutes[0]?.vias).toHaveLength(2)
+})

--- a/tests/final-via-optimization-transactional-acceptance.test.ts
+++ b/tests/final-via-optimization-transactional-acceptance.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "bun:test"
-import type { DrcEvaluator } from "high-density-repair03/lib"
+import { createPipeline7AutoroutingDrcEvaluator } from "lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/create-pipeline7-autorouting-drc-evaluator"
+import { createPipeline7RelaxedDrcEvaluator } from "lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/create-pipeline7-relaxed-drc-evaluator"
+import { convertPipeline7HdRoutesToSimplifiedPcbTraces } from "lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/convertPipeline7HdRoutesToSimplifiedPcbTraces"
 import { FinalViaOptimizationSolver } from "lib/solvers/FinalViaOptimizationSolver/FinalViaOptimizationSolver"
 import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
 import type { HighDensityRoute } from "lib/types/high-density-types"
@@ -39,28 +41,31 @@ test("final via optimization accepts only a DRC-safe converted via reduction", (
       ],
     },
   ]
-  const noErrors = (() => ({ errors: [] })) as DrcEvaluator
+  const connMap = getConnectivityMapFromSimpleRouteJson(srj)
+  const conversionOptions = {
+    connections: srj.connections,
+    originalConnections: srj.connections,
+    layerCount: srj.layerCount,
+    obstacles: srj.obstacles,
+    defaultViaHoleDiameter: 0.15,
+    connMap,
+    srjWithPointPairs: srj,
+    originalSrj: srj,
+  }
   const solver = new FinalViaOptimizationSolver({
     hdRoutes,
     originalSrj: srj,
     obstacles: [],
     layerCount: 2,
-    connMap: getConnectivityMapFromSimpleRouteJson(srj),
-    productionDrcEvaluator: noErrors,
-    relaxedDrcEvaluator: noErrors,
+    connMap,
+    productionDrcEvaluator:
+      createPipeline7AutoroutingDrcEvaluator(conversionOptions),
+    relaxedDrcEvaluator: createPipeline7RelaxedDrcEvaluator(conversionOptions),
     convert: (routes) =>
-      routes.map((route) => ({
-        type: "pcb_trace" as const,
-        pcb_trace_id: route.connectionName,
-        connection_name: route.connectionName,
-        route: route.vias.map((via) => ({
-          route_type: "via" as const,
-          x: via.x,
-          y: via.y,
-          from_layer: "top",
-          to_layer: "bottom",
-        })),
-      })),
+      convertPipeline7HdRoutesToSimplifiedPcbTraces({
+        ...conversionOptions,
+        hdRoutes: routes,
+      }),
   })
 
   solver.solve()

--- a/tests/pipeline7-post-processing-before-power-expansion.test.ts
+++ b/tests/pipeline7-post-processing-before-power-expansion.test.ts
@@ -32,8 +32,12 @@ test("Pipeline7 runs post-processing before default power expansion", () => {
     ],
   })
   const powerTraceExpansionStep = solver.pipelineDef.at(-1)
-  const lengthMatchingPostProcessingStep = solver.pipelineDef.at(-2)
+  const finalViaOptimizationStep = solver.pipelineDef.at(-2)
+  const lengthMatchingPostProcessingStep = solver.pipelineDef.at(-3)
   expect(powerTraceExpansionStep?.solverName).toBe("powerTraceExpansionSolver")
+  expect(finalViaOptimizationStep?.solverName).toBe(
+    "finalViaOptimizationSolver",
+  )
   expect(lengthMatchingPostProcessingStep?.solverName).toBe(
     "lengthMatchingPostProcessingSolver",
   )

--- a/tests/pipeline7-post-processing-before-power-expansion.test.ts
+++ b/tests/pipeline7-post-processing-before-power-expansion.test.ts
@@ -48,7 +48,7 @@ test("Pipeline7 runs post-processing before default power expansion", () => {
   } as any)
   expect(powerTraceParams).toHaveLength(2)
   expect((powerTraceParams[0] as any).fixedTraces).toEqual([])
-  expect(powerTraceParams[1]).toEqual({
+  expect(powerTraceParams[1] as any).toEqual({
     allowNewVias: false,
     onlyConnectionNames: [],
   })


### PR DESCRIPTION
## Root cause

Pipeline 7's via simplification runs before width assignment and global/exact DRC repair, so final routes can retain safe same-layer excursions.

## Change

Adds `FinalViaOptimizationSolver` immediately after differential-pair post-processing and before power-trace expansion. It clones each eligible route, performs bounded deterministic same-layer excursion collapse, rebuilds transition metadata, converts through the production Pipeline 7 converter, then accepts only if production DRC, relaxed DRC, converted via count, trace length, route identity, terminals, and protected copper invariants all pass. Power expansion remains last and disallows new vias.

Differential pairs, power traces, preloaded traces, jumpers, through-obstacle routes, terminal-via routes, and via-in-pad routes are left unchanged.

## Validation

- `bun test` focused Pipeline 7 and final-optimization tests — pass
- `bun run build` — pass
- `bunx tsc --noEmit` is blocked by an existing `allowNewVias` assertion/type mismatch in `tests/pipeline7-post-processing-before-power-expansion.test.ts`.

## Benchmark status

Blacksmith benchmark execution was not available in this environment, so no benchmark before/after data is claimed. Required datasets: `dataset01`, `srj12`, `srj16`, `srj18`, `srj19`, `srj20`, `srj21`, `srj23`, `srj24`, and `srj27`.

| Dataset | Baseline completion / DRC / vias / time | Branch completion / DRC / vias / time |
| --- | --- | --- |
| Required suite | Not run here | Not run here |

Representative via reduction is covered by the focused clear `top → bottom → top` test.