### PR TITLE
Fix sample 10 mixed exact DRC residue

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "zdwiel-dataset": "git+https://github.com/dwiel/tscircuit-benchmark.git#be36518b5bf51755dae92c230061ab3cf4e3e063",
     "high-density-repair01": "git+https://github.com/tscircuit/high-density-repair01.git#cefc7be547ff727bd31573ac096b850da847af46",
     "high-density-repair02": "https://codeload.github.com/tscircuit/high-density-repair02/tar.gz/2afc0cbba3bf2f7eb6b9cd33615d21e9ad9352d4",
-    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#f6eff10e950e3a572fb416e398966b264cda4404",
+    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#7de70105130c0c245782766c9ed44720165653d4",
     "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d"
   },
   "dependencies": {


### PR DESCRIPTION
## Issue

Dataset 18 sample 10 reaches the exact-DRC stage with a mixed cluster of trace and via-to-trace errors. The targeted clearance sweep selected only trace errors, so it could not repair the cluster in one accepted candidate.

## Implementation

Update high-density-repair03 so the existing targeted sweep also selects via-to-trace clearance errors. Existing force geometry and the strictly-better full-board DRC acceptance check are unchanged.

Repair PR: https://github.com/tscircuit/high-density-repair03/pull/52
Reproduction PR: https://github.com/tscircuit/tscircuit-autorouter/pull/1920

## Validation

Hosted sample-10 snapshot and benchmark pending.