### PR TITLE
Validate safe trace via repair on affected samples

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "zdwiel-dataset": "git+https://github.com/dwiel/tscircuit-benchmark.git#be36518b5bf51755dae92c230061ab3cf4e3e063",
     "high-density-repair01": "git+https://github.com/tscircuit/high-density-repair01.git#cefc7be547ff727bd31573ac096b850da847af46",
     "high-density-repair02": "https://codeload.github.com/tscircuit/high-density-repair02/tar.gz/2afc0cbba3bf2f7eb6b9cd33615d21e9ad9352d4",
-    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#f6eff10e950e3a572fb416e398966b264cda4404",
+    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#2646ac857b5fa3520b46905a45023c99b985f093",
     "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d"
   },
   "dependencies": {


### PR DESCRIPTION
## Issue

Dataset 18 sample 8 and Dataset 24 sample 2 are the current benchmark failures containing same-net via-clearance errors after exact DRC repair.

## Validation

Pin the focused repair from tscircuit/high-density-repair03#54 so both production samples can be rerun through Pipeline 7 in GitHub Actions.

The repair removes one option override: the safe trace branch now preserves the caller-enabled targeted sweep and can use the existing same-net via canonicalization.

Reproduction: tscircuit/high-density-repair03#53.