### PR TITLE
Repair terminal traces crossing SMT pads

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "zdwiel-dataset": "git+https://github.com/dwiel/tscircuit-benchmark.git#be36518b5bf51755dae92c230061ab3cf4e3e063",
     "high-density-repair01": "git+https://github.com/tscircuit/high-density-repair01.git#cefc7be547ff727bd31573ac096b850da847af46",
     "high-density-repair02": "https://codeload.github.com/tscircuit/high-density-repair02/tar.gz/2afc0cbba3bf2f7eb6b9cd33615d21e9ad9352d4",
-    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#92e447384070b69414af530ec447b20fe6e53e95",
+    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#08f379e536f350ba18f48ad21557f28021c8ae12",
     "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d"
   },
   "dependencies": {


### PR DESCRIPTION
## Issue

A terminal-side trace can remain on foreign SMT pads when the valid repair requires moving its complete span to another layer. Local layer moves consumed the repair candidate window before that escape was evaluated.

## Implementation

Pin tscircuit/high-density-repair03#58 (reproduction: tscircuit/high-density-repair03#57). For trace-vs-obstacle errors, complete-span layer escapes are now tried before local layer moves. Other DRC errors keep their existing candidate order.

## Results

- Dataset 24 sample 9: DRC failed on the logical base; [the fix passes DRC](https://github.com/tscircuit/tscircuit-autorouter/pull/1941#issuecomment-5200705163).
- Dataset 18 sample 16: still solves and still fails DRC, so this fix does not claim to cover that SMT-pad shape ([result](https://github.com/tscircuit/tscircuit-autorouter/pull/1941#issuecomment-5200747060)).
- Regression check: all previously passing samples remain passing—[dataset 18 samples 1, 5, 10, 11, 12](https://github.com/tscircuit/tscircuit-autorouter/pull/1941#issuecomment-5200767505) and [dataset 24 samples 6, 8, 10](https://github.com/tscircuit/tscircuit-autorouter/pull/1941#issuecomment-5200878895).

All dataset commands used concurrency 1.
