### PR TITLE
Add repro for circular BGA pads treated as rectangular obstacles

### DIFF
--- a/tests/repro/__snapshots__/circular-bga-pad-rectangular-approximation.snap.svg
+++ b/tests/repro/__snapshots__/circular-bga-pad-rectangular-approximation.snap.svg
@@ -1,0 +1,44 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><rect data-type="rect" data-label="bga-pad-0-0 rectangular obstacle" data-x="0" data-y="0" x="40.00000000000003" y="466.66666666666663" width="133.33333333333331" height="133.33333333333326" fill="rgba(255, 0, 0, 0.2)" stroke="red" stroke-width="0.0037500000000000007"/></g><g><rect data-type="rect" data-label="bga-pad-0-1 rectangular obstacle" data-x="0.8" data-y="0" x="253.33333333333331" y="466.66666666666663" width="133.33333333333334" height="133.33333333333326" fill="rgba(255, 0, 0, 0.2)" stroke="red" stroke-width="0.0037500000000000007"/></g><g><rect data-type="rect" data-label="bga-pad-0-2 rectangular obstacle" data-x="1.6" data-y="0" x="466.66666666666663" y="466.66666666666663" width="133.33333333333331" height="133.33333333333326" fill="rgba(255, 0, 0, 0.2)" stroke="red" stroke-width="0.0037500000000000007"/></g><g><rect data-type="rect" data-label="bga-pad-1-0 rectangular obstacle" data-x="0" data-y="0.8" x="40.00000000000003" y="253.33333333333326" width="133.33333333333331" height="133.33333333333337" fill="rgba(255, 0, 0, 0.2)" stroke="red" stroke-width="0.0037500000000000007"/></g><g><rect data-type="rect" data-label="bga-pad-1-1 rectangular obstacle" data-x="0.8" data-y="0.8" x="253.33333333333331" y="253.33333333333326" width="133.33333333333334" height="133.33333333333337" fill="rgba(255, 0, 0, 0.2)" stroke="red" stroke-width="0.0037500000000000007"/></g><g><rect data-type="rect" data-label="bga-pad-1-2 rectangular obstacle" data-x="1.6" data-y="0.8" x="466.66666666666663" y="253.33333333333326" width="133.33333333333331" height="133.33333333333337" fill="rgba(255, 0, 0, 0.2)" stroke="red" stroke-width="0.0037500000000000007"/></g><g><rect data-type="rect" data-label="bga-pad-2-0 rectangular obstacle" data-x="0" data-y="1.6" x="40.00000000000003" y="39.99999999999997" width="133.33333333333331" height="133.33333333333331" fill="rgba(255, 0, 0, 0.2)" stroke="red" stroke-width="0.0037500000000000007"/></g><g><rect data-type="rect" data-label="bga-pad-2-1 rectangular obstacle" data-x="0.8" data-y="1.6" x="253.33333333333331" y="39.99999999999997" width="133.33333333333334" height="133.33333333333331" fill="rgba(255, 0, 0, 0.2)" stroke="red" stroke-width="0.0037500000000000007"/></g><g><rect data-type="rect" data-label="bga-pad-2-2 rectangular obstacle" data-x="1.6" data-y="1.6" x="466.66666666666663" y="39.99999999999997" width="133.33333333333331" height="133.33333333333331" fill="rgba(255, 0, 0, 0.2)" stroke="red" stroke-width="0.0037500000000000007"/></g><circle data-type="circle" data-label="" data-x="0" data-y="0" cx="106.66666666666669" cy="533.3333333333333" r="66.66666666666666" fill="rgba(0, 120, 255, 0.2)" stroke="blue" stroke-width="0.0037500000000000007"/><circle data-type="circle" data-label="" data-x="0.8" data-y="0" cx="320" cy="533.3333333333333" r="66.66666666666666" fill="rgba(0, 120, 255, 0.2)" stroke="blue" stroke-width="0.0037500000000000007"/><circle data-type="circle" data-label="" data-x="1.6" data-y="0" cx="533.3333333333333" cy="533.3333333333333" r="66.66666666666666" fill="rgba(0, 120, 255, 0.2)" stroke="blue" stroke-width="0.0037500000000000007"/><circle data-type="circle" data-label="" data-x="0" data-y="0.8" cx="106.66666666666669" cy="319.99999999999994" r="66.66666666666666" fill="rgba(0, 120, 255, 0.2)" stroke="blue" stroke-width="0.0037500000000000007"/><circle data-type="circle" data-label="" data-x="0.8" data-y="0.8" cx="320" cy="319.99999999999994" r="66.66666666666666" fill="rgba(0, 120, 255, 0.2)" stroke="blue" stroke-width="0.0037500000000000007"/><circle data-type="circle" data-label="" data-x="1.6" data-y="0.8" cx="533.3333333333333" cy="319.99999999999994" r="66.66666666666666" fill="rgba(0, 120, 255, 0.2)" stroke="blue" stroke-width="0.0037500000000000007"/><circle data-type="circle" data-label="" data-x="0" data-y="1.6" cx="106.66666666666669" cy="106.66666666666663" r="66.66666666666666" fill="rgba(0, 120, 255, 0.2)" stroke="blue" stroke-width="0.0037500000000000007"/><circle data-type="circle" data-label="" data-x="0.8" data-y="1.6" cx="320" cy="106.66666666666663" r="66.66666666666666" fill="rgba(0, 120, 255, 0.2)" stroke="blue" stroke-width="0.0037500000000000007"/><circle data-type="circle" data-label="" data-x="1.6" data-y="1.6" cx="533.3333333333333" cy="106.66666666666663" r="66.66666666666666" fill="rgba(0, 120, 255, 0.2)" stroke="blue" stroke-width="0.0037500000000000007"/><circle data-type="circle" data-label="" data-x="0.245" data-y="0.245" cx="172" cy="467.99999999999994" r="10.666666666666666" fill="red" stroke="red" stroke-width="0.0037500000000000007"/><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":266.66666666666663,"c":0,"e":106.66666666666669,"b":0,"d":-266.66666666666663,"f":533.3333333333333};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/repro/circular-bga-pad-rectangular-approximation.test.ts
+++ b/tests/repro/circular-bga-pad-rectangular-approximation.test.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "bun:test"
+import type { GraphicsObject } from "graphics-debug"
+import type { Obstacle, SimpleRouteJson } from "lib/types"
+import { addApproximatingRectsToSrj } from "lib/utils/addApproximatingRectsToSrj"
+
+type CircularObstacle = Obstacle & { shape: "circle" }
+
+test("repro: circular BGA pads retain square corner obstacles", (): void => {
+  const padDiameter = 0.5
+  const pitch = 0.8
+  const circularPads: CircularObstacle[] = []
+
+  for (let row = 0; row < 3; row++) {
+    for (let column = 0; column < 3; column++) {
+      circularPads.push({
+        obstacleId: `bga-pad-${row}-${column}`,
+        componentId: "U1",
+        type: "rect",
+        shape: "circle",
+        layers: ["top"],
+        center: { x: column * pitch, y: row * pitch },
+        width: padDiameter,
+        height: padDiameter,
+        connectedTo: [`U1-${row}-${column}`],
+      })
+    }
+  }
+
+  const input: SimpleRouteJson = {
+    layerCount: 2,
+    minTraceWidth: 0.1,
+    minViaDiameter: 0.3,
+    bounds: { minX: -1, minY: -1, maxX: 3, maxY: 3 },
+    obstacles: circularPads,
+    connections: [],
+  }
+
+  const preprocessed = addApproximatingRectsToSrj(input)
+  const firstPad = preprocessed.obstacles.find(
+    (obstacle) => obstacle.obstacleId === "bga-pad-0-0",
+  )!
+  const pointInsideSquareButOutsideCircle = {
+    x: firstPad.center.x + padDiameter * 0.49,
+    y: firstPad.center.y + padDiameter * 0.49,
+  }
+  const isBlockedByRectApproximation =
+    Math.abs(pointInsideSquareButOutsideCircle.x - firstPad.center.x) <=
+      firstPad.width / 2 &&
+    Math.abs(pointInsideSquareButOutsideCircle.y - firstPad.center.y) <=
+      firstPad.height / 2
+  const distanceFromCircleCenter = Math.hypot(
+    pointInsideSquareButOutsideCircle.x - firstPad.center.x,
+    pointInsideSquareButOutsideCircle.y - firstPad.center.y,
+  )
+
+  expect(preprocessed.obstacles).toHaveLength(9)
+  expect(isBlockedByRectApproximation).toBe(true)
+  expect(distanceFromCircleCenter).toBeGreaterThan(padDiameter / 2)
+
+  const visualization: GraphicsObject = {
+    title: "Circular BGA pads retained as rectangular obstacles",
+    rects: preprocessed.obstacles.map((obstacle) => ({
+      center: obstacle.center,
+      width: obstacle.width,
+      height: obstacle.height,
+      fill: "rgba(255, 0, 0, 0.2)",
+      stroke: "red",
+      label: `${obstacle.obstacleId} rectangular obstacle`,
+    })),
+    circles: [
+      ...circularPads.map((pad) => ({
+        center: pad.center,
+        radius: padDiameter / 2,
+        fill: "rgba(0, 120, 255, 0.2)",
+        stroke: "blue",
+        label: `${pad.obstacleId} actual circle`,
+      })),
+      {
+        center: pointInsideSquareButOutsideCircle,
+        radius: 0.04,
+        fill: "red",
+        stroke: "red",
+        label: "falsely blocked square corner",
+      },
+    ],
+  }
+
+  expect(visualization).toMatchGraphicsSvg(import.meta.path)
+})


### PR DESCRIPTION
## Summary
- add a regression test demonstrating that circular BGA pads remain rectangular after obstacle preprocessing
- verify that points outside the physical circle but inside its bounding square are incorrectly blocked
- add an SVG snapshot visualizing the rectangular approximation and falsely blocked corner