### PR TITLE
Ablate shared via site repair

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "zdwiel-dataset": "git+https://github.com/dwiel/tscircuit-benchmark.git#be36518b5bf51755dae92c230061ab3cf4e3e063",
     "high-density-repair01": "git+https://github.com/tscircuit/high-density-repair01.git#cefc7be547ff727bd31573ac096b850da847af46",
     "high-density-repair02": "https://codeload.github.com/tscircuit/high-density-repair02/tar.gz/2afc0cbba3bf2f7eb6b9cd33615d21e9ad9352d4",
-    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#92e447384070b69414af530ec447b20fe6e53e95",
+    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#1b8a4c0439d0afa44d2a6140b28852235df8cbc9",
     "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d"
   },
   "dependencies": {


### PR DESCRIPTION
## Question

Did the improvements come from the shared-via-site repair, or only from increasing the exact-repair broad iteration limit from 8 to 12?

## Control

Keep `broadMaxIterations: 12` and pin high-density-repair03 to `1b8a4c0`, the exact parent of the shared-via-site fix.

This changes one dependency pin and removes only the repair under investigation.

## Results

| Sample | Merged repair + 12 iterations | 12 iterations without repair |
| --- | --- | --- |
| Dataset 18 sample 8 | 19 DRC, 0 via-clearance, 301 vias | 24 DRC, 4 via-clearance, 301 vias |
| Dataset 24 sample 2 | 75 DRC, 0 via-clearance, 331 vias | 75 DRC, 2 via-clearance, 331 vias |

Hosted controls: [dataset 18 sample 8](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/31086701437) and [dataset 24 sample 2](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/31087785173).

The first dataset 24 control timed out in the upstream HighDensitySolver before repair. The linked rerun used a 900-second sample timeout and reached the comparable solved output.

## Conclusion

The iteration increase alone does not reproduce the repair's via-clearance improvement. The shared-via-site fix removes four via-clearance errors and five total DRC errors from dataset 18 sample 8, and removes two via-clearance errors from dataset 24 sample 2. Dataset 24's total DRC count remains unchanged, so its improvement is specific to the targeted error class.

CI includes expected fixed-output snapshot failures because this control deliberately restores the old behavior. Those snapshots are intentionally not updated.

Investigation only; this PR should not be merged.