### PR TITLE
Benchmark SMT pad repair performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "zdwiel-dataset": "git+https://github.com/dwiel/tscircuit-benchmark.git#be36518b5bf51755dae92c230061ab3cf4e3e063",
     "high-density-repair01": "git+https://github.com/tscircuit/high-density-repair01.git#cefc7be547ff727bd31573ac096b850da847af46",
     "high-density-repair02": "https://codeload.github.com/tscircuit/high-density-repair02/tar.gz/2afc0cbba3bf2f7eb6b9cd33615d21e9ad9352d4",
-    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#92e447384070b69414af530ec447b20fe6e53e95",
+    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#27eeeeaedab77bd713ee30f123931886a6820818",
     "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d"
   },
   "dependencies": {


### PR DESCRIPTION
## Purpose

Benchmark-only mirror of #1941. This PR is not intended to merge.

It applies the same high-density-repair03 commit so timing experiments can run here without adding test comments to the wanted PR.

## Comparison

Dataset 18 samples 3, 9, and 16 ran sequentially with concurrency 1. The control is version-bump PR #1943.

| Sample | Control R1 | Fix R1 | Control R2 | Fix R2 | Control avg | Fix avg |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 3 | 55.6s | 46.0s | 46.5s | 47.0s | 51.1s | 46.5s |
| 9 | 115.7s | 105.2s | 104.0s | 103.3s | 109.9s | 104.3s |
| 16 | 111.0s | 89.2s | 89.6s | 87.8s | 100.3s | 88.5s |

Runs: [control R1](https://github.com/tscircuit/tscircuit-autorouter/pull/1943#issuecomment-5203083721), [fix R1](https://github.com/tscircuit/tscircuit-autorouter/pull/1945#issuecomment-5203151985), [control R2](https://github.com/tscircuit/tscircuit-autorouter/pull/1943#issuecomment-5203211344), [fix R2](https://github.com/tscircuit/tscircuit-autorouter/pull/1945#issuecomment-5203329752).

The fix does not reproduce the apparent slowdown. Round 2 is within 2% for every sample. The unchanged control itself varies by 11–24% between rounds, which explains the misleading single full-run comparison.
