### PR TITLE
fix(topology): drop sub-epsilon obstacles that abort topology merging

### DIFF
--- a/lib/solvers/TopologyPlanningSolver/MultiGraphTopologyPlannerSolver.ts
+++ b/lib/solvers/TopologyPlanningSolver/MultiGraphTopologyPlannerSolver.ts
@@ -187,7 +187,7 @@ export class MultiGraphTopologyPlannerSolver extends BasePipelineSolver<MultiGra
   private getComponentNoConnectionSrjs(): SimpleRouteJson[] {
     return this.normalizedInput.components.map((component) =>
       createComponentSrj({
-        inputSrj: this.inputProblem.inputSrj,
+        inputSrj: this.normalizedInput.inputSrj,
         component,
       }),
     )

--- a/lib/solvers/TopologyPlanningSolver/capacity-node-geometry.ts
+++ b/lib/solvers/TopologyPlanningSolver/capacity-node-geometry.ts
@@ -40,6 +40,28 @@ export function isValidCapacityBounds(bounds: Bounds): boolean {
   return hasValidWidth && hasValidHeight
 }
 
+/**
+ * Removes obstacles that are thinner than GEOMETRY_EPSILON in either dimension.
+ *
+ * Topology generation turns every obstacle rect into capacity mesh nodes, and a
+ * rect below GEOMETRY_EPSILON produces a node that `isValidCapacityBounds`
+ * rejects, so it aborts TopologyMergingSolver input validation. Such a rect also
+ * carries no routable or blocking area: it cannot hold a port point and no trace
+ * can collide with it. Topology planning drops it at its input so every stage
+ * uses one definition of real geometry.
+ */
+export function dropDegenerateObstacles(obstacles: Obstacle[]): Obstacle[] {
+  return obstacles.filter((obstacle) => {
+    const obstacleBounds = getBoundFromCenteredRect({
+      center: obstacle.center,
+      width: obstacle.width,
+      height: obstacle.height,
+    })
+
+    return isValidCapacityBounds(obstacleBounds)
+  })
+}
+
 export function isNodeInsideOrOverlappingObstacle({
   node,
   obstacle,

--- a/lib/solvers/TopologyPlanningSolver/topologyPlanningShared.ts
+++ b/lib/solvers/TopologyPlanningSolver/topologyPlanningShared.ts
@@ -24,12 +24,14 @@ import "lib/solvers/BgaTopologyGeneratorSolver/BgaTopologyGeneratorSolver"
 import "lib/solvers/QfpThermalPadTopologyGeneratorSolver/QfpThermalPadTopologyGeneratorSolver"
 import "lib/solvers/QfpTopologyGeneratorSolver/QfpTopologyGeneratorSolver"
 import "lib/solvers/SoicTopologyGeneratorSolver/SoicTopologyGeneratorSolver"
+import { dropDegenerateObstacles } from "./capacity-node-geometry"
 import type {
   MultiGraphTopologyPlannerSolverParams,
   SerializedTopologyComponentInput,
 } from "./MultiGraphTopologyPlannerSolver"
 
 export interface NormalizedTopologyPlannerInput {
+  inputSrj: SimpleRouteJson
   globalNoConnectionSrj: SimpleRouteJson
   components: SerializedTopologyComponentInput[]
 }
@@ -119,19 +121,20 @@ export function createComponentSrj({
 export function normalizeInput(
   input: MultiGraphTopologyPlannerSolverParams,
 ): NormalizedTopologyPlannerInput {
+  const inputSrj = withoutDegenerateObstacles(input.inputSrj)
   const detectedComponents = input.componentDetectionOutput ?? []
   const serializedDetectedComponents = serializeDetectedComponents({
     detectedComponents,
-    inputSrj: input.inputSrj,
+    inputSrj,
   })
   const globalNoConnectionSrj =
     input.globalNoConnectionSrj ??
     (detectedComponents.length > 0
       ? createComponentObstacleSrj({
           detectedComponents,
-          inputSrj: input.inputSrj,
+          inputSrj,
         })
-      : input.inputSrj) ??
+      : inputSrj) ??
     input.brokenSrj?.componentsAsObstaclesSrj
   const components =
     input.components ??
@@ -146,8 +149,20 @@ export function normalizeInput(
   }
 
   return {
-    globalNoConnectionSrj,
+    inputSrj,
+    globalNoConnectionSrj: withoutDegenerateObstacles(globalNoConnectionSrj),
     components,
+  }
+}
+
+/**
+ * Applies the shared degenerate geometry policy to an SRJ handed to topology
+ * planning. See dropDegenerateObstacles for why sub-epsilon rects are dropped.
+ */
+function withoutDegenerateObstacles(srj: SimpleRouteJson): SimpleRouteJson {
+  return {
+    ...srj,
+    obstacles: dropDegenerateObstacles(srj.obstacles),
   }
 }
 

--- a/tests/features/topology/merged-topology/degenerate-component-obstacle-nodes.test.ts
+++ b/tests/features/topology/merged-topology/degenerate-component-obstacle-nodes.test.ts
@@ -1,0 +1,134 @@
+import { expect, test } from "bun:test"
+import {
+  getCapacityMeshNodeBounds,
+  isValidCapacityBounds,
+} from "lib/solvers/TopologyPlanningSolver/capacity-node-geometry"
+import type { Obstacle, SimpleRouteJson } from "lib/types"
+import {
+  createTopologyMergingSolverFromPlanning,
+  createTopologyPlanningSolverForMerging,
+} from "../../../fixtures/topology-merging-test-utils"
+
+type ObstacleSpec = {
+  id: string
+  x: number
+  y: number
+  width: number
+  height: number
+  componentId?: string
+  connectedTo?: string[]
+}
+
+function createObstacle({
+  id,
+  x,
+  y,
+  width,
+  height,
+  componentId,
+  connectedTo = [],
+}: ObstacleSpec): Obstacle {
+  return {
+    obstacleId: id,
+    componentId,
+    type: "rect",
+    layers: ["top"],
+    __zLayers: [0],
+    center: { x, y },
+    width,
+    height,
+    connectedTo,
+  }
+}
+
+/**
+ * A BGA grid with one sub-GEOMETRY_EPSILON member pad. The component-local
+ * topology solve turns every member pad into capacity nodes, so the degenerate
+ * pad produces zero-area nodes in the "component-0" group.
+ */
+function createBgaWithDegenerateMemberSrj(): SimpleRouteJson {
+  const obstacles: Obstacle[] = []
+  const positions = [-1.5, -0.5, 0.5, 1.5]
+
+  for (const x of positions) {
+    for (const y of positions) {
+      obstacles.push(
+        createObstacle({
+          id: `u_bga_${obstacles.length}`,
+          componentId: "u_bga",
+          x,
+          y,
+          width: 0.25,
+          height: 0.25,
+        }),
+      )
+    }
+  }
+
+  obstacles.push(
+    createObstacle({
+      id: "u_bga_dust",
+      componentId: "u_bga",
+      x: 0,
+      y: 1,
+      width: 5e-10,
+      height: 0.25,
+    }),
+  )
+
+  return {
+    layerCount: 2,
+    minTraceWidth: 0.12,
+    minViaPadDiameter: 0.35,
+    defaultObstacleMargin: 0.12,
+    bounds: { minX: -4, maxX: 4, minY: -4, maxY: 4 },
+    obstacles: [
+      ...obstacles,
+      createObstacle({
+        id: "outside_pad",
+        x: 3.2,
+        y: 3.2,
+        width: 0.3,
+        height: 0.3,
+        connectedTo: ["outside_port"],
+      }),
+    ],
+    connections: [
+      {
+        name: "bga_net",
+        pointsToConnect: [
+          { pointId: "bga_inner_port", x: -0.5, y: -0.5, layer: "top" },
+          { pointId: "outside_port", x: 3.2, y: 3.2, layer: "top" },
+        ],
+      },
+    ],
+  }
+}
+
+test("degenerate component pads do not reach topology merging as nodes", (): void => {
+  const inputSrj = createBgaWithDegenerateMemberSrj()
+  const topologyPlanningSolver =
+    createTopologyPlanningSolverForMerging(inputSrj)
+  topologyPlanningSolver.solve()
+
+  const componentMeshNodes = topologyPlanningSolver
+    .getOutput()
+    .componentMeshNodes.flat()
+  const degenerateNodeIds = componentMeshNodes
+    .filter((node) => !isValidCapacityBounds(getCapacityMeshNodeBounds(node)))
+    .map((node) => node.capacityMeshNodeId)
+
+  expect(topologyPlanningSolver.failed).toBe(false)
+  expect(componentMeshNodes.length).toBeGreaterThan(0)
+  expect(degenerateNodeIds).toEqual([])
+
+  const topologyMergingSolver = createTopologyMergingSolverFromPlanning({
+    inputSrj,
+    topologyPlanningSolver,
+  })
+  topologyMergingSolver.solve()
+
+  expect(topologyMergingSolver.solved).toBe(true)
+  expect(topologyMergingSolver.failed).toBe(false)
+  expect(topologyMergingSolver.getOutput().length).toBeGreaterThan(0)
+})

--- a/tests/features/topology/merged-topology/degenerate-global-obstacle-nodes.test.ts
+++ b/tests/features/topology/merged-topology/degenerate-global-obstacle-nodes.test.ts
@@ -1,0 +1,115 @@
+import { expect, test } from "bun:test"
+import {
+  getCapacityMeshNodeBounds,
+  isValidCapacityBounds,
+} from "lib/solvers/TopologyPlanningSolver/capacity-node-geometry"
+import type { Obstacle, SimpleRouteJson } from "lib/types"
+import {
+  createTopologyMergingSolverFromPlanning,
+  createTopologyPlanningSolverForMerging,
+} from "../../../fixtures/topology-merging-test-utils"
+
+type ObstacleSpec = {
+  id: string
+  x: number
+  y: number
+  width: number
+  height: number
+  connectedTo?: string[]
+}
+
+function createObstacle({
+  id,
+  x,
+  y,
+  width,
+  height,
+  connectedTo = [],
+}: ObstacleSpec): Obstacle {
+  return {
+    obstacleId: id,
+    type: "rect",
+    layers: ["top"],
+    __zLayers: [0],
+    center: { x, y },
+    width,
+    height,
+    connectedTo,
+  }
+}
+
+/**
+ * Two obstacles whose dimensions sit between 0 and GEOMETRY_EPSILON. RectDiff
+ * only drops rects with a non-positive dimension, so these reach topology
+ * planning and become zero-area capacity nodes.
+ */
+function createDegenerateObstacleSrj(): SimpleRouteJson {
+  return {
+    layerCount: 2,
+    minTraceWidth: 0.12,
+    minViaPadDiameter: 0.35,
+    defaultObstacleMargin: 0.12,
+    bounds: { minX: -5, maxX: 5, minY: -5, maxY: 5 },
+    obstacles: [
+      createObstacle({ id: "dust_width", x: 0, y: 0, width: 5e-10, height: 1 }),
+      createObstacle({
+        id: "dust_height",
+        x: 2,
+        y: 2,
+        width: 1,
+        height: 1e-10,
+      }),
+      createObstacle({
+        id: "start_pad",
+        x: -4,
+        y: -4,
+        width: 0.3,
+        height: 0.3,
+        connectedTo: ["start_port"],
+      }),
+      createObstacle({
+        id: "end_pad",
+        x: 4,
+        y: 4,
+        width: 0.3,
+        height: 0.3,
+        connectedTo: ["end_port"],
+      }),
+    ],
+    connections: [
+      {
+        name: "dust_net",
+        pointsToConnect: [
+          { pointId: "start_port", x: -4, y: -4, layer: "top" },
+          { pointId: "end_port", x: 4, y: 4, layer: "top" },
+        ],
+      },
+    ],
+  }
+}
+
+test("degenerate obstacles do not reach topology merging as global nodes", (): void => {
+  const inputSrj = createDegenerateObstacleSrj()
+  const topologyPlanningSolver =
+    createTopologyPlanningSolverForMerging(inputSrj)
+  topologyPlanningSolver.solve()
+
+  const globalMeshNodes = topologyPlanningSolver.getOutput().globalMeshNodes
+  const degenerateNodeIds = globalMeshNodes
+    .filter((node) => !isValidCapacityBounds(getCapacityMeshNodeBounds(node)))
+    .map((node) => node.capacityMeshNodeId)
+
+  expect(topologyPlanningSolver.failed).toBe(false)
+  expect(globalMeshNodes.length).toBeGreaterThan(0)
+  expect(degenerateNodeIds).toEqual([])
+
+  const topologyMergingSolver = createTopologyMergingSolverFromPlanning({
+    inputSrj,
+    topologyPlanningSolver,
+  })
+  topologyMergingSolver.solve()
+
+  expect(topologyMergingSolver.solved).toBe(true)
+  expect(topologyMergingSolver.failed).toBe(false)
+  expect(topologyMergingSolver.getOutput().length).toBeGreaterThan(0)
+})


### PR DESCRIPTION
Fixes #1614

## Repro

Two tests, both failing on `main` before the fix.

`tests/features/topology/merged-topology/degenerate-global-obstacle-nodes.test.ts`
builds a small two layer board whose obstacle list contains one rect `5e-10` wide
and one `1e-10` tall. Topology planning turns them into zero-area capacity nodes
and the pipeline aborts with the error from the issue:

```
TopologyMergingSolver: node "cmn_12" in group "global" has invalid bounds
```

`tests/features/topology/merged-topology/degenerate-component-obstacle-nodes.test.ts`
does the same for a BGA whose member pads include one sub-epsilon pad. That one
fails in the component-local group:

```
TopologyMergingSolver: node "free-u_bga-u_bga_dust-1" in group "component-0" has invalid bounds
```

## Root cause

Two stages disagree about what counts as geometry.

- RectDiff drops a rect only when a dimension is non-positive (`w <= 0 || h <= 0`).
- `isValidCapacityBounds` requires both dimensions to be strictly greater than
  `GEOMETRY_EPSILON`, which is `1e-9`.

An obstacle whose width or height lands in `(0, 1e-9]` passes the first gate and
fails the second. It survives into `topologyOutput.globalMeshNodes` (or into a
component group through the BGA/QFP/SOIC generators) and `TopologyMergingSolver`
input validation throws on it. An obstacle dimension of exactly `0` is already
dropped upstream, so the window is narrow and easy to miss.

Two details the repro corrects in the report: the degenerate node does not
originate inside the global mesh stage, it is the obstacle rect handed to that
stage (the failing node carries exactly the obstacle's dimensions). The same
input also produces degenerate component-local nodes, which the report does not
mention.

## Fix

Topology planning drops obstacles that are degenerate under the same predicate
the capacity node validation uses, at its input, before any topology is
generated. `dropDegenerateObstacles` sits next to `isValidCapacityBounds` so the
two definitions cannot drift. `normalizeInput` applies it to the SRJ that every
downstream stage derives from, which covers the global RectDiff solve and the
component-local solves.

This is an explicit policy, not a swallowed error. A rect thinner than a
picometre carries no routable and no blocking area: it cannot hold a port point
and no trace can collide with it, so removing it cannot change a route. Nothing
has failed at normalization time. The loud validation in `TopologyMergingSolver`
is untouched, so it still throws for every other invalid input.

#1615 went the other way and filtered nodes after the generators had produced
them. It was closed by the stale bot without review. Removing the geometry at the
input is what the issue asked for and it covers the component groups as well.

## Behaviour on existing boards

No board in the repo carries such an obstacle, so the filter is a no-op
everywhere except on the broken input in the issue. Measured by scanning every
SRJ the repo can route:

| corpus | SRJs | obstacles | in `(0, 1e-9]` |
| --- | --- | --- | --- |
| `fixtures/**/*.json` | 189 | 39,039 | 0 |
| bundled benchmark datasets | 1,012 | 136,654 | 0 |

## Verified locally

- `bun test tests/features/topology tests/component-detection-bga-only.test.ts`:
  35 pass, 0 fail, 21 files
- the two new tests: 2 pass with the fix, both fail on an unmodified checkout of
  the parent commit with the node ids quoted above
- `bun test tests/pipeline7-final-net-colors.test.ts
  tests/pipeline7-lock-terminal-ports.test.ts
  tests/features/arduino-uno-inner-pours.test.ts
  tests/srj-obstacle-component-id.test.ts tests/e2e1.test.ts`: 6 pass, 1 skip,
  0 fail
- `bunx tsc --noEmit`: clean
- `bunx biome format` on the five touched files: clean
- `bun run build`: success

Happy to split this into a repro PR and a fix PR if you prefer that order; the
two commits are already separated that way.

AI assistance (Claude, Anthropic) was used in developing this change. The design,
review and verification were done by the author.

