### PR TITLE
Support immutable via anchors during trace simplification

### DIFF
--- a/lib/solvers/SameNetViaMergerSolver/SameNetViaMergerSolver.ts
+++ b/lib/solvers/SameNetViaMergerSolver/SameNetViaMergerSolver.ts
@@ -16,6 +16,8 @@ export interface SameNetViaMergerSolverInput {
   inputHdRoutes: HighDensityRoute[]
   /** Routed copper that participates in collision checks but is never changed. */
   otherHdRoutes?: ReadonlyArray<HighDensityRoute>
+  /** Explicit connection metadata for routes whose names are not in connMap. */
+  netByConnectionName?: ReadonlyMap<string, string>
   obstacles: Obstacle[]
   colorMap: Record<string, string>
   layerCount: number
@@ -30,6 +32,7 @@ type Via = {
   net: string
   routeIndex: number
   layers: number[]
+  mutable: boolean
 }
 
 const NEAR_VIA_MERGE_DISTANCE_MULTIPLIER = 2.5
@@ -38,7 +41,9 @@ const OBSTACLE_MARGIN = 0.1
 const tryGetNetForRoute = (
   connMap: ConnectivityMap,
   route: HighDensityRoute,
+  netByConnectionName?: ReadonlyMap<string, string>,
 ): string | undefined =>
+  netByConnectionName?.get(route.connectionName) ??
   connMap.idToNetMap[route.connectionName] ??
   (route.rootConnectionName
     ? connMap.idToNetMap[route.rootConnectionName]
@@ -47,8 +52,9 @@ const tryGetNetForRoute = (
 const getNetForRoute = (
   connMap: ConnectivityMap,
   route: HighDensityRoute,
+  netByConnectionName?: ReadonlyMap<string, string>,
 ): string => {
-  const net = tryGetNetForRoute(connMap, route)
+  const net = tryGetNetForRoute(connMap, route, netByConnectionName)
   if (!net) {
     throw new Error(
       `SameNetViaMergerSolver could not find net for route "${route.connectionName}"`,
@@ -80,6 +86,7 @@ const canMoveViaTo = (
     mergedViaHdRoutes: HighDensityRoute[]
     hdRouteSHI: HighDensityRouteSpatialIndex
     obstacleSHI: ObstacleSpatialHashIndex
+    netByConnectionName?: ReadonlyMap<string, string>
   },
 ): boolean => {
   const route = context.mergedViaHdRoutes[viaToRemove.routeIndex]
@@ -123,7 +130,11 @@ const canMoveViaTo = (
     for (const { conflictingRoute, distance } of conflictingRoutes) {
       if (conflictingRoute.connectionName === route.connectionName) continue
       if (
-        tryGetNetForRoute(context.connMap, conflictingRoute) === viaToRemove.net
+        tryGetNetForRoute(
+          context.connMap,
+          conflictingRoute,
+          context.netByConnectionName,
+        ) === viaToRemove.net
       )
         continue
 
@@ -179,6 +190,7 @@ export class SameNetViaMergerSolver extends BaseSolver {
   outline?: Array<{ x: number; y: number }>
   obstacles: Obstacle[]
   viasByNet: Map<string, Via[]>
+  netByConnectionName?: ReadonlyMap<string, string>
 
   obstacleSHI: ObstacleSpatialHashIndex
   hdRouteSHI: HighDensityRouteSpatialIndex
@@ -216,6 +228,7 @@ export class SameNetViaMergerSolver extends BaseSolver {
     this.vias = []
     this.offendingVias = []
     this.connMap = input.connMap
+    this.netByConnectionName = input.netByConnectionName
 
     this.viasByNet = new Map<string, Via[]>()
 
@@ -226,8 +239,17 @@ export class SameNetViaMergerSolver extends BaseSolver {
     this.vias = []
     this.viasByNet = new Map<string, Via[]>()
 
-    for (let i = 0; i < this.mergedViaHdRoutes.length; i++) {
-      const route = this.mergedViaHdRoutes[i]
+    const addRouteVias = (
+      route: HighDensityRoute,
+      routeIndex: number,
+      mutable: boolean,
+    ) => {
+      if (route.vias.length === 0) return
+      const net = mutable
+        ? getNetForRoute(this.connMap, route, this.netByConnectionName)
+        : tryGetNetForRoute(this.connMap, route, this.netByConnectionName)
+      if (!net) return
+
       for (let j = 0; j < route.vias.length; j++) {
         const viaPoint = route.vias[j]
         const layers = [...new Set(route.route.map((p) => p.z))]
@@ -241,9 +263,10 @@ export class SameNetViaMergerSolver extends BaseSolver {
           x: viaPoint.x,
           y: viaPoint.y,
           diameter: route.viaDiameter,
-          net: getNetForRoute(this.connMap, route),
+          net,
           layers,
-          routeIndex: i,
+          routeIndex,
+          mutable,
         }
         this.vias.push(via)
         const list = this.viasByNet.get(via.net)
@@ -251,12 +274,28 @@ export class SameNetViaMergerSolver extends BaseSolver {
         else this.viasByNet.set(via.net, [via])
       }
     }
+
+    for (let i = 0; i < this.mergedViaHdRoutes.length; i++) {
+      addRouteVias(this.mergedViaHdRoutes[i]!, i, true)
+    }
+    for (let i = 0; i < (this.input.otherHdRoutes?.length ?? 0); i++) {
+      addRouteVias(
+        this.input.otherHdRoutes![i]!,
+        this.mergedViaHdRoutes.length + i,
+        false,
+      )
+    }
   }
 
   private getViaKey(via: Via): string {
-    return [via.routeIndex, via.x, via.y, via.layers.join(","), via.net].join(
-      ":",
-    )
+    return [
+      via.mutable ? "mutable" : "immutable",
+      via.routeIndex,
+      via.x,
+      via.y,
+      via.layers.join(","),
+      via.net,
+    ].join(":")
   }
 
   private dedupeRouteVias(route: HighDensityRoute): void {
@@ -312,6 +351,7 @@ export class SameNetViaMergerSolver extends BaseSolver {
               if (candidateIndex === viaIndex) continue
 
               const candidate = viasInNet[candidateIndex]
+              if (!candidate.mutable) continue
 
               const pairDx = keep.x - candidate.x
               const pairDy = keep.y - candidate.y
@@ -321,7 +361,10 @@ export class SameNetViaMergerSolver extends BaseSolver {
               const nearMergeDistance =
                 directOverlapDistance * NEAR_VIA_MERGE_DISTANCE_MULTIPLIER
 
-              if (squaredDistance === 0) continue
+              if (squaredDistance === 0) {
+                if (!keep.mutable) remove.push(candidate)
+                continue
+              }
 
               if (
                 squaredDistance <=
@@ -338,6 +381,7 @@ export class SameNetViaMergerSolver extends BaseSolver {
                   mergedViaHdRoutes: this.mergedViaHdRoutes,
                   hdRouteSHI: this.hdRouteSHI,
                   obstacleSHI: this.obstacleSHI,
+                  netByConnectionName: this.netByConnectionName,
                 })
               ) {
                 remove.push(candidate)
@@ -353,6 +397,9 @@ export class SameNetViaMergerSolver extends BaseSolver {
     candidateGroups.sort((a, b) => {
       if (b.remove.length !== a.remove.length) {
         return b.remove.length - a.remove.length
+      }
+      if (a.keep.mutable !== b.keep.mutable) {
+        return a.keep.mutable ? 1 : -1
       }
       if (b.keep.layers.length !== a.keep.layers.length) {
         return b.keep.layers.length - a.keep.layers.length
@@ -381,6 +428,11 @@ export class SameNetViaMergerSolver extends BaseSolver {
   }
 
   private moveViaTo(viaToRemove: Via, viaKeep: Via, rebuildVias = true): void {
+    if (!viaToRemove.mutable) {
+      throw new Error(
+        "SameNetViaMergerSolver cannot mutate an immutable via anchor",
+      )
+    }
     const routeToUpdate = this.mergedViaHdRoutes[viaToRemove.routeIndex]
     if (!routeToUpdate) {
       throw new Error(
@@ -433,10 +485,10 @@ export class SameNetViaMergerSolver extends BaseSolver {
       route[routePointIndex] = { ...point, x: viaKeep.x, y: viaKeep.y }
     }
 
-    routeToUpdate.vias = routeToUpdate.vias.map((vx) => {
+    routeToUpdate.vias = routeToUpdate.vias.flatMap((vx) => {
       if (vx.x !== viaToRemove.x || vx.y !== viaToRemove.y) return vx
       replacedVia = true
-      return { x: viaKeep.x, y: viaKeep.y }
+      return viaKeep.mutable ? [{ x: viaKeep.x, y: viaKeep.y }] : []
     })
     if (!replacedVia) {
       throw new Error(

--- a/lib/solvers/TraceSimplificationSolver/TraceSimplificationSolver.ts
+++ b/lib/solvers/TraceSimplificationSolver/TraceSimplificationSolver.ts
@@ -72,6 +72,7 @@ export class TraceSimplificationSolver extends BaseSolver {
    *   - layerCount: Number of routing layers
    *   - minTraceToPadEdgeClearance: Minimum trace-edge clearance to pads/vias
    *   - otherHdRoutes: Immutable routed traces to avoid while simplifying
+   *   - netByConnectionName: Explicit net metadata for synthetic route names
    *   - iterations: Number of complete simplification iterations (default: 2)
    */
   constructor(
@@ -85,6 +86,7 @@ export class TraceSimplificationSolver extends BaseSolver {
       readonly layerCount: number
       readonly minTraceToPadEdgeClearance?: number
       readonly otherHdRoutes?: ReadonlyArray<HighDensityRoute>
+      readonly netByConnectionName?: ReadonlyMap<string, string>
     },
   ) {
     super()
@@ -254,6 +256,7 @@ export class TraceSimplificationSolver extends BaseSolver {
           this.activeSubSolver = new SameNetViaMergerSolver({
             inputHdRoutes: this.hdRoutes,
             otherHdRoutes: [...(this.simplificationConfig.otherHdRoutes ?? [])],
+            netByConnectionName: this.simplificationConfig.netByConnectionName,
             obstacles: [...this.simplificationConfig.obstacles],
             colorMap: { ...this.simplificationConfig.colorMap },
             layerCount: this.simplificationConfig.layerCount,

--- a/tests/solvers/same-net-via-merger-immutable-anchor.test.ts
+++ b/tests/solvers/same-net-via-merger-immutable-anchor.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { SameNetViaMergerSolver } from "lib/solvers/SameNetViaMergerSolver/SameNetViaMergerSolver"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+
+const makeViaRoute = ({
+  connectionName,
+  rootConnectionName,
+  x,
+}: {
+  connectionName: string
+  rootConnectionName: string
+  x: number
+}): HighDensityRoute => ({
+  connectionName,
+  rootConnectionName,
+  traceThickness: 0.1,
+  viaDiameter: 0.3,
+  route: [
+    { x: x - 0.5, y: 0, z: 0 },
+    { x, y: 0, z: 0 },
+    { x, y: 0, z: 1 },
+    { x: x + 0.5, y: 0, z: 1 },
+  ],
+  vias: [{ x, y: 0 }],
+})
+
+test("same-net via merging reuses an immutable via without mutating it", () => {
+  const editableRoute = makeViaRoute({
+    connectionName: "editable",
+    rootConnectionName: "net0",
+    x: 0.02,
+  })
+  const immutableRoute = makeViaRoute({
+    connectionName: "preloaded_fixed_0",
+    rootConnectionName: "net0",
+    x: 0,
+  })
+  const immutableSnapshot = structuredClone(immutableRoute)
+  const solver = new SameNetViaMergerSolver({
+    inputHdRoutes: [editableRoute],
+    otherHdRoutes: [immutableRoute],
+    netByConnectionName: new Map([["preloaded_fixed_0", "net0"]]),
+    obstacles: [],
+    colorMap: {},
+    layerCount: 2,
+    connMap: new ConnectivityMap({
+      net0: ["editable"],
+    }),
+  })
+
+  solver.solve()
+
+  expect(solver.failed).toBeFalse()
+  const [mergedRoute] = solver.getMergedViaHdRoutes()!
+  expect(mergedRoute!.vias).toHaveLength(0)
+  expect(
+    mergedRoute!.route.filter(
+      (point, pointIndex) =>
+        pointIndex > 0 && point.z !== mergedRoute!.route[pointIndex - 1]!.z,
+    ),
+  ).toEqual([{ x: 0, y: 0, z: 1 }])
+  expect(immutableRoute).toEqual(immutableSnapshot)
+})


### PR DESCRIPTION
## What changed

- includes vias from immutable `otherHdRoutes` as same-net merge anchors
- never mutates or re-emits immutable anchor vias
- accepts explicit net metadata for synthetic connection names
- passes that metadata through `TraceSimplificationSolver`

## Validation

- `bun test --timeout 9999999 tests/solvers/same-net-via-merger-immutable-anchor.test.ts`
- `bun test --timeout 9999999 tests/solvers/same-net-via-merger-direct-overlap-star.test.ts tests/features/same-net-via-clearance-repair-visual.test.ts`
- `bunx tsc --noEmit`

## Stack

- Depends on #1954
- Next: Pipeline9 B01 routing