### PR TITLE
Evaluate Pipeline9 routes jointly with preloaded copper

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/lock-hd-route-terminals.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/lock-hd-route-terminals.ts
@@ -97,7 +97,9 @@ export const lockHdRouteTerminals = (
           pcb_port_id: endTerminal.pcb_port_id,
         }
       }
-      return point
+      const interiorPoint = { ...point }
+      delete interiorPoint.pcb_port_id
+      return interiorPoint
     })
 
     return { ...hdRoute, route }

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph.ts
@@ -72,11 +72,11 @@ import {
   type PreloadedHighDensityRoute,
 } from "./convert-preloaded-traces-to-hd-routes"
 import { Pipeline9HighDensitySolver } from "./pipeline9-high-density-solver"
+import { createPipeline9RelaxedDrcEvaluator } from "./create-pipeline9-relaxed-drc-evaluator"
 import { PreloadedTraceGraphSolver } from "./preloaded-trace-graph-solver"
 import { PreprocessSimpleRouteJsonWithoutTraceObstaclesSolver } from "./preprocess-simple-route-json-without-trace-obstacles-solver"
 import { MergedComponentTopologyView } from "../AutoroutingPipeline7_MultiGraph/MergedComponentTopologyView"
 import { convertPipeline7HdRoutesToSimplifiedPcbTraces } from "../AutoroutingPipeline7_MultiGraph/convertPipeline7HdRoutesToSimplifiedPcbTraces"
-import { createPipeline7RelaxedDrcEvaluator } from "../AutoroutingPipeline7_MultiGraph/create-pipeline7-relaxed-drc-evaluator"
 import { lockHdRouteTerminals } from "../AutoroutingPipeline7_MultiGraph/lock-hd-route-terminals"
 
 interface CapacityMeshSolverOptions {
@@ -702,7 +702,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
       "exactGeometryDrcForceImproveSolver",
       GlobalDrcBranchPortfolioSolver,
       (cms) => {
-        const relaxedDrcEvaluator = createPipeline7RelaxedDrcEvaluator({
+        const relaxedDrcEvaluator = createPipeline9RelaxedDrcEvaluator({
           connections: cms.netToPointPairsSolver?.newConnections ?? [],
           originalConnections: cms.originalSrj.connections,
           layerCount: cms.srj.layerCount,
@@ -711,6 +711,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
           connMap: cms.connMap,
           srjWithPointPairs: cms.srjWithPointPairs!,
           originalSrj: cms.originalSrj,
+          mutatedPreloadedTraces: cms.getMutatedPreloadedTraces(),
         })
 
         return [
@@ -726,6 +727,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
             enableLargeBoardBroadFallback: false,
             enableTargetedErrorSweep: true,
             enablePostSolveClearanceRelaxation: false,
+            enableSafeTraceLayerMoves: true,
             enableViaInPadLayerMoves: true,
             viaInPadMaxIterations: 32,
             broadMaxIterations: 8,
@@ -785,7 +787,15 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
         )
         return [
           {
-            hdRoutes: cms.exactGeometryDrcForceImproveSolver!.getOutput(),
+            hdRoutes: lockHdRouteTerminals(
+              cms.exactGeometryDrcForceImproveSolver!.getOutput(),
+              connections,
+              new Map(
+                (cms.highDensityStitchSolver?.mergedHdRoutes ?? []).map(
+                  (route) => [route.connectionName, route],
+                ),
+              ),
+            ),
             differentialPairs,
             obstacles: cms.srj.obstacles,
             bounds: cms.srj.bounds,

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/create-pipeline9-relaxed-drc-evaluator.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/create-pipeline9-relaxed-drc-evaluator.ts
@@ -1,0 +1,56 @@
+import type { DrcEvaluator } from "high-density-repair03/lib"
+import { convertPipeline7HdRoutesToSimplifiedPcbTraces } from "lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/convertPipeline7HdRoutesToSimplifiedPcbTraces"
+import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
+import type { SimpleRouteJson, SimplifiedPcbTrace } from "lib/types"
+import type { ConvertPipeline7HdRoutesOptions } from "../AutoroutingPipeline7_MultiGraph/convertPipeline7HdRoutesToSimplifiedPcbTraces"
+import { normalizePipeline9DrcErrorsForRepair } from "./normalize-pipeline9-drc-errors-for-repair"
+import { preparePipeline9DrcRoutedTraces } from "./prepare-pipeline9-drc-routed-traces"
+
+type CreatePipeline9RelaxedDrcEvaluatorOptions = Omit<
+  ConvertPipeline7HdRoutesOptions,
+  "hdRoutes"
+> & {
+  srjWithPointPairs: SimpleRouteJson
+  originalSrj: SimpleRouteJson
+  mutatedPreloadedTraces: SimplifiedPcbTrace[]
+}
+
+/** Scores candidates using the same preloaded-trace replacement rules as output. */
+export const createPipeline9RelaxedDrcEvaluator = (
+  options: CreatePipeline9RelaxedDrcEvaluatorOptions,
+): DrcEvaluator => {
+  return ({ routes, hdRoutes }) => {
+    const evaluatedRoutes = routes ?? hdRoutes
+    if (!evaluatedRoutes) {
+      throw new Error("Pipeline9 relaxed DRC evaluation requires HD routes")
+    }
+
+    const newTraces = convertPipeline7HdRoutesToSimplifiedPcbTraces({
+      ...options,
+      hdRoutes: evaluatedRoutes,
+    })
+    const newTraceIds = new Set(newTraces.map((trace) => trace.pcb_trace_id))
+    const { errors, errorsWithCenters, circuitJson } = evaluateRelaxedDrc({
+      inputSrj: options.originalSrj,
+      srjWithPointPairs: options.srjWithPointPairs,
+      routedTraces: preparePipeline9DrcRoutedTraces({
+        originalPreloadedTraces: options.originalSrj.traces ?? [],
+        mutatedPreloadedTraces: options.mutatedPreloadedTraces,
+        newTraces,
+      }),
+    })
+
+    return {
+      errors: normalizePipeline9DrcErrorsForRepair({
+        errors: errors as unknown as Record<string, unknown>[],
+        circuitJson,
+        newTraceIds,
+      }),
+      errorsWithCenters: normalizePipeline9DrcErrorsForRepair({
+        errors: errorsWithCenters as unknown as Record<string, unknown>[],
+        circuitJson,
+        newTraceIds,
+      }),
+    }
+  }
+}

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/normalize-pipeline9-drc-errors-for-repair.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/normalize-pipeline9-drc-errors-for-repair.ts
@@ -1,0 +1,61 @@
+import type { AnyCircuitElement } from "circuit-json"
+
+type DrcError = Record<string, unknown>
+
+/** Makes the movable new route the primary identity in joint DRC errors. */
+export const normalizePipeline9DrcErrorsForRepair = ({
+  errors,
+  circuitJson,
+  newTraceIds,
+}: {
+  errors: DrcError[]
+  circuitJson: AnyCircuitElement[]
+  newTraceIds: ReadonlySet<string>
+}): DrcError[] => {
+  const traceIdByViaId = new Map(
+    circuitJson.flatMap((element) =>
+      element.type === "pcb_via" &&
+      typeof element.pcb_via_id === "string" &&
+      typeof element.pcb_trace_id === "string"
+        ? [[element.pcb_via_id, element.pcb_trace_id] as const]
+        : [],
+    ),
+  )
+
+  return errors.map((error) => {
+    const primaryTraceId = error.pcb_trace_id
+    if (typeof primaryTraceId !== "string") return error
+
+    const errorId = error.pcb_trace_error_id
+    const pairPrefix = `overlap_${primaryTraceId}_`
+    const otherTraceId =
+      typeof errorId === "string" && errorId.startsWith(pairPrefix)
+        ? errorId.slice(pairPrefix.length)
+        : undefined
+    if (
+      !newTraceIds.has(primaryTraceId) &&
+      otherTraceId &&
+      newTraceIds.has(otherTraceId)
+    ) {
+      return {
+        ...error,
+        pcb_trace_id: otherTraceId,
+        pcb_trace_ids: [otherTraceId, primaryTraceId],
+        pcb_trace_error_id: `overlap_${otherTraceId}_${primaryTraceId}`,
+      }
+    }
+
+    const viaId = error.pcb_via_id
+    const viaTraceId =
+      typeof viaId === "string" ? traceIdByViaId.get(viaId) : undefined
+    if (viaTraceId && newTraceIds.has(viaTraceId)) {
+      return {
+        ...error,
+        pcb_trace_id: viaTraceId,
+        pcb_via_ids: [viaId],
+      }
+    }
+
+    return error
+  })
+}

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/prepare-pipeline9-drc-routed-traces.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/prepare-pipeline9-drc-routed-traces.ts
@@ -1,0 +1,48 @@
+import type { SimplifiedPcbTrace } from "lib/types"
+
+/**
+ * Keeps candidate trace ids aligned with the DRC repair solver while retaining
+ * preloaded copper whose id collides with a new point-pair trace.
+ */
+export const preparePipeline9DrcRoutedTraces = ({
+  originalPreloadedTraces,
+  mutatedPreloadedTraces,
+  newTraces,
+}: {
+  originalPreloadedTraces: readonly SimplifiedPcbTrace[]
+  mutatedPreloadedTraces: readonly SimplifiedPcbTrace[]
+  newTraces: SimplifiedPcbTrace[]
+}): SimplifiedPcbTrace[] => {
+  const newTraceIds = new Set(newTraces.map((trace) => trace.pcb_trace_id))
+  const mutatedPreloadedTraceById = new Map(
+    mutatedPreloadedTraces.map((trace) => [trace.pcb_trace_id, trace]),
+  )
+  const usedTraceIds = new Set([
+    ...originalPreloadedTraces.map((trace) => trace.pcb_trace_id),
+    ...newTraceIds,
+  ])
+  const preloadedCollisionCopies = originalPreloadedTraces
+    .filter((trace) => newTraceIds.has(trace.pcb_trace_id))
+    .map((trace) => {
+      const currentTrace =
+        mutatedPreloadedTraceById.get(trace.pcb_trace_id) ?? trace
+      const baseId = `${trace.pcb_trace_id}_preloaded`
+      let pcbTraceId = baseId
+      let suffix = 2
+      while (usedTraceIds.has(pcbTraceId)) {
+        pcbTraceId = `${baseId}_${suffix}`
+        suffix += 1
+      }
+      usedTraceIds.add(pcbTraceId)
+      return { ...currentTrace, pcb_trace_id: pcbTraceId }
+    })
+  const nonCollidingMutatedPreloadedTraces = mutatedPreloadedTraces.filter(
+    (trace) => !newTraceIds.has(trace.pcb_trace_id),
+  )
+
+  return [
+    ...preloadedCollisionCopies,
+    ...nonCollidingMutatedPreloadedTraces,
+    ...newTraces,
+  ]
+}

--- a/tests/features/pipeline9-joint-drc-repair-metadata.test.ts
+++ b/tests/features/pipeline9-joint-drc-repair-metadata.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { normalizePipeline9DrcErrorsForRepair } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/normalize-pipeline9-drc-errors-for-repair"
+import { preparePipeline9DrcRoutedTraces } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/prepare-pipeline9-drc-routed-traces"
+import type { SimplifiedPcbTrace } from "lib/types"
+
+test("Pipeline9 joint DRC metadata keeps new route identities repairable", () => {
+  const preloaded: SimplifiedPcbTrace = {
+    type: "pcb_trace",
+    pcb_trace_id: "shared_trace_id",
+    connection_name: "fixed_connection",
+    route: [],
+  }
+  const mutated = {
+    ...preloaded,
+    route: [
+      { route_type: "wire" as const, x: 1, y: 0, width: 0.1, layer: "top" },
+    ],
+  }
+  const newTrace: SimplifiedPcbTrace = {
+    type: "pcb_trace",
+    pcb_trace_id: "shared_trace_id",
+    connection_name: "new_connection",
+    route: [],
+  }
+
+  const routedTraces = preparePipeline9DrcRoutedTraces({
+    originalPreloadedTraces: [preloaded],
+    mutatedPreloadedTraces: [mutated],
+    newTraces: [newTrace],
+  })
+  expect(routedTraces.map((trace) => trace.pcb_trace_id)).toEqual([
+    "shared_trace_id_preloaded",
+    "shared_trace_id",
+  ])
+  expect(routedTraces[0]?.route).toEqual(mutated.route)
+
+  const [tracePairError, viaError] = normalizePipeline9DrcErrorsForRepair({
+    errors: [
+      {
+        pcb_trace_id: "shared_trace_id_preloaded",
+        pcb_trace_error_id: "overlap_shared_trace_id_preloaded_shared_trace_id",
+      },
+      {
+        pcb_trace_id: "shared_trace_id_preloaded",
+        pcb_via_id: "new_via",
+      },
+    ],
+    circuitJson: [
+      {
+        type: "pcb_via",
+        pcb_via_id: "new_via",
+        pcb_trace_id: "shared_trace_id",
+        x: 0,
+        y: 0,
+        outer_diameter: 0.3,
+        hole_diameter: 0.2,
+        layers: ["top", "bottom"],
+      },
+    ] as AnyCircuitElement[],
+    newTraceIds: new Set(["shared_trace_id"]),
+  })
+  expect(tracePairError?.pcb_trace_id).toBe("shared_trace_id")
+  expect(tracePairError?.pcb_trace_ids).toEqual([
+    "shared_trace_id",
+    "shared_trace_id_preloaded",
+  ])
+  expect(viaError?.pcb_trace_id).toBe("shared_trace_id")
+  expect(viaError?.pcb_via_ids).toEqual(["new_via"])
+})

--- a/tests/features/pipeline9-srj23-sample25-terminal-metadata.test.ts
+++ b/tests/features/pipeline9-srj23-sample25-terminal-metadata.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph"
+import { loadScenarioBySampleNumber } from "../../scripts/benchmark/scenarios"
+
+test("Pipeline9 keeps repaired SRJ23 sample 25 PCB port metadata on route endpoints", async () => {
+  const { scenario } = await loadScenarioBySampleNumber("srj23", 25)
+  const solver = new AutoroutingPipelineSolver9_PreloadedTraceGraph(
+    structuredClone(scenario),
+    { cacheProvider: null, effort: 1 },
+  )
+
+  solver.solve()
+
+  expect(solver.solved).toBeTrue()
+  expect(solver.failed).toBeFalse()
+  const output = solver.lengthMatchingPostProcessingSolver?.getOutput()
+  expect(output).toBeDefined()
+  for (const hdRoute of output?.hdRoutes ?? []) {
+    for (const interiorPoint of hdRoute.route.slice(1, -1)) {
+      expect(interiorPoint.pcb_port_id).toBeUndefined()
+    }
+  }
+})


### PR DESCRIPTION
## What changed

- gives Pipeline9's exact DRC portfolio a joint evaluator containing original, regionally replaced, and newly routed copper
- keeps candidate trace identities distinct when a new trace id collides with a preloaded id
- normalizes DRC trace ids back to repairable new-route identities
- removes stale PCB terminal metadata from interior locked-route points
- does not make any additional preloaded trace movable in this layer

## Validation

- joint DRC metadata and replacement semantics
- corrected SRJ23 samples 4 and 25
- Pipeline7 terminal-lock regression
- `bunx tsc --noEmit`
- `bun run build`

## Stack

- Depends on #1957
- Next: selective preloaded-trace joint repair