### PR TITLE
Selectively repair preloaded traces implicated by joint DRC

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph.ts
@@ -3,10 +3,7 @@ import { PostProcessingSolver } from "@tscircuit/length-matching-solver"
 import { ConnectivityMap } from "circuit-json-to-connectivity-map"
 import type { GraphicsObject, Line } from "graphics-debug"
 import { HighDensityForceImproveSolver } from "high-density-repair01/lib/HighDensityForceImproveSolver"
-import {
-  GlobalDrcBranchPortfolioSolver,
-  GlobalDrcForceImproveSolver,
-} from "high-density-repair03/lib"
+import { GlobalDrcForceImproveSolver } from "high-density-repair03/lib"
 import { getGlobalInMemoryCache } from "lib/cache/setupGlobalCaches"
 import { CacheProvider } from "lib/cache/types"
 import { ComponentDetectionSolver } from "lib/solvers/ComponentDetectionSolver/ComponentDetectionSolver"
@@ -67,12 +64,13 @@ import { TraceSimplificationSolver } from "../../solvers/TraceSimplificationSolv
 import { TraceWidthSolver } from "../../solvers/TraceWidthSolver/TraceWidthSolver"
 import { applyFixedRouteReplacementsToPreloadedTraces } from "./apply-fixed-route-replacements-to-preloaded-traces"
 import { assignUniquePcbTraceIdsToNewTraces } from "./assign-unique-pcb-trace-ids-to-new-traces"
+import { getPipeline9NetByConnectionName } from "./get-pipeline9-net-by-connection-name"
 import {
   convertPreloadedTraceToHdRoutes,
   type PreloadedHighDensityRoute,
 } from "./convert-preloaded-traces-to-hd-routes"
 import { Pipeline9HighDensitySolver } from "./pipeline9-high-density-solver"
-import { createPipeline9RelaxedDrcEvaluator } from "./create-pipeline9-relaxed-drc-evaluator"
+import { Pipeline9JointDrcRepairSolver } from "./pipeline9-joint-drc-repair-solver"
 import { PreloadedTraceGraphSolver } from "./preloaded-trace-graph-solver"
 import { PreprocessSimpleRouteJsonWithoutTraceObstaclesSolver } from "./preprocess-simple-route-json-without-trace-obstacles-solver"
 import { MergedComponentTopologyView } from "../AutoroutingPipeline7_MultiGraph/MergedComponentTopologyView"
@@ -233,7 +231,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
   highDensityRepairSolver?: Pipeline4HighDensityRepairSolver
   highDensityStitchSolver?: MultipleHighDensityRouteStitchSolver3
   globalDrcForceImproveSolver?: GlobalDrcForceImproveSolver
-  exactGeometryDrcForceImproveSolver?: GlobalDrcBranchPortfolioSolver
+  pipeline9JointDrcRepairSolver?: Pipeline9JointDrcRepairSolver
   singleLayerNodeMerger?: SingleLayerNodeMergerSolver
   strawSolver?: StrawSolver
   deadEndSolver?: DeadEndSolver
@@ -646,10 +644,15 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
               cms.connMap,
             ),
           )
+        const newHdRoutes = cms.highDensityStitchSolver!.mergedHdRoutes
+        const netByConnectionName = getPipeline9NetByConnectionName(
+          [...newHdRoutes, ...preloadedHdRoutes],
+          cms.connMap,
+        )
 
         return [
           {
-            hdRoutes: cms.highDensityStitchSolver!.mergedHdRoutes,
+            hdRoutes: newHdRoutes,
             obstacles: cms.srj.obstacles,
             connMap: cms.connMap,
             colorMap: cms.colorMap,
@@ -658,6 +661,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
             layerCount: cms.srj.layerCount,
             minTraceToPadEdgeClearance: cms.srj.minTraceToPadEdgeClearance,
             otherHdRoutes: preloadedHdRoutes,
+            netByConnectionName,
             iterations: 2,
           },
         ]
@@ -699,39 +703,32 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
       ],
     ),
     definePipelineStep(
-      "exactGeometryDrcForceImproveSolver",
-      GlobalDrcBranchPortfolioSolver,
+      "pipeline9JointDrcRepairSolver",
+      Pipeline9JointDrcRepairSolver,
       (cms) => {
-        const relaxedDrcEvaluator = createPipeline9RelaxedDrcEvaluator({
-          connections: cms.netToPointPairsSolver?.newConnections ?? [],
-          originalConnections: cms.originalSrj.connections,
-          layerCount: cms.srj.layerCount,
-          obstacles: cms.srj.obstacles,
-          defaultViaHoleDiameter: cms.viaHoleDiameter,
-          connMap: cms.connMap,
-          srjWithPointPairs: cms.srjWithPointPairs!,
-          originalSrj: cms.originalSrj,
-          mutatedPreloadedTraces: cms.getMutatedPreloadedTraces(),
-        })
-
+        const regionalPreloadedTraceUpdates =
+          cms.getRegionalPreloadedTraceUpdates()
         return [
           {
-            srj: cms.srjWithPointPairs! as any,
-            hdRoutes: cms.globalDrcForceImproveSolver!.getOutput(),
+            srj: cms.srjWithPointPairs!,
+            srjWithPointPairs: cms.srjWithPointPairs!,
+            originalSrj: cms.originalSrj,
+            newConnections: cms.netToPointPairsSolver?.newConnections ?? [],
+            newHdRoutes: cms.globalDrcForceImproveSolver!.getOutput(),
+            updatedPreloadedTraces:
+              regionalPreloadedTraceUpdates.updatedPreloadedTraces,
+            mutatedPreloadedTraceIds: new Set(
+              regionalPreloadedTraceUpdates.mutatedPreloadedTraces.map(
+                (trace) => trace.pcb_trace_id,
+              ),
+            ),
             connMap: cms.connMap,
+            obstacles: cms.srj.obstacles,
+            layerCount: cms.srj.layerCount,
+            defaultViaDiameter: cms.viaDiameter,
+            defaultViaHoleDiameter: cms.viaHoleDiameter,
             effort: cms.effort,
-            viaHoleDiameter: cms.viaHoleDiameter,
-            drcEvaluator: relaxedDrcEvaluator,
-            viaInPadDrcEvaluator: relaxedDrcEvaluator,
-            maxIterations: 32,
-            enableLargeBoardBroadFallback: false,
-            enableTargetedErrorSweep: true,
-            enablePostSolveClearanceRelaxation: false,
-            enableSafeTraceLayerMoves: true,
-            enableViaInPadLayerMoves: true,
-            viaInPadMaxIterations: 32,
-            broadMaxIterations: 8,
-            broadPassMultiplier: 3,
+            colorMap: cms.colorMap,
           },
         ]
       },
@@ -788,7 +785,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
         return [
           {
             hdRoutes: lockHdRouteTerminals(
-              cms.exactGeometryDrcForceImproveSolver!.getOutput(),
+              structuredClone(cms.pipeline9JointDrcRepairSolver!.getOutput()),
               connections,
               new Map(
                 (cms.highDensityStitchSolver?.mergedHdRoutes ?? []).map(
@@ -1037,8 +1034,8 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
       this.preprocessSimpleRouteJsonSolver?.visualize()
     const globalDrcForceImproveViz =
       this.globalDrcForceImproveSolver?.visualize()
-    const exactGeometryDrcForceImproveViz =
-      this.exactGeometryDrcForceImproveSolver?.visualize()
+    const pipeline9JointDrcRepairViz =
+      this.pipeline9JointDrcRepairSolver?.visualize()
     const visualizations = [
       problemViz,
       processedProblemViz,
@@ -1068,7 +1065,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
       traceSimplificationViz,
       traceWidthViz,
       globalDrcForceImproveViz,
-      exactGeometryDrcForceImproveViz,
+      pipeline9JointDrcRepairViz,
       lengthMatchingPostProcessingViz,
       this.solved
         ? combineVisualizations(
@@ -1146,9 +1143,13 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
   }
 
   _getOutputHdRoutes(): HighDensityRoute[] {
+    const postProcessedRoutes =
+      (this.originalSrj.differentialPairs?.length ?? 0) > 0
+        ? this.lengthMatchingPostProcessingSolver?.getOutput().hdRoutes
+        : undefined
     return (
-      this.lengthMatchingPostProcessingSolver?.getOutput().hdRoutes ??
-      this.exactGeometryDrcForceImproveSolver?.getOutput() ??
+      postProcessedRoutes ??
+      this.pipeline9JointDrcRepairSolver?.getOutput() ??
       this.globalDrcForceImproveSolver?.getOutput() ??
       this.traceWidthSolver?.getHdRoutesWithWidths() ??
       this.traceSimplificationSolver?.simplifiedHdRoutes ??
@@ -1187,11 +1188,17 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
   }
 
   getUpdatedPreloadedTraces(): SimplifiedPcbTraces {
-    return this.getRegionalPreloadedTraceUpdates().updatedPreloadedTraces
+    return (
+      this.pipeline9JointDrcRepairSolver?.getUpdatedPreloadedTraces() ??
+      this.getRegionalPreloadedTraceUpdates().updatedPreloadedTraces
+    )
   }
 
   getMutatedPreloadedTraces(): SimplifiedPcbTraces {
-    return this.getRegionalPreloadedTraceUpdates().mutatedPreloadedTraces
+    return (
+      this.pipeline9JointDrcRepairSolver?.getMutatedPreloadedTraces() ??
+      this.getRegionalPreloadedTraceUpdates().mutatedPreloadedTraces
+    )
   }
 
   private getNewOutputSimplifiedPcbTraces(): SimplifiedPcbTraces {

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/get-pipeline9-net-by-connection-name.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/get-pipeline9-net-by-connection-name.ts
@@ -1,0 +1,20 @@
+import type { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+
+export const getPipeline9NetByConnectionName = (
+  routes: ReadonlyArray<HighDensityRoute>,
+  connMap: ConnectivityMap,
+): ReadonlyMap<string, string> =>
+  new Map(
+    routes.flatMap((route) => {
+      const netName =
+        connMap.getNetConnectedToId(route.connectionName) ??
+        (route.rootConnectionName
+          ? (connMap.getNetConnectedToId(route.rootConnectionName) ??
+            (connMap.netMap[route.rootConnectionName]
+              ? route.rootConnectionName
+              : undefined))
+          : undefined)
+      return netName ? [[route.connectionName, netName] as const] : []
+    }),
+  )

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/get-pipeline9-preloaded-trace-ids-in-initial-drc-regions.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/get-pipeline9-preloaded-trace-ids-in-initial-drc-regions.ts
@@ -1,0 +1,72 @@
+import type { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import type { SimplifiedPcbTrace } from "lib/types"
+import { convertPreloadedTraceToHdRoutes } from "./convert-preloaded-traces-to-hd-routes"
+
+const REGIONAL_PROMOTION_HALF_SIZE = 1.5
+
+const getTracePairErrorCenters = (
+  errorsWithCenters: Array<Record<string, unknown>>,
+) =>
+  errorsWithCenters.flatMap((error) => {
+    if (
+      error.type !== "pcb_trace_error" ||
+      !Array.isArray(error.pcb_port_ids) ||
+      error.pcb_port_ids.length < 4
+    )
+      return []
+    const center = error.center
+    return center &&
+      typeof center === "object" &&
+      "x" in center &&
+      "y" in center &&
+      typeof center.x === "number" &&
+      typeof center.y === "number"
+      ? [{ x: center.x, y: center.y }]
+      : []
+  })
+
+/**
+ * Makes every preloaded trace crossing an initial trace-pair DRC region
+ * available to the last-resort regional rerouter. Connectivity still comes
+ * from trace metadata; geometry only determines membership in the region.
+ */
+export const getPipeline9PreloadedTraceIdsInInitialDrcRegions = ({
+  errorsWithCenters,
+  traces,
+  layerCount,
+  defaultViaDiameter,
+  connMap,
+}: {
+  errorsWithCenters: Array<Record<string, unknown>>
+  traces: SimplifiedPcbTrace[]
+  layerCount: number
+  defaultViaDiameter: number
+  connMap: ConnectivityMap
+}): Set<string> => {
+  const repairCenters = getTracePairErrorCenters(errorsWithCenters)
+  const traceIds = new Set<string>()
+  for (let traceIndex = 0; traceIndex < traces.length; traceIndex++) {
+    const trace = traces[traceIndex]!
+    const sections = convertPreloadedTraceToHdRoutes(
+      trace,
+      traceIndex,
+      layerCount,
+      defaultViaDiameter,
+      connMap,
+    )
+    const intersectsRepairRegion = repairCenters.some((center) =>
+      sections.some((section) => {
+        const xs = section.route.map((point) => point.x)
+        const ys = section.route.map((point) => point.y)
+        return (
+          Math.min(...xs) <= center.x + REGIONAL_PROMOTION_HALF_SIZE &&
+          Math.max(...xs) >= center.x - REGIONAL_PROMOTION_HALF_SIZE &&
+          Math.min(...ys) <= center.y + REGIONAL_PROMOTION_HALF_SIZE &&
+          Math.max(...ys) >= center.y - REGIONAL_PROMOTION_HALF_SIZE
+        )
+      }),
+    )
+    if (intersectsRepairRegion) traceIds.add(trace.pcb_trace_id)
+  }
+  return traceIds
+}

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/get-pipeline9-preloaded-via-pair-trace-groups.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/get-pipeline9-preloaded-via-pair-trace-groups.ts
@@ -1,0 +1,46 @@
+import type { AnyCircuitElement } from "circuit-json"
+
+export const getPipeline9PreloadedViaPairTraceGroups = ({
+  errors,
+  circuitJson,
+  originalTraceIdByPreparedTraceId,
+}: {
+  errors: Array<Record<string, unknown>>
+  circuitJson: AnyCircuitElement[]
+  originalTraceIdByPreparedTraceId: ReadonlyMap<string, string>
+}): string[][] => {
+  const preparedTraceIdByViaId = new Map(
+    circuitJson.flatMap((element) =>
+      element.type === "pcb_via" &&
+      typeof element.pcb_via_id === "string" &&
+      typeof element.pcb_trace_id === "string"
+        ? [[element.pcb_via_id, element.pcb_trace_id] as const]
+        : [],
+    ),
+  )
+
+  return errors.flatMap((error) => {
+    if (
+      error.type !== "pcb_via_clearance_error" ||
+      !Array.isArray(error.pcb_via_ids) ||
+      typeof error.actual_clearance !== "number" ||
+      error.actual_clearance >= 0
+    )
+      return []
+    const originalTraceIds = error.pcb_via_ids
+      .flatMap((viaId) => {
+        if (typeof viaId !== "string") return []
+        const preparedTraceId = preparedTraceIdByViaId.get(viaId)
+        if (!preparedTraceId) return []
+        return [
+          originalTraceIdByPreparedTraceId.get(preparedTraceId) ??
+            preparedTraceId,
+        ]
+      })
+      .filter(
+        (traceId, traceIndex, allTraceIds) =>
+          allTraceIds.indexOf(traceId) === traceIndex,
+      )
+    return originalTraceIds.length > 0 ? [originalTraceIds] : []
+  })
+}

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/merge-pipeline9-movable-preloaded-vias.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/merge-pipeline9-movable-preloaded-vias.ts
@@ -1,0 +1,42 @@
+import type { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { SameNetViaMergerSolver } from "lib/solvers/SameNetViaMergerSolver/SameNetViaMergerSolver"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+import type { Obstacle } from "lib/types/srj-types"
+import { getPipeline9NetByConnectionName } from "./get-pipeline9-net-by-connection-name"
+
+export const mergePipeline9MovablePreloadedVias = ({
+  routes,
+  otherHdRoutes,
+  obstacles,
+  colorMap,
+  layerCount,
+  connMap,
+}: {
+  routes: HighDensityRoute[]
+  otherHdRoutes: HighDensityRoute[]
+  obstacles: Obstacle[]
+  colorMap: Record<string, string>
+  layerCount: number
+  connMap: ConnectivityMap
+}): HighDensityRoute[] => {
+  const netByConnectionName = getPipeline9NetByConnectionName(
+    [...routes, ...otherHdRoutes],
+    connMap,
+  )
+  const solver = new SameNetViaMergerSolver({
+    inputHdRoutes: routes,
+    otherHdRoutes,
+    netByConnectionName,
+    obstacles,
+    colorMap,
+    layerCount,
+    connMap,
+  })
+  solver.solve()
+  if (solver.failed) {
+    throw new Error(
+      `Pipeline9 could not merge movable preloaded vias: ${solver.error ?? "unknown error"}`,
+    )
+  }
+  return solver.getMergedViaHdRoutes() ?? routes
+}

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/normalize-pipeline9-drc-errors-for-repair.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/normalize-pipeline9-drc-errors-for-repair.ts
@@ -24,35 +24,64 @@ export const normalizePipeline9DrcErrorsForRepair = ({
 
   return errors.map((error) => {
     const primaryTraceId = error.pcb_trace_id
-    if (typeof primaryTraceId !== "string") return error
-
-    const errorId = error.pcb_trace_error_id
-    const pairPrefix = `overlap_${primaryTraceId}_`
-    const otherTraceId =
-      typeof errorId === "string" && errorId.startsWith(pairPrefix)
-        ? errorId.slice(pairPrefix.length)
-        : undefined
     if (
-      !newTraceIds.has(primaryTraceId) &&
-      otherTraceId &&
-      newTraceIds.has(otherTraceId)
+      typeof primaryTraceId === "string" &&
+      typeof error.pcb_trace_error_id === "string"
     ) {
-      return {
-        ...error,
-        pcb_trace_id: otherTraceId,
-        pcb_trace_ids: [otherTraceId, primaryTraceId],
-        pcb_trace_error_id: `overlap_${otherTraceId}_${primaryTraceId}`,
+      const pairPrefix = `overlap_${primaryTraceId}_`
+      const otherTraceId = error.pcb_trace_error_id.startsWith(pairPrefix)
+        ? error.pcb_trace_error_id.slice(pairPrefix.length)
+        : undefined
+      if (
+        !newTraceIds.has(primaryTraceId) &&
+        otherTraceId &&
+        newTraceIds.has(otherTraceId)
+      ) {
+        return {
+          ...error,
+          pcb_trace_id: otherTraceId,
+          pcb_trace_ids: [otherTraceId, primaryTraceId],
+          pcb_trace_error_id: `overlap_${otherTraceId}_${primaryTraceId}`,
+        }
       }
     }
 
-    const viaId = error.pcb_via_id
-    const viaTraceId =
-      typeof viaId === "string" ? traceIdByViaId.get(viaId) : undefined
-    if (viaTraceId && newTraceIds.has(viaTraceId)) {
+    const viaIds = [
+      ...(typeof error.pcb_via_id === "string" ? [error.pcb_via_id] : []),
+      ...(Array.isArray(error.pcb_via_ids)
+        ? error.pcb_via_ids.filter(
+            (viaId): viaId is string => typeof viaId === "string",
+          )
+        : []),
+    ].filter(
+      (viaId, viaIndex, allViaIds) => allViaIds.indexOf(viaId) === viaIndex,
+    )
+    const viaTraceIds = viaIds
+      .flatMap((viaId) => {
+        const traceId = traceIdByViaId.get(viaId)
+        return traceId ? [traceId] : []
+      })
+      .filter(
+        (traceId, traceIndex, allTraceIds) =>
+          allTraceIds.indexOf(traceId) === traceIndex,
+      )
+    const primaryMovableViaTraceId = viaTraceIds.find((traceId) =>
+      newTraceIds.has(traceId),
+    )
+    if (primaryMovableViaTraceId) {
+      const traceIds = [
+        primaryMovableViaTraceId,
+        ...viaTraceIds,
+        ...(typeof primaryTraceId === "string" ? [primaryTraceId] : []),
+      ].filter(
+        (traceId, traceIndex, allTraceIds) =>
+          allTraceIds.indexOf(traceId) === traceIndex,
+      )
       return {
         ...error,
-        pcb_trace_id: viaTraceId,
-        pcb_via_ids: [viaId],
+        pcb_trace_id: primaryMovableViaTraceId,
+        pcb_trace_ids: traceIds,
+        pcb_via_ids: viaIds,
       }
     }
 

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-joint-drc-repair-solver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-joint-drc-repair-solver.ts
@@ -1,0 +1,711 @@
+import type { AnyCircuitElement } from "circuit-json"
+import type { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import type { GraphicsObject } from "graphics-debug"
+import {
+  GlobalDrcBranchPortfolioSolver,
+  type DrcEvaluator,
+} from "high-density-repair03/lib"
+import { BaseSolver } from "lib/solvers/BaseSolver"
+import type {
+  Obstacle,
+  SimpleRouteConnection,
+  SimpleRouteJson,
+  SimplifiedPcbTrace,
+} from "lib/types"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+import { convertHdRouteToSimplifiedRoute } from "lib/utils/convertHdRouteToSimplifiedRoute"
+import { mapZToLayerName } from "lib/utils/mapZToLayerName"
+import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
+import { convertPipeline7HdRoutesToSimplifiedPcbTraces } from "../AutoroutingPipeline7_MultiGraph/convertPipeline7HdRoutesToSimplifiedPcbTraces"
+import { assignUniquePcbTraceIdsToNewTraces } from "./assign-unique-pcb-trace-ids-to-new-traces"
+import {
+  convertPreloadedTraceToHdRoutes,
+  type PreloadedHighDensityRoute,
+} from "./convert-preloaded-traces-to-hd-routes"
+import { normalizePipeline9DrcErrorsForRepair } from "./normalize-pipeline9-drc-errors-for-repair"
+import { preparePipeline9DrcRoutedTracesWithMetadata } from "./prepare-pipeline9-drc-routed-traces"
+import { getPipeline9PreloadedTraceIdsInInitialDrcRegions } from "./get-pipeline9-preloaded-trace-ids-in-initial-drc-regions"
+import { mergePipeline9MovablePreloadedVias } from "./merge-pipeline9-movable-preloaded-vias"
+import { getPipeline9PreloadedViaPairTraceGroups } from "./get-pipeline9-preloaded-via-pair-trace-groups"
+
+type Pipeline9JointDrcRepairSolverParams = {
+  srj: SimpleRouteJson
+  srjWithPointPairs: SimpleRouteJson
+  originalSrj: SimpleRouteJson
+  newConnections: SimpleRouteConnection[]
+  newHdRoutes: HighDensityRoute[]
+  updatedPreloadedTraces: SimplifiedPcbTrace[]
+  mutatedPreloadedTraceIds: ReadonlySet<string>
+  connMap: ConnectivityMap
+  obstacles: Obstacle[]
+  layerCount: number
+  defaultViaDiameter: number
+  defaultViaHoleDiameter: number
+  effort: number
+  colorMap: Record<string, string>
+}
+
+type MovablePreloadedTrace = {
+  originalTrace: SimplifiedPcbTrace
+  syntheticConnectionName: string
+  hdRoute: HighDensityRoute
+}
+
+const POINT_EPSILON = 1e-9
+
+const pointsAreEqual = (
+  left: HighDensityRoute["route"][number],
+  right: HighDensityRoute["route"][number],
+) =>
+  Math.abs(left.x - right.x) <= POINT_EPSILON &&
+  Math.abs(left.y - right.y) <= POINT_EPSILON &&
+  left.z === right.z
+
+const pointsHaveSamePosition = (
+  left: HighDensityRoute["route"][number],
+  right: HighDensityRoute["route"][number],
+) =>
+  Math.abs(left.x - right.x) <= POINT_EPSILON &&
+  Math.abs(left.y - right.y) <= POINT_EPSILON
+
+const convertPreloadedTraceToSingleHdRoute = ({
+  trace,
+  traceIndex,
+  syntheticConnectionName,
+  layerCount,
+  defaultViaDiameter,
+  connMap,
+}: {
+  trace: SimplifiedPcbTrace
+  traceIndex: number
+  syntheticConnectionName: string
+  layerCount: number
+  defaultViaDiameter: number
+  connMap: ConnectivityMap
+}): HighDensityRoute => {
+  if (
+    trace.route.some(
+      (routePoint) => routePoint.route_type === "through_obstacle",
+    )
+  ) {
+    throw new Error(
+      `Pipeline9 cannot exactly repair through-obstacle preloaded trace "${trace.pcb_trace_id}"`,
+    )
+  }
+
+  const traceSections = convertPreloadedTraceToHdRoutes(
+    trace,
+    traceIndex,
+    layerCount,
+    defaultViaDiameter,
+    connMap,
+  )
+  if (traceSections.length === 0) {
+    throw new Error(
+      `Pipeline9 cannot exactly repair empty preloaded trace "${trace.pcb_trace_id}"`,
+    )
+  }
+
+  const route: HighDensityRoute["route"] = []
+  for (const section of traceSections) {
+    if (route.length === 0) {
+      route.push(...section.route)
+      continue
+    }
+    const previousEnd = route.at(-1)!
+    if (section.route[0] && pointsAreEqual(previousEnd, section.route[0])) {
+      route.push(...section.route.slice(1))
+      continue
+    }
+    if (
+      section.route.at(-1) &&
+      pointsAreEqual(previousEnd, section.route.at(-1)!)
+    ) {
+      route.push(...section.route.slice(0, -1).reverse())
+      continue
+    }
+    throw new Error(
+      `Pipeline9 cannot reconnect preloaded trace "${trace.pcb_trace_id}" for exact repair`,
+    )
+  }
+
+  const startPcbPortId = trace.connectsTo?.[0]
+  const endPcbPortId = trace.connectsTo?.at(-1)
+  if (typeof startPcbPortId === "string" && route[0]) {
+    route[0] = { ...route[0], pcb_port_id: startPcbPortId }
+  }
+  if (typeof endPcbPortId === "string" && route.at(-1)) {
+    route[route.length - 1] = {
+      ...route.at(-1)!,
+      pcb_port_id: endPcbPortId,
+    }
+  }
+
+  return {
+    connectionName: syntheticConnectionName,
+    rootConnectionName:
+      connMap.getNetConnectedToId(trace.connection_name) ??
+      trace.connection_name,
+    traceThickness: Math.max(
+      ...traceSections.map((section) => section.traceThickness),
+    ),
+    viaDiameter: Math.max(
+      ...traceSections.map((section) => section.viaDiameter),
+    ),
+    route,
+    vias: route.slice(0, -1).flatMap((point, pointIndex) => {
+      const nextPoint = route[pointIndex + 1]!
+      return point.z !== nextPoint.z && pointsHaveSamePosition(point, nextPoint)
+        ? [{ x: nextPoint.x, y: nextPoint.y }]
+        : []
+    }),
+  }
+}
+
+const getTraceIdsFromDrcErrors = ({
+  errors,
+  circuitJson,
+}: {
+  errors: Array<Record<string, unknown>>
+  circuitJson: AnyCircuitElement[]
+}): Set<string> => {
+  const traceIdByViaId = new Map(
+    circuitJson.flatMap((element) =>
+      element.type === "pcb_via" &&
+      typeof element.pcb_via_id === "string" &&
+      typeof element.pcb_trace_id === "string"
+        ? [[element.pcb_via_id, element.pcb_trace_id] as const]
+        : [],
+    ),
+  )
+  const traceIds = new Set<string>()
+  for (const error of errors) {
+    const primaryTraceId =
+      typeof error.pcb_trace_id === "string" ? error.pcb_trace_id : undefined
+    if (typeof error.pcb_trace_id === "string") {
+      traceIds.add(error.pcb_trace_id)
+    }
+    if (Array.isArray(error.pcb_trace_ids)) {
+      for (const traceId of error.pcb_trace_ids) {
+        if (typeof traceId === "string") traceIds.add(traceId)
+      }
+    }
+    if (typeof error.pcb_via_id === "string") {
+      const traceId = traceIdByViaId.get(error.pcb_via_id)
+      if (traceId) traceIds.add(traceId)
+    }
+    if (Array.isArray(error.pcb_via_ids)) {
+      for (const viaId of error.pcb_via_ids) {
+        if (typeof viaId !== "string") continue
+        const traceId = traceIdByViaId.get(viaId)
+        if (traceId) traceIds.add(traceId)
+      }
+    }
+    const pairPrefix = primaryTraceId ? `overlap_${primaryTraceId}_` : undefined
+    if (
+      pairPrefix &&
+      typeof error.pcb_trace_error_id === "string" &&
+      error.pcb_trace_error_id.startsWith(pairPrefix)
+    ) {
+      traceIds.add(error.pcb_trace_error_id.slice(pairPrefix.length))
+    }
+  }
+  return traceIds
+}
+
+const remapDrcTraceIds = (
+  errors: Array<Record<string, unknown>>,
+  solverTraceIdByEvaluationTraceId: ReadonlyMap<string, string>,
+): Array<Record<string, unknown>> =>
+  errors.map((error) => {
+    const explicitEvaluationTraceIds = Array.isArray(error.pcb_trace_ids)
+      ? error.pcb_trace_ids.filter(
+          (traceId): traceId is string => typeof traceId === "string",
+        )
+      : []
+    const primaryEvaluationTraceId =
+      typeof error.pcb_trace_id === "string" ? error.pcb_trace_id : undefined
+    const pairPrefix = primaryEvaluationTraceId
+      ? `overlap_${primaryEvaluationTraceId}_`
+      : undefined
+    const encodedOtherEvaluationTraceId =
+      pairPrefix &&
+      typeof error.pcb_trace_error_id === "string" &&
+      error.pcb_trace_error_id.startsWith(pairPrefix)
+        ? error.pcb_trace_error_id.slice(pairPrefix.length)
+        : undefined
+    const evaluationTraceIds = [
+      ...(primaryEvaluationTraceId ? [primaryEvaluationTraceId] : []),
+      ...explicitEvaluationTraceIds,
+      ...(encodedOtherEvaluationTraceId ? [encodedOtherEvaluationTraceId] : []),
+    ].filter(
+      (traceId, traceIndex, traceIds) =>
+        traceIds.indexOf(traceId) === traceIndex,
+    )
+    const primarySolverTraceId = primaryEvaluationTraceId
+      ? solverTraceIdByEvaluationTraceId.get(primaryEvaluationTraceId)
+      : undefined
+    const solverTraceIds = evaluationTraceIds.flatMap((traceId) => {
+      const solverTraceId = solverTraceIdByEvaluationTraceId.get(traceId)
+      return solverTraceId ? [solverTraceId] : []
+    })
+    return {
+      ...error,
+      ...(primarySolverTraceId ? { pcb_trace_id: primarySolverTraceId } : {}),
+      ...(solverTraceIds.length > 0 ? { pcb_trace_ids: solverTraceIds } : {}),
+      ...(solverTraceIds.length >= 2
+        ? {
+            pcb_trace_error_id: `overlap_${solverTraceIds[0]}_${solverTraceIds[1]}`,
+          }
+        : {}),
+    }
+  })
+
+const createSyntheticConnection = (
+  movableTrace: MovablePreloadedTrace,
+  layerCount: number,
+): SimpleRouteConnection => {
+  const start = movableTrace.hdRoute.route[0]!
+  const end = movableTrace.hdRoute.route.at(-1)!
+  return {
+    name: movableTrace.syntheticConnectionName,
+    rootConnectionName: movableTrace.hdRoute.rootConnectionName,
+    __netConnectionName: movableTrace.originalTrace.connection_name,
+    nominalTraceWidth: movableTrace.hdRoute.traceThickness,
+    pointsToConnect: [
+      {
+        x: start.x,
+        y: start.y,
+        layer: mapZToLayerName(start.z, layerCount),
+        pointId: `${movableTrace.syntheticConnectionName}:start`,
+      },
+      {
+        x: end.x,
+        y: end.y,
+        layer: mapZToLayerName(end.z, layerCount),
+        pointId: `${movableTrace.syntheticConnectionName}:end`,
+      },
+    ],
+  }
+}
+
+/**
+ * Gives the existing exact DRC portfolio ownership of only the preloaded
+ * traces that participate in a remaining joint-output DRC error.
+ */
+export class Pipeline9JointDrcRepairSolver extends BaseSolver {
+  readonly params: Pipeline9JointDrcRepairSolverParams
+  readonly inputNewHdRoutes: HighDensityRoute[]
+  readonly inputUpdatedPreloadedTraces: SimplifiedPcbTrace[]
+  readonly movablePreloadedTraces: MovablePreloadedTrace[]
+  readonly fixedPreloadedObstacleRoutes: PreloadedHighDensityRoute[]
+  readonly syntheticConnectionNames: ReadonlySet<string>
+  readonly exactRepairSolver?: GlobalDrcBranchPortfolioSolver
+  private drcEvaluator?: DrcEvaluator
+  private combinedOutput?: HighDensityRoute[]
+
+  constructor(params: Pipeline9JointDrcRepairSolverParams) {
+    super()
+    this.params = params
+    this.inputNewHdRoutes = params.newHdRoutes
+    this.inputUpdatedPreloadedTraces = params.updatedPreloadedTraces
+
+    const currentMutatedPreloadedTraces = params.updatedPreloadedTraces.filter(
+      (trace) => params.mutatedPreloadedTraceIds.has(trace.pcb_trace_id),
+    )
+    const currentNewTraces = convertPipeline7HdRoutesToSimplifiedPcbTraces({
+      connections: params.newConnections,
+      originalConnections: params.originalSrj.connections,
+      hdRoutes: params.newHdRoutes,
+      layerCount: params.layerCount,
+      obstacles: params.obstacles,
+      defaultViaHoleDiameter: params.defaultViaHoleDiameter,
+      connMap: params.connMap,
+    })
+    const preparedCurrentOutput = preparePipeline9DrcRoutedTracesWithMetadata({
+      originalPreloadedTraces: params.originalSrj.traces ?? [],
+      mutatedPreloadedTraces: currentMutatedPreloadedTraces,
+      newTraces: currentNewTraces,
+    })
+    const currentDrc = evaluateRelaxedDrc({
+      inputSrj: params.originalSrj,
+      srjWithPointPairs: params.srjWithPointPairs,
+      routedTraces: preparedCurrentOutput.routedTraces,
+    })
+    const preparedTraceIdsInErrors = getTraceIdsFromDrcErrors({
+      errors: currentDrc.errors as unknown as Array<Record<string, unknown>>,
+      circuitJson: currentDrc.circuitJson,
+    })
+    const updatedPreloadedTraceById = new Map(
+      params.updatedPreloadedTraces.map((trace) => [trace.pcb_trace_id, trace]),
+    )
+    const movablePreloadedTraceIds = new Set<string>()
+    for (const preparedTraceId of preparedTraceIdsInErrors) {
+      const originalTraceId =
+        preparedCurrentOutput.originalPreloadedTraceIdByPreparedTraceId.get(
+          preparedTraceId,
+        ) ?? preparedTraceId
+      if (updatedPreloadedTraceById.has(originalTraceId)) {
+        movablePreloadedTraceIds.add(originalTraceId)
+      }
+    }
+    for (const traceId of getPipeline9PreloadedTraceIdsInInitialDrcRegions({
+      errorsWithCenters: currentDrc.errorsWithCenters as unknown as Array<
+        Record<string, unknown>
+      >,
+      traces: params.updatedPreloadedTraces,
+      layerCount: params.layerCount,
+      defaultViaDiameter: params.defaultViaDiameter,
+      connMap: params.connMap,
+    })) {
+      movablePreloadedTraceIds.add(traceId)
+    }
+
+    this.movablePreloadedTraces = [...movablePreloadedTraceIds].map(
+      (traceId, movableTraceIndex) => {
+        const originalTrace = updatedPreloadedTraceById.get(traceId)!
+        const originalTraceIndex = params.updatedPreloadedTraces.findIndex(
+          (trace) => trace.pcb_trace_id === traceId,
+        )
+        const syntheticConnectionName = `pipeline9_preloaded_drc_${movableTraceIndex}`
+        return {
+          originalTrace,
+          syntheticConnectionName,
+          hdRoute: convertPreloadedTraceToSingleHdRoute({
+            trace: originalTrace,
+            traceIndex: originalTraceIndex,
+            syntheticConnectionName,
+            layerCount: params.layerCount,
+            defaultViaDiameter: params.defaultViaDiameter,
+            connMap: params.connMap,
+          }),
+        }
+      },
+    )
+    this.syntheticConnectionNames = new Set(
+      this.movablePreloadedTraces.map(
+        (movableTrace) => movableTrace.syntheticConnectionName,
+      ),
+    )
+    this.fixedPreloadedObstacleRoutes = params.updatedPreloadedTraces.flatMap(
+      (trace, traceIndex) =>
+        movablePreloadedTraceIds.has(trace.pcb_trace_id)
+          ? []
+          : convertPreloadedTraceToHdRoutes(
+              trace,
+              traceIndex,
+              params.layerCount,
+              params.defaultViaDiameter,
+              params.connMap,
+            ),
+    )
+    const movableTraceIndexByOriginalTraceId = new Map(
+      this.movablePreloadedTraces.map((movableTrace, movableTraceIndex) => [
+        movableTrace.originalTrace.pcb_trace_id,
+        movableTraceIndex,
+      ]),
+    )
+    for (const originalTraceIds of getPipeline9PreloadedViaPairTraceGroups({
+      errors: currentDrc.errors as unknown as Array<Record<string, unknown>>,
+      circuitJson: currentDrc.circuitJson,
+      originalTraceIdByPreparedTraceId:
+        preparedCurrentOutput.originalPreloadedTraceIdByPreparedTraceId,
+    })) {
+      const movableTraceIndexes = originalTraceIds.flatMap((traceId) => {
+        const movableTraceIndex =
+          movableTraceIndexByOriginalTraceId.get(traceId)
+        return movableTraceIndex === undefined ? [] : [movableTraceIndex]
+      })
+      if (movableTraceIndexes.length === 0) continue
+      const movableTraceIndexSet = new Set(movableTraceIndexes)
+      const mergedRoutes = mergePipeline9MovablePreloadedVias({
+        routes: movableTraceIndexes.map(
+          (movableTraceIndex) =>
+            this.movablePreloadedTraces[movableTraceIndex]!.hdRoute,
+        ),
+        otherHdRoutes: [
+          ...params.newHdRoutes,
+          ...this.fixedPreloadedObstacleRoutes,
+          ...this.movablePreloadedTraces.flatMap(
+            (movableTrace, movableTraceIndex) =>
+              movableTraceIndexSet.has(movableTraceIndex)
+                ? []
+                : [movableTrace.hdRoute],
+          ),
+        ],
+        obstacles: params.obstacles,
+        colorMap: params.colorMap,
+        layerCount: params.layerCount,
+        connMap: params.connMap,
+      })
+      for (
+        let groupIndex = 0;
+        groupIndex < movableTraceIndexes.length;
+        groupIndex++
+      ) {
+        this.movablePreloadedTraces[movableTraceIndexes[groupIndex]!]!.hdRoute =
+          mergedRoutes[groupIndex]!
+      }
+    }
+    this.stats = {
+      initialJointDrcIssueCount: currentDrc.errors.length,
+      movablePreloadedTraceCount: this.movablePreloadedTraces.length,
+    }
+
+    if (currentDrc.errors.length === 0) {
+      this.solved = true
+      return
+    }
+
+    const movableOriginalTraceIds = new Set(
+      this.movablePreloadedTraces.map(
+        (movableTrace) => movableTrace.originalTrace.pcb_trace_id,
+      ),
+    )
+    const nonMovableMutatedPreloadedTraces =
+      currentMutatedPreloadedTraces.filter(
+        (trace) => !movableOriginalTraceIds.has(trace.pcb_trace_id),
+      )
+    const syntheticConnectionByName = new Map(
+      this.movablePreloadedTraces.map((movableTrace) => [
+        movableTrace.syntheticConnectionName,
+        createSyntheticConnection(movableTrace, params.layerCount),
+      ]),
+    )
+    const extendedSrjWithPointPairs: SimpleRouteJson = {
+      ...params.srjWithPointPairs,
+      connections: [
+        ...params.srjWithPointPairs.connections,
+        ...syntheticConnectionByName.values(),
+      ],
+    }
+
+    const drcEvaluator: DrcEvaluator = ({ routes, hdRoutes }) => {
+      const evaluatedRoutes = routes ?? hdRoutes
+      if (!evaluatedRoutes) {
+        throw new Error("Pipeline9 joint DRC repair requires HD routes")
+      }
+      const evaluatedNewRoutes = evaluatedRoutes.filter(
+        (route) => !this.syntheticConnectionNames.has(route.connectionName),
+      )
+      const evaluatedNewTraces = convertPipeline7HdRoutesToSimplifiedPcbTraces({
+        connections: params.newConnections,
+        originalConnections: params.originalSrj.connections,
+        hdRoutes: evaluatedNewRoutes,
+        layerCount: params.layerCount,
+        obstacles: params.obstacles,
+        defaultViaHoleDiameter: params.defaultViaHoleDiameter,
+        connMap: params.connMap,
+      })
+      const uniquelyNamedNewTraces = assignUniquePcbTraceIdsToNewTraces(
+        evaluatedNewTraces,
+        params.originalSrj.traces ?? [],
+      )
+      const evaluatedMovablePreloadedTraces = this.movablePreloadedTraces.map(
+        (movableTrace) => {
+          const evaluatedRoute = evaluatedRoutes.find(
+            (route) =>
+              route.connectionName === movableTrace.syntheticConnectionName,
+          )
+          if (!evaluatedRoute) {
+            throw new Error(
+              `Pipeline9 joint DRC repair lost preloaded route "${movableTrace.originalTrace.pcb_trace_id}"`,
+            )
+          }
+          return {
+            ...movableTrace.originalTrace,
+            __replaces_pcb_trace_id: movableTrace.originalTrace.pcb_trace_id,
+            route: convertHdRouteToSimplifiedRoute(
+              evaluatedRoute,
+              params.layerCount,
+              {
+                defaultViaHoleDiameter: params.defaultViaHoleDiameter,
+                obstacles: params.obstacles,
+                connMap: params.connMap,
+              },
+            ),
+          }
+        },
+      )
+      const solverTraceIdByEvaluationTraceId = new Map<string, string>()
+      for (
+        let traceIndex = 0;
+        traceIndex < evaluatedNewTraces.length;
+        traceIndex++
+      ) {
+        solverTraceIdByEvaluationTraceId.set(
+          uniquelyNamedNewTraces[traceIndex]!.pcb_trace_id,
+          evaluatedNewTraces[traceIndex]!.pcb_trace_id,
+        )
+      }
+      for (const movableTrace of this.movablePreloadedTraces) {
+        solverTraceIdByEvaluationTraceId.set(
+          movableTrace.originalTrace.pcb_trace_id,
+          `${movableTrace.syntheticConnectionName}_0`,
+        )
+      }
+      const movableTraceIds = new Set(solverTraceIdByEvaluationTraceId.values())
+      const evaluatedDrc = evaluateRelaxedDrc({
+        inputSrj: params.originalSrj,
+        srjWithPointPairs: params.srjWithPointPairs,
+        routedTraces: [
+          ...nonMovableMutatedPreloadedTraces,
+          ...evaluatedMovablePreloadedTraces,
+          ...uniquelyNamedNewTraces,
+        ],
+      })
+      const remappedCircuitJson = evaluatedDrc.circuitJson.map((element) => {
+        if (
+          !("pcb_trace_id" in element) ||
+          typeof element.pcb_trace_id !== "string"
+        )
+          return element
+        const solverTraceId = solverTraceIdByEvaluationTraceId.get(
+          element.pcb_trace_id,
+        )
+        return solverTraceId
+          ? { ...element, pcb_trace_id: solverTraceId }
+          : element
+      })
+      return {
+        errors: normalizePipeline9DrcErrorsForRepair({
+          errors: remapDrcTraceIds(
+            evaluatedDrc.errors as unknown as Array<Record<string, unknown>>,
+            solverTraceIdByEvaluationTraceId,
+          ),
+          circuitJson: remappedCircuitJson,
+          newTraceIds: movableTraceIds,
+        }),
+        errorsWithCenters: normalizePipeline9DrcErrorsForRepair({
+          errors: remapDrcTraceIds(
+            evaluatedDrc.errorsWithCenters as unknown as Array<
+              Record<string, unknown>
+            >,
+            solverTraceIdByEvaluationTraceId,
+          ),
+          circuitJson: remappedCircuitJson,
+          newTraceIds: movableTraceIds,
+        }),
+      }
+    }
+    this.drcEvaluator = drcEvaluator
+
+    this.exactRepairSolver = new GlobalDrcBranchPortfolioSolver({
+      srj: extendedSrjWithPointPairs as any,
+      hdRoutes: [
+        ...params.newHdRoutes,
+        ...this.movablePreloadedTraces.map(
+          (movableTrace) => movableTrace.hdRoute,
+        ),
+      ],
+      connMap: params.connMap,
+      effort: params.effort,
+      viaHoleDiameter: params.defaultViaHoleDiameter,
+      drcEvaluator,
+      viaInPadDrcEvaluator: drcEvaluator,
+      maxIterations: 64,
+      enableLargeBoardBroadFallback: false,
+      enableTargetedErrorSweep: true,
+      enablePostSolveClearanceRelaxation: false,
+      enableSafeTraceLayerMoves: true,
+      enableViaInPadLayerMoves: true,
+      viaInPadMaxIterations: 64,
+      broadMaxIterations: 16,
+      broadPassMultiplier: 3,
+    })
+    this.activeSubSolver = this.exactRepairSolver
+    this.MAX_ITERATIONS = this.exactRepairSolver.MAX_ITERATIONS + 1
+  }
+
+  override getSolverName(): string {
+    return "Pipeline9JointDrcRepairSolver"
+  }
+
+  override _step(): void {
+    if (!this.exactRepairSolver) {
+      this.solved = true
+      return
+    }
+    this.exactRepairSolver.step()
+    this.progress = this.exactRepairSolver.progress
+    if (this.exactRepairSolver.failed) {
+      this.failed = true
+      this.error = this.exactRepairSolver.error
+      return
+    }
+    if (!this.exactRepairSolver.solved) return
+    this.combinedOutput = this.exactRepairSolver.getOutput()
+    this.stats = {
+      ...this.stats,
+      ...this.exactRepairSolver.stats,
+    }
+    this.solved = true
+  }
+
+  private getCombinedOutput(): HighDensityRoute[] {
+    return (
+      this.combinedOutput ??
+      this.exactRepairSolver?.getOutput() ??
+      this.inputNewHdRoutes
+    )
+  }
+
+  getOutput(): HighDensityRoute[] {
+    return this.getCombinedOutput().filter(
+      (route) => !this.syntheticConnectionNames.has(route.connectionName),
+    )
+  }
+
+  getUpdatedPreloadedTraces(): SimplifiedPcbTrace[] {
+    const outputRouteByConnectionName = new Map(
+      this.getCombinedOutput().map((route) => [route.connectionName, route]),
+    )
+    const repairedTraceById = new Map(
+      this.movablePreloadedTraces.map((movableTrace) => {
+        const outputRoute = outputRouteByConnectionName.get(
+          movableTrace.syntheticConnectionName,
+        )
+        if (!outputRoute) {
+          throw new Error(
+            `Pipeline9 joint DRC repair output is missing "${movableTrace.syntheticConnectionName}"`,
+          )
+        }
+        return [
+          movableTrace.originalTrace.pcb_trace_id,
+          {
+            ...movableTrace.originalTrace,
+            __replaces_pcb_trace_id: movableTrace.originalTrace.pcb_trace_id,
+            route: convertHdRouteToSimplifiedRoute(
+              outputRoute,
+              this.params.layerCount,
+              {
+                defaultViaHoleDiameter: this.params.defaultViaHoleDiameter,
+                obstacles: this.params.obstacles,
+                connMap: this.params.connMap,
+              },
+            ),
+          },
+        ] as const
+      }),
+    )
+    return this.inputUpdatedPreloadedTraces.map(
+      (trace) => repairedTraceById.get(trace.pcb_trace_id) ?? trace,
+    )
+  }
+
+  getMutatedPreloadedTraces(): SimplifiedPcbTrace[] {
+    const mutatedTraceIds = new Set([
+      ...this.params.mutatedPreloadedTraceIds,
+      ...this.movablePreloadedTraces.map(
+        (movableTrace) => movableTrace.originalTrace.pcb_trace_id,
+      ),
+    ])
+    return this.getUpdatedPreloadedTraces().filter((trace) =>
+      mutatedTraceIds.has(trace.pcb_trace_id),
+    )
+  }
+
+  override visualize(): GraphicsObject {
+    return this.exactRepairSolver?.visualize() ?? {}
+  }
+}

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-joint-drc-repair-utils.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-joint-drc-repair-utils.ts
@@ -1,0 +1,85 @@
+import type { DrcEvaluator } from "high-density-repair03/lib"
+import type { SimpleRouteConnection } from "lib/types"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+
+export type Pipeline9DrcError = Record<string, unknown>
+
+const SCORE_EPSILON = 1e-9
+
+export const clonePipeline9HdRoutes = (
+  routes: HighDensityRoute[],
+): HighDensityRoute[] =>
+  routes.map((route) => ({
+    ...route,
+    route: route.route.map((point) => ({ ...point })),
+    vias: route.vias.map((via) => ({ ...via })),
+  }))
+
+export const getPipeline9DrcErrors = (
+  drcEvaluator: DrcEvaluator,
+  routes: HighDensityRoute[],
+): Pipeline9DrcError[] => {
+  const result = drcEvaluator({ hdRoutes: routes, traces: [] })
+  return (
+    Array.isArray(result) ? result : (result.errorsWithCenters ?? result.errors)
+  ) as Pipeline9DrcError[]
+}
+
+const getDrcIssueScore = (errors: Pipeline9DrcError[]) =>
+  errors.reduce((score, error) => {
+    if (
+      typeof error.actual_clearance === "number" &&
+      typeof error.minimum_clearance === "number"
+    ) {
+      return (
+        score + Math.max(0, error.minimum_clearance - error.actual_clearance)
+      )
+    }
+    const message = typeof error.message === "string" ? error.message : ""
+    const gap = message.match(/gap: (-?\d+(?:\.\d+)?)mm/)
+    if (gap) {
+      return score + Math.max(0, 0.1 - Number.parseFloat(gap[1]!))
+    }
+    return score + 1
+  }, 0)
+
+export const isPipeline9DrcCandidateBetter = (
+  candidateErrors: Pipeline9DrcError[],
+  currentErrors: Pipeline9DrcError[],
+) =>
+  candidateErrors.length < currentErrors.length ||
+  (candidateErrors.length === currentErrors.length &&
+    getDrcIssueScore(candidateErrors) <
+      getDrcIssueScore(currentErrors) - SCORE_EPSILON)
+
+export const getPipeline9RouteIndexByTraceId = ({
+  routes,
+  newConnections,
+  syntheticConnectionNames,
+}: {
+  routes: HighDensityRoute[]
+  newConnections: SimpleRouteConnection[]
+  syntheticConnectionNames: ReadonlySet<string>
+}) => {
+  const routableConnectionNames = new Set([
+    ...newConnections.map((connection) => connection.name),
+    ...syntheticConnectionNames,
+  ])
+  const routeCountByConnectionName = new Map<string, number>()
+  const routeIndexByTraceId = new Map<string, number>()
+  for (let routeIndex = 0; routeIndex < routes.length; routeIndex++) {
+    const route = routes[routeIndex]!
+    if (!routableConnectionNames.has(route.connectionName)) continue
+    const connectionRouteIndex =
+      routeCountByConnectionName.get(route.connectionName) ?? 0
+    routeCountByConnectionName.set(
+      route.connectionName,
+      connectionRouteIndex + 1,
+    )
+    routeIndexByTraceId.set(
+      `${route.connectionName}_${connectionRouteIndex}`,
+      routeIndex,
+    )
+  }
+  return routeIndexByTraceId
+}

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/prepare-pipeline9-drc-routed-traces.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/prepare-pipeline9-drc-routed-traces.ts
@@ -1,10 +1,15 @@
 import type { SimplifiedPcbTrace } from "lib/types"
 
+export type PreparedPipeline9DrcRoutedTraces = {
+  routedTraces: SimplifiedPcbTrace[]
+  originalPreloadedTraceIdByPreparedTraceId: Map<string, string>
+}
+
 /**
  * Keeps candidate trace ids aligned with the DRC repair solver while retaining
  * preloaded copper whose id collides with a new point-pair trace.
  */
-export const preparePipeline9DrcRoutedTraces = ({
+export const preparePipeline9DrcRoutedTracesWithMetadata = ({
   originalPreloadedTraces,
   mutatedPreloadedTraces,
   newTraces,
@@ -12,7 +17,7 @@ export const preparePipeline9DrcRoutedTraces = ({
   originalPreloadedTraces: readonly SimplifiedPcbTrace[]
   mutatedPreloadedTraces: readonly SimplifiedPcbTrace[]
   newTraces: SimplifiedPcbTrace[]
-}): SimplifiedPcbTrace[] => {
+}): PreparedPipeline9DrcRoutedTraces => {
   const newTraceIds = new Set(newTraces.map((trace) => trace.pcb_trace_id))
   const mutatedPreloadedTraceById = new Map(
     mutatedPreloadedTraces.map((trace) => [trace.pcb_trace_id, trace]),
@@ -21,6 +26,7 @@ export const preparePipeline9DrcRoutedTraces = ({
     ...originalPreloadedTraces.map((trace) => trace.pcb_trace_id),
     ...newTraceIds,
   ])
+  const originalPreloadedTraceIdByPreparedTraceId = new Map<string, string>()
   const preloadedCollisionCopies = originalPreloadedTraces
     .filter((trace) => newTraceIds.has(trace.pcb_trace_id))
     .map((trace) => {
@@ -34,15 +40,31 @@ export const preparePipeline9DrcRoutedTraces = ({
         suffix += 1
       }
       usedTraceIds.add(pcbTraceId)
-      return { ...currentTrace, pcb_trace_id: pcbTraceId }
+      originalPreloadedTraceIdByPreparedTraceId.set(
+        pcbTraceId,
+        trace.pcb_trace_id,
+      )
+      return {
+        ...currentTrace,
+        pcb_trace_id: pcbTraceId,
+        __replaces_pcb_trace_id: trace.pcb_trace_id,
+      }
     })
   const nonCollidingMutatedPreloadedTraces = mutatedPreloadedTraces.filter(
     (trace) => !newTraceIds.has(trace.pcb_trace_id),
   )
 
-  return [
-    ...preloadedCollisionCopies,
-    ...nonCollidingMutatedPreloadedTraces,
-    ...newTraces,
-  ]
+  return {
+    routedTraces: [
+      ...preloadedCollisionCopies,
+      ...nonCollidingMutatedPreloadedTraces,
+      ...newTraces,
+    ],
+    originalPreloadedTraceIdByPreparedTraceId,
+  }
 }
+
+export const preparePipeline9DrcRoutedTraces = (
+  options: Parameters<typeof preparePipeline9DrcRoutedTracesWithMetadata>[0],
+): SimplifiedPcbTrace[] =>
+  preparePipeline9DrcRoutedTracesWithMetadata(options).routedTraces

--- a/tests/features/pipeline9-minimal-preloaded-trace-graph.test.ts
+++ b/tests/features/pipeline9-minimal-preloaded-trace-graph.test.ts
@@ -72,15 +72,16 @@ test("Pipeline9 owns copied stages with minimal preloaded-trace changes", () => 
     pipeline7.pipelineDef.map((step) => [step.solverName, step.solverClass]),
   )
   const pipeline7SharedStageCount = pipeline7.pipelineDef.filter(
-    (step) => step.solverName !== "powerTraceExpansionSolver",
+    (step) =>
+      step.solverName !== "powerTraceExpansionSolver" &&
+      step.solverName !== "exactGeometryDrcForceImproveSolver",
   ).length
-  expect(solver.pipelineDef).toHaveLength(pipeline7SharedStageCount + 1)
+  expect(solver.pipelineDef).toHaveLength(pipeline7SharedStageCount + 2)
   for (const stageName of [
     "highDensityForceImproveSolver",
     "highDensityRepairSolver",
     "highDensityStitchSolver",
     "globalDrcForceImproveSolver",
-    "exactGeometryDrcForceImproveSolver",
   ]) {
     expect(
       solver.pipelineDef.find((step) => step.solverName === stageName)
@@ -92,6 +93,12 @@ test("Pipeline9 owns copied stages with minimal preloaded-trace changes", () => 
       (step) => step.solverName === "highDensityRouteSolver",
     )?.solverClass,
   ).toBe(Pipeline9HighDensitySolver)
+  expect(
+    solver.pipelineDef.some(
+      (step) => step.solverName === "exactGeometryDrcForceImproveSolver",
+    ),
+  ).toBeFalse()
+
   solver.solve()
 
   expect(solver.solved).toBe(true)
@@ -118,4 +125,8 @@ test("Pipeline9 owns copied stages with minimal preloaded-trace changes", () => 
       ),
     ),
   ).toBe(false)
+  const outputTraceIds = solver
+    .getOutputSimplifiedPcbTraces()
+    .map((trace) => trace.pcb_trace_id)
+  expect(new Set(outputTraceIds).size).toBe(outputTraceIds.length)
 })

--- a/tests/features/pipeline9-srj23-sample37-via-repair.test.ts
+++ b/tests/features/pipeline9-srj23-sample37-via-repair.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph"
+import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
+import { loadScenarioBySampleNumber } from "../../scripts/benchmark/scenarios"
+
+test("Pipeline9 uses net metadata to merge the preloaded via in SRJ23 sample 37", async () => {
+  const { scenario } = await loadScenarioBySampleNumber("srj23", 37)
+  const solver = new AutoroutingPipelineSolver9_PreloadedTraceGraph(
+    structuredClone(scenario),
+    { cacheProvider: null, effort: 1 },
+  )
+
+  solver.solve()
+
+  expect(solver.solved).toBeTrue()
+  expect(solver.failed).toBeFalse()
+  const { errors } = evaluateRelaxedDrc({
+    inputSrj: scenario,
+    srjWithPointPairs: solver.srjWithPointPairs!,
+    routedTraces: solver.getOutputSimplifiedPcbTraces(),
+  })
+  expect(errors).toHaveLength(0)
+})

--- a/tests/features/pipeline9-srj23-sample74-via-pair-repair.test.ts
+++ b/tests/features/pipeline9-srj23-sample74-via-pair-repair.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph"
+import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
+import { loadScenarioBySampleNumber } from "../../scripts/benchmark/scenarios"
+
+test("Pipeline9 repairs a via pair introduced by SRJ23 sample 74 regional fallback", async () => {
+  const { scenario } = await loadScenarioBySampleNumber("srj23", 74)
+  const solver = new AutoroutingPipelineSolver9_PreloadedTraceGraph(
+    structuredClone(scenario),
+    { cacheProvider: null, effort: 1 },
+  )
+
+  solver.solve()
+
+  expect(solver.solved).toBeTrue()
+  expect(solver.failed).toBeFalse()
+  expect(
+    solver.pipeline9JointDrcRepairSolver?.stats.initialJointDrcIssueCount,
+  ).toBeGreaterThan(0)
+  const { errors } = evaluateRelaxedDrc({
+    inputSrj: scenario,
+    srjWithPointPairs: solver.srjWithPointPairs!,
+    routedTraces: solver.getOutputSimplifiedPcbTraces(),
+  })
+  expect(errors).toHaveLength(0)
+}, 30_000)


### PR DESCRIPTION
## What changed

- identifies preloaded traces participating in joint relaxed-DRC errors
- exposes only those traces as synthetic movable routes to the exact repair portfolio
- keeps every other preloaded trace fixed and present as an obstacle
- maps synthetic and MST route names to actual connectivity nets through metadata
- consolidates same-net movable/preloaded via pairs without mutating immutable anchors
- contains no regional-B01, terminal-escape, or targeted-detour post-pass

## Validation

- corrected SRJ23 samples 4, 25, 37, and 74
- Pipeline9 minimal-stage and joint-metadata regressions
- `bunx tsc --noEmit`
- `bun run build`

## Stack

- Depends on #1958
- Next: regional B01 joint repair