### PR TITLE
Repair Pipeline9 joint DRC regions with B01

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/apply-pipeline9-regional-b01-repairs.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/apply-pipeline9-regional-b01-repairs.ts
@@ -1,0 +1,373 @@
+import type { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import type { DrcEvaluator } from "high-density-repair03/lib"
+import type { SimpleRouteConnection, SimpleRouteJson } from "lib/types"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+import type { PreloadedHighDensityRoute } from "./convert-preloaded-traces-to-hd-routes"
+import {
+  createRegionalFallbackProblem,
+  spliceFixedRouteSection,
+} from "./pipeline9-regional-fallback"
+import { Pipeline9HighDensitySolver } from "./pipeline9-high-density-solver"
+import { Pipeline9RegionalFallbackSolver } from "./pipeline9-regional-fallback-solver"
+import {
+  getPipeline9DrcErrors,
+  getPipeline9RouteIndexByTraceId,
+  isPipeline9DrcCandidateBetter,
+  type Pipeline9DrcError,
+} from "./pipeline9-joint-drc-repair-utils"
+
+type RegionalB01RepairResult = {
+  routes: HighDensityRoute[]
+  attemptedCandidateCount: number
+  acceptedCandidateCount: number
+  fallbackCandidateCount: number
+}
+
+const REGION_SIZES = [3, 4, 5]
+
+const getErrorCenter = (error: Pipeline9DrcError) => {
+  const center = error.center
+  return center &&
+    typeof center === "object" &&
+    "x" in center &&
+    "y" in center &&
+    typeof center.x === "number" &&
+    typeof center.y === "number"
+    ? { x: center.x, y: center.y }
+    : undefined
+}
+
+const getRepairCenter = (error: Pipeline9DrcError, srj: SimpleRouteJson) => {
+  const obstacleId =
+    typeof error.pcb_pad_id === "string"
+      ? error.pcb_pad_id
+      : typeof error.pcb_trace_error_id === "string"
+        ? error.pcb_trace_error_id.match(
+            /(pcb_(?:smtpad|plated_hole|hole|keepout)_\d+)$/,
+          )?.[1]
+        : undefined
+  if (obstacleId) {
+    const obstacle = srj.obstacles.find(
+      (candidate) =>
+        candidate.obstacleId === obstacleId ||
+        candidate.connectedTo[0] === obstacleId,
+    )
+    if (obstacle) return obstacle.center
+  }
+  return getErrorCenter(error)
+}
+
+const asRegionalRoutes = (
+  routes: HighDensityRoute[],
+): PreloadedHighDensityRoute[] =>
+  routes.map((route, routeIndex) => ({
+    ...route,
+    preloadedTraceId: `pipeline9_joint_candidate_${routeIndex}`,
+    preloadedTraceIndex: routeIndex,
+    preloadedRouteIndex: 0,
+  }))
+
+const getRegionalCandidate = ({
+  routes,
+  fixedObstacleRoutes,
+  routeIndex,
+  center,
+  regionSize,
+  srj,
+  connMap,
+  colorMap,
+  viaDiameter,
+  traceWidth,
+  obstacleMargin,
+  effort,
+}: {
+  routes: HighDensityRoute[]
+  fixedObstacleRoutes: PreloadedHighDensityRoute[]
+  routeIndex: number
+  center: { x: number; y: number }
+  regionSize: number
+  srj: SimpleRouteJson
+  connMap: ConnectivityMap
+  colorMap: Record<string, string>
+  viaDiameter: number
+  traceWidth: number
+  obstacleMargin: number
+  effort: number
+}):
+  | {
+      routes: HighDensityRoute[]
+      usedFallback: boolean
+    }
+  | undefined => {
+  const regionalRoutes = asRegionalRoutes(routes)
+  const movableRoute = regionalRoutes[routeIndex]
+  if (!movableRoute) return undefined
+  const node = {
+    capacityMeshNodeId: `pipeline9_joint_drc_${routeIndex}_${regionSize}`,
+    center,
+    width: regionSize,
+    height: regionSize,
+    availableZ: Array.from({ length: srj.layerCount }, (_, z) => z),
+    portPoints: [],
+    portPointsInPairs: [],
+  }
+  const movableProblem = createRegionalFallbackProblem(node, [movableRoute])
+  const movableSection = movableProblem.fixedRouteSectionsByConnectionName.get(
+    movableRoute.connectionName,
+  )
+  if (!movableSection) return undefined
+
+  const fixedRoutes = regionalRoutes.filter(
+    (_, candidateRouteIndex) => candidateRouteIndex !== routeIndex,
+  )
+  const solver = new Pipeline9HighDensitySolver({
+    nodePortPoints: [movableProblem.nodeWithPortPoints],
+    fixedHdRoutes: [...fixedRoutes, ...fixedObstacleRoutes],
+    connMap,
+    colorMap,
+    obstacles: srj.obstacles,
+    layerCount: srj.layerCount,
+    viaDiameter,
+    traceWidth,
+    obstacleMargin,
+    effort,
+    preserveTerminalPcbPortIds: true,
+    includeBoardObstacles: true,
+    enableRegionalFallback: false,
+    maxB01Rips: 120,
+  })
+  solver.solve()
+  if (!solver.solved || solver.failed) return undefined
+  const replacement = solver.routes.find(
+    (route) => route.connectionName === movableRoute.connectionName,
+  )
+  if (!replacement) return undefined
+
+  return {
+    routes: routes.map((route, candidateRouteIndex) =>
+      candidateRouteIndex === routeIndex
+        ? spliceFixedRouteSection(movableSection, replacement)
+        : route,
+    ),
+    usedFallback: Number(solver.stats.fallbackNodeCount ?? 0) > 0,
+  }
+}
+
+const getRegularRegionalCandidate = ({
+  routes,
+  center,
+  regionSize,
+  srj,
+  connMap,
+  colorMap,
+  viaDiameter,
+  traceWidth,
+  obstacleMargin,
+  effort,
+}: {
+  routes: HighDensityRoute[]
+  center: { x: number; y: number }
+  regionSize: number
+  srj: SimpleRouteJson
+  connMap: ConnectivityMap
+  colorMap: Record<string, string>
+  viaDiameter: number
+  traceWidth: number
+  obstacleMargin: number
+  effort: number
+}): HighDensityRoute[] | undefined => {
+  const regionalRoutes = asRegionalRoutes(routes)
+  const node = {
+    capacityMeshNodeId: "pipeline9_joint_drc_regular_fallback",
+    center,
+    width: regionSize,
+    height: regionSize,
+    availableZ: Array.from({ length: srj.layerCount }, (_, z) => z),
+    portPoints: [],
+    portPointsInPairs: [],
+  }
+  const problem = createRegionalFallbackProblem(node, regionalRoutes)
+  if (problem.fixedRouteSectionsByConnectionName.size === 0) return undefined
+  const solver = new Pipeline9RegionalFallbackSolver({
+    nodeWithPortPoints: problem.nodeWithPortPoints,
+    colorMap,
+    connMap,
+    viaDiameter,
+    traceWidth,
+    obstacleMargin,
+    effort,
+    obstacles: srj.obstacles,
+    layerCount: srj.layerCount,
+  })
+  solver.solve()
+  if (!solver.solved || solver.failed) return undefined
+  const replacementByConnectionName = new Map(
+    solver.getOutput().map((route) => [route.connectionName, route]),
+  )
+  const replacedRouteByOriginalIndex = new Map<number, HighDensityRoute>()
+  const removedOriginalIndexes = new Set<number>()
+  for (const [
+    connectionName,
+    section,
+  ] of problem.fixedRouteSectionsByConnectionName) {
+    const replacement = replacementByConnectionName.get(connectionName)
+    if (!replacement) return undefined
+    replacedRouteByOriginalIndex.set(
+      section.sourceRoutes[0]!.preloadedTraceIndex,
+      spliceFixedRouteSection(section, replacement),
+    )
+    for (const sourceRoute of section.sourceRoutes.slice(1)) {
+      removedOriginalIndexes.add(sourceRoute.preloadedTraceIndex)
+    }
+  }
+  return regionalRoutes.flatMap((route, routeIndex) => {
+    if (removedOriginalIndexes.has(routeIndex)) return []
+    return [replacedRouteByOriginalIndex.get(routeIndex) ?? route]
+  })
+}
+
+/**
+ * Reroutes one exact DRC participant with B01 in a sub-15mm window. B01 sees
+ * every other route plus board copper as obstacles. If no B01 candidate helps,
+ * one regular high-density candidate jointly reroutes all traces in the region.
+ */
+export const applyPipeline9RegionalB01Repairs = ({
+  srj,
+  routes,
+  fixedObstacleRoutes,
+  newConnections,
+  syntheticConnectionNames,
+  drcEvaluator,
+  connMap,
+  colorMap,
+  viaDiameter,
+  traceWidth,
+  obstacleMargin,
+  effort,
+}: {
+  srj: SimpleRouteJson
+  routes: HighDensityRoute[]
+  fixedObstacleRoutes: PreloadedHighDensityRoute[]
+  newConnections: SimpleRouteConnection[]
+  syntheticConnectionNames: ReadonlySet<string>
+  drcEvaluator: DrcEvaluator
+  connMap: ConnectivityMap
+  colorMap: Record<string, string>
+  viaDiameter: number
+  traceWidth: number
+  obstacleMargin: number
+  effort: number
+}): RegionalB01RepairResult => {
+  let currentRoutes = routes
+  let currentErrors = getPipeline9DrcErrors(drcEvaluator, currentRoutes)
+  let attemptedCandidateCount = 0
+  let acceptedCandidateCount = 0
+  let fallbackCandidateCount = 0
+
+  for (let pass = 0; pass < 2; pass++) {
+    let acceptedOnPass = false
+    const routeIndexByTraceId = getPipeline9RouteIndexByTraceId({
+      routes: currentRoutes,
+      newConnections,
+      syntheticConnectionNames,
+    })
+    const repairableErrors = currentErrors.filter(
+      (error) =>
+        (error.type === "pcb_trace_error" ||
+          error.type === "pcb_pad_trace_clearance_error" ||
+          error.type === "pcb_via_trace_clearance_error") &&
+        typeof error.pcb_trace_id === "string",
+    )
+    for (const error of repairableErrors) {
+      const center = getRepairCenter(error, srj)
+      const traceIds = [
+        error.pcb_trace_id,
+        ...(Array.isArray(error.pcb_trace_ids) ? error.pcb_trace_ids : []),
+      ]
+        .filter(
+          (traceId): traceId is string =>
+            typeof traceId === "string" && routeIndexByTraceId.has(traceId),
+        )
+        .filter(
+          (traceId, traceIndex, allTraceIds) =>
+            allTraceIds.indexOf(traceId) === traceIndex,
+        )
+      if (!center) continue
+      let bestRoutes = currentRoutes
+      let bestErrors = currentErrors
+      for (const traceId of traceIds.slice(0, 2)) {
+        const routeIndex = routeIndexByTraceId.get(traceId)
+        if (routeIndex === undefined) continue
+        for (const regionSize of REGION_SIZES) {
+          const candidate = getRegionalCandidate({
+            routes: currentRoutes,
+            fixedObstacleRoutes,
+            routeIndex,
+            center,
+            regionSize,
+            srj,
+            connMap,
+            colorMap,
+            viaDiameter,
+            traceWidth,
+            obstacleMargin,
+            effort,
+          })
+          if (!candidate) continue
+          attemptedCandidateCount++
+          if (candidate.usedFallback) fallbackCandidateCount++
+          const candidateErrors = getPipeline9DrcErrors(
+            drcEvaluator,
+            candidate.routes,
+          )
+          if (isPipeline9DrcCandidateBetter(candidateErrors, bestErrors)) {
+            bestRoutes = candidate.routes
+            bestErrors = candidateErrors
+          }
+          if (bestErrors.length === 0) break
+        }
+        if (bestErrors.length === 0) break
+      }
+      if (bestRoutes === currentRoutes) {
+        const fallbackRoutes = getRegularRegionalCandidate({
+          routes: currentRoutes,
+          center,
+          regionSize: 3,
+          srj,
+          connMap,
+          colorMap,
+          viaDiameter,
+          traceWidth,
+          obstacleMargin,
+          effort,
+        })
+        if (fallbackRoutes) {
+          attemptedCandidateCount++
+          fallbackCandidateCount++
+          const fallbackErrors = getPipeline9DrcErrors(
+            drcEvaluator,
+            fallbackRoutes,
+          )
+          if (isPipeline9DrcCandidateBetter(fallbackErrors, bestErrors)) {
+            bestRoutes = fallbackRoutes
+            bestErrors = fallbackErrors
+          }
+        }
+      }
+      if (bestRoutes !== currentRoutes) {
+        currentRoutes = bestRoutes
+        currentErrors = bestErrors
+        acceptedCandidateCount++
+        acceptedOnPass = true
+      }
+    }
+    if (!acceptedOnPass || currentErrors.length === 0) break
+  }
+
+  return {
+    routes: currentRoutes,
+    attemptedCandidateCount,
+    acceptedCandidateCount,
+    fallbackCandidateCount,
+  }
+}

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-joint-drc-repair-solver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-joint-drc-repair-solver.ts
@@ -22,6 +22,7 @@ import {
   convertPreloadedTraceToHdRoutes,
   type PreloadedHighDensityRoute,
 } from "./convert-preloaded-traces-to-hd-routes"
+import { applyPipeline9RegionalB01Repairs } from "./apply-pipeline9-regional-b01-repairs"
 import { normalizePipeline9DrcErrorsForRepair } from "./normalize-pipeline9-drc-errors-for-repair"
 import { preparePipeline9DrcRoutedTracesWithMetadata } from "./prepare-pipeline9-drc-routed-traces"
 import { getPipeline9PreloadedTraceIdsInInitialDrcRegions } from "./get-pipeline9-preloaded-trace-ids-in-initial-drc-regions"
@@ -634,10 +635,33 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
       return
     }
     if (!this.exactRepairSolver.solved) return
-    this.combinedOutput = this.exactRepairSolver.getOutput()
+    const regionalB01RepairResult = applyPipeline9RegionalB01Repairs({
+      srj: this.params.srj,
+      routes: this.exactRepairSolver.getOutput(),
+      fixedObstacleRoutes: this.fixedPreloadedObstacleRoutes,
+      newConnections: this.params.newConnections,
+      syntheticConnectionNames: this.syntheticConnectionNames,
+      drcEvaluator: this.drcEvaluator!,
+      connMap: this.params.connMap,
+      colorMap: this.params.colorMap,
+      viaDiameter: this.params.defaultViaDiameter,
+      traceWidth: this.params.srj.minTraceWidth,
+      obstacleMargin:
+        this.params.srj.defaultObstacleMargin ??
+        this.params.srj.minTraceToPadEdgeClearance ??
+        0.15,
+      effort: this.params.effort,
+    })
+    this.combinedOutput = regionalB01RepairResult.routes
     this.stats = {
       ...this.stats,
       ...this.exactRepairSolver.stats,
+      regionalB01RepairCandidateCount:
+        regionalB01RepairResult.attemptedCandidateCount,
+      regionalB01RepairAcceptedCount:
+        regionalB01RepairResult.acceptedCandidateCount,
+      regionalB01RepairFallbackCandidateCount:
+        regionalB01RepairResult.fallbackCandidateCount,
     }
     this.solved = true
   }

--- a/tests/features/pipeline9-srj23-sample21-regional-b01-repair.test.ts
+++ b/tests/features/pipeline9-srj23-sample21-regional-b01-repair.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph"
+import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
+import { loadScenarioBySampleNumber } from "../../scripts/benchmark/scenarios"
+
+test("Pipeline9 uses regional B01 to clear an SRJ23 trace-pair conflict", async () => {
+  const { scenario } = await loadScenarioBySampleNumber("srj23", 21)
+  const solver = new AutoroutingPipelineSolver9_PreloadedTraceGraph(
+    structuredClone(scenario),
+    { cacheProvider: null, effort: 1 },
+  )
+
+  solver.solve()
+
+  expect(solver.solved).toBeTrue()
+  expect(solver.failed).toBeFalse()
+  expect(
+    solver.pipeline9JointDrcRepairSolver?.stats.regionalB01RepairAcceptedCount,
+  ).toBeGreaterThan(0)
+  const { errors } = evaluateRelaxedDrc({
+    inputSrj: scenario,
+    srjWithPointPairs: solver.srjWithPointPairs!,
+    routedTraces: solver.getOutputSimplifiedPcbTraces(),
+  })
+  expect(errors).toHaveLength(0)
+})

--- a/tests/features/pipeline9-srj23-sample44-all-preloaded-obstacles.test.ts
+++ b/tests/features/pipeline9-srj23-sample44-all-preloaded-obstacles.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph"
+import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
+import { loadScenarioBySampleNumber } from "../../scripts/benchmark/scenarios"
+
+test("Pipeline9 regional B01 sees every fixed preloaded trace in SRJ23 sample 44", async () => {
+  const { scenario } = await loadScenarioBySampleNumber("srj23", 44)
+  const solver = new AutoroutingPipelineSolver9_PreloadedTraceGraph(
+    structuredClone(scenario),
+    { cacheProvider: null, effort: 1 },
+  )
+
+  solver.solve()
+
+  expect(solver.solved).toBeTrue()
+  expect(solver.failed).toBeFalse()
+  expect(
+    solver.pipeline9JointDrcRepairSolver?.stats.regionalB01RepairAcceptedCount,
+  ).toBeGreaterThan(0)
+  const { errors } = evaluateRelaxedDrc({
+    inputSrj: scenario,
+    srjWithPointPairs: solver.srjWithPointPairs!,
+    routedTraces: solver.getOutputSimplifiedPcbTraces(),
+  })
+  expect(errors).toHaveLength(0)
+})

--- a/tests/features/pipeline9-srj23-sample46-regional-trace-set.test.ts
+++ b/tests/features/pipeline9-srj23-sample46-regional-trace-set.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph"
+import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
+import { loadScenarioBySampleNumber } from "../../scripts/benchmark/scenarios"
+
+test("Pipeline9 makes every preloaded trace in an SRJ23 sample 46 DRC region reroutable", async () => {
+  const { scenario } = await loadScenarioBySampleNumber("srj23", 46)
+  const solver = new AutoroutingPipelineSolver9_PreloadedTraceGraph(
+    structuredClone(scenario),
+    { cacheProvider: null, effort: 1 },
+  )
+
+  solver.solve()
+
+  expect(solver.solved).toBeTrue()
+  expect(solver.failed).toBeFalse()
+  expect(
+    solver.pipeline9JointDrcRepairSolver?.stats.regionalB01RepairAcceptedCount,
+  ).toBeGreaterThan(0)
+  const { errors } = evaluateRelaxedDrc({
+    inputSrj: scenario,
+    srjWithPointPairs: solver.srjWithPointPairs!,
+    routedTraces: solver.getOutputSimplifiedPcbTraces(),
+  })
+  expect(errors).toHaveLength(0)
+})

--- a/tests/features/pipeline9-srj23-sample65-board-obstacle-repair.test.ts
+++ b/tests/features/pipeline9-srj23-sample65-board-obstacle-repair.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph"
+import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
+import { loadScenarioBySampleNumber } from "../../scripts/benchmark/scenarios"
+
+test("Pipeline9 respects the exact SRJ23 pad obstacle center", async () => {
+  const { scenario } = await loadScenarioBySampleNumber("srj23", 65)
+  const solver = new AutoroutingPipelineSolver9_PreloadedTraceGraph(
+    structuredClone(scenario),
+    { cacheProvider: null, effort: 1 },
+  )
+
+  solver.solve()
+
+  expect(solver.solved).toBeTrue()
+  expect(solver.failed).toBeFalse()
+  const { errors } = evaluateRelaxedDrc({
+    inputSrj: scenario,
+    srjWithPointPairs: solver.srjWithPointPairs!,
+    routedTraces: solver.getOutputSimplifiedPcbTraces(),
+  })
+  expect(errors).toHaveLength(0)
+})

--- a/tests/features/pipeline9-srj23-sample70-centered-via-repair.test.ts
+++ b/tests/features/pipeline9-srj23-sample70-centered-via-repair.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph"
+import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
+import { loadScenarioBySampleNumber } from "../../scripts/benchmark/scenarios"
+
+test("Pipeline9 regional B01 uses the exact via error center in SRJ23 sample 70", async () => {
+  const { scenario } = await loadScenarioBySampleNumber("srj23", 70)
+  const solver = new AutoroutingPipelineSolver9_PreloadedTraceGraph(
+    structuredClone(scenario),
+    { cacheProvider: null, effort: 1 },
+  )
+
+  solver.solve()
+
+  expect(solver.solved).toBeTrue()
+  expect(solver.failed).toBeFalse()
+  expect(
+    solver.pipeline9JointDrcRepairSolver?.stats.regionalB01RepairAcceptedCount,
+  ).toBeGreaterThan(0)
+  const { errors } = evaluateRelaxedDrc({
+    inputSrj: scenario,
+    srjWithPointPairs: solver.srjWithPointPairs!,
+    routedTraces: solver.getOutputSimplifiedPcbTraces(),
+  })
+  expect(errors).toHaveLength(0)
+})


### PR DESCRIPTION
Stacked on #1959.

This layer adds a post-exact regional repair pass for the remaining joint DRC errors. It attempts to reroute one implicated trace with high-density-b01 while every other routed and preloaded trace remains a fixed obstacle. Only when no B01 candidate improves DRC does it use the already-established regular high-density regional fallback to jointly reroute that local region. Regions are 3–5 mm and stay well below the 15x15 mm B01 limit.

Focused coverage:
- SRJ23 sample 21: trace-pair conflict repaired
- sample 44: every fixed preloaded obstacle is visible
- sample 46: complete regional trace set is repairable
- sample 65: exact pad obstacle center
- sample 70: exact via error center
- inherited samples 37 and 74 remain passing

Validation:
- `bun test <five new SRJ23 test files> --timeout 300000` (5 pass)
- `bun test tests/features/pipeline9-srj23-sample37-via-repair.test.ts tests/features/pipeline9-srj23-sample74-via-pair-repair.test.ts --timeout 300000` (2 pass)
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`