### PR TITLE
Bound Pipeline9 preliminary joint DRC search

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-joint-drc-repair-solver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-joint-drc-repair-solver.ts
@@ -30,6 +30,12 @@ import { getPipeline9PreloadedTraceIdsInInitialDrcRegions } from "./get-pipeline
 import { mergePipeline9MovablePreloadedVias } from "./merge-pipeline9-movable-preloaded-vias"
 import { getPipeline9PreloadedViaPairTraceGroups } from "./get-pipeline9-preloaded-via-pair-trace-groups"
 
+// This generic portfolio is only the preliminary repair. Each candidate runs
+// joint DRC over all copper; unresolved errors continue into Pipeline9's
+// regional B01 pass, where the search is local and obstacle-aware.
+const PRELIMINARY_EXACT_REPAIR_MAX_ITERATIONS = 8
+const PRELIMINARY_EXACT_REPAIR_BROAD_MAX_ITERATIONS = 4
+
 type Pipeline9JointDrcRepairSolverParams = {
   srj: SimpleRouteJson
   srjWithPointPairs: SimpleRouteJson
@@ -604,15 +610,13 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
       effort: params.effort,
       viaHoleDiameter: params.defaultViaHoleDiameter,
       drcEvaluator,
-      viaInPadDrcEvaluator: drcEvaluator,
-      maxIterations: 64,
+      maxIterations: PRELIMINARY_EXACT_REPAIR_MAX_ITERATIONS,
       enableLargeBoardBroadFallback: false,
       enableTargetedErrorSweep: true,
       enablePostSolveClearanceRelaxation: false,
-      enableSafeTraceLayerMoves: true,
-      enableViaInPadLayerMoves: true,
-      viaInPadMaxIterations: 64,
-      broadMaxIterations: 16,
+      enableSafeTraceLayerMoves: false,
+      enableViaInPadLayerMoves: false,
+      broadMaxIterations: PRELIMINARY_EXACT_REPAIR_BROAD_MAX_ITERATIONS,
       broadPassMultiplier: 3,
     })
     this.activeSubSolver = this.exactRepairSolver

--- a/tests/features/pipeline9-srj23-sample52-bounded-joint-drc.test.ts
+++ b/tests/features/pipeline9-srj23-sample52-bounded-joint-drc.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph"
+import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
+import { loadScenarioBySampleNumber } from "../../scripts/benchmark/scenarios"
+
+test("Pipeline9 bounds preliminary joint DRC work for SRJ23 sample 52", async () => {
+  const { scenario } = await loadScenarioBySampleNumber("srj23", 52)
+  const solver = new AutoroutingPipelineSolver9_PreloadedTraceGraph(
+    structuredClone(scenario),
+    { cacheProvider: null, effort: 1 },
+  )
+
+  solver.solve()
+
+  expect(solver.solved).toBeTrue()
+  expect(solver.failed).toBeFalse()
+  expect(
+    Number(
+      solver.pipeline9JointDrcRepairSolver?.stats
+        .globalDrcForceImproveMaxIterations,
+    ),
+  ).toBeLessThanOrEqual(8)
+  const { errors } = evaluateRelaxedDrc({
+    inputSrj: scenario,
+    srjWithPointPairs: solver.srjWithPointPairs!,
+    routedTraces: solver.getOutputSimplifiedPcbTraces(),
+  })
+  expect(errors).toHaveLength(0)
+})

--- a/tests/features/pipeline9-srj23-sample53-bounded-joint-drc.test.ts
+++ b/tests/features/pipeline9-srj23-sample53-bounded-joint-drc.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph"
+import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
+import { loadScenarioBySampleNumber } from "../../scripts/benchmark/scenarios"
+
+test("Pipeline9 bounds preliminary joint DRC work for SRJ23 sample 53", async () => {
+  const { scenario } = await loadScenarioBySampleNumber("srj23", 53)
+  const solver = new AutoroutingPipelineSolver9_PreloadedTraceGraph(
+    structuredClone(scenario),
+    { cacheProvider: null, effort: 1 },
+  )
+
+  solver.solve()
+
+  expect(solver.solved).toBeTrue()
+  expect(solver.failed).toBeFalse()
+  expect(
+    Number(
+      solver.pipeline9JointDrcRepairSolver?.stats
+        .globalDrcForceImproveMaxIterations,
+    ),
+  ).toBeLessThanOrEqual(8)
+  const { errors } = evaluateRelaxedDrc({
+    inputSrj: scenario,
+    srjWithPointPairs: solver.srjWithPointPairs!,
+    routedTraces: solver.getOutputSimplifiedPcbTraces(),
+  })
+  expect(errors).toHaveLength(0)
+})


### PR DESCRIPTION
Stacked on #1961.

The generic global joint-DRC portfolio runs full-board relaxed DRC for every candidate. Pipeline9 now has a dedicated regional B01 repair pass after it, so this commit makes the global portfolio preliminary: 8 targeted iterations, up to 4 broad iterations, and no duplicate safe-layer/via-in-pad portfolio phases. Unresolved errors continue into the obstacle-aware regional B01 layer.

This removes the SRJ23 sample 52/53 benchmark timeouts without weakening DRC:
- sample 52: ~435s -> ~69s locally
- sample 53: ~169s -> ~23s locally
- full SRJ23 local benchmark: 100.0% completion, 97.4% relaxed DRC, 0/76 timeouts, P95 25.3s

The remaining relaxed failures are samples 42 and 72, whose required terminal pads overlap different-net plated holes in the input geometry.

Validation:
- new focused sample 52/53 tests (2 pass)
- 10 joint/regional/via/terminal regression files (10 pass, 146 assertions)
- full 76-sample SRJ23 benchmark
- `bunx tsc --noEmit`
- `bun run build`
- `bun run format:check`
- `git diff --check`