### PR TITLE
fix: apply defaultObstacleMargin to Pipeline 4 segment point spacing

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline4_TinyHypergraph/AutoroutingPipelineSolver4_TinyHypergraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline4_TinyHypergraph/AutoroutingPipelineSolver4_TinyHypergraph.ts
@@ -235,6 +235,7 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
           nodes: cms.capacityNodes!,
           edges: cms.capacityEdges || [],
           traceWidth: cms.minTraceWidth,
+          obstacleMargin: cms.srj.defaultObstacleMargin ?? 0.15,
           colorMap: cms.colorMap,
           shouldReturnCrampedPortPoints: true,
         },

--- a/tests/obstacle-margin-produced-clearance-monotonic.test.ts
+++ b/tests/obstacle-margin-produced-clearance-monotonic.test.ts
@@ -1,0 +1,106 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver4 } from "lib/autorouter-pipelines/AutoroutingPipeline4_TinyHypergraph/AutoroutingPipelineSolver4_TinyHypergraph"
+import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
+import { minimumDistanceBetweenSegments } from "lib/utils/minimumDistanceBetweenSegments"
+import type { SimpleRouteJson, SimplifiedPcbTrace } from "lib/types"
+import type { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import bugReport from "../fixtures/bug-reports/bugreport01-be84eb/bugreport01-be84eb.json" with {
+  type: "json",
+}
+
+interface WireSegment {
+  connectionName: string
+  layer: string
+  start: { x: number; y: number }
+  end: { x: number; y: number }
+  width: number
+}
+
+const collectWireSegments = (
+  traces: SimplifiedPcbTrace[],
+  fallbackWidth: number,
+): WireSegment[] => {
+  const segments: WireSegment[] = []
+  for (const trace of traces) {
+    for (let index = 0; index < trace.route.length - 1; index += 1) {
+      const start = trace.route[index]!
+      const end = trace.route[index + 1]!
+      if (start.route_type !== "wire" || end.route_type !== "wire") continue
+      if (start.layer !== end.layer) continue
+      segments.push({
+        connectionName: trace.connection_name,
+        layer: start.layer,
+        start: { x: start.x, y: start.y },
+        end: { x: end.x, y: end.y },
+        width: start.width ?? fallbackWidth,
+      })
+    }
+  }
+  return segments
+}
+
+// Smallest edge-to-edge gap between copper of two different electrical nets on
+// the same layer. Same-net segments are allowed to touch, so they are skipped
+// via the connectivity map. This mirrors how issue #1523 measured "produced
+// clearance".
+const minDifferentNetClearance = (
+  traces: SimplifiedPcbTrace[],
+  connMap: ConnectivityMap,
+  fallbackWidth: number,
+): number => {
+  const segments = collectWireSegments(traces, fallbackWidth)
+  let smallest = Number.POSITIVE_INFINITY
+  for (let i = 0; i < segments.length; i += 1) {
+    for (let j = i + 1; j < segments.length; j += 1) {
+      const a = segments[i]!
+      const b = segments[j]!
+      if (a.layer !== b.layer) continue
+      if (a.connectionName === b.connectionName) continue
+      if (connMap.areIdsConnected(a.connectionName, b.connectionName)) continue
+      const centerlineGap = minimumDistanceBetweenSegments(
+        a.start,
+        a.end,
+        b.start,
+        b.end,
+      )
+      const edgeGap = centerlineGap - (a.width / 2 + b.width / 2)
+      if (edgeGap < smallest) smallest = edgeGap
+    }
+  }
+  return smallest
+}
+
+// Regression test for #1523: routing the reported fixture at increasing
+// defaultObstacleMargin used to leave the produced clearance flat or
+// non-monotonic (0.1135 -> 0.1257 -> 0.0992 -> 0.1139 on pipeline 4). Once the
+// margin reaches the segment point spacing it must not decrease as the margin
+// grows, and the largest margin must produce clearly more clearance than no
+// margin at all.
+test("increasing defaultObstacleMargin increases produced clearance (pipeline 4)", () => {
+  const baseSrj = (bugReport as { simple_route_json: SimpleRouteJson })
+    .simple_route_json
+  const margins = [0, 0.1, 0.2, 0.3]
+
+  const clearances = margins.map((margin): number => {
+    const srj = structuredClone(baseSrj)
+    srj.defaultObstacleMargin = margin
+    const solver = new AutoroutingPipelineSolver4(srj)
+    solver.solve()
+    expect(solver.solved).toBe(true)
+    expect(solver.failed).toBe(false)
+    const connMap = getConnectivityMapFromSimpleRouteJson(srj)
+    return minDifferentNetClearance(
+      solver.getOutputSimpleRouteJson().traces ?? [],
+      connMap,
+      srj.minTraceWidth,
+    )
+  })
+
+  const EPSILON = 0.01
+  for (let index = 1; index < clearances.length; index += 1) {
+    expect(clearances[index]!).toBeGreaterThanOrEqual(
+      clearances[index - 1]! - EPSILON,
+    )
+  }
+  expect(clearances.at(-1)! - clearances[0]!).toBeGreaterThanOrEqual(0.03)
+})

--- a/tests/obstacle-margin-segment-point-spacing.test.ts
+++ b/tests/obstacle-margin-segment-point-spacing.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver4 } from "lib/autorouter-pipelines/AutoroutingPipeline4_TinyHypergraph/AutoroutingPipelineSolver4_TinyHypergraph"
+import type { SimpleRouteJson } from "lib/types"
+
+const makeSrj = (defaultObstacleMargin: number): SimpleRouteJson => ({
+  layerCount: 2,
+  minTraceWidth: 0.15,
+  defaultObstacleMargin,
+  obstacles: [],
+  connections: [
+    {
+      name: "c1",
+      pointsToConnect: [
+        { x: -1, y: 0, layer: "top" },
+        { x: 1, y: 0, layer: "top" },
+      ],
+    },
+  ],
+  bounds: { minX: -5, maxX: 5, minY: -5, maxY: 5 },
+})
+
+// The segment point spacing is traceWidth + obstacleMargin, so it is the stage
+// that sets how far apart different-net traces sit where they cross capacity
+// mesh node boundaries. Pipeline 4 must hand the srj margin to it, otherwise the
+// spacing is pinned to the solver default and the configured margin has no
+// effect on the produced clearance (issue #1523).
+test("availableSegmentPointSolver receives defaultObstacleMargin from the srj", () => {
+  const margin = 0.3
+  const solver = new AutoroutingPipelineSolver4(makeSrj(margin))
+
+  const step = solver.pipelineDef.find(
+    (pipelineStep) => pipelineStep.solverName === "availableSegmentPointSolver",
+  )
+  expect(step).toBeDefined()
+
+  const params = step!.getConstructorParams(solver)[0] as {
+    obstacleMargin?: number
+  }
+  expect(params.obstacleMargin).toBe(margin)
+})


### PR DESCRIPTION
Fixes #1523

## What was wrong

Setting `defaultObstacleMargin` (or `obstacleMargin`) did not change the produced trace to trace clearance. Routing the reported `bugreport01` fixture on pipeline 4 at rising margins produced a smallest different-net gap that wobbled around 0.11 mm instead of growing:

| defaultObstacleMargin | min different-net gap (mm), before |
| --- | --- |
| 0.0 | 0.1135 |
| 0.1 | 0.1257 |
| 0.2 | 0.0992 |
| 0.3 | 0.1139 |

The gap at margin 0.2 is smaller than at margin 0, so there is no way to widen clearance by asking for a larger margin. These are the reporter's exact numbers.

The gap is measured between segments of different electrical nets on the same layer, edge to edge (center distance minus both half widths). Same-net segments are excluded through the connectivity map, so this is a real different-net gap and not two pieces of one net.

## Root cause

`AvailableSegmentPointSolver` places the port points that traces use to cross between capacity mesh nodes. Its spacing is

```
minPortSpacing = traceWidth + obstacleMargin
```

and that spacing sets both how many port points fit on a shared edge and how far they sit from the edge ends. It is the stage that decides how close two different-net traces can sit where they cross a node boundary.

The pipeline constructs this solver with `traceWidth` but without `obstacleMargin`, so it fell back to its own default of 0.15. The configured `defaultObstacleMargin` never reached it, so the spacing was pinned to `traceWidth + 0.15` no matter what the board asked for.

## Fix

Pass the margin the board configured into the pipeline 4 segment point step, using the same `cms.srj.defaultObstacleMargin ?? 0.15` expression the escape-via and high-density steps in this file already use:

```ts
obstacleMargin: cms.srj.defaultObstacleMargin ?? 0.15,
```

With the margin threaded through, the produced clearance grows with it:

| defaultObstacleMargin | min different-net gap (mm), after |
| --- | --- |
| 0.0 | 0.1100 |
| 0.1 | 0.1137 |
| 0.2 | 0.1569 |
| 0.3 | 0.1672 |

## Tests

Two tests, both failing on `main` before the change.

- `tests/obstacle-margin-segment-point-spacing.test.ts` asserts the pipeline 4 segment point step receives `obstacleMargin` equal to the srj `defaultObstacleMargin`. Before the fix it is `undefined`.
- `tests/obstacle-margin-produced-clearance-monotonic.test.ts` routes `bugreport01` at margins 0, 0.1, 0.2 and 0.3 and asserts the smallest different-net clearance never decreases as the margin rises and that the largest margin produces clearly more clearance than no margin at all. Before the fix the 0.2 case drops to 0.0992 and fails.

## Behaviour on existing boards

The default stays 0.15, so any board that does not set `defaultObstacleMargin` gets identical spacing. No fixture routed through pipeline 4 sets a different margin, so the full suite passes with no snapshot updates.

## Scope

The same omission exists in the other pipelines that build `AvailableSegmentPointSolver`. Threading the margin there alone is not a clean win: pipelines 2 and 7 also run `UniformPortDistributionSolver` and the route stitch clearance validator, both of which still enforce a fixed clearance rather than the configured margin, so the generator change on its own can move a gap the wrong way at some margins. Making those pipelines honor the configured margin end to end is a larger change across those two stages. This PR keeps to pipeline 4, where the generator change is sufficient, monotonic and a no-op on every board that does not set the margin. Happy to extend it to the sibling pipelines in the same PR if you prefer.

## Not a swallowed error

This changes an input value that was defaulted. It does not catch or continue past a failure. The solver still validates its own state.

## Verified locally

- the two new tests: 2 pass with the change, both fail on `main` with the values quoted above
- `bun test` full suite, run locally as 6 parallel shards: 432 pass, 50 skip, 6 fail. All 6 fails are per-test timeouts (in-code limits of 30 to 300 s exceeded under parallel CPU load), not assertion or snapshot failures. None of the six sets `defaultObstacleMargin`, so the changed step gets the same 0.15 as before and their output is unchanged. They pass when rerun without the parallel load. Upstream CI runs the suite in 5 isolated shards and is the authoritative full-suite result.
- `bunx tsc --noEmit`: clean
- `bun run build`: success (ESM 2.15 MB, dts 274.86 KB)

AI assistance (Claude, Anthropic) was used in developing this change. I designed it, reviewed it and verified it with the checks above. I own the change and can explain it and answer questions.
