### PR TITLE
Reproduce unpruned component boundary ports

### DIFF
--- a/tests/features/__snapshots__/component-boundary-port-pruning.snap.svg
+++ b/tests/features/__snapshots__/component-boundary-port-pruning.snap.svg
@@ -1,0 +1,54 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="0,0 3.92,0" data-type="line" data-label="" points="40,442.7086746885134 299.25925925925924,442.7086746885134" fill="none" stroke="rgba(25,25,25,0.62)" stroke-width="3.306878306878307"/></g><g><polyline data-points="3.92,0 3.92,3.3" data-type="line" data-label="" points="299.25925925925924,442.7086746885134 299.25925925925924,224.45470643454513" fill="none" stroke="rgba(25,25,25,0.62)" stroke-width="3.306878306878307"/></g><g><polyline data-points="3.92,3.3 0,3.3" data-type="line" data-label="" points="299.25925925925924,224.45470643454513 40,224.45470643454513" fill="none" stroke="rgba(25,25,25,0.62)" stroke-width="3.306878306878307"/></g><g><polyline data-points="0,3.3 0,0" data-type="line" data-label="" points="40,224.45470643454513 40,442.7086746885134" fill="none" stroke="rgba(25,25,25,0.62)" stroke-width="3.306878306878307"/></g><g><polyline data-points="1.96,0 1.96,3" data-type="line" data-label="component-boundary" points="169.62962962962962,442.7086746885134 169.62962962962962,244.29597627581495" fill="none" stroke="#94a3b8" stroke-width="1px" stroke-dasharray="4 4"/></g><g><polyline data-points="4.5472,0 8.4672,0" data-type="line" data-label="" points="340.74074074074076,442.7086746885134 600,442.7086746885134" fill="none" stroke="rgba(25,25,25,0.62)" stroke-width="3.306878306878307"/></g><g><polyline data-points="8.4672,0 8.4672,3.3" data-type="line" data-label="" points="600,442.7086746885134 600,224.45470643454513" fill="none" stroke="rgba(25,25,25,0.62)" stroke-width="3.306878306878307"/></g><g><polyline data-points="8.4672,3.3 4.5472,3.3" data-type="line" data-label="" points="600,224.45470643454513 340.74074074074076,224.45470643454513" fill="none" stroke="rgba(25,25,25,0.62)" stroke-width="3.306878306878307"/></g><g><polyline data-points="4.5472,3.3 4.5472,0" data-type="line" data-label="" points="340.74074074074076,224.45470643454513 340.74074074074076,442.7086746885134" fill="none" stroke="rgba(25,25,25,0.62)" stroke-width="3.306878306878307"/></g><g><polyline data-points="6.5072,0 6.5072,3" data-type="line" data-label="component-boundary" points="470.3703703703704,442.7086746885134 470.3703703703704,244.29597627581495" fill="none" stroke="#94a3b8" stroke-width="1px" stroke-dasharray="4 4"/></g><g><rect data-type="rect" data-label="Input: 5 cramped component ports step:0 layer:all" data-x="1.96" data-y="1.65" x="40" y="224.45470643454516" width="259.25925925925924" height="218.25396825396825" fill="rgba(255,255,255,0)" stroke="rgba(25,25,25,0.42)" stroke-width="0.01512"/></g><g><rect data-type="rect" data-label="component-left" data-x="0.96" data-y="1.5" x="40" y="244.29597627581495" width="126.98412698412699" height="198.41269841269843" fill="#e2e8f0" stroke="#64748b" stroke-width="0.01512"/></g><g><rect data-type="rect" data-label="component-right" data-x="2.96" data-y="1.5" x="172.2751322751323" y="244.29597627581495" width="126.98412698412696" height="198.41269841269843" fill="#e2e8f0" stroke="#64748b" stroke-width="0.01512"/></g><g><rect data-type="rect" data-label="Issue: all 5 unused ports remain step:1 layer:all" data-x="6.5072" data-y="1.65" x="340.74074074074076" y="224.45470643454516" width="259.25925925925924" height="218.25396825396825" fill="rgba(255,255,255,0)" stroke="rgba(25,25,25,0.42)" stroke-width="0.01512"/></g><g><rect data-type="rect" data-label="component-left" data-x="5.5072" data-y="1.5" x="340.74074074074076" y="244.29597627581495" width="126.98412698412699" height="198.41269841269843" fill="#e2e8f0" stroke="#64748b" stroke-width="0.01512"/></g><g><rect data-type="rect" data-label="component-right" data-x="7.5072" data-y="1.5" x="473.015873015873" y="244.29597627581495" width="126.98412698412699" height="198.41269841269843" fill="#e2e8f0" stroke="#64748b" stroke-width="0.01512"/></g><text data-type="text" data-label="5 real port-points" data-x="1.96" data-y="3.3" x="169.62962962962962" y="224.45470643454513" fill="#0f172a" font-size="11.904761904761905" font-family="sans-serif" text-anchor="middle" dominant-baseline="text-after-edge">5 real port-points</text><text data-type="text" data-label="Input: 5 cramped component ports" data-x="0" data-y="3.710710322580645" x="40" y="197.2913253114866" fill="rgb(18,18,18)" font-size="13.067502986857825" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge">Input: 5 cramped component ports</text><text data-type="text" data-label="step:0" data-x="0.98" data-y="3.48942" x="104.81481481481481" y="211.92692865676736" fill="rgb(190,92,12)" font-size="13.067502986857825" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge">step:0</text><text data-type="text" data-label=" layer:all" data-x="1.7149999999999999" data-y="3.48942" x="153.42592592592592" y="211.92692865676736" fill="rgb(120,58,175)" font-size="13.067502986857825" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge"> layer:all</text><text data-type="text" data-label="5 real port-points" data-x="6.5072" data-y="3.3" x="470.3703703703704" y="224.45470643454513" fill="#0f172a" font-size="11.904761904761905" font-family="sans-serif" text-anchor="middle" dominant-baseline="text-after-edge">5 real port-points</text><text data-type="text" data-label="Issue: all 5 unused ports remain" data-x="4.5472" data-y="3.710710322580645" x="340.74074074074076" y="197.2913253114866" fill="rgb(18,18,18)" font-size="13.067502986857825" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge">Issue: all 5 unused ports remain</text><text data-type="text" data-label="step:1" data-x="5.527200000000001" data-y="3.48942" x="405.5555555555556" y="211.92692865676736" fill="rgb(190,92,12)" font-size="13.067502986857825" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge">step:1</text><text data-type="text" data-label=" layer:all" data-x="6.262200000000001" data-y="3.48942" x="454.16666666666674" y="211.92692865676736" fill="rgb(120,58,175)" font-size="13.067502986857825" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge"> layer:all</text><g><circle data-type="point" data-label="component-boundary-port-0
+real cramped port-point" data-x="1.96" data-y="0.7" cx="169.62962962962962" cy="396.4123783922171" r="3" fill="#2563eb"/></g><g><circle data-type="point" data-label="component-boundary-port-1
+real cramped port-point" data-x="1.96" data-y="1.1" cx="169.62962962962962" cy="369.95735193719065" r="3" fill="#2563eb"/></g><g><circle data-type="point" data-label="component-boundary-port-2
+real cramped port-point" data-x="1.96" data-y="1.5" cx="169.62962962962962" cy="343.50232548216417" r="3" fill="#2563eb"/></g><g><circle data-type="point" data-label="component-boundary-port-3
+real cramped port-point" data-x="1.96" data-y="1.9" cx="169.62962962962962" cy="317.04729902713774" r="3" fill="#2563eb"/></g><g><circle data-type="point" data-label="component-boundary-port-4
+real cramped port-point" data-x="1.96" data-y="2.3" cx="169.62962962962962" cy="290.59227257211126" r="3" fill="#2563eb"/></g><g><circle data-type="point" data-label="component-boundary-port-0
+real cramped port-point" data-x="6.5072" data-y="0.7" cx="470.3703703703704" cy="396.4123783922171" r="3" fill="#2563eb"/></g><g><circle data-type="point" data-label="component-boundary-port-1
+real cramped port-point" data-x="6.5072" data-y="1.1" cx="470.3703703703704" cy="369.95735193719065" r="3" fill="#2563eb"/></g><g><circle data-type="point" data-label="component-boundary-port-2
+real cramped port-point" data-x="6.5072" data-y="1.5" cx="470.3703703703704" cy="343.50232548216417" r="3" fill="#2563eb"/></g><g><circle data-type="point" data-label="component-boundary-port-3
+real cramped port-point" data-x="6.5072" data-y="1.9" cx="470.3703703703704" cy="317.04729902713774" r="3" fill="#2563eb"/></g><g><circle data-type="point" data-label="component-boundary-port-4
+real cramped port-point" data-x="6.5072" data-y="2.3" cx="470.3703703703704" cy="290.59227257211126" r="3" fill="#2563eb"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":66.13756613756614,"c":0,"e":40,"b":0,"d":-66.13756613756614,"f":442.7086746885134};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/features/component-boundary-port-pruning.test.ts
+++ b/tests/features/component-boundary-port-pruning.test.ts
@@ -1,0 +1,138 @@
+import "bun-match-svg"
+import { expect, test } from "bun:test"
+import type { GraphicsObject } from "graphics-debug"
+import { MultiTargetNecessaryCrampedPortPointSolver } from "lib/solvers/NecessaryCrampedPortPointSolver/MultiTargetNecessaryCrampedPortPointSolver"
+import type {
+  SegmentPortPoint,
+  SharedEdgeSegment,
+} from "lib/solvers/AvailableSegmentPointSolver/AvailableSegmentPointSolver"
+import type { CapacityMeshNode, SimpleRouteJson } from "lib/types"
+import { getGraphicsSvgFrames } from "tests/fixtures/solver-svg-frames"
+
+const capacityMeshNodes: CapacityMeshNode[] = [
+  {
+    capacityMeshNodeId: "component-left",
+    center: { x: -1, y: 0 },
+    width: 2,
+    height: 3,
+    layer: "top",
+    availableZ: [0, 1],
+    _isComponentTopologyNode: true,
+  },
+  {
+    capacityMeshNodeId: "component-right",
+    center: { x: 1, y: 0 },
+    width: 2,
+    height: 3,
+    layer: "top",
+    availableZ: [0, 1],
+    _isComponentTopologyNode: true,
+  },
+]
+
+const portPoints: SegmentPortPoint[] = [-0.8, -0.4, 0, 0.4, 0.8].map(
+  (y, index) => ({
+    segmentPortPointId: `component-boundary-port-${index}`,
+    x: 0,
+    y,
+    availableZ: [0],
+    nodeIds: ["component-left", "component-right"],
+    edgeId: "component-boundary",
+    connectionName: null,
+    distToCentermostPortOnZ: Math.abs(y),
+    cramped: true,
+  }),
+)
+
+const sharedEdgeSegment: SharedEdgeSegment = {
+  edgeId: "component-boundary",
+  nodeIds: ["component-left", "component-right"],
+  start: { x: 0, y: -1.5 },
+  end: { x: 0, y: 1.5 },
+  availableZ: [0],
+  portPoints,
+}
+
+const simpleRouteJson: SimpleRouteJson = {
+  layerCount: 2,
+  minTraceWidth: 0.1,
+  obstacles: [],
+  connections: [],
+  bounds: { minX: -2, maxX: 2, minY: -2, maxY: 2 },
+}
+
+const visualizeBoundary = (
+  displayedPortPoints: SegmentPortPoint[],
+): GraphicsObject => ({
+  rects: capacityMeshNodes.map((node) => ({
+    center: node.center,
+    width: node.width - 0.08,
+    height: node.height,
+    fill: "#e2e8f0",
+    stroke: "#64748b",
+    label: node.capacityMeshNodeId,
+  })),
+  lines: [
+    {
+      points: [sharedEdgeSegment.start, sharedEdgeSegment.end],
+      strokeColor: "#94a3b8",
+      strokeDash: "4 4",
+      label: sharedEdgeSegment.edgeId,
+    },
+  ],
+  points: displayedPortPoints.map((portPoint) => ({
+    x: portPoint.x,
+    y: portPoint.y,
+    color: "#2563eb",
+    label: `${portPoint.segmentPortPointId}\nreal cramped port-point`,
+  })),
+  texts: [
+    {
+      x: 0,
+      y: 1.8,
+      text: `${displayedPortPoints.length} real port-point${displayedPortPoints.length === 1 ? "" : "s"}`,
+      anchorSide: "bottom_center",
+      fontSize: 0.18,
+      color: "#0f172a",
+    },
+  ],
+})
+
+test("shows component boundary port pruning", async () => {
+  const solverInput = {
+    capacityMeshNodes,
+    sharedEdgeSegments: [sharedEdgeSegment],
+    simpleRouteJson,
+    numberOfCrampedPortPointsToKeep: 0,
+    preserveNonNecessaryMultilayerPorts: false,
+  }
+  const solver = new MultiTargetNecessaryCrampedPortPointSolver(solverInput)
+
+  solver.solve()
+
+  const outputPortPoints = solver.getOutput()[0]!.portPoints
+  expect(solver.solved).toBe(true)
+  expect(outputPortPoints.length).toBeGreaterThan(0)
+  await expect(
+    getGraphicsSvgFrames({
+      frames: [
+        {
+          name: "Input: 5 cramped component ports",
+          step: 0,
+          iteration: 0,
+          graphics: visualizeBoundary(portPoints),
+        },
+        {
+          name:
+            outputPortPoints.length === portPoints.length
+              ? "Issue: all 5 unused ports remain"
+              : `Result: ${outputPortPoints.length} connectivity port remains`,
+          step: 1,
+          iteration: solver.iterations,
+          graphics: visualizeBoundary(outputPortPoints),
+        },
+      ],
+      columns: 2,
+    }),
+  ).toMatchSvgSnapshot(import.meta.path)
+})


### PR DESCRIPTION
## What this reproduces

Pipeline 7 currently exempts component-local regions from cramped-port filtering. The cramped-port solver also preserves every multilayer escape point, even when the caller requests those non-necessary points to be pruned.

The fixture contains two real component regions with five real cramped port-points on their shared boundary. None is required by a terminal route, but all five remain in the output. Repeating this across a dense component creates a much larger detailed-routing graph than the physical routing demand requires.

![All five unused component boundary ports remain](https://raw.githubusercontent.com/tscircuit/tscircuit-autorouter/agent/repro-component-boundary-pruning/tests/features/__snapshots__/component-boundary-port-pruning.snap.svg)

The gray rectangles are the actual capacity-mesh regions, the dashed line is their actual shared boundary, and the blue dots are the `SegmentPortPoint` objects returned by the solver.

## Validation

```text
bun test tests/features/component-boundary-port-pruning.test.ts --timeout 9999999
1 pass, 0 fail
```
