### PR TITLE
Update length matching solver

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@tscircuit/hypergraph": "^0.0.71",
     "@tscircuit/jumper-topology-generator": "^0.0.4",
     "@tscircuit/krt-wasm": "^0.1.0",
-    "@tscircuit/length-matching-solver": "git+https://github.com/tscircuit/length-matching-solver.git#42fcd91d094e3b75e71debcb39e8eab791cba8a2",
+    "@tscircuit/length-matching-solver": "git+https://github.com/tscircuit/length-matching-solver.git#d3cbaa62c6ec1a1a53cad4d6e2e58859274e26b4",
     "@tscircuit/math-utils": "^0.0.36",
     "@tscircuit/power-trace-expander": "git+https://github.com/tscircuit/power-trace-expander.git#2ebc65792485c6154c237204abd75a5ea0c52be0",
     "@tscircuit/rectdiff": "git+https://github.com/tscircuit/rectdiff.git#ba0f5e0356fa95572c44b2c5539b1a159bd6c7b6",


### PR DESCRIPTION
## Summary

- update `@tscircuit/length-matching-solver` from `42fcd91d` to `d3cbaa62`
- include the latest asymmetric-terminal fix while retaining backward-compatible non-ideal post-processing output

## Validation

- `bun test tests/pipeline7-post-processing-before-power-expansion.test.ts tests/pipeline7-post-processing-mixed-connection-length-matching.test.ts tests/pipeline7-differential-pair-routing-phase.test.ts tests/features/pipeline9-minimal-preloaded-trace-graph.test.ts --timeout 9999999`
- `bun run build`