### PR TITLE
test(high-density): reproduce invalid solved geometry

### DIFF
--- a/tests/features/never-fail-growth-high-density/__snapshots__/impossible-single-layer-crossing.snap.svg
+++ b/tests/features/never-fail-growth-high-density/__snapshots__/impossible-single-layer-crossing.snap.svg
@@ -1,0 +1,53 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="-1,0 1,0" data-type="line" data-label="a
+z0
+invalid fallback route" points="40,320 600,320" fill="none" stroke="#dc2626" stroke-width="42"/></g><g><polyline data-points="0,-1 0,1" data-type="line" data-label="b
+z0
+invalid fallback route" points="320,600 320,40" fill="none" stroke="#2563eb" stroke-width="42"/></g><g><rect data-type="rect" data-label="cn_crossing
+single-layer node has same-layer crossings" data-x="0" data-y="0" x="40" y="40" width="560" height="560" fill="rgba(245, 158, 11, 0.12)" stroke="rgba(217, 119, 6, 0.8)" stroke-width="0.0035714285714285713"/></g><g><circle data-type="point" data-label="a
+z0" data-x="-1" data-y="0" cx="40" cy="320" r="3" fill="#dc2626"/></g><g><circle data-type="point" data-label="a
+z0" data-x="1" data-y="0" cx="600" cy="320" r="3" fill="#dc2626"/></g><g><circle data-type="point" data-label="b
+z0" data-x="0" data-y="-1" cx="320" cy="600" r="3" fill="#2563eb"/></g><g><circle data-type="point" data-label="b
+z0" data-x="0" data-y="1" cx="320" cy="40" r="3" fill="#2563eb"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":280,"c":0,"e":320,"b":0,"d":-280,"f":320};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/features/never-fail-growth-high-density/impossible-single-layer-crossing.test.ts
+++ b/tests/features/never-fail-growth-high-density/impossible-single-layer-crossing.test.ts
@@ -1,5 +1,6 @@
 import { doSegmentsIntersect } from "@tscircuit/math-utils"
 import { expect, test } from "bun:test"
+import { getSvgFromGraphicsObject } from "graphics-debug"
 import { GrowShrinkHighDensityIntraNodeSolver } from "lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver"
 import { makeCrossingSingleLayerNode } from "./test-helpers"
 
@@ -23,4 +24,7 @@ test("GrowShrinkHighDensityIntraNodeSolver immediately returns invalid geometry 
     true,
   )
   expect(solver.visualize().lines).toHaveLength(2)
+  expect(getSvgFromGraphicsObject(solver.visualize())).toMatchSvgSnapshot(
+    import.meta.path,
+  )
 })


### PR DESCRIPTION
## Reproduction

`GrowShrinkHighDensityIntraNodeSolver` recognizes an impossible single-layer port ordering, constructs two direct routes that cross, and marks the node solved.

The existing focused fixture now records that behavior as an SVG snapshot:

- four alternating boundary ports on one available layer;
- two different-net traces crossing at the center;
- `solver.solved === true`;
- `invalidGeometryFallback === true`.

No production code changes are included. The stacked fix uses this exact test and naturally changes the SVG from crossing copper to a failed region with no emitted routes.

![Known-invalid high-density output marked solved](https://raw.githubusercontent.com/tscircuit/tscircuit-autorouter/agent/repro-invalid-high-density-output/tests/features/never-fail-growth-high-density/__snapshots__/impossible-single-layer-crossing.snap.svg)

## Validation

- `bun test tests/features/never-fail-growth-high-density/impossible-single-layer-crossing.test.ts --timeout 9999999`
