### PR TITLE
Add dataset-srj28 benchmark integration

### DIFF
--- a/benchmark.sh
+++ b/benchmark.sh
@@ -87,7 +87,7 @@ Options:
   --effort N           Override scenario effort multiplier
   --sample-timeout D   Override per-sample timeout directly; otherwise timeout is 300s + 60s * effort
   --sample-numbers L   Run comma-separated 1-based sample numbers from the dataset order
-  --dataset NAME       Dataset to benchmark: 1/dataset01 (default), zdwiel, 5/srj05, 11/srj11, 12/srj12, 13/srj13, 14/srj14, 15/srj15, 16/srj16, 18/srj18, 19/srj19, 20/srj20, 21/srj21, 23/srj23, or 24/srj24
+  --dataset NAME       Dataset to benchmark: 1/dataset01 (default), zdwiel, 5/srj05, 11/srj11, 12/srj12, 13/srj13, 14/srj14, 15/srj15, 16/srj16, 18/srj18, 19/srj19, 20/srj20, 21/srj21, 23/srj23, 24/srj24, 27/srj27, or 28/srj28
   --include-assignable Include assignable pipelines (excluded by default)
   -h, --help           Show this help
 
@@ -123,6 +123,8 @@ Examples:
   ./benchmark.sh --dataset 21
   ./benchmark.sh --dataset 23
   ./benchmark.sh --dataset 24
+  ./benchmark.sh --dataset 27
+  ./benchmark.sh --dataset 28
   ./benchmark.sh --include-assignable
 EOF
 

--- a/fixtures/benchmarks/dataset-srj28.fixture.tsx
+++ b/fixtures/benchmarks/dataset-srj28.fixture.tsx
@@ -1,0 +1,24 @@
+import * as datasetSrj28 from "@tscircuit/dataset-srj28-partially-prerouted"
+import {
+  DatasetBenchmarkFixture,
+  type DatasetCircuit,
+} from "./DatasetBenchmarkFixture"
+
+const circuitKeyPattern = /^circuit(\d{3})$/
+
+const circuits = Object.entries(datasetSrj28)
+  .map(([key, srj]) => {
+    const circuitMatch = key.match(circuitKeyPattern)
+    if (!circuitMatch) return null
+
+    return {
+      id: circuitMatch[1],
+      srj: srj as DatasetCircuit["srj"],
+    }
+  })
+  .filter((circuit): circuit is DatasetCircuit => circuit !== null)
+  .sort((a, b) => Number(a.id) - Number(b.id))
+
+export default () => (
+  <DatasetBenchmarkFixture datasetLabel="dataset-srj28" circuits={circuits} />
+)

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@tscircuit/dataset-srj05": "git+https://github.com/tscircuit/dataset-srj05.git#9a49c126a89c083dc4d2b72cd17184735f637762",
     "@tscircuit/dataset-srj24": "git+https://github.com/tscircuit/dataset-srj24.git#0973fa8a123276ff0f5de1fc7edef31efccb9cc9",
     "@tscircuit/dataset-srj27-power-traces": "git+https://github.com/tscircuit/dataset-srj27-power-traces.git#eb24d36",
+    "@tscircuit/dataset-srj28-partially-prerouted": "git+https://github.com/tscircuit/dataset-srj28-partially-prerouted.git#5b1673544b6ade4480612539ba6574ad414fddc0",
     "@tscircuit/fixed-via-hypergraph-solver": "https://codeload.github.com/tscircuit/fixed-via-hypergraph-solver/tar.gz/bed37a6201b5dd07c9cc68b828917ecc20d6d049",
     "@tscircuit/hypergraph": "^0.0.71",
     "@tscircuit/jumper-topology-generator": "^0.0.4",

--- a/scripts/benchmark/scenarios.ts
+++ b/scripts/benchmark/scenarios.ts
@@ -17,6 +17,7 @@ export const DATASET_NAMES = [
   "srj23",
   "srj24",
   "srj27",
+  "srj28",
 ] as const
 
 export type DatasetName = (typeof DATASET_NAMES)[number]
@@ -24,7 +25,7 @@ export type DatasetName = (typeof DATASET_NAMES)[number]
 type DatasetModule = Record<string, unknown>
 
 export const DATASET_OPTIONS_LABEL =
-  "1/dataset01, zdwiel, 5/srj05, 11/srj11, 12/srj12, 13/srj13, 14/srj14, 15/srj15, 16/srj16, 18/srj18, 19/srj19, 20/srj20, 21/srj21, 23/srj23, 24/srj24, 27/srj27"
+  "1/dataset01, zdwiel, 5/srj05, 11/srj11, 12/srj12, 13/srj13, 14/srj14, 15/srj15, 16/srj16, 18/srj18, 19/srj19, 20/srj20, 21/srj21, 23/srj23, 24/srj24, 27/srj27, 28/srj28"
 
 const datasetAliases: Record<string, DatasetName> = {
   "1": "dataset01",
@@ -102,6 +103,11 @@ const datasetAliases: Record<string, DatasetName> = {
   srj27: "srj27",
   "dataset-srj27-power-traces": "srj27",
   "@tscircuit/dataset-srj27-power-traces": "srj27",
+  "28": "srj28",
+  dataset28: "srj28",
+  srj28: "srj28",
+  "dataset-srj28-partially-prerouted": "srj28",
+  "@tscircuit/dataset-srj28-partially-prerouted": "srj28",
   zdwiel: "zdwiel",
 }
 
@@ -234,6 +240,10 @@ const datasetLoaders: Record<DatasetName, () => Promise<DatasetModule>> = {
       ? (dataset as DatasetModule)
       : module
   },
+  srj28: async () =>
+    (await import(
+      "@tscircuit/dataset-srj28-partially-prerouted"
+    )) as DatasetModule,
 }
 
 const datasetScenarioKeyPatterns: Record<DatasetName, RegExp> = {
@@ -253,6 +263,7 @@ const datasetScenarioKeyPatterns: Record<DatasetName, RegExp> = {
   srj23: /^circuit\d{3}$/,
   srj24: /^sample\d{3}$/,
   srj27: /^sample\d{3}$/,
+  srj28: /^circuit\d{3}$/,
 }
 
 export const toSimpleRouteJson = (value: unknown): SimpleRouteJson | null => {

--- a/tests/benchmark-dataset-aliases.test.ts
+++ b/tests/benchmark-dataset-aliases.test.ts
@@ -31,4 +31,7 @@ test("benchmark dataset aliases resolve to canonical dataset names", () => {
   expect(parseDatasetName("27")).toBe("srj27")
   expect(parseDatasetName("dataset27")).toBe("srj27")
   expect(parseDatasetName("dataset-srj27-power-traces")).toBe("srj27")
+  expect(parseDatasetName("28")).toBe("srj28")
+  expect(parseDatasetName("dataset28")).toBe("srj28")
+  expect(parseDatasetName("dataset-srj28-partially-prerouted")).toBe("srj28")
 })

--- a/tests/benchmark-dataset-scenarios.test.ts
+++ b/tests/benchmark-dataset-scenarios.test.ts
@@ -15,6 +15,7 @@ test("benchmark datasets load in sample order", async () => {
   const srj23Scenarios = await loadScenarios("srj23")
   const srj24Scenarios = await loadScenarios("srj24")
   const srj27Scenarios = await loadScenarios("srj27")
+  const srj28Scenarios = await loadScenarios("srj28")
 
   expect(srj11Scenarios).toHaveLength(26)
   expect(srj11Scenarios[0][0]).toBe("sample001Circuit")
@@ -66,6 +67,11 @@ test("benchmark datasets load in sample order", async () => {
   expect(srj27Scenarios[5][0]).toBe("sample006")
   expect(srj27Scenarios[0][1].connections.length).toBeGreaterThan(0)
 
+  expect(srj28Scenarios).toHaveLength(85)
+  expect(srj28Scenarios[0][0]).toBe("circuit001")
+  expect(srj28Scenarios[84][0]).toBe("circuit181")
+  expect(srj28Scenarios[0][1].traces?.length).toBeGreaterThan(0)
+
   const sample11 = await loadScenarioBySampleNumber("srj11", 11)
   expect(sample11.scenarioName).toBe("sample011Circuit")
   expect(sample11.totalSamples).toBe(26)
@@ -97,4 +103,8 @@ test("benchmark datasets load in sample order", async () => {
   const sample27 = await loadScenarioBySampleNumber("srj27", 6)
   expect(sample27.scenarioName).toBe("sample006")
   expect(sample27.totalSamples).toBe(6)
+
+  const sample28 = await loadScenarioBySampleNumber("srj28", 85)
+  expect(sample28.scenarioName).toBe("circuit181")
+  expect(sample28.totalSamples).toBe(85)
 })


### PR DESCRIPTION
## Summary

- pin `dataset-srj28-partially-prerouted` at merged commit `5b167354`
- add `28`, `srj28`, dataset name, and package-name aliases
- load all 85 `circuitNNN` samples through the benchmark CLI
- expose the dataset in the Cosmos benchmark fixture UI
- extend help text and focused loader/alias coverage

Dataset source: https://github.com/tscircuit/dataset-srj28-partially-prerouted

## Validation

- `bun test tests/benchmark-dataset-aliases.test.ts tests/benchmark-dataset-scenarios.test.ts --timeout 9999999`
- `bun run build`
- `bunx tsc --noEmit`
- `./benchmark.sh --dataset 28 --scenario-limit 1 --concurrency 1 --sample-timeout 120s` (routing completed; sample retained an existing relaxed-DRC residue)