### PR TITLE
Reproduce competing Pipeline 7 portal capacity

### DIFF
--- a/tests/solvers/__snapshots__/capacity-aware-port-point-pathing-solver.snap.svg
+++ b/tests/solvers/__snapshots__/capacity-aware-port-point-pathing-solver.snap.svg
@@ -1,0 +1,44 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="0,0 5.5,0" data-type="line" data-label="" points="40,574.0036680079111 600,574.0036680079111" fill="none" stroke="rgba(25,25,25,0.62)" stroke-width="5.090909090909091"/></g><g><polyline data-points="5.5,0 5.5,4.5" data-type="line" data-label="" points="600,574.0036680079111 600,115.82184982609294" fill="none" stroke="rgba(25,25,25,0.62)" stroke-width="5.090909090909091"/></g><g><polyline data-points="5.5,4.5 0,4.5" data-type="line" data-label="" points="600,115.82184982609294 40,115.82184982609294" fill="none" stroke="rgba(25,25,25,0.62)" stroke-width="5.090909090909091"/></g><g><polyline data-points="0,4.5 0,0" data-type="line" data-label="" points="40,115.82184982609294 40,574.0036680079111" fill="none" stroke="rgba(25,25,25,0.62)" stroke-width="5.090909090909091"/></g><g><polyline data-points="0.75,1.05 4.75,1.05" data-type="line" data-label="route-0" points="116.36363636363636,467.0945770988202 523.6363636363636,467.0945770988202" fill="none" stroke="#ef4444" stroke-width="5.090909090909091"/></g><g><polyline data-points="0.75,1.45 4.75,1.45" data-type="line" data-label="route-1" points="116.36363636363636,426.36730437154745 523.6363636363636,426.36730437154745" fill="none" stroke="#2563eb" stroke-width="5.090909090909091"/></g><g><rect data-type="rect" data-label="Input: 2 nets compete for a 1-lane shortcut step:0 layer:all" data-x="2.75" data-y="2.25" x="40" y="115.82184982609294" width="560" height="458.18181818181813" fill="rgba(255,255,255,0)" stroke="rgba(25,25,25,0.42)" stroke-width="0.009821428571428571"/></g><g><rect data-type="rect" data-label="start" data-x="0.75" data-y="1.25" x="40" y="370.36730437154745" width="152.72727272727272" height="152.72727272727275" fill="rgba(226, 232, 240, 0.25)" stroke="#94a3b8" stroke-width="0.009821428571428571"/></g><g><rect data-type="rect" data-label="shortcut" data-x="2.75" data-y="1.25" x="243.63636363636363" y="370.36730437154745" width="152.72727272727275" height="152.72727272727275" fill="rgba(226, 232, 240, 0.25)" stroke="#94a3b8" stroke-width="0.009821428571428571"/></g><g><rect data-type="rect" data-label="detour" data-x="2.75" data-y="3.25" x="243.63636363636363" y="166.73094073518382" width="152.72727272727275" height="152.72727272727275" fill="rgba(226, 232, 240, 0.25)" stroke="#94a3b8" stroke-width="0.009821428571428571"/></g><g><rect data-type="rect" data-label="end" data-x="4.75" data-y="1.25" x="447.27272727272725" y="370.36730437154745" width="152.72727272727275" height="152.72727272727275" fill="rgba(226, 232, 240, 0.25)" stroke="#94a3b8" stroke-width="0.009821428571428571"/></g><circle data-type="circle" data-label="" data-x="1.75" data-y="1.25" cx="218.1818181818182" cy="446.7309407351838" r="9.163636363636362" fill="#cbd5e1" stroke="#334155" stroke-width="0.009821428571428571"/><circle data-type="circle" data-label="" data-x="3.75" data-y="1.25" cx="421.8181818181818" cy="446.7309407351838" r="9.163636363636362" fill="#cbd5e1" stroke="#334155" stroke-width="0.009821428571428571"/><circle data-type="circle" data-label="" data-x="1.75" data-y="2.25" cx="218.1818181818182" cy="344.912758917002" r="9.163636363636362" fill="#cbd5e1" stroke="#334155" stroke-width="0.009821428571428571"/><circle data-type="circle" data-label="" data-x="3.75" data-y="2.25" cx="421.8181818181818" cy="344.912758917002" r="9.163636363636362" fill="#cbd5e1" stroke="#334155" stroke-width="0.009821428571428571"/><text data-type="text" data-label="start" data-x="0.75" data-y="1.75" x="116.36363636363636" y="395.8218498260929" fill="black" font-size="14.254545454545456" font-family="sans-serif" text-anchor="middle" dominant-baseline="central">start</text><text data-type="text" data-label="shortcut: 1 lane" data-x="2.75" data-y="1.75" x="320" y="395.8218498260929" fill="black" font-size="14.254545454545456" font-family="sans-serif" text-anchor="middle" dominant-baseline="central">shortcut: 1 lane</text><text data-type="text" data-label="detour: 1 lane" data-x="2.75" data-y="3.75" x="320" y="192.18548618972926" fill="black" font-size="14.254545454545456" font-family="sans-serif" text-anchor="middle" dominant-baseline="central">detour: 1 lane</text><text data-type="text" data-label="end" data-x="4.75" data-y="1.75" x="523.6363636363636" y="395.8218498260929" fill="black" font-size="14.254545454545456" font-family="sans-serif" text-anchor="middle" dominant-baseline="central">end</text><text data-type="text" data-label="Input: 2 nets compete for a 1-lane shortcut" data-x="0" data-y="4.9893577644411105" x="40" y="65.99633199208893" fill="rgb(18,18,18)" font-size="21.005251312828207" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge">Input: 2 nets compete for a 1-lane shortcut</text><text data-type="text" data-label="step:0" data-x="1.7267441860465114" data-y="4.7583" x="215.81395348837205" y="89.52221346245653" fill="rgb(190,92,12)" font-size="21.00525131282821" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge">step:0</text><text data-type="text" data-label=" layer:all" data-x="2.494186046511628" data-y="4.7583" x="293.95348837209303" y="89.52221346245653" fill="rgb(120,58,175)" font-size="21.00525131282821" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge"> layer:all</text><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":101.81818181818181,"c":0,"e":40,"b":0,"d":-101.81818181818181,"f":574.0036680079111};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e;
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/solvers/capacity-aware-port-point-pathing-solver.test.ts
+++ b/tests/solvers/capacity-aware-port-point-pathing-solver.test.ts
@@ -1,0 +1,110 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { buildHyperGraph } from "lib/solvers/PortPointPathingSolver/hgportpointpathingsolver"
+import type { CapacityMeshNode, SimpleRouteConnection } from "lib/types"
+import { getGraphicsSvgFrames } from "tests/fixtures/solver-svg-frames"
+
+const capacityMeshNodes: CapacityMeshNode[] = [
+  { capacityMeshNodeId: "start", x: -2, y: 0 },
+  { capacityMeshNodeId: "shortcut", x: 0, y: 0 },
+  { capacityMeshNodeId: "detour", x: 0, y: 2 },
+  { capacityMeshNodeId: "end", x: 2, y: 0 },
+].map(({ capacityMeshNodeId, x, y }) => ({
+  capacityMeshNodeId,
+  center: { x, y },
+  width: 1.5,
+  height: 1.5,
+  layer: "top",
+  availableZ: [0],
+}))
+
+const connections: SimpleRouteConnection[] = [-0.2, 0.2].map((y, index) => ({
+  name: `route-${index}`,
+  pointsToConnect: [
+    { x: -2, y, layer: "top" },
+    { x: 2, y, layer: "top" },
+  ],
+}))
+
+test("reproduces two nets competing for one physical shortcut lane", async () => {
+  const connectivityMap = new ConnectivityMap({})
+  for (const connection of connections) {
+    connectivityMap.addConnections([[connection.name]])
+  }
+  const portalDefinitions = [
+    { nodeIds: ["start", "shortcut"], x: -1, y: 0 },
+    { nodeIds: ["shortcut", "end"], x: 1, y: 0 },
+    { nodeIds: ["start", "detour"], x: -1, y: 1 },
+    { nodeIds: ["detour", "end"], x: 1, y: 1 },
+  ] as const
+  const segmentPortPoints = portalDefinitions.map(
+    ({ nodeIds, x, y }, index) => ({
+      segmentPortPointId: `portal-${index}`,
+      x,
+      y,
+      availableZ: [0],
+      nodeIds: [...nodeIds] as [string, string],
+      edgeId: `edge-${index}`,
+      connectionName: null,
+      distToCentermostPortOnZ: 0,
+      cramped: false,
+    }),
+  )
+  const { graph } = buildHyperGraph({
+    capacityMeshNodes,
+    segmentPortPoints,
+    layerCount: 1,
+    connectivityMap,
+    simpleRouteJsonConnections: connections,
+  })
+
+  expect(connections).toHaveLength(2)
+  expect(graph.ports).toHaveLength(4)
+  expect(graph.ports.every((port) => port.d.z === 0)).toBe(true)
+
+  const svg = getGraphicsSvgFrames({
+    frames: [
+      {
+        name: "Input: 2 nets compete for a 1-lane shortcut",
+        step: 0,
+        graphics: {
+          rects: graph.regions.map((region) => ({
+            center: region.d.center,
+            width: region.d.width,
+            height: region.d.height,
+            fill: "rgba(226, 232, 240, 0.25)",
+            stroke: "#94a3b8",
+            label: region.regionId,
+          })),
+          circles: graph.ports.map((port) => ({
+            center: port.d,
+            radius: 0.09,
+            fill: "#cbd5e1",
+            stroke: "#334155",
+            label: "1 physical lane",
+          })),
+          lines: connections.map((connection, index) => ({
+            points: connection.pointsToConnect,
+            strokeColor: index === 0 ? "#ef4444" : "#2563eb",
+            strokeWidth: 0.05,
+            label: connection.name,
+          })),
+          texts: graph.regions.map((region) => ({
+            x: region.d.center.x,
+            y: region.d.center.y + 0.5,
+            text:
+              region.regionId === "shortcut" || region.regionId === "detour"
+                ? `${region.regionId}: 1 lane`
+                : region.regionId,
+            fontSize: 0.14,
+            anchorSide: "center" as const,
+          })),
+        },
+      },
+    ],
+    columns: 1,
+    cellWidth: 5.5,
+    cellHeight: 4.5,
+  })
+  await expect(svg).toMatchSvgSnapshot(import.meta.path)
+})


### PR DESCRIPTION
## Problem

Pipeline 7 currently chooses exact physical port points while it is still deciding the board-wide route corridor. On a large board, those two decisions multiply the search state.

This PR adds a small reproduction of the capacity decision:

- two different nets both prefer the short middle corridor;
- that corridor has one physical lane on each boundary;
- a longer upper corridor is available;
- production routing code is unchanged.

The fixture uses the real hypergraph builder, real mesh regions, and real physical portal points. The pale rectangles are mesh regions, the gray circles are physical lanes, and the red/blue lines are the two requested nets.

![Two nets competing for one physical shortcut lane](https://raw.githubusercontent.com/tscircuit/tscircuit-autorouter/agent/repro-pipeline7-portal-capacity/tests/solvers/__snapshots__/capacity-aware-port-point-pathing-solver.snap.svg)

The stacked fix reuses this exact test and snapshot. It should naturally add a result where one net uses the shortcut, one uses the detour, and portal overflow is zero.

## Validation

- `bun test --timeout 9999999 tests/solvers/capacity-aware-port-point-pathing-solver.test.ts`
