### PR TITLE
Rename differential pair post-processing solver

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -232,7 +232,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
   strawSolver?: StrawSolver
   deadEndSolver?: DeadEndSolver
   traceSimplificationSolver?: TraceSimplificationSolver
-  lengthMatchingPostProcessingSolver?: DifferentialPairPostProcessingSolver
+  differentialPairPostProcessingSolver?: DifferentialPairPostProcessingSolver
   powerTraceExpansionSolver?: PowerTraceExpansionSolver
   availableSegmentPointSolver?: AvailableSegmentPointSolver
   portPointPathingSolver?: TinyHypergraphPortPointPathingSolver
@@ -701,7 +701,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
       },
     ),
     definePipelineStep(
-      "lengthMatchingPostProcessingSolver",
+      "differentialPairPostProcessingSolver",
       DifferentialPairPostProcessingSolver,
       (cms) => {
         const netToPointPairsSolver = cms.netToPointPairsSolver
@@ -897,7 +897,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
     // @ts-ignore
     this.activeSubSolver = new pipelineStepDef.solverClass(...constructorParams)
     if (
-      pipelineStepDef.solverName === "lengthMatchingPostProcessingSolver" ||
+      pipelineStepDef.solverName === "differentialPairPostProcessingSolver" ||
       pipelineStepDef.solverName === "powerTraceExpansionSolver"
     )
       this.MAX_ITERATIONS = Math.max(
@@ -949,8 +949,8 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
     const highDensityRepairViz = this.highDensityRepairSolver?.visualize()
     const highDensityStitchViz = this.highDensityStitchSolver?.visualize()
     const traceSimplificationViz = this.traceSimplificationSolver?.visualize()
-    const lengthMatchingPostProcessingViz =
-      this.lengthMatchingPostProcessingSolver?.visualize()
+    const differentialPairPostProcessingViz =
+      this.differentialPairPostProcessingSolver?.visualize()
     const traceWidthViz = this.traceWidthSolver?.visualize()
     const necessaryCrampedPortPointSolverViz =
       this.necessaryCrampedPortPointSolver?.visualize()
@@ -1076,7 +1076,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
       traceWidthViz,
       globalDrcForceImproveViz,
       exactGeometryDrcForceImproveViz,
-      lengthMatchingPostProcessingViz,
+      differentialPairPostProcessingViz,
       this.solved
         ? combineVisualizations(
             { lines: problemLines },
@@ -1154,7 +1154,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
 
   _getOutputHdRoutes(): HighDensityRoute[] {
     return (
-      this.lengthMatchingPostProcessingSolver?.getOutput().hdRoutes ??
+      this.differentialPairPostProcessingSolver?.getOutput().hdRoutes ??
       this.exactGeometryDrcForceImproveSolver?.getOutput() ??
       this.globalDrcForceImproveSolver?.getOutput() ??
       this.traceWidthSolver?.getHdRoutesWithWidths() ??

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph.ts
@@ -236,7 +236,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
   strawSolver?: StrawSolver
   deadEndSolver?: DeadEndSolver
   traceSimplificationSolver?: TraceSimplificationSolver
-  lengthMatchingPostProcessingSolver?: PostProcessingSolver
+  differentialPairPostProcessingSolver?: PostProcessingSolver
   availableSegmentPointSolver?: AvailableSegmentPointSolver
   portPointPathingSolver?: TinyHypergraphPortPointPathingSolver
   multiSectionPortPointOptimizer?: MultiSectionPortPointOptimizer
@@ -734,7 +734,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
       },
     ),
     definePipelineStep(
-      "lengthMatchingPostProcessingSolver",
+      "differentialPairPostProcessingSolver",
       PostProcessingSolver,
       (cms) => {
         const netToPointPairsSolver = cms.netToPointPairsSolver
@@ -889,7 +889,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
     const constructorParams = pipelineStepDef.getConstructorParams(this)
     // @ts-ignore
     this.activeSubSolver = new pipelineStepDef.solverClass(...constructorParams)
-    if (pipelineStepDef.solverName === "lengthMatchingPostProcessingSolver")
+    if (pipelineStepDef.solverName === "differentialPairPostProcessingSolver")
       this.MAX_ITERATIONS = Math.max(
         this.MAX_ITERATIONS,
         this.iterations + this.activeSubSolver.MAX_ITERATIONS + 1,
@@ -939,8 +939,8 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
     const highDensityRepairViz = this.highDensityRepairSolver?.visualize()
     const highDensityStitchViz = this.highDensityStitchSolver?.visualize()
     const traceSimplificationViz = this.traceSimplificationSolver?.visualize()
-    const lengthMatchingPostProcessingViz =
-      this.lengthMatchingPostProcessingSolver?.visualize()
+    const differentialPairPostProcessingViz =
+      this.differentialPairPostProcessingSolver?.visualize()
     const traceWidthViz = this.traceWidthSolver?.visualize()
     const necessaryCrampedPortPointSolverViz =
       this.necessaryCrampedPortPointSolver?.visualize()
@@ -1066,7 +1066,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
       traceWidthViz,
       globalDrcForceImproveViz,
       pipeline9JointDrcRepairViz,
-      lengthMatchingPostProcessingViz,
+      differentialPairPostProcessingViz,
       this.solved
         ? combineVisualizations(
             { lines: problemLines },
@@ -1145,7 +1145,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
   _getOutputHdRoutes(): HighDensityRoute[] {
     const postProcessedRoutes =
       (this.originalSrj.differentialPairs?.length ?? 0) > 0
-        ? this.lengthMatchingPostProcessingSolver?.getOutput().hdRoutes
+        ? this.differentialPairPostProcessingSolver?.getOutput().hdRoutes
         : undefined
     return (
       postProcessedRoutes ??

--- a/tests/pipeline7-differential-pair-routing-phase.test.ts
+++ b/tests/pipeline7-differential-pair-routing-phase.test.ts
@@ -169,10 +169,10 @@ test("Pipeline7 completes post-processing for a routed differential pair", () =>
   expect(solver.failed).toBe(false)
   expect(solver.solved).toBe(true)
   expect(
-    solver.lengthMatchingPostProcessingSolver?.postProcessingSolver,
+    solver.differentialPairPostProcessingSolver?.postProcessingSolver,
   ).toBeDefined()
   expect(
-    solver.lengthMatchingPostProcessingSolver?.lengthMatchingSolver,
+    solver.differentialPairPostProcessingSolver?.lengthMatchingSolver,
   ).toBeUndefined()
   expect(solver.getOutputSimpleRouteJson().traces).toHaveLength(2)
 })

--- a/tests/pipeline7-post-processing-ambiguous-differential-pair.test.ts
+++ b/tests/pipeline7-post-processing-ambiguous-differential-pair.test.ts
@@ -29,7 +29,7 @@ test("Pipeline7 rejects a differential pair member split across final routes", (
     ],
   })
   const lengthMatchingPostProcessingStep = solver.pipelineDef.find(
-    (step) => step.solverName === "lengthMatchingPostProcessingSolver",
+    (step) => step.solverName === "differentialPairPostProcessingSolver",
   )!
 
   expect(() =>

--- a/tests/pipeline7-post-processing-before-power-expansion.test.ts
+++ b/tests/pipeline7-post-processing-before-power-expansion.test.ts
@@ -35,7 +35,7 @@ test("Pipeline7 runs post-processing before default power expansion", () => {
   const lengthMatchingPostProcessingStep = solver.pipelineDef.at(-2)
   expect(powerTraceExpansionStep?.solverName).toBe("powerTraceExpansionSolver")
   expect(lengthMatchingPostProcessingStep?.solverName).toBe(
-    "lengthMatchingPostProcessingSolver",
+    "differentialPairPostProcessingSolver",
   )
 
   const powerTraceParams = powerTraceExpansionStep!.getConstructorParams({


### PR DESCRIPTION
## Summary

- rename `lengthMatchingPostProcessingSolver` to `differentialPairPostProcessingSolver`
- update the Pipeline 7 and Pipeline 9 phase names and consumers
- update only the required test references, without changing behavioral expectations

## Why

The solver handles differential-pair post-processing, not only length matching, so the new name better describes its responsibility.

## Validation

- `bun test tests/pipeline7-post-processing-ambiguous-differential-pair.test.ts tests/pipeline7-post-processing-before-power-expansion.test.ts tests/pipeline7-differential-pair-routing-phase.test.ts --timeout 9999999`
- `bun run build`