### PR TITLE
Speed up intra-node cache key hashing

### DIFF
--- a/lib/solvers/HighDensitySolver/CachedIntraNodeRouteSolver.ts
+++ b/lib/solvers/HighDensitySolver/CachedIntraNodeRouteSolver.ts
@@ -172,7 +172,10 @@ export class CachedIntraNodeRouteSolver
       normalizedConnMap,
     }
 
-    const cacheKey = `intranode-solver:${objectHash(keyData)}`
+    const cacheKey = `intranode-solver:${objectHash(keyData, {
+      respectType: false,
+      unorderedObjects: false,
+    })}`
     const cacheToSolveSpaceTransform: CacheToIntraNodeSolverTransform = {}
 
     this.cacheKey = cacheKey

--- a/tests/caching/cached-intra-node-route-solver-key-determinism.test.ts
+++ b/tests/caching/cached-intra-node-route-solver-key-determinism.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test"
+import { CachedIntraNodeRouteSolver } from "lib/solvers/HighDensitySolver/CachedIntraNodeRouteSolver"
+import type { NodeWithPortPoints } from "lib/types/high-density-types"
+
+const makeNode = (): NodeWithPortPoints => ({
+  capacityMeshNodeId: "cmn_test",
+  center: { x: 0, y: 0 },
+  width: 2,
+  height: 1,
+  availableZ: [0, 1],
+  portPoints: [
+    { connectionName: "A", x: -1, y: -0.5, z: 0 },
+    { connectionName: "A", x: 1, y: -0.5, z: 0 },
+    { connectionName: "B", x: -1, y: 0.5, z: 1 },
+    { connectionName: "B", x: 1, y: 0.5, z: 1 },
+  ],
+})
+
+test("equivalent inputs produce the same SHA-1 cache key", () => {
+  const solverOptions = {
+    traceWidth: 0.15,
+    viaDiameter: 0.3,
+    obstacleMargin: 0.15,
+    hyperParameters: { SHUFFLE_SEED: 0 },
+  }
+  const firstSolver = new CachedIntraNodeRouteSolver({
+    ...solverOptions,
+    nodeWithPortPoints: makeNode(),
+  })
+  const secondSolver = new CachedIntraNodeRouteSolver({
+    ...solverOptions,
+    nodeWithPortPoints: makeNode(),
+  })
+
+  const firstKey = firstSolver.computeCacheKeyAndTransform().cacheKey
+  const secondKey = secondSolver.computeCacheKeyAndTransform().cacheKey
+
+  expect(firstKey).toBe(secondKey)
+  expect(firstKey).toMatch(/^intranode-solver:[a-f0-9]{40}$/)
+})


### PR DESCRIPTION
## Summary

- speed up intra-node cache-key hashing by disabling prototype/type metadata hashing
- skip object-key sorting because the cache-key input is already normalized and constructed in deterministic order
- preserve the existing SHA-1 cache-key format
- add focused coverage for deterministic, SHA-1-shaped cache keys

## Why

Profiling Pipeline 7 on `dataset01` identified `object-hash` recursive dispatch as a material hot path. On sample 32 it consumed about 1.55 seconds (15.9% of profiled time), with 4,646 intra-node cache misses requiring key computation.

`keyData` is JSON-shaped, explicitly normalized, and assembled in deterministic property order. The default `object-hash` behavior was therefore spending time hashing type/prototype metadata and sorting object keys without adding useful cache-key semantics.

## Blacksmith end-to-end benchmark

Pipeline 7, effort 1. Latest `/benchmark-all` run for rebased head `895c2df` against `main` `92bb330`. Lower timing is better.

| Dataset | Completion (main → PR) | Timeouts (main → PR) | P50 (main → PR) | P50 improvement | P95 (main → PR) | P95 improvement |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| [`dataset01`](https://github.com/tscircuit/tscircuit-autorouter/pull/2016#issuecomment-5228364672) | 100.0% → 100.0% (unchanged) | 0 → 0 (unchanged) | 7.8s → 5.5s | **+29.5%** | 29.7s → 24.7s | **+16.8%** |
| [`srj18`](https://github.com/tscircuit/tscircuit-autorouter/pull/2016#issuecomment-5228364699) | 43.8% → 50.0% (**+6.2 pp; 14.2% more completed**) | 8 → 7 (**12.5% fewer**) | 155.4s → 142.9s | **+8.0%** | 175.0s → 237.5s | **-35.7%**† |
| [`srj19`](https://github.com/tscircuit/tscircuit-autorouter/pull/2016#issuecomment-5228364738) | 79.0% → 82.0% (**+3.0 pp; 3.8% more completed**) | 42 → 36 (**14.3% fewer**) | 47.7s → 40.5s | **+15.1%** | 260.6s → 278.3s | **-6.8%**† |
| [`srj20`](https://github.com/tscircuit/tscircuit-autorouter/pull/2016#issuecomment-5228364744) | 69.5% → 70.5% (**+1.0 pp; 1.4% more completed**) | 61 → 59 (**3.3% fewer**) | 40.3s → 35.1s | **+12.9%** | 259.9s → 237.4s | **+8.7%** |
| [`srj21`](https://github.com/tscircuit/tscircuit-autorouter/pull/2016#issuecomment-5228364879) | 100.0% → 100.0% (unchanged) | 0 → 0 (unchanged) | 2.5s → 2.2s | **+12.0%** | 5.1s → 4.1s | **+19.6%** |
| [`srj23`](https://github.com/tscircuit/tscircuit-autorouter/pull/2016#issuecomment-5228365000) | 98.7% → 98.7% (unchanged) | 0 → 0 (unchanged) | 7.0s → 6.3s | **+10.0%** | 137.6s → 119.0s | **+13.5%** |

† Timing percentiles are calculated over completed routes. On `srj18`, sample 8 changes from timeout to solved in 284.5s. On `srj19`, six former timeouts now complete in 313.1–352.2s. These recovered, long-running routes enter the completed-route population, so P95 rises even while completion improves, timeouts fall, and P50 improves. `srj20` similarly recovers two former timeouts (314.5s and 357.2s), while still improving P95 by 8.7%.

## Validation

- focused cache-key test passes after rebasing
- `git diff --check` passes
- CI build, format check, typecheck, and all eight test shards pass
- full Blacksmith `/benchmark-all` completed on the exact rebased head
