### PR TITLE
Continue length matching after rerouting failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@tscircuit/hypergraph": "^0.0.71",
     "@tscircuit/jumper-topology-generator": "^0.0.4",
     "@tscircuit/krt-wasm": "^0.1.0",
-    "@tscircuit/length-matching-solver": "git+https://github.com/tscircuit/length-matching-solver.git#ce7f5d92319cfe40f94dc50611f4420f51706bec",
+    "@tscircuit/length-matching-solver": "git+https://github.com/tscircuit/length-matching-solver.git#a429b4db4e46896a03259949d7975da2514b6c14",
     "@tscircuit/math-utils": "^0.0.36",
     "@tscircuit/power-trace-expander": "git+https://github.com/tscircuit/power-trace-expander.git#6fa2ac79cf13129c47432db3a23e61c17067e912",
     "@tscircuit/rectdiff": "git+https://github.com/tscircuit/rectdiff.git#0d114226549e6c14a88a8dbd03dbd69bd2d41c5d",


### PR DESCRIPTION
## Summary

- pin `@tscircuit/length-matching-solver` to the fix from tscircuit/length-matching-solver#46
- preserve autorouter's existing boundary: provide routes, consume `hdRoutes`, and ignore diagnostics

## Root cause

When coupled rerouting returned `no-valid-candidate`, the post-processing pipeline excluded that preserved pair from the subsequent length-matching input. The upstream fix includes every declared pair in length matching even when rerouting could not improve it.

## Stack

- depends on tscircuit/length-matching-solver#46
- unblocks the routing-phase regression currently visible in tscircuit/core#3082

## Validation

- `bun install`
- upstream fix reproduced against the exact Core routing-phase input: skew improves from 4.386862395114932 mm to 2.7361224397282058e-11 mm after rerouting reports `no-valid-candidate`
- no test suite was run per request
