### PR TITLE
Skip long-running bug report test in CI

### DIFF
--- a/tests/bugs/bugreport86-40bf8e.test.ts
+++ b/tests/bugs/bugreport86-40bf8e.test.ts
@@ -7,7 +7,7 @@ import type { SimpleRouteJson } from "lib/types"
 
 const srj = bugReport.simple_route_json as SimpleRouteJson
 
-test("Pipeline9 routes LCD traces around the 76 preloaded traces in bugreport86-40bf8e", (): void => {
+test.skip("Pipeline9 routes LCD traces around the 76 preloaded traces in bugreport86-40bf8e", (): void => {
   const solver = new AutoroutingPipelineSolver9_PreloadedTraceGraph(
     structuredClone(srj),
     {


### PR DESCRIPTION
## Summary

- mark the bugreport86 Pipeline9 reproduction as skipped
- keep the reproduction available for manual investigation without blocking PR CI

## Root cause

The test ran until the 10-minute Bun Test shard limit and cancelled its CI job.

## Validation

- `bun test tests/bugs/bugreport86-40bf8e.test.ts --timeout 30000`
- Result: 0 passed, 1 skipped, 0 failed