### PR TITLE
Reduce multi-crossing via detours atomically

### DIFF
--- a/lib/solvers/CrossingViaReductionSolver/crossing-via-reduction-solver.ts
+++ b/lib/solvers/CrossingViaReductionSolver/crossing-via-reduction-solver.ts
@@ -820,6 +820,62 @@ export class CrossingViaReductionSolver extends BaseSolver {
     )
   }
 
+  /**
+   * Multi-route changes feed another path-simplification pass. Avoid using a
+   * route that already has unresolved copper conflicts as one of its inputs:
+   * reshaping that route downstream can turn a pre-existing intermediate
+   * conflict into a final DRC regression far from the relocated via.
+   *
+   * This runs only after a multi-crossing candidate passes its delta checks,
+   * so the common rejected-candidate path stays fast.
+   */
+  private candidateRoutesHaveNoExternalCopperConflicts(
+    candidate: CrossingReductionCandidate,
+    baseIndexes: BaseClearanceIndexes,
+  ): boolean {
+    const candidateRoutes = [
+      candidate.detourRoute,
+      ...candidate.transitionUpdates.map(({ route }) => route),
+    ]
+    const candidateConnectionNames = new Set(
+      candidateRoutes.map(({ connectionName }) => connectionName),
+    )
+    const routeIndexes = [
+      baseIndexes.mutableRoutes,
+      ...(baseIndexes.immutableRoutes ? [baseIndexes.immutableRoutes] : []),
+    ]
+
+    for (const route of candidateRoutes) {
+      for (const section of breakRouteIntoSections(route)) {
+        for (let index = 1; index < section.points.length; index++) {
+          const start = section.points[index - 1]
+          const end = section.points[index]
+          for (const routeIndex of routeIndexes) {
+            const hasExternalConflict = routeIndex
+              .getConflictingRoutesForSegment(
+                start,
+                end,
+                route.traceThickness / 2 + this.traceMargin,
+              )
+              .some(
+                ({ conflictingRoute }) =>
+                  !candidateConnectionNames.has(
+                    conflictingRoute.connectionName,
+                  ) &&
+                  !routesAreSameNet(
+                    route,
+                    conflictingRoute,
+                    this.input.connMap,
+                  ),
+              )
+            if (hasExternalConflict) return false
+          }
+        }
+      }
+    }
+    return true
+  }
+
   private buildTransitionSegmentIndex(
     sectionsByRoute: RouteSection[][],
     relevantLayerTransitions: ReadonlySet<string>,
@@ -1132,6 +1188,16 @@ export class CrossingViaReductionSolver extends BaseSolver {
       transitionUpdates,
     }
     if (!this.candidateIsClear(candidate, baseClearanceIndexes)) return null
+    if (
+      !this.candidateRoutesHaveNoExternalCopperConflicts(
+        candidate,
+        baseClearanceIndexes,
+      )
+    ) {
+      this.stats.multiCrossingPreexistingConflictRejections =
+        (this.stats.multiCrossingPreexistingConflictRejections ?? 0) + 1
+      return null
+    }
     this.stats.multiCrossingReductions =
       (this.stats.multiCrossingReductions ?? 0) + 1
     this.stats.transitionRoutesMovedByMultiCrossingReductions =

--- a/lib/solvers/CrossingViaReductionSolver/crossing-via-reduction-solver.ts
+++ b/lib/solvers/CrossingViaReductionSolver/crossing-via-reduction-solver.ts
@@ -40,10 +40,12 @@ type TransitionSide = "start" | "end"
 
 type CrossingReductionCandidate = {
   detourRouteIndex: number
-  transitionRouteIndex: number
   detourRoute: HighDensityRoute
-  transitionRoute: HighDensityRoute
-  relocatedVia: { x: number; y: number }
+  transitionUpdates: Array<{
+    routeIndex: number
+    route: HighDensityRoute
+    relocatedVias: Array<{ x: number; y: number }>
+  }>
 }
 
 type IndexedTransitionSegment = {
@@ -87,6 +89,7 @@ const STATIC_GEOMETRY_ONLY_CLEARANCE_INDEX: RouteClearanceIndex = {
 const EPSILON = 1e-6
 const DEFAULT_TRACE_MARGIN = 0.1
 const DEFAULT_OBSTACLE_MARGIN = 0.15
+const MAX_MULTI_CROSSING_SELECTIONS = 4
 
 const getSegmentKey = (start: RoutePoint, end: RoutePoint): string => {
   const startKey = `${start.x}:${start.y}:${start.z}`
@@ -341,17 +344,17 @@ const hasTransitionOnSide = ({
 
 const createCandidateClearanceIndex = ({
   baseIndexes,
-  candidatePairRoute,
+  otherCandidateRoutes,
   ignoredConnectionNames,
   originalRouteSegmentKeys,
 }: {
   baseIndexes: BaseClearanceIndexes
-  candidatePairRoute: HighDensityRoute
+  otherCandidateRoutes: ReadonlyArray<HighDensityRoute>
   ignoredConnectionNames: ReadonlySet<string>
   originalRouteSegmentKeys: ReadonlySet<string>
 }): RouteClearanceIndex => {
   const candidatePairIndex = new HighDensityRouteSpatialIndex([
-    candidatePairRoute,
+    ...otherCandidateRoutes,
   ])
   return {
     getConflictingRoutesForSegment: (start, end, margin) => {
@@ -399,10 +402,10 @@ const createCandidateClearanceIndex = ({
 
 /**
  * Removes the two-via layer detour in an A-B-A route when it crosses an
- * A-layer section whose existing via is adjacent to the crossing. The change
- * is atomic: the detour moves to A while the adjacent route's via moves past
- * the crossing and extends B through it. Every candidate is clearance-checked
- * as a route pair before either route is changed.
+ * A-layer sections whose existing vias are adjacent to the crossings. The
+ * change is atomic: the detour moves to A while each adjacent via moves past
+ * its crossing and extends B through it. Every candidate route set is
+ * clearance-checked before any route is changed.
  */
 export class CrossingViaReductionSolver extends BaseSolver {
   private readonly input: CrossingViaReductionSolverInput
@@ -497,6 +500,94 @@ export class CrossingViaReductionSolver extends BaseSolver {
         vias: recomputeVias(routePoints),
       },
       relocatedVia: { x: split.point.x, y: split.point.y },
+    }
+  }
+
+  private relocateTransitionVias({
+    route,
+    sections,
+    crossingGroups,
+    detourZ,
+    detourTraceThickness,
+  }: {
+    route: HighDensityRoute
+    sections: RouteSection[]
+    crossingGroups: IndexedCrossingGroup[]
+    detourZ: number
+    detourTraceThickness: number
+  }): {
+    route: HighDensityRoute
+    relocatedVias: Array<{ x: number; y: number }>
+  } | null {
+    const groupsBySection = new Map<number, IndexedCrossingGroup[]>()
+    for (const crossingGroup of crossingGroups) {
+      const groups =
+        groupsBySection.get(crossingGroup.transitionSectionIndex) ?? []
+      groups.push(crossingGroup)
+      groupsBySection.set(crossingGroup.transitionSectionIndex, groups)
+    }
+
+    const replacements: Array<{
+      section: RouteSection
+      points: RoutePoint[]
+    }> = []
+    const relocatedVias: Array<{ x: number; y: number }> = []
+    const viaClearance =
+      route.viaDiameter / 2 +
+      detourTraceThickness / 2 +
+      this.traceMargin +
+      EPSILON
+
+    for (const [sectionIndex, sectionGroups] of groupsBySection) {
+      if (sectionGroups.length !== 1) return null
+      const section = sections[sectionIndex]
+      const crossingGroup = sectionGroups[0]
+      if (
+        !hasTransitionOnSide({
+          sections,
+          sectionIndex,
+          targetZ: detourZ,
+          side: crossingGroup.side,
+        })
+      ) {
+        return null
+      }
+      const newViaDistance =
+        crossingGroup.side === "start"
+          ? Math.max(...crossingGroup.crossingDistances) + viaClearance
+          : Math.min(...crossingGroup.crossingDistances) - viaClearance
+      const split = splitSectionAtDistance(section.points, newViaDistance)
+      if (!split) return null
+      const prefixZ = crossingGroup.side === "start" ? detourZ : section.z
+      const suffixZ = crossingGroup.side === "start" ? section.z : detourZ
+      replacements.push({
+        section,
+        points: [
+          ...split.prefix.map((point) => ({ ...point, z: prefixZ })),
+          ...split.suffix.map((point) => ({ ...point, z: suffixZ })),
+        ],
+      })
+      relocatedVias.push({ x: split.point.x, y: split.point.y })
+    }
+
+    let routePoints = route.route.map((point) => ({ ...point }))
+    for (const replacement of replacements.sort(
+      (first, second) => second.section.startIndex - first.section.startIndex,
+    )) {
+      routePoints = [
+        ...routePoints.slice(0, replacement.section.startIndex),
+        ...replacement.points,
+        ...routePoints.slice(replacement.section.endIndex + 1),
+      ]
+    }
+    routePoints = removeConsecutiveDuplicatePoints(routePoints)
+    return {
+      route: {
+        ...route,
+        route: routePoints,
+        vias: recomputeVias(routePoints),
+      },
+      relocatedVias,
     }
   }
 
@@ -655,50 +746,77 @@ export class CrossingViaReductionSolver extends BaseSolver {
     candidate: CrossingReductionCandidate,
     baseIndexes: BaseClearanceIndexes,
   ): boolean {
-    const ignoredConnectionNames = new Set([
-      this.reducedHdRoutes[candidate.detourRouteIndex].connectionName,
-      this.reducedHdRoutes[candidate.transitionRouteIndex].connectionName,
-    ])
+    const candidateRoutes = [
+      {
+        routeIndex: candidate.detourRouteIndex,
+        route: candidate.detourRoute,
+      },
+      ...candidate.transitionUpdates,
+    ]
+    const ignoredConnectionNames = new Set(
+      candidateRoutes.map(
+        ({ routeIndex }) => this.reducedHdRoutes[routeIndex].connectionName,
+      ),
+    )
     const originalDetourRouteSegmentKeys = getRouteSegmentKeys(
       this.reducedHdRoutes[candidate.detourRouteIndex],
     )
-    const originalTransitionRouteSegmentKeys = getRouteSegmentKeys(
-      this.reducedHdRoutes[candidate.transitionRouteIndex],
-    )
     const detourObstacleIndex = createCandidateClearanceIndex({
       baseIndexes,
-      candidatePairRoute: candidate.transitionRoute,
+      otherCandidateRoutes: candidate.transitionUpdates.map(
+        ({ route }) => route,
+      ),
       ignoredConnectionNames,
       originalRouteSegmentKeys: originalDetourRouteSegmentKeys,
     })
-    const transitionObstacleIndex = createCandidateClearanceIndex({
-      baseIndexes,
-      candidatePairRoute: candidate.detourRoute,
-      ignoredConnectionNames,
-      originalRouteSegmentKeys: originalTransitionRouteSegmentKeys,
-    })
     this.stats.candidateClearanceChecks =
       (this.stats.candidateClearanceChecks ?? 0) + 1
-    return (
-      this.routeIsClear(
+    if (
+      !this.routeIsClear(
         candidate.detourRoute,
         detourObstacleIndex,
         originalDetourRouteSegmentKeys,
-      ) &&
-      this.routeIsClear(
-        candidate.transitionRoute,
-        transitionObstacleIndex,
-        originalTransitionRouteSegmentKeys,
-      ) &&
-      this.relocatedViaIsClear(
-        candidate.transitionRoute,
-        candidate.relocatedVia,
-        transitionObstacleIndex,
-      ) &&
-      this.changedSectionsAreStaticallyClear(
-        candidate.detourRoute,
-        originalDetourRouteSegmentKeys,
       )
+    ) {
+      return false
+    }
+
+    for (const transitionUpdate of candidate.transitionUpdates) {
+      const originalSegmentKeys = getRouteSegmentKeys(
+        this.reducedHdRoutes[transitionUpdate.routeIndex],
+      )
+      const transitionObstacleIndex = createCandidateClearanceIndex({
+        baseIndexes,
+        otherCandidateRoutes: candidateRoutes
+          .filter(
+            ({ routeIndex }) => routeIndex !== transitionUpdate.routeIndex,
+          )
+          .map(({ route }) => route),
+        ignoredConnectionNames,
+        originalRouteSegmentKeys: originalSegmentKeys,
+      })
+      if (
+        !this.routeIsClear(
+          transitionUpdate.route,
+          transitionObstacleIndex,
+          originalSegmentKeys,
+        ) ||
+        transitionUpdate.relocatedVias.some(
+          (relocatedVia) =>
+            !this.relocatedViaIsClear(
+              transitionUpdate.route,
+              relocatedVia,
+              transitionObstacleIndex,
+            ),
+        )
+      ) {
+        return false
+      }
+    }
+
+    return this.changedSectionsAreStaticallyClear(
+      candidate.detourRoute,
+      originalDetourRouteSegmentKeys,
     )
   }
 
@@ -932,14 +1050,94 @@ export class CrossingViaReductionSolver extends BaseSolver {
 
     const candidate: CrossingReductionCandidate = {
       detourRouteIndex,
-      transitionRouteIndex,
       detourRoute: collapsedDetour,
-      transitionRoute: relocatedTransition.route,
-      relocatedVia: relocatedTransition.relocatedVia,
+      transitionUpdates: [
+        {
+          routeIndex: transitionRouteIndex,
+          route: relocatedTransition.route,
+          relocatedVias: [relocatedTransition.relocatedVia],
+        },
+      ],
     }
     return this.candidateIsClear(candidate, baseClearanceIndexes)
       ? candidate
       : null
+  }
+
+  private tryCreateMultiCrossingCandidate({
+    detourRouteIndex,
+    detourSection,
+    targetZ,
+    crossingGroups,
+    sectionsByRoute,
+    baseClearanceIndexes,
+  }: {
+    detourRouteIndex: number
+    detourSection: RouteSection
+    targetZ: number
+    crossingGroups: IndexedCrossingGroup[]
+    sectionsByRoute: RouteSection[][]
+    baseClearanceIndexes: BaseClearanceIndexes
+  }): CrossingReductionCandidate | null {
+    if (crossingGroups.length < 2) return null
+    const detourRoute = this.reducedHdRoutes[detourRouteIndex]
+    const transitionUpdates: CrossingReductionCandidate["transitionUpdates"] =
+      []
+    const groupsByRoute = new Map<number, IndexedCrossingGroup[]>()
+    for (const crossingGroup of crossingGroups) {
+      const routeGroups =
+        groupsByRoute.get(crossingGroup.transitionRouteIndex) ?? []
+      routeGroups.push(crossingGroup)
+      groupsByRoute.set(crossingGroup.transitionRouteIndex, routeGroups)
+    }
+    for (const [routeIndex, routeGroups] of groupsByRoute) {
+      const transitionRoute = this.reducedHdRoutes[routeIndex]
+      const relocatedTransition = this.relocateTransitionVias({
+        route: transitionRoute,
+        sections: sectionsByRoute[routeIndex],
+        crossingGroups: routeGroups,
+        detourZ: detourSection.z,
+        detourTraceThickness: detourRoute.traceThickness,
+      })
+      if (!relocatedTransition) return null
+      transitionUpdates.push({
+        routeIndex,
+        route: relocatedTransition.route,
+        relocatedVias: relocatedTransition.relocatedVias,
+      })
+    }
+
+    const collapsedDetour = this.collapseDetourSection({
+      route: detourRoute,
+      section: detourSection,
+      targetZ,
+    })
+    const originalViaCount =
+      detourRoute.vias.length +
+      [...groupsByRoute.keys()].reduce(
+        (sum, transitionRouteIndex) =>
+          sum + this.reducedHdRoutes[transitionRouteIndex].vias.length,
+        0,
+      )
+    const candidateViaCount =
+      collapsedDetour.vias.length +
+      transitionUpdates.reduce((sum, { route }) => sum + route.vias.length, 0)
+    if (originalViaCount - candidateViaCount !== 2) return null
+
+    this.stats.multiCrossingCandidates =
+      (this.stats.multiCrossingCandidates ?? 0) + 1
+    const candidate: CrossingReductionCandidate = {
+      detourRouteIndex,
+      detourRoute: collapsedDetour,
+      transitionUpdates,
+    }
+    if (!this.candidateIsClear(candidate, baseClearanceIndexes)) return null
+    this.stats.multiCrossingReductions =
+      (this.stats.multiCrossingReductions ?? 0) + 1
+    this.stats.transitionRoutesMovedByMultiCrossingReductions =
+      (this.stats.transitionRoutesMovedByMultiCrossingReductions ?? 0) +
+      transitionUpdates.length
+    return candidate
   }
 
   private findCrossingReduction(): CrossingReductionCandidate | null {
@@ -997,16 +1195,84 @@ export class CrossingViaReductionSolver extends BaseSolver {
         targetZ: detourCandidate.targetZ,
         transitionSegmentIndex,
       })
-      for (const crossingGroup of crossingGroups) {
-        const transitionRouteIndex = crossingGroup.transitionRouteIndex
-        const transitionRoute = this.reducedHdRoutes[transitionRouteIndex]
-        if (
-          transitionRoute.jumpers?.length ||
-          routesAreSameNet(detourRoute, transitionRoute, this.input.connMap)
-        ) {
-          continue
+      const actionableCrossingGroups = crossingGroups.filter(
+        ({ transitionRouteIndex }) => {
+          const transitionRoute = this.reducedHdRoutes[transitionRouteIndex]
+          return (
+            !transitionRoute.jumpers?.length &&
+            !routesAreSameNet(detourRoute, transitionRoute, this.input.connMap)
+          )
+        },
+      )
+      const crossingGroupOptions = new Map<string, IndexedCrossingGroup[]>()
+      for (const crossingGroup of actionableCrossingGroups) {
+        const key = `${crossingGroup.transitionRouteIndex}:${crossingGroup.transitionSectionIndex}`
+        const options = crossingGroupOptions.get(key) ?? []
+        options.push(crossingGroup)
+        crossingGroupOptions.set(key, options)
+      }
+      if (crossingGroupOptions.size > 1) {
+        baseClearanceIndexes ??= {
+          mutableRoutes: new HighDensityRouteSpatialIndex(this.reducedHdRoutes),
+          immutableRoutes: this.input.otherHdRoutes?.length
+            ? new HighDensityRouteSpatialIndex([...this.input.otherHdRoutes])
+            : null,
         }
+        let selections: Array<{
+          groups: IndexedCrossingGroup[]
+          movement: number
+        }> = [{ groups: [], movement: 0 }]
+        const getMovementDistance = (group: IndexedCrossingGroup) => {
+          const route = this.reducedHdRoutes[group.transitionRouteIndex]
+          const section =
+            sectionsByRoute[group.transitionRouteIndex][
+              group.transitionSectionIndex
+            ]
+          const viaClearance =
+            route.viaDiameter / 2 +
+            detourRoute.traceThickness / 2 +
+            this.traceMargin +
+            EPSILON
+          const newViaDistance =
+            group.side === "start"
+              ? Math.max(...group.crossingDistances) + viaClearance
+              : Math.min(...group.crossingDistances) - viaClearance
+          return group.side === "start"
+            ? newViaDistance
+            : getSectionLength(section.points) - newViaDistance
+        }
+        for (const options of crossingGroupOptions.values()) {
+          const sortedOptions = options
+            .map((group) => ({ group, movement: getMovementDistance(group) }))
+            .sort((first, second) => first.movement - second.movement)
+          selections = selections
+            .flatMap((selection) =>
+              sortedOptions.map((option) => ({
+                groups: [...selection.groups, option.group],
+                movement: selection.movement + option.movement,
+              })),
+            )
+            .sort((first, second) => first.movement - second.movement)
+            .slice(0, MAX_MULTI_CROSSING_SELECTIONS)
+        }
+        for (const selection of selections) {
+          const candidate = this.tryCreateMultiCrossingCandidate({
+            detourRouteIndex,
+            detourSection,
+            targetZ: detourCandidate.targetZ,
+            crossingGroups: selection.groups,
+            sectionsByRoute,
+            baseClearanceIndexes,
+          })
+          if (candidate) return candidate
+        }
+        continue
+      }
 
+      const singleGroupOptions =
+        crossingGroupOptions.values().next().value ?? []
+      for (const crossingGroup of singleGroupOptions) {
+        const transitionRouteIndex = crossingGroup.transitionRouteIndex
         const transitionSections = sectionsByRoute[transitionRouteIndex]
         const transitionSection =
           transitionSections[crossingGroup.transitionSectionIndex]
@@ -1042,8 +1308,9 @@ export class CrossingViaReductionSolver extends BaseSolver {
     }
 
     this.reducedHdRoutes[candidate.detourRouteIndex] = candidate.detourRoute
-    this.reducedHdRoutes[candidate.transitionRouteIndex] =
-      candidate.transitionRoute
+    for (const transitionUpdate of candidate.transitionUpdates) {
+      this.reducedHdRoutes[transitionUpdate.routeIndex] = transitionUpdate.route
+    }
     this.stats.crossingViaReductions =
       (this.stats.crossingViaReductions ?? 0) + 1
     this.stats.viasRemovedByCrossingReductions =

--- a/tests/features/pipeline7-srj20-sample169-multi-crossing-drc.test.ts
+++ b/tests/features/pipeline7-srj20-sample169-multi-crossing-drc.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver7_MultiGraph } from "lib"
+import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
+import { loadScenarioBySampleNumber } from "scripts/benchmark/scenarios"
+
+test("Pipeline7 keeps srj20 sample169 DRC-clean after multi-crossing simplification", async () => {
+  const { scenario } = await loadScenarioBySampleNumber("srj20", 169)
+  const solver = new AutoroutingPipelineSolver7_MultiGraph(scenario)
+
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  const routedTraces = solver.getOutputSimplifiedPcbTraces()
+  const { errors } = evaluateRelaxedDrc({
+    inputSrj: scenario,
+    srjWithPointPairs: solver.srjWithPointPairs!,
+    routedTraces,
+  })
+  const viaCount = routedTraces.reduce(
+    (sum, trace) =>
+      sum + trace.route.filter((point) => point.route_type === "via").length,
+    0,
+  )
+
+  expect(errors).toHaveLength(0)
+  expect(viaCount).toBe(37)
+})

--- a/tests/fixtures/crossing-via-reduction-multi-crossing-routes.ts
+++ b/tests/fixtures/crossing-via-reduction-multi-crossing-routes.ts
@@ -1,0 +1,72 @@
+import type { HighDensityRoute } from "lib/types/high-density-types"
+
+export const createMultiRouteCrossing = (): HighDensityRoute[] => [
+  {
+    connectionName: "detour",
+    traceThickness: 0.15,
+    viaDiameter: 0.4,
+    route: [
+      { x: -2, y: 4, z: 0, pcb_port_id: "detour-start" },
+      { x: -2, y: 3, z: 0 },
+      { x: -2, y: 3, z: 1 },
+      { x: -2, y: -3, z: 1 },
+      { x: -2, y: -3, z: 0 },
+      { x: -2, y: -4, z: 0, pcb_port_id: "detour-end" },
+    ],
+    vias: [
+      { x: -2, y: 3 },
+      { x: -2, y: -3 },
+    ],
+  },
+  {
+    connectionName: "transition-a",
+    traceThickness: 0.15,
+    viaDiameter: 0.4,
+    route: [
+      { x: 1, y: 1, z: 1, pcb_port_id: "transition-a-start" },
+      { x: 0, y: 1, z: 1 },
+      { x: 0, y: 1, z: 0 },
+      { x: -3, y: 1, z: 0, pcb_port_id: "transition-a-end" },
+    ],
+    vias: [{ x: 0, y: 1 }],
+  },
+  {
+    connectionName: "transition-b",
+    traceThickness: 0.15,
+    viaDiameter: 0.4,
+    route: [
+      { x: 1, y: -1, z: 1, pcb_port_id: "transition-b-start" },
+      { x: 0, y: -1, z: 1 },
+      { x: 0, y: -1, z: 0 },
+      { x: -3, y: -1, z: 0, pcb_port_id: "transition-b-end" },
+    ],
+    vias: [{ x: 0, y: -1 }],
+  },
+]
+
+export const createSameRouteMultiSectionCrossing = (): HighDensityRoute[] => [
+  createMultiRouteCrossing()[0],
+  {
+    connectionName: "transition",
+    traceThickness: 0.15,
+    viaDiameter: 0.4,
+    route: [
+      { x: 1, y: 1, z: 1, pcb_port_id: "transition-start" },
+      { x: 0, y: 1, z: 1 },
+      { x: 0, y: 1, z: 0 },
+      { x: -3, y: 1, z: 0 },
+      { x: -3, y: 1, z: 1 },
+      { x: -4, y: 1, z: 1 },
+      { x: -4, y: -4, z: 1 },
+      { x: 0, y: -4, z: 1 },
+      { x: 0, y: -1, z: 1 },
+      { x: 0, y: -1, z: 0 },
+      { x: -3, y: -1, z: 0, pcb_port_id: "transition-end" },
+    ],
+    vias: [
+      { x: 0, y: 1 },
+      { x: -3, y: 1 },
+      { x: 0, y: -1 },
+    ],
+  },
+]

--- a/tests/solvers/__snapshots__/crossing-via-reduction-multi-crossing-visual.snap.svg
+++ b/tests/solvers/__snapshots__/crossing-via-reduction-multi-crossing-visual.snap.svg
@@ -1,0 +1,94 @@
+<svg width="1012" height="696" viewBox="0 0 1012 696" xmlns="http://www.w3.org/2000/svg">
+  <g transform="translate(0, 0) scale(1, 1) translate(0, 0)">
+    <rect width="100%" height="100%" fill="white"/><text x="16" y="22" font-family="monospace" font-size="15" font-weight="700" fill="#111">BEFORE • 4 VIAS</text><text x="16" y="43" font-family="monospace" font-size="12" fill="#444">One detour crosses two routes on its terminal layer.</text><text x="16" y="61" font-family="monospace" font-size="12" fill="#444">Each crossing route already has an adjacent via.</text><g transform="translate(0 76)"><rect width="100%" height="100%" fill="#0d1b2a"/><g><polyline data-points="-2,4 -2,3" data-type="line" data-label="detour (z=0)" points="182.5,40 182.5,107.5" fill="none" stroke="#d32f2f" stroke-width="10.125"/></g><g><polyline data-points="-2,3 -2,-3" data-type="line" data-label="detour (z=1)" points="182.5,107.5 182.5,512.5" fill="none" stroke="#3367a8" stroke-width="10.125"/></g><g><polyline data-points="-2,-3 -2,-4" data-type="line" data-label="detour (z=0)" points="182.5,512.5 182.5,580" fill="none" stroke="#d32f2f" stroke-width="10.125"/></g><g><polyline data-points="1,1 0,1" data-type="line" data-label="transition-a (z=1)" points="385,242.5 317.5,242.5" fill="none" stroke="#3367a8" stroke-width="10.125"/></g><g><polyline data-points="0,1 -3,1" data-type="line" data-label="transition-a (z=0)" points="317.5,242.5 115,242.5" fill="none" stroke="#d32f2f" stroke-width="10.125"/></g><g><polyline data-points="1,-1 0,-1" data-type="line" data-label="transition-b (z=1)" points="385,377.5 317.5,377.5" fill="none" stroke="#3367a8" stroke-width="10.125"/></g><g><polyline data-points="0,-1 -3,-1" data-type="line" data-label="transition-b (z=0)" points="317.5,377.5 115,377.5" fill="none" stroke="#d32f2f" stroke-width="10.125"/></g><circle data-type="circle" data-label="" data-x="-2" data-y="3" cx="182.5" cy="107.5" r="13.5" fill="#ff20d6" stroke="black" stroke-width="0.014814814814814815"/><circle data-type="circle" data-label="" data-x="-2" data-y="-3" cx="182.5" cy="512.5" r="13.5" fill="#ff20d6" stroke="black" stroke-width="0.014814814814814815"/><circle data-type="circle" data-label="" data-x="0" data-y="1" cx="317.5" cy="242.5" r="13.5" fill="#ff20d6" stroke="black" stroke-width="0.014814814814814815"/><circle data-type="circle" data-label="" data-x="0" data-y="-1" cx="317.5" cy="377.5" r="13.5" fill="#ff20d6" stroke="black" stroke-width="0.014814814814814815"/><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="620" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="500" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '500');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '620');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":67.5,"c":0,"e":317.5,"b":0,"d":-67.5,"f":310};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e;
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></g>
+  </g>
+  <g transform="translate(512, 0) scale(1, 1) translate(0, 0)">
+    <rect width="100%" height="100%" fill="white"/><text x="16" y="22" font-family="monospace" font-size="15" font-weight="700" fill="#111">AFTER • 2 VIAS</text><text x="16" y="43" font-family="monospace" font-size="12" fill="#444">Both existing vias move past the crossings atomically.</text><text x="16" y="61" font-family="monospace" font-size="12" fill="#444">The detour stays on one layer and loses its via pair.</text><g transform="translate(0 76)"><rect width="100%" height="100%" fill="#0d1b2a"/><g><polyline data-points="-2,4 -2,3" data-type="line" data-label="detour (z=0)" points="182.5,40 182.5,107.5" fill="none" stroke="#d32f2f" stroke-width="10.125"/></g><g><polyline data-points="-2,3 -2,-3" data-type="line" data-label="detour (z=0)" points="182.5,107.5 182.5,512.5" fill="none" stroke="#d32f2f" stroke-width="10.125"/></g><g><polyline data-points="-2,-3 -2,-4" data-type="line" data-label="detour (z=0)" points="182.5,512.5 182.5,580" fill="none" stroke="#d32f2f" stroke-width="10.125"/></g><g><polyline data-points="1,1 0,1" data-type="line" data-label="transition-a (z=1)" points="385,242.5 317.5,242.5" fill="none" stroke="#3367a8" stroke-width="10.125"/></g><g><polyline data-points="0,1 -2.375001,1" data-type="line" data-label="transition-a (z=1)" points="317.5,242.5 157.1874325,242.5" fill="none" stroke="#3367a8" stroke-width="10.125"/></g><g><polyline data-points="-2.375001,1 -3,1" data-type="line" data-label="transition-a (z=0)" points="157.1874325,242.5 115,242.5" fill="none" stroke="#d32f2f" stroke-width="10.125"/></g><g><polyline data-points="1,-1 0,-1" data-type="line" data-label="transition-b (z=1)" points="385,377.5 317.5,377.5" fill="none" stroke="#3367a8" stroke-width="10.125"/></g><g><polyline data-points="0,-1 -2.375001,-1" data-type="line" data-label="transition-b (z=1)" points="317.5,377.5 157.1874325,377.5" fill="none" stroke="#3367a8" stroke-width="10.125"/></g><g><polyline data-points="-2.375001,-1 -3,-1" data-type="line" data-label="transition-b (z=0)" points="157.1874325,377.5 115,377.5" fill="none" stroke="#d32f2f" stroke-width="10.125"/></g><circle data-type="circle" data-label="" data-x="-2.375001" data-y="1" cx="157.1874325" cy="242.5" r="13.5" fill="#ff20d6" stroke="black" stroke-width="0.014814814814814815"/><circle data-type="circle" data-label="" data-x="-2.375001" data-y="-1" cx="157.1874325" cy="377.5" r="13.5" fill="#ff20d6" stroke="black" stroke-width="0.014814814814814815"/><g id="crosshair__stack1" style="display: none"><line id="crosshair-h__stack1" y1="0" y2="620" stroke="#666" stroke-width="0.5"/><line id="crosshair-v__stack1" x1="0" x2="500" stroke="#666" stroke-width="0.5"/><text id="coordinates__stack1" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '500');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '620');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":67.5,"c":0,"e":317.5,"b":0,"d":-67.5,"f":310};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e;
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></g>
+  </g>
+</svg>

--- a/tests/solvers/crossing-via-reduction-multi-crossing-visual.test.ts
+++ b/tests/solvers/crossing-via-reduction-multi-crossing-visual.test.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { type GraphicsObject, getSvgFromGraphicsObject } from "graphics-debug"
+import { CrossingViaReductionSolver } from "lib/solvers/CrossingViaReductionSolver/crossing-via-reduction-solver"
+import { stackSvgsHorizontally } from "stack-svgs"
+import { createMultiRouteCrossing } from "tests/fixtures/crossing-via-reduction-multi-crossing-routes"
+
+const addPanelHeader = ({
+  svg,
+  title,
+  details,
+}: {
+  svg: string
+  title: string
+  details: [string, string]
+}): string => {
+  const headerHeight = 76
+  const bodyStart = svg.indexOf(">") + 1
+  const bodyEnd = svg.lastIndexOf("</svg>")
+  const width = Number(svg.match(/\bwidth="([^"]+)"/)?.[1] ?? 500)
+  const height = Number(svg.match(/\bheight="([^"]+)"/)?.[1] ?? 620)
+  return `<svg width="${width}" height="${
+    height + headerHeight
+  }" viewBox="0 0 ${width} ${
+    height + headerHeight
+  }" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><text x="16" y="22" font-family="monospace" font-size="15" font-weight="700" fill="#111">${title}</text><text x="16" y="43" font-family="monospace" font-size="12" fill="#444">${details[0]}</text><text x="16" y="61" font-family="monospace" font-size="12" fill="#444">${details[1]}</text><g transform="translate(0 ${headerHeight})">${svg.slice(
+    bodyStart,
+    bodyEnd,
+  )}</g></svg>`
+}
+
+test("visualizes atomic multi-crossing via reduction", () => {
+  const solver = new CrossingViaReductionSolver({
+    inputHdRoutes: createMultiRouteCrossing(),
+    obstacles: [],
+    connMap: new ConnectivityMap({
+      detour_net: ["detour"],
+      transition_a_net: ["transition-a"],
+      transition_b_net: ["transition-b"],
+    }),
+    layerCount: 2,
+  })
+  const beforeGraphics = solver.visualize()
+
+  solver.solve()
+
+  const renderFrame = (graphics: GraphicsObject): string =>
+    getSvgFromGraphicsObject(graphics, {
+      backgroundColor: "#0d1b2a",
+      svgWidth: 500,
+      svgHeight: 620,
+      hideInlineLabels: true,
+    })
+
+  expect(
+    stackSvgsHorizontally(
+      [
+        addPanelHeader({
+          svg: renderFrame(beforeGraphics),
+          title: "BEFORE • 4 VIAS",
+          details: [
+            "One detour crosses two routes on its terminal layer.",
+            "Each crossing route already has an adjacent via.",
+          ],
+        }),
+        addPanelHeader({
+          svg: renderFrame(solver.visualize()),
+          title: "AFTER • 2 VIAS",
+          details: [
+            "Both existing vias move past the crossings atomically.",
+            "The detour stays on one layer and loses its via pair.",
+          ],
+        }),
+      ],
+      { gap: 12, normalizeSize: false },
+    ),
+  ).toMatchSvgSnapshot(import.meta.path)
+})

--- a/tests/solvers/crossing-via-reduction-multi-route.test.ts
+++ b/tests/solvers/crossing-via-reduction-multi-route.test.ts
@@ -54,3 +54,37 @@ test("relocates multiple sections of one crossing route atomically", () => {
   expect(routes[0].vias).toHaveLength(0)
   expect(routes[1].vias).toHaveLength(3)
 })
+
+test("rejects a multi-crossing rewrite with a pre-existing route conflict", () => {
+  const routes = createMultiRouteCrossing()
+  routes.push({
+    connectionName: "existing-conflict",
+    traceThickness: 0.15,
+    viaDiameter: 0.4,
+    route: [
+      { x: 0.75, y: 0.5, z: 1 },
+      { x: 0.75, y: 1.5, z: 1 },
+    ],
+    vias: [],
+  })
+  const solver = new CrossingViaReductionSolver({
+    inputHdRoutes: routes,
+    obstacles: [],
+    connMap: new ConnectivityMap({
+      detour_net: ["detour"],
+      transition_a_net: ["transition-a"],
+      transition_b_net: ["transition-b"],
+      conflict_net: ["existing-conflict"],
+    }),
+    layerCount: 2,
+  })
+
+  solver.solve()
+
+  expect(solver.failed).toBe(false)
+  expect(solver.stats.crossingViaReductions).toBeUndefined()
+  expect(solver.stats.multiCrossingPreexistingConflictRejections).toBe(1)
+  expect(
+    solver.getReducedHdRoutes().flatMap((route) => route.vias),
+  ).toHaveLength(4)
+})

--- a/tests/solvers/crossing-via-reduction-multi-route.test.ts
+++ b/tests/solvers/crossing-via-reduction-multi-route.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { CrossingViaReductionSolver } from "lib/solvers/CrossingViaReductionSolver/crossing-via-reduction-solver"
+import {
+  createMultiRouteCrossing,
+  createSameRouteMultiSectionCrossing,
+} from "tests/fixtures/crossing-via-reduction-multi-crossing-routes"
+
+test("atomically relocates multiple crossing vias to remove one detour", () => {
+  const solver = new CrossingViaReductionSolver({
+    inputHdRoutes: createMultiRouteCrossing(),
+    obstacles: [],
+    connMap: new ConnectivityMap({
+      detour_net: ["detour"],
+      transition_a_net: ["transition-a"],
+      transition_b_net: ["transition-b"],
+    }),
+    layerCount: 2,
+  })
+
+  solver.solve()
+
+  const routes = solver.getReducedHdRoutes()
+  expect(solver.failed).toBe(false)
+  expect(solver.stats.crossingViaReductions).toBe(1)
+  expect(solver.stats.multiCrossingReductions).toBe(1)
+  expect(solver.stats.transitionRoutesMovedByMultiCrossingReductions).toBe(2)
+  expect(routes.flatMap((route) => route.vias)).toHaveLength(2)
+  expect(routes[0].vias).toHaveLength(0)
+  expect(routes[0].route.every((point) => point.z === 0)).toBe(true)
+  expect(routes[1].vias[0]!.x).toBeLessThan(-2)
+  expect(routes[2].vias[0]!.x).toBeLessThan(-2)
+})
+
+test("relocates multiple sections of one crossing route atomically", () => {
+  const solver = new CrossingViaReductionSolver({
+    inputHdRoutes: createSameRouteMultiSectionCrossing(),
+    obstacles: [],
+    connMap: new ConnectivityMap({
+      detour_net: ["detour"],
+      transition_net: ["transition"],
+    }),
+    layerCount: 2,
+  })
+
+  solver.solve()
+
+  const routes = solver.getReducedHdRoutes()
+  expect(solver.failed).toBe(false)
+  expect(solver.stats.crossingViaReductions).toBe(1)
+  expect(solver.stats.multiCrossingReductions).toBe(1)
+  expect(solver.stats.transitionRoutesMovedByMultiCrossingReductions).toBe(1)
+  expect(routes.flatMap((route) => route.vias)).toHaveLength(3)
+  expect(routes[0].vias).toHaveLength(0)
+  expect(routes[1].vias).toHaveLength(3)
+})


### PR DESCRIPTION
## Summary

Follow-up to #2021. A two-via detour can cross several transition sections, so relocating one adjacent via at a time leaves the collapsed detour shorted against the remaining crossings. This change:

- groups blockers by transition route and section, then relocates all required vias atomically with the detour collapse
- handles blockers on different routes and on distinct sections of the same route
- ranks start/end alternatives by total via movement and evaluates at most four combinations
- clearance-checks every modified route against static geometry, unchanged routes, and every other candidate route before applying anything
- rejects an otherwise valid multi-crossing candidate when one of its routes has a pre-existing external copper conflict, preventing downstream path simplification from turning that conflict into a final DRC regression

Each accepted reduction removes exactly two vias.

## `/benchmark-all` via-count results

Results below come from the six [full benchmark workflows](https://github.com/tscircuit/tscircuit-autorouter/pull/2031#issuecomment-5228209802) on `207dcec`. Via totals compare cases solved by both revisions so added completions do not inflate the PR total.

| Dataset | Common solved | `main` vias | This PR | Change | Completion | Relaxed DRC pass rate |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| dataset01 | 85 | 3,333 | 3,327 | **-6** | 85 → 85 | 90.6% → 90.6% |
| srj18 | 7 | 1,153 | 1,153 | 0 | **7 → 8** | 25.0% → 25.0% |
| srj19 | 158 | 12,186 | 12,176 | **-10** | **158 → 159** | 38.0% → 38.0% |
| srj20 | 139 | 11,959 | 11,947 | **-12** | **139 → 140** | 27.0% → 27.0% |
| srj21 | 10 | 121 | 121 | 0 | 10 → 10 | 90.0% → 90.0% |
| srj23 | 75 | 1,006 | 1,006 | 0 | 75 → 75 | 14.5% → 14.5% |
| **Total** | **474** | **29,758** | **29,730** | **-28** | **+3 solved** | **0 common-case DRC flips** |

The reductions are concentrated in 12 cases; no common solved case gains vias:

| Dataset | Improved samples |
| --- | --- |
| dataset01 | #37: -4, #61: -2 |
| srj19 | #36: -2, #70: -2, #86: -2, #136: -2, #185: -2 |
| srj20 | #1: -2, #3: -2, #23: -4, #78: -2, #162: -2 |

The conservative external-conflict guard trades away 10 vias from the initial unguarded result (`-38` → `-28`) and removes its one observed DRC regression.

## Performance

| Dataset | p50 (`main` → PR) | p95 (`main` → PR) |
| --- | ---: | ---: |
| dataset01 | 7.8s → 8.3s (+6.3%) | 29.7s → 31.5s (+6.3%) |
| srj18 | 155.4s → 146.8s (-5.5%) | 175.0s → 244.5s* |
| srj19 | 47.7s → 42.0s (-11.8%) | 260.6s → 268.4s (+3.0%)* |
| srj20 | 40.3s → 36.7s (-8.7%) | 259.9s → 248.0s (-4.6%) |
| srj21 | 2.5s → 2.6s (+1.0%) | 5.1s → 4.7s (-7.9%) |
| srj23 | 7.0s → 6.5s (-6.7%) | 137.6s → 126.8s (-7.9%) |

\* srj18 and srj19 each complete an additional long-running case on the PR, making their solved-case p95 population less directly comparable. Four of six p50s improve; the two increases are +0.49s and +0.03s.

The search stays bounded and avoids guaranteed-doomed single-crossing attempts. On a controlled sequential dataset01 run, candidate clearance checks fell from 12,594 to 7,571 (**-39.9%**). The external-conflict scan runs only after a multi-crossing candidate has already passed its normal delta-clearance checks.

## Before / after

![Atomic multi-crossing via reduction](https://raw.githubusercontent.com/tscircuit/tscircuit-autorouter/207dcec91eba2fbafe89b3c4828103e710ff9d8c/tests/solvers/__snapshots__/crossing-via-reduction-multi-crossing-visual.snap.svg)

The detour drops from two vias to zero while the two already-required transition vias move just past their crossings: **4 vias → 2 vias**.

## Validation

- focused solver and Pipeline7 DRC regression tests: 9 pass
- `bunx tsc --noEmit`
- `bun run build`
- GitHub CI: all 8 test shards, format, type-check, build, and deployment pass
- `/benchmark-all`: all 6 workflows pass
