### PR TITLE
Reproduce obstacle-crossing route stitch

### DIFF
--- a/tests/features/__snapshots__/stitch-endpoint-path-prefers-continuous-fragments.snap.svg
+++ b/tests/features/__snapshots__/stitch-endpoint-path-prefers-continuous-fragments.snap.svg
@@ -1,0 +1,44 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="-2,0 0,0" data-type="line" data-label="" points="40,416.55172413793105 426.2068965517241,416.55172413793105" fill="none" stroke="hsl(120, 100%, 40%)" stroke-width="19.310344827586206"/></g><g><polyline data-points="0,0 0.9,0" data-type="line" data-label="" points="426.2068965517241,416.55172413793105 600,416.55172413793105" fill="none" stroke="hsl(120, 100%, 40%)" stroke-width="19.310344827586206"/></g><g><circle data-type="point" data-label="" data-x="-2" data-y="0" cx="40" cy="416.55172413793105" r="3" fill="hsl(120, 100%, 40%)"/></g><g><circle data-type="point" data-label="" data-x="0" data-y="0" cx="426.2068965517241" cy="416.55172413793105" r="3" fill="hsl(120, 100%, 40%)"/></g><g><circle data-type="point" data-label="" data-x="0.9" data-y="0" cx="600" cy="416.55172413793105" r="3" fill="hsl(120, 100%, 40%)"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":193.10344827586206,"c":0,"e":426.2068965517241,"b":0,"d":-193.10344827586206,"f":416.55172413793105};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/features/stitch-endpoint-path-prefers-continuous-fragments.test.ts
+++ b/tests/features/stitch-endpoint-path-prefers-continuous-fragments.test.ts
@@ -1,0 +1,87 @@
+import { expect, test } from "bun:test"
+import { getSvgFromGraphicsObject } from "graphics-debug"
+import { MultipleHighDensityRouteStitchSolver3 } from "lib/solvers/RouteStitchingSolver/MultipleHighDensityRouteStitchSolver3"
+import type { HighDensityIntraNodeRoute } from "lib/types/high-density-types"
+
+function createRouteFragment({
+  regionId,
+  points,
+}: {
+  regionId: string
+  points: Array<{ x: number; y: number; z: number }>
+}): HighDensityIntraNodeRoute {
+  return {
+    connectionName: "trace-a",
+    regionId,
+    route: points,
+    traceThickness: 0.1,
+    viaDiameter: 0.3,
+    vias: [],
+  }
+}
+
+test("visualizes route stitching around a blocking obstacle", () => {
+  const routes = [
+    createRouteFragment({
+      regionId: "main",
+      points: [
+        { x: -2, y: 0, z: 0 },
+        { x: 0, y: 0, z: 0 },
+      ],
+    }),
+    createRouteFragment({
+      regionId: "escape-1",
+      points: [
+        { x: 0, y: 0, z: 0 },
+        { x: 0, y: 0.5, z: 0 },
+      ],
+    }),
+    createRouteFragment({
+      regionId: "escape-2",
+      points: [
+        { x: 0, y: 0.5, z: 0 },
+        { x: 0.9, y: 0.5, z: 0 },
+      ],
+    }),
+    createRouteFragment({
+      regionId: "escape-3",
+      points: [
+        { x: 0.9, y: 0.5, z: 0 },
+        { x: 0.9, y: 0, z: 0 },
+      ],
+    }),
+  ]
+
+  const solver = new MultipleHighDensityRouteStitchSolver3({
+    connections: [
+      {
+        name: "trace-a",
+        pointsToConnect: [
+          { x: -2, y: 0, layer: "top" },
+          { x: 0.9, y: 0, layer: "top" },
+        ],
+      },
+    ],
+    hdRoutes: routes,
+    layerCount: 2,
+    obstacles: [
+      {
+        type: "rect",
+        componentId: "blocker",
+        layers: ["top"],
+        center: { x: 0.45, y: 0 },
+        width: 0.4,
+        height: 0.4,
+        connectedTo: ["other-net"],
+      },
+    ],
+  } as ConstructorParameters<typeof MultipleHighDensityRouteStitchSolver3>[0])
+
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(getSvgFromGraphicsObject(solver.visualize())).toMatchSvgSnapshot(
+    import.meta.path,
+    { tolerance: 0 },
+  )
+})


### PR DESCRIPTION
## Summary

- add a focused route-stitching visualization with a continuous detour around a blocking component
- capture the current unsafe shortcut, where the synthetic terminal stitch crosses that foreign obstacle
- keep this PR test-only so the stacked fix updates the same SVG snapshot

## Stack

- base: main
- next: #2040

## Test

- bun test tests/features/stitch-endpoint-path-prefers-continuous-fragments.test.ts