### PR TITLE
fix(pipeline7): propagate adaptive high-density budgets

### DIFF
--- a/lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver.ts
+++ b/lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver.ts
@@ -365,10 +365,20 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
       this.expandAdaptiveSearch()
     }
 
+    const activeCandidate = this.getSupervisedSolverWithBestFitness()?.solver
+    const activeCandidateIterationLimit = activeCandidate?.MAX_ITERATIONS
     super._step()
 
     if (!this.solved && !this.failed && this.shouldExpandPortfolio()) {
       this.expandAdaptiveSearch()
+    }
+
+    if (
+      !this.solved &&
+      !this.failed &&
+      activeCandidate?.MAX_ITERATIONS !== activeCandidateIterationLimit
+    ) {
+      this.refreshDynamicIterationLimit()
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "high-density-repair01": "git+https://github.com/tscircuit/high-density-repair01.git#cefc7be547ff727bd31573ac096b850da847af46",
     "high-density-repair02": "https://codeload.github.com/tscircuit/high-density-repair02/tar.gz/2afc0cbba3bf2f7eb6b9cd33615d21e9ad9352d4",
     "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#6943de12da0ac5f47358b0861110f3ae7edcd8c1",
-    "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d",
+    "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#667404c606d59a2c30fbf6d69086479fb69ca40b",
     "@tscircuit/high-density-b01": "git+https://github.com/tscircuit/high-density-b01.git#1309684"
   },
   "dependencies": {

--- a/tests/features/portfolio-single-intra-node-dynamic-budget.test.ts
+++ b/tests/features/portfolio-single-intra-node-dynamic-budget.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "bun:test"
+import { IntraNodeRouteSolver } from "lib/solvers/HighDensitySolver/IntraNodeSolver"
+import { PortfolioSingleIntraNodeSolver } from "lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver"
+import type { NodeWithPortPoints } from "lib/types/high-density-types"
+
+const TEST_NODE: NodeWithPortPoints = {
+  capacityMeshNodeId: "dynamic-budget-test-node",
+  center: { x: 0, y: 0 },
+  width: 1,
+  height: 1,
+  portPoints: [
+    { connectionName: "test-route", x: -0.4, y: 0, z: 0 },
+    { connectionName: "test-route", x: 0.4, y: 0, z: 0 },
+  ],
+}
+
+class DeadlineExtendingIntraNodeSolver extends IntraNodeRouteSolver {
+  constructor() {
+    super({ nodeWithPortPoints: TEST_NODE })
+    this.MAX_ITERATIONS = 1
+  }
+
+  override _step(): void {
+    this.MAX_ITERATIONS = 1_000
+  }
+}
+
+class DynamicBudgetPortfolioSolver extends PortfolioSingleIntraNodeSolver {
+  candidate = new DeadlineExtendingIntraNodeSolver()
+
+  constructor() {
+    super({ nodeWithPortPoints: TEST_NODE })
+    this.MIN_SUBSTEPS = 1
+  }
+
+  override initializeSolvers(): void {
+    this.supervisedSolvers = [
+      {
+        hyperParameters: {},
+        solver: this.candidate,
+        h: 0,
+        g: 0,
+        f: 0,
+      },
+    ]
+    this.MAX_ITERATIONS = 1
+  }
+}
+
+test("portfolio follows a child solver's extended iteration deadline", () => {
+  const portfolioSolver = new DynamicBudgetPortfolioSolver()
+  portfolioSolver.initializeSolvers()
+  const initialPortfolioDeadline = portfolioSolver.MAX_ITERATIONS
+
+  portfolioSolver.step()
+
+  expect(portfolioSolver.candidate.MAX_ITERATIONS).toBe(1_000)
+  expect(portfolioSolver.MAX_ITERATIONS).toBeGreaterThan(
+    initialPortfolioDeadline,
+  )
+  expect(portfolioSolver.failed).toBe(false)
+})


### PR DESCRIPTION
Depends on:

- tscircuit/high-density-a01#87 — exact `srj24` sample 1 reproduction
- tscircuit/high-density-a01#88 — direct A01 fixes

## Problem

The dense region in `srj24` sample 1 is still adding completed routes when A01 reaches its initial estimated budget. The A01 fix extends its own deadline while that progress continues, but the surrounding autorouter portfolio had already copied the old deadline and could stop first.

## Fix

- consume the fixed A01 commit
- when the candidate that just ran changes its iteration limit, recompute the portfolio limit from the candidates' remaining work

The portfolio does not receive a larger fixed budget and does not poll every candidate on every step. It reacts only when the active child changes its own limit.

## Visual reproduction

The exact same fixture and layer-by-layer snapshot is used on both sides of the A01 stack:

| Before | After |
| --- | --- |
| ![A01 stops after 31 of 46 routes](https://raw.githubusercontent.com/tscircuit/high-density-a01/agent/srj24-sample1-a01-repro/tests/repros/srj24-sample001-cmn1/__snapshots__/srj24-sample001-cmn1.snap.svg) | ![A01 completes all 46 routes](https://raw.githubusercontent.com/tscircuit/high-density-a01/agent/srj24-sample1-a01-fix/tests/repros/srj24-sample001-cmn1/__snapshots__/srj24-sample001-cmn1.snap.svg) |

Each panel is the same physical region on one PCB layer. Colored dots are terminals, colored paths are traces on that layer, and gray circles are through-vias.

## Verification

- focused portfolio budget-propagation regression test passes
- autorouter production build passes
- A01 package suite: 59 passed, 2 skipped, 0 failed
- exact dense-region fixture: 46/46 routes, 0 geometry violations

The end-to-end Pipeline 7 result will be recorded below by the GitHub `srj24` sample 1 benchmark; no local full-dataset benchmark was used.
