### PR TITLE
Honor via-to-pad clearance for escape vias

### DIFF
--- a/lib/solvers/EscapeViaLocationSolver/EscapeViaLocationSolver.ts
+++ b/lib/solvers/EscapeViaLocationSolver/EscapeViaLocationSolver.ts
@@ -97,6 +97,7 @@ export class EscapeViaLocationSolver extends BaseSolver {
   obstacleMargin: number
   escapeOffset: number
   requiredTraceClearance: number
+  requiredViaToPadClearance: number
   requiredViaToViaClearance: number
   outputSrj: SimpleRouteJson
   escapeViaMetadataByPointId: Map<string, EscapeViaMetadata>
@@ -113,8 +114,13 @@ export class EscapeViaLocationSolver extends BaseSolver {
     this.minTraceWidth = opts.minTraceWidth ?? ogSrj.minTraceWidth
     this.obstacleMargin =
       opts.obstacleMargin ?? ogSrj.defaultObstacleMargin ?? 0.15
+    this.requiredViaToPadClearance = Math.max(
+      this.obstacleMargin,
+      ogSrj.minViaEdgeToPadEdgeClearance ?? 0,
+    )
     this.escapeOffset =
-      this.viaRadius + Math.max(this.minTraceWidth / 2, this.obstacleMargin)
+      this.viaRadius +
+      Math.max(this.minTraceWidth / 2, this.requiredViaToPadClearance)
     this.requiredTraceClearance =
       this.minTraceWidth / 2 + this.obstacleMargin / 2
     this.requiredViaToViaClearance = this.viaDiameter + this.obstacleMargin
@@ -609,7 +615,10 @@ export class EscapeViaLocationSolver extends BaseSolver {
       const clearance = pointToBoxDistance(candidate, obstacle) - this.viaRadius
       minClearance = Math.min(minClearance, clearance)
 
-      if (minClearance + GEOMETRIC_TOLERANCE < this.obstacleMargin) {
+      if (
+        minClearance + GEOMETRIC_TOLERANCE <
+        this.requiredViaToPadClearance
+      ) {
         return minClearance
       }
     }
@@ -738,7 +747,12 @@ export class EscapeViaLocationSolver extends BaseSolver {
           sourceZ,
           targetZ,
         })
-        if (minClearance + GEOMETRIC_TOLERANCE < this.obstacleMargin) continue
+        if (
+          minClearance + GEOMETRIC_TOLERANCE <
+          this.requiredViaToPadClearance
+        ) {
+          continue
+        }
         const minPlacedEscapeViaClearance =
           this.getMinPlacedEscapeViaClearance(candidate)
         if (

--- a/lib/solvers/EscapeViaLocationSolver/EscapeViaLocationSolver.ts
+++ b/lib/solvers/EscapeViaLocationSolver/EscapeViaLocationSolver.ts
@@ -615,10 +615,7 @@ export class EscapeViaLocationSolver extends BaseSolver {
       const clearance = pointToBoxDistance(candidate, obstacle) - this.viaRadius
       minClearance = Math.min(minClearance, clearance)
 
-      if (
-        minClearance + GEOMETRIC_TOLERANCE <
-        this.requiredViaToPadClearance
-      ) {
+      if (minClearance + GEOMETRIC_TOLERANCE < this.requiredViaToPadClearance) {
         return minClearance
       }
     }

--- a/tests/features/pour-via-escape/escape-via-respects-via-pad-clearance.test.ts
+++ b/tests/features/pour-via-escape/escape-via-respects-via-pad-clearance.test.ts
@@ -48,9 +48,7 @@ test("escape vias honor the explicit via-to-pad clearance", () => {
     connections: [
       {
         name: "net.GND",
-        pointsToConnect: [
-          { x: 0, y: 0, layer: "top", pointId: "source-pad" },
-        ],
+        pointsToConnect: [{ x: 0, y: 0, layer: "top", pointId: "source-pad" }],
       },
     ],
   }
@@ -66,8 +64,7 @@ test("escape vias honor the explicit via-to-pad clearance", () => {
 
   expect(escapePoint).toBeDefined()
   for (const pad of neighboringPads) {
-    const clearance =
-      pointToBoxDistance(escapePoint!, pad) - viaDiameter / 2
+    const clearance = pointToBoxDistance(escapePoint!, pad) - viaDiameter / 2
     expect(clearance).toBeGreaterThanOrEqual(requiredClearance - 1e-4)
   }
 })

--- a/tests/features/pour-via-escape/escape-via-respects-via-pad-clearance.test.ts
+++ b/tests/features/pour-via-escape/escape-via-respects-via-pad-clearance.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "bun:test"
+import { pointToBoxDistance } from "@tscircuit/math-utils"
+import { EscapeViaLocationSolver } from "../../../lib/solvers/EscapeViaLocationSolver/EscapeViaLocationSolver"
+import type { Obstacle, SimpleRouteJson } from "../../../lib/types"
+
+test("escape vias honor the explicit via-to-pad clearance", () => {
+  const requiredClearance = 0.1
+  const viaDiameter = 0.6
+  const neighboringPads: Obstacle[] = [-0.2, 0.2].map((y) => ({
+    obstacleId: `neighbor-${y}`,
+    type: "rect",
+    layers: ["top"],
+    center: { x: 0, y },
+    width: 0.65,
+    height: 0.15,
+    connectedTo: [`other-${y}`],
+  }))
+  const srj: SimpleRouteJson = {
+    layerCount: 4,
+    minTraceWidth: 0.15,
+    minViaHoleDiameter: 0.3,
+    minViaPadDiameter: viaDiameter,
+    minViaEdgeToPadEdgeClearance: requiredClearance,
+    defaultObstacleMargin: 0.01,
+    bounds: { minX: -3, maxX: 3, minY: -3, maxY: 3 },
+    obstacles: [
+      {
+        obstacleId: "source-pad",
+        type: "rect",
+        layers: ["top"],
+        center: { x: 0, y: 0 },
+        width: 0.65,
+        height: 0.15,
+        connectedTo: ["net.GND", "source-pad"],
+      },
+      ...neighboringPads,
+      {
+        obstacleId: "gnd-pour",
+        type: "rect",
+        layers: ["inner1"],
+        center: { x: 0, y: 0 },
+        width: 5,
+        height: 5,
+        connectedTo: ["net.GND"],
+        isCopperPour: true,
+      },
+    ],
+    connections: [
+      {
+        name: "net.GND",
+        pointsToConnect: [
+          { x: 0, y: 0, layer: "top", pointId: "source-pad" },
+        ],
+      },
+    ],
+  }
+
+  const solver = new EscapeViaLocationSolver(srj)
+  solver.solve()
+
+  const escapePoint = solver
+    .getOutputSimpleRouteJson()
+    .connections[0]?.pointsToConnect.find((point) =>
+      point.pointId?.startsWith("escape-via:"),
+    )
+
+  expect(escapePoint).toBeDefined()
+  for (const pad of neighboringPads) {
+    const clearance =
+      pointToBoxDistance(escapePoint!, pad) - viaDiameter / 2
+    expect(clearance).toBeGreaterThanOrEqual(requiredClearance - 1e-4)
+  }
+})


### PR DESCRIPTION
## Summary
- honor Simple Route JSON's explicit minimum via-edge-to-pad-edge clearance when placing copper-pour escape vias
- include that clearance in the initial escape offset and candidate obstacle rejection
- add a minimal fine-pitch pad regression using a 0.6 mm via

## Root cause
EscapeViaLocationSolver used only defaultObstacleMargin when sizing and validating escape-via candidates. When that generic margin was smaller than minViaEdgeToPadEdgeClearance, a candidate could be accepted despite violating the board's via-to-pad DRC. The reproduction produced 0.0953 mm clearance for a required 0.1 mm.

## Impact
Escape vias now use the stricter of the generic obstacle margin and the explicit via-to-pad clearance. Existing designs without the explicit field preserve their current behavior.

## Verification
- focused new regression plus existing escape-via regression suite: 4 passed, 0 failed
- TypeScript noEmit: pass
- package build including declarations: pass

The local full visual test preload could not load its macOS native sharp binary; the focused tests were run with only that preload temporarily disabled.