### PR TITLE
Use dense TinyHypergraph candidate storage for bounded graphs

### DIFF
--- a/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
+++ b/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
@@ -167,6 +167,15 @@ const TINY_SECTION_SOLVER_BASE_OPTIONS: TinyHyperGraphSectionSolverOptions = {
 const DUPLICATE_PORT_TRAVERSAL_PENALTY = 150
 const DEFAULT_CRAMPED_PORT_TRAVERSAL_PENALTY = 150
 const MAX_CONNECTIONS_FOR_DUPLICATE_CONGESTED_PORT_PREPASS = 180
+const MAX_DENSE_CANDIDATE_HOPS = 4_000_000
+
+export const shouldUseSparseCandidateStorage = (
+  portCount: number,
+  regionCount: number,
+): boolean => {
+  const hopCount = portCount * regionCount
+  return hopCount > MAX_DENSE_CANDIDATE_HOPS
+}
 
 const getEffortScale = (effort: number) => Math.max(effort, 1e-2)
 
@@ -180,12 +189,13 @@ const getTinyViaSizeOptions = (
 const getTinyHyperGraphSolveGraphOptions = (
   effort: number,
   minViaPadDiameter?: number,
+  useSparseCandidateStorage = true,
 ): TinyHyperGraphSolverOptions => {
   const effortScale = getEffortScale(effort)
   return {
     ...TINY_SOLVE_GRAPH_BASE_OPTIONS,
     ...getTinyViaSizeOptions(minViaPadDiameter),
-    USE_SPARSE_CANDIDATE_STORAGE: true,
+    USE_SPARSE_CANDIDATE_STORAGE: useSparseCandidateStorage,
     RIP_THRESHOLD_RAMP_ATTEMPTS: Math.ceil(10 * effortScale),
     MAX_ITERATIONS: Math.ceil(2_000_000 * effortScale),
   }
@@ -194,12 +204,13 @@ const getTinyHyperGraphSolveGraphOptions = (
 const getTinyHyperGraphSectionSolverOptions = (
   effort: number,
   minViaPadDiameter?: number,
+  useSparseCandidateStorage = true,
 ): TinyHyperGraphSectionSolverOptions => {
   const effortScale = getEffortScale(effort)
   return {
     ...TINY_SECTION_SOLVER_BASE_OPTIONS,
     ...getTinyViaSizeOptions(minViaPadDiameter),
-    USE_SPARSE_CANDIDATE_STORAGE: true,
+    USE_SPARSE_CANDIDATE_STORAGE: useSparseCandidateStorage,
     RIP_THRESHOLD_RAMP_ATTEMPTS: Math.ceil(16 * effortScale),
     MAX_ITERATIONS: Math.ceil(1_000_000 * effortScale),
   }
@@ -228,7 +239,14 @@ const getTinyHyperGraphPipelineInput = (
     serializedHyperGraph,
     createSectionMask: ({ topology }) => new Int8Array(topology.portCount),
     solveGraphOptions: {
-      ...getTinyHyperGraphSolveGraphOptions(effort, minViaPadDiameter),
+      ...getTinyHyperGraphSolveGraphOptions(
+        effort,
+        minViaPadDiameter,
+        shouldUseSparseCandidateStorage(
+          serializedHyperGraph.ports.length,
+          serializedHyperGraph.regions.length,
+        ),
+      ),
       ...(enablePartialRipForGraph
         ? {
             PARTIAL_RIP_MIN_ROUTE_COUNT: 0,
@@ -243,6 +261,10 @@ const getTinyHyperGraphPipelineInput = (
     sectionSolverOptions: getTinyHyperGraphSectionSolverOptions(
       effort,
       minViaPadDiameter,
+      shouldUseSparseCandidateStorage(
+        serializedHyperGraph.ports.length,
+        serializedHyperGraph.regions.length,
+      ),
     ),
   }
 }

--- a/tests/tinyhypergraph-candidate-storage.test.ts
+++ b/tests/tinyhypergraph-candidate-storage.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from "bun:test"
+import { shouldUseSparseCandidateStorage } from "lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver"
+
+test("TinyHypergraph candidate storage stays dense below the hop budget", () => {
+  expect(shouldUseSparseCandidateStorage(2000, 2000)).toBe(false)
+  expect(shouldUseSparseCandidateStorage(2001, 2000)).toBe(true)
+})


### PR DESCRIPTION
## Summary

Use dense typed-array candidate storage when a TinyHypergraph has at most 4,000,000 port×region hops, while retaining sparse storage for larger graphs. Apply the same choice to both whole-graph and section solver options, and add a focused threshold boundary test.

This reduces candidate `Map` overhead on bounded graphs without exposing large graphs to unbounded dense allocation.

## Benchmark results

Campaign `campaign-20260810T093158Z-5d53f53e`, phase 4  
Record `20260810T114330Z-16b122e6`

Three paired baseline/candidate trials:

- dataset01: completion 100.0% → 100.0%, relaxed DRC 90.0% → 90.0%, timeouts 0.0% → 0.0%, p50 3.21s → 2.99s (6.6% faster), p95 17.52s → 16.24s (5.8% faster), average vias 36.7 → 36.7
- srj18: completion 37.5% → 37.5%, relaxed DRC 31.3% → 31.3%, timeouts 56.2% → 56.2%, p50 65.13s → 64.97s, p95 86.76s → 86.96s, average vias 164.0 → 164.0

Focused srj18 profiling reduced port-point pathing from 1497ms to about 1455ms with the same 153,501 iterations.

## Validation

- `bun test tests/tinyhypergraph-candidate-storage.test.ts --timeout 9999999`
- `bun run build`