### PR TITLE
Protect autorouter benchmark integrity from invalid PCB placements

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@tsci/tscircuit.dataset-srj20-partial-bga-breakouts": "git+https://github.com/tscircuit/dataset-srj20.git#9384fb8f45fb479b97178ddfa42fc74c69afbbec",
     "@tsci/0hmX.multi-component-dataset-srj01": "git+https://github.com/tscircuit/multi-component-dataset-srj01.git#abf9d17c966d466b56ac21b735c6bb6f4518919d",
     "@tsci/tscircuit.dataset-srj12-bus-routing": "git+https://github.com/tscircuit/dataset-srj12-bus-routing.git#ba82f86a7d1288566b7144eb8661ad2549c5f328",
-    "@tscircuit/autorouting-dataset-01": "git+https://github.com/tscircuit/autorouting-dataset-01.git#52c45500b04d0380aa2a1be9b4c6f32d9b138553",
+    "@tscircuit/autorouting-dataset-01": "git+https://github.com/tscircuit/autorouting-dataset-01.git#4f795dcfee01db1573670e1edac52814457b666c",
     "@tscircuit/checks": "^0.0.145",
     "@tscircuit/circuit-json-util": "^0.0.94",
     "@tscircuit/core": "0.0.337",


### PR DESCRIPTION
## Impact

This protects autorouter benchmark integrity: DRC improvements can no longer come from physically invalid benchmark boards.

Using canonical Pipeline 7 at effort 1, the validated dataset changes:

| Metric | Previous dataset | Validated dataset |
| --- | ---: | ---: |
| Completed | 85/85 | 85/85 |
| DRC clean | 77/85 (90.6%) | 82/85 (96.5%) |
| Clean → failing regressions | — | 0 |
| Average vias | 37.71 | 37.52 |

Five boards become newly DRC-clean: `circuit114`, `circuit134`, `circuit137`, `circuit142`, and `circuit148`. The remaining failures—`circuit018`, `circuit140`, and `circuit143`—are real routing-clearance issues rather than invalid source placements.

## Root cause

The autorouter was pinned to dataset01 before its placement-quality gate. Some benchmark inputs contained impossible physical layouts, including plated holes over SMT pads, cross-net footprint overlaps, and components outside the board. Those inputs could distort DRC results and hide the router's actual behavior.

## Change

Pin `@tscircuit/autorouting-dataset-01` from `52c4550` to merged dataset commit `4f795dc` ([dataset PR #126](https://github.com/tscircuit/autorouting-dataset-01/pull/126)).

That dataset revision:

- validates rendered Circuit JSON with tscircuit's official `runAllPlacementChecks`
- blocks cross-component footprint overlaps and off-board components
- repairs 22 affected circuit placements
- keeps the benchmark snapshots in the dataset PR body rather than this repository

No autorouter solver code changes in this PR.

## Validation

- confirmed merged dataset commit `4f795dc` has the same circuit, dataset, and package content as benchmarked head `5484f97`
- `bun run build`
- canonical `tscircuit-autorouter` `v0.0.790` (`3acb05de`), Pipeline 7, effort 1: 85/85 completed, 82/85 DRC-clean, zero clean-to-failing regressions
