### PR TITLE
Add RP2040 USB-C pad-clearance regression case

### DIFF
--- a/fixtures/bug-reports/bugreport91-rp2040-usbc-clearance/bugreport91-rp2040-usbc-clearance.srj.json
+++ b/fixtures/bug-reports/bugreport91-rp2040-usbc-clearance/bugreport91-rp2040-usbc-clearance.srj.json
@@ -1,0 +1,10502 @@
+{
+  "bounds": {
+    "minX": -20.2,
+    "maxX": 2.2699999999999996,
+    "minY": -27.050000000000004,
+    "maxY": 39.025
+  },
+  "obstacles": [
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_0",
+        "pcb_port_id": "pcb_port_0"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -12,
+        "y": 23.8
+      },
+      "width": 0.95,
+      "height": 1.2,
+      "connectedTo": [
+        "pcb_smtpad_0",
+        "source_trace_69",
+        "source_trace_6",
+        "source_trace_5",
+        "source_net_15",
+        "pcb_port_0",
+        "pcb_smtpad_2",
+        "pcb_port_2",
+        "pcb_smtpad_104",
+        "pcb_port_108"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_1",
+        "pcb_port_id": "pcb_port_1"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -12,
+        "y": 27.2
+      },
+      "width": 0.95,
+      "height": 1.2,
+      "connectedTo": [
+        "pcb_smtpad_1",
+        "source_trace_67",
+        "source_trace_52",
+        "source_trace_51",
+        "source_trace_4",
+        "source_net_14",
+        "pcb_port_1",
+        "pcb_smtpad_27",
+        "pcb_port_31",
+        "pcb_smtpad_36",
+        "pcb_port_40",
+        "pcb_smtpad_139",
+        "pcb_port_143"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_2",
+        "pcb_port_id": "pcb_port_2"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -14.7,
+        "y": 21.29
+      },
+      "width": 0.64,
+      "height": 0.54,
+      "connectedTo": [
+        "pcb_smtpad_2",
+        "source_trace_69",
+        "source_trace_6",
+        "source_trace_5",
+        "source_net_15",
+        "pcb_smtpad_0",
+        "pcb_port_0",
+        "pcb_port_2",
+        "pcb_smtpad_104",
+        "pcb_port_108"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_3",
+        "pcb_port_id": "pcb_port_3"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -14.7,
+        "y": 22.310000000000002
+      },
+      "width": 0.64,
+      "height": 0.54,
+      "connectedTo": [
+        "pcb_smtpad_3",
+        "source_trace_7",
+        "pcb_port_3",
+        "pcb_smtpad_106",
+        "pcb_port_110"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_4",
+        "pcb_port_id": "pcb_port_4"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -14.51,
+        "y": -0.5
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_4",
+        "source_trace_106",
+        "source_trace_100",
+        "source_trace_94",
+        "source_trace_83",
+        "source_trace_78",
+        "source_trace_76",
+        "source_trace_72",
+        "source_trace_70",
+        "source_trace_50",
+        "source_trace_48",
+        "source_trace_46",
+        "source_trace_43",
+        "source_trace_42",
+        "source_trace_41",
+        "source_trace_40",
+        "source_trace_39",
+        "source_trace_38",
+        "source_trace_25",
+        "source_trace_23",
+        "source_trace_21",
+        "source_trace_17",
+        "source_trace_14",
+        "source_trace_12",
+        "source_trace_10",
+        "source_trace_8",
+        "source_net_16",
+        "pcb_port_4",
+        "pcb_smtpad_6",
+        "pcb_port_6",
+        "pcb_smtpad_8",
+        "pcb_port_8",
+        "pcb_smtpad_10",
+        "pcb_port_10",
+        "pcb_smtpad_12",
+        "pcb_port_12",
+        "pcb_smtpad_14",
+        "pcb_port_14",
+        "pcb_smtpad_17",
+        "pcb_port_17",
+        "pcb_smtpad_21",
+        "pcb_port_21",
+        "pcb_smtpad_22",
+        "pcb_port_22",
+        "pcb_smtpad_38",
+        "pcb_port_42",
+        "pcb_smtpad_47",
+        "pcb_port_51",
+        "pcb_smtpad_59",
+        "pcb_port_63",
+        "pcb_smtpad_70",
+        "pcb_port_74",
+        "pcb_smtpad_79",
+        "pcb_port_83",
+        "pcb_smtpad_81",
+        "pcb_port_85",
+        "pcb_smtpad_85",
+        "pcb_port_89",
+        "pcb_smtpad_86",
+        "pcb_port_90",
+        "pcb_smtpad_108",
+        "pcb_port_112",
+        "pcb_smtpad_126",
+        "pcb_port_130",
+        "pcb_smtpad_129",
+        "pcb_port_133",
+        "pcb_smtpad_141",
+        "pcb_port_145",
+        "pcb_smtpad_145",
+        "pcb_port_149",
+        "pcb_smtpad_151",
+        "pcb_port_155",
+        "pcb_smtpad_156",
+        "pcb_port_160"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_5",
+        "pcb_port_id": "pcb_port_5"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -13.49,
+        "y": -0.5
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_5",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_port_5",
+        "pcb_smtpad_7",
+        "pcb_port_7",
+        "pcb_smtpad_9",
+        "pcb_port_9",
+        "pcb_smtpad_11",
+        "pcb_port_11",
+        "pcb_smtpad_13",
+        "pcb_port_13",
+        "pcb_smtpad_15",
+        "pcb_port_15",
+        "pcb_smtpad_19",
+        "pcb_port_19",
+        "pcb_smtpad_23",
+        "pcb_port_23",
+        "pcb_smtpad_25",
+        "pcb_port_25",
+        "pcb_plated_hole_0",
+        "pcb_port_26",
+        "pcb_plated_hole_1",
+        "pcb_port_27",
+        "pcb_plated_hole_2",
+        "pcb_port_28",
+        "pcb_plated_hole_3",
+        "pcb_port_29",
+        "pcb_smtpad_26",
+        "pcb_port_30",
+        "pcb_smtpad_37",
+        "pcb_port_41",
+        "pcb_smtpad_56",
+        "pcb_port_60",
+        "pcb_smtpad_94",
+        "pcb_port_98",
+        "pcb_smtpad_101",
+        "pcb_port_102",
+        "pcb_smtpad_103",
+        "pcb_port_107",
+        "pcb_smtpad_105",
+        "pcb_port_109",
+        "pcb_smtpad_112",
+        "pcb_port_113",
+        "pcb_smtpad_110",
+        "pcb_port_114",
+        "pcb_smtpad_115",
+        "pcb_port_119",
+        "pcb_smtpad_120",
+        "pcb_port_124",
+        "pcb_smtpad_121",
+        "pcb_port_126",
+        "pcb_smtpad_123",
+        "pcb_port_128",
+        "pcb_smtpad_132",
+        "pcb_port_136",
+        "pcb_smtpad_134",
+        "pcb_port_138",
+        "pcb_smtpad_140",
+        "pcb_port_144",
+        "pcb_smtpad_142",
+        "pcb_port_146",
+        "pcb_smtpad_144",
+        "pcb_port_148",
+        "pcb_smtpad_146",
+        "pcb_port_150",
+        "pcb_smtpad_148",
+        "pcb_port_152",
+        "pcb_smtpad_150",
+        "pcb_port_154",
+        "pcb_smtpad_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_0"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_6",
+        "pcb_port_id": "pcb_port_6"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -13.51,
+        "y": 10.5
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_6",
+        "source_trace_106",
+        "source_trace_100",
+        "source_trace_94",
+        "source_trace_83",
+        "source_trace_78",
+        "source_trace_76",
+        "source_trace_72",
+        "source_trace_70",
+        "source_trace_50",
+        "source_trace_48",
+        "source_trace_46",
+        "source_trace_43",
+        "source_trace_42",
+        "source_trace_41",
+        "source_trace_40",
+        "source_trace_39",
+        "source_trace_38",
+        "source_trace_25",
+        "source_trace_23",
+        "source_trace_21",
+        "source_trace_17",
+        "source_trace_14",
+        "source_trace_12",
+        "source_trace_10",
+        "source_trace_8",
+        "source_net_16",
+        "pcb_smtpad_4",
+        "pcb_port_4",
+        "pcb_port_6",
+        "pcb_smtpad_8",
+        "pcb_port_8",
+        "pcb_smtpad_10",
+        "pcb_port_10",
+        "pcb_smtpad_12",
+        "pcb_port_12",
+        "pcb_smtpad_14",
+        "pcb_port_14",
+        "pcb_smtpad_17",
+        "pcb_port_17",
+        "pcb_smtpad_21",
+        "pcb_port_21",
+        "pcb_smtpad_22",
+        "pcb_port_22",
+        "pcb_smtpad_38",
+        "pcb_port_42",
+        "pcb_smtpad_47",
+        "pcb_port_51",
+        "pcb_smtpad_59",
+        "pcb_port_63",
+        "pcb_smtpad_70",
+        "pcb_port_74",
+        "pcb_smtpad_79",
+        "pcb_port_83",
+        "pcb_smtpad_81",
+        "pcb_port_85",
+        "pcb_smtpad_85",
+        "pcb_port_89",
+        "pcb_smtpad_86",
+        "pcb_port_90",
+        "pcb_smtpad_108",
+        "pcb_port_112",
+        "pcb_smtpad_126",
+        "pcb_port_130",
+        "pcb_smtpad_129",
+        "pcb_port_133",
+        "pcb_smtpad_141",
+        "pcb_port_145",
+        "pcb_smtpad_145",
+        "pcb_port_149",
+        "pcb_smtpad_151",
+        "pcb_port_155",
+        "pcb_smtpad_156",
+        "pcb_port_160"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_7",
+        "pcb_port_id": "pcb_port_7"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -12.49,
+        "y": 10.5
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_7",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_smtpad_5",
+        "pcb_port_5",
+        "pcb_port_7",
+        "pcb_smtpad_9",
+        "pcb_port_9",
+        "pcb_smtpad_11",
+        "pcb_port_11",
+        "pcb_smtpad_13",
+        "pcb_port_13",
+        "pcb_smtpad_15",
+        "pcb_port_15",
+        "pcb_smtpad_19",
+        "pcb_port_19",
+        "pcb_smtpad_23",
+        "pcb_port_23",
+        "pcb_smtpad_25",
+        "pcb_port_25",
+        "pcb_plated_hole_0",
+        "pcb_port_26",
+        "pcb_plated_hole_1",
+        "pcb_port_27",
+        "pcb_plated_hole_2",
+        "pcb_port_28",
+        "pcb_plated_hole_3",
+        "pcb_port_29",
+        "pcb_smtpad_26",
+        "pcb_port_30",
+        "pcb_smtpad_37",
+        "pcb_port_41",
+        "pcb_smtpad_56",
+        "pcb_port_60",
+        "pcb_smtpad_94",
+        "pcb_port_98",
+        "pcb_smtpad_101",
+        "pcb_port_102",
+        "pcb_smtpad_103",
+        "pcb_port_107",
+        "pcb_smtpad_105",
+        "pcb_port_109",
+        "pcb_smtpad_112",
+        "pcb_port_113",
+        "pcb_smtpad_110",
+        "pcb_port_114",
+        "pcb_smtpad_115",
+        "pcb_port_119",
+        "pcb_smtpad_120",
+        "pcb_port_124",
+        "pcb_smtpad_121",
+        "pcb_port_126",
+        "pcb_smtpad_123",
+        "pcb_port_128",
+        "pcb_smtpad_132",
+        "pcb_port_136",
+        "pcb_smtpad_134",
+        "pcb_port_138",
+        "pcb_smtpad_140",
+        "pcb_port_144",
+        "pcb_smtpad_142",
+        "pcb_port_146",
+        "pcb_smtpad_144",
+        "pcb_port_148",
+        "pcb_smtpad_146",
+        "pcb_port_150",
+        "pcb_smtpad_148",
+        "pcb_port_152",
+        "pcb_smtpad_150",
+        "pcb_port_154",
+        "pcb_smtpad_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_0"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_8",
+        "pcb_port_id": "pcb_port_8"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -18,
+        "y": 4.01
+      },
+      "width": 0.64,
+      "height": 0.54,
+      "connectedTo": [
+        "pcb_smtpad_8",
+        "source_trace_106",
+        "source_trace_100",
+        "source_trace_94",
+        "source_trace_83",
+        "source_trace_78",
+        "source_trace_76",
+        "source_trace_72",
+        "source_trace_70",
+        "source_trace_50",
+        "source_trace_48",
+        "source_trace_46",
+        "source_trace_43",
+        "source_trace_42",
+        "source_trace_41",
+        "source_trace_40",
+        "source_trace_39",
+        "source_trace_38",
+        "source_trace_25",
+        "source_trace_23",
+        "source_trace_21",
+        "source_trace_17",
+        "source_trace_14",
+        "source_trace_12",
+        "source_trace_10",
+        "source_trace_8",
+        "source_net_16",
+        "pcb_smtpad_4",
+        "pcb_port_4",
+        "pcb_smtpad_6",
+        "pcb_port_6",
+        "pcb_port_8",
+        "pcb_smtpad_10",
+        "pcb_port_10",
+        "pcb_smtpad_12",
+        "pcb_port_12",
+        "pcb_smtpad_14",
+        "pcb_port_14",
+        "pcb_smtpad_17",
+        "pcb_port_17",
+        "pcb_smtpad_21",
+        "pcb_port_21",
+        "pcb_smtpad_22",
+        "pcb_port_22",
+        "pcb_smtpad_38",
+        "pcb_port_42",
+        "pcb_smtpad_47",
+        "pcb_port_51",
+        "pcb_smtpad_59",
+        "pcb_port_63",
+        "pcb_smtpad_70",
+        "pcb_port_74",
+        "pcb_smtpad_79",
+        "pcb_port_83",
+        "pcb_smtpad_81",
+        "pcb_port_85",
+        "pcb_smtpad_85",
+        "pcb_port_89",
+        "pcb_smtpad_86",
+        "pcb_port_90",
+        "pcb_smtpad_108",
+        "pcb_port_112",
+        "pcb_smtpad_126",
+        "pcb_port_130",
+        "pcb_smtpad_129",
+        "pcb_port_133",
+        "pcb_smtpad_141",
+        "pcb_port_145",
+        "pcb_smtpad_145",
+        "pcb_port_149",
+        "pcb_smtpad_151",
+        "pcb_port_155",
+        "pcb_smtpad_156",
+        "pcb_port_160"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_9",
+        "pcb_port_id": "pcb_port_9"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -18,
+        "y": 2.99
+      },
+      "width": 0.64,
+      "height": 0.54,
+      "connectedTo": [
+        "pcb_smtpad_9",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_smtpad_5",
+        "pcb_port_5",
+        "pcb_smtpad_7",
+        "pcb_port_7",
+        "pcb_port_9",
+        "pcb_smtpad_11",
+        "pcb_port_11",
+        "pcb_smtpad_13",
+        "pcb_port_13",
+        "pcb_smtpad_15",
+        "pcb_port_15",
+        "pcb_smtpad_19",
+        "pcb_port_19",
+        "pcb_smtpad_23",
+        "pcb_port_23",
+        "pcb_smtpad_25",
+        "pcb_port_25",
+        "pcb_plated_hole_0",
+        "pcb_port_26",
+        "pcb_plated_hole_1",
+        "pcb_port_27",
+        "pcb_plated_hole_2",
+        "pcb_port_28",
+        "pcb_plated_hole_3",
+        "pcb_port_29",
+        "pcb_smtpad_26",
+        "pcb_port_30",
+        "pcb_smtpad_37",
+        "pcb_port_41",
+        "pcb_smtpad_56",
+        "pcb_port_60",
+        "pcb_smtpad_94",
+        "pcb_port_98",
+        "pcb_smtpad_101",
+        "pcb_port_102",
+        "pcb_smtpad_103",
+        "pcb_port_107",
+        "pcb_smtpad_105",
+        "pcb_port_109",
+        "pcb_smtpad_112",
+        "pcb_port_113",
+        "pcb_smtpad_110",
+        "pcb_port_114",
+        "pcb_smtpad_115",
+        "pcb_port_119",
+        "pcb_smtpad_120",
+        "pcb_port_124",
+        "pcb_smtpad_121",
+        "pcb_port_126",
+        "pcb_smtpad_123",
+        "pcb_port_128",
+        "pcb_smtpad_132",
+        "pcb_port_136",
+        "pcb_smtpad_134",
+        "pcb_port_138",
+        "pcb_smtpad_140",
+        "pcb_port_144",
+        "pcb_smtpad_142",
+        "pcb_port_146",
+        "pcb_smtpad_144",
+        "pcb_port_148",
+        "pcb_smtpad_146",
+        "pcb_port_150",
+        "pcb_smtpad_148",
+        "pcb_port_152",
+        "pcb_smtpad_150",
+        "pcb_port_154",
+        "pcb_smtpad_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_0"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_10",
+        "pcb_port_id": "pcb_port_10"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -14.51,
+        "y": -1.5
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_10",
+        "source_trace_106",
+        "source_trace_100",
+        "source_trace_94",
+        "source_trace_83",
+        "source_trace_78",
+        "source_trace_76",
+        "source_trace_72",
+        "source_trace_70",
+        "source_trace_50",
+        "source_trace_48",
+        "source_trace_46",
+        "source_trace_43",
+        "source_trace_42",
+        "source_trace_41",
+        "source_trace_40",
+        "source_trace_39",
+        "source_trace_38",
+        "source_trace_25",
+        "source_trace_23",
+        "source_trace_21",
+        "source_trace_17",
+        "source_trace_14",
+        "source_trace_12",
+        "source_trace_10",
+        "source_trace_8",
+        "source_net_16",
+        "pcb_smtpad_4",
+        "pcb_port_4",
+        "pcb_smtpad_6",
+        "pcb_port_6",
+        "pcb_smtpad_8",
+        "pcb_port_8",
+        "pcb_port_10",
+        "pcb_smtpad_12",
+        "pcb_port_12",
+        "pcb_smtpad_14",
+        "pcb_port_14",
+        "pcb_smtpad_17",
+        "pcb_port_17",
+        "pcb_smtpad_21",
+        "pcb_port_21",
+        "pcb_smtpad_22",
+        "pcb_port_22",
+        "pcb_smtpad_38",
+        "pcb_port_42",
+        "pcb_smtpad_47",
+        "pcb_port_51",
+        "pcb_smtpad_59",
+        "pcb_port_63",
+        "pcb_smtpad_70",
+        "pcb_port_74",
+        "pcb_smtpad_79",
+        "pcb_port_83",
+        "pcb_smtpad_81",
+        "pcb_port_85",
+        "pcb_smtpad_85",
+        "pcb_port_89",
+        "pcb_smtpad_86",
+        "pcb_port_90",
+        "pcb_smtpad_108",
+        "pcb_port_112",
+        "pcb_smtpad_126",
+        "pcb_port_130",
+        "pcb_smtpad_129",
+        "pcb_port_133",
+        "pcb_smtpad_141",
+        "pcb_port_145",
+        "pcb_smtpad_145",
+        "pcb_port_149",
+        "pcb_smtpad_151",
+        "pcb_port_155",
+        "pcb_smtpad_156",
+        "pcb_port_160"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_11",
+        "pcb_port_id": "pcb_port_11"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -13.49,
+        "y": -1.5
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_11",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_smtpad_5",
+        "pcb_port_5",
+        "pcb_smtpad_7",
+        "pcb_port_7",
+        "pcb_smtpad_9",
+        "pcb_port_9",
+        "pcb_port_11",
+        "pcb_smtpad_13",
+        "pcb_port_13",
+        "pcb_smtpad_15",
+        "pcb_port_15",
+        "pcb_smtpad_19",
+        "pcb_port_19",
+        "pcb_smtpad_23",
+        "pcb_port_23",
+        "pcb_smtpad_25",
+        "pcb_port_25",
+        "pcb_plated_hole_0",
+        "pcb_port_26",
+        "pcb_plated_hole_1",
+        "pcb_port_27",
+        "pcb_plated_hole_2",
+        "pcb_port_28",
+        "pcb_plated_hole_3",
+        "pcb_port_29",
+        "pcb_smtpad_26",
+        "pcb_port_30",
+        "pcb_smtpad_37",
+        "pcb_port_41",
+        "pcb_smtpad_56",
+        "pcb_port_60",
+        "pcb_smtpad_94",
+        "pcb_port_98",
+        "pcb_smtpad_101",
+        "pcb_port_102",
+        "pcb_smtpad_103",
+        "pcb_port_107",
+        "pcb_smtpad_105",
+        "pcb_port_109",
+        "pcb_smtpad_112",
+        "pcb_port_113",
+        "pcb_smtpad_110",
+        "pcb_port_114",
+        "pcb_smtpad_115",
+        "pcb_port_119",
+        "pcb_smtpad_120",
+        "pcb_port_124",
+        "pcb_smtpad_121",
+        "pcb_port_126",
+        "pcb_smtpad_123",
+        "pcb_port_128",
+        "pcb_smtpad_132",
+        "pcb_port_136",
+        "pcb_smtpad_134",
+        "pcb_port_138",
+        "pcb_smtpad_140",
+        "pcb_port_144",
+        "pcb_smtpad_142",
+        "pcb_port_146",
+        "pcb_smtpad_144",
+        "pcb_port_148",
+        "pcb_smtpad_146",
+        "pcb_port_150",
+        "pcb_smtpad_148",
+        "pcb_port_152",
+        "pcb_smtpad_150",
+        "pcb_port_154",
+        "pcb_smtpad_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_0"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_12",
+        "pcb_port_id": "pcb_port_12"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -11,
+        "y": -6.49
+      },
+      "width": 0.64,
+      "height": 0.54,
+      "connectedTo": [
+        "pcb_smtpad_12",
+        "source_trace_106",
+        "source_trace_100",
+        "source_trace_94",
+        "source_trace_83",
+        "source_trace_78",
+        "source_trace_76",
+        "source_trace_72",
+        "source_trace_70",
+        "source_trace_50",
+        "source_trace_48",
+        "source_trace_46",
+        "source_trace_43",
+        "source_trace_42",
+        "source_trace_41",
+        "source_trace_40",
+        "source_trace_39",
+        "source_trace_38",
+        "source_trace_25",
+        "source_trace_23",
+        "source_trace_21",
+        "source_trace_17",
+        "source_trace_14",
+        "source_trace_12",
+        "source_trace_10",
+        "source_trace_8",
+        "source_net_16",
+        "pcb_smtpad_4",
+        "pcb_port_4",
+        "pcb_smtpad_6",
+        "pcb_port_6",
+        "pcb_smtpad_8",
+        "pcb_port_8",
+        "pcb_smtpad_10",
+        "pcb_port_10",
+        "pcb_port_12",
+        "pcb_smtpad_14",
+        "pcb_port_14",
+        "pcb_smtpad_17",
+        "pcb_port_17",
+        "pcb_smtpad_21",
+        "pcb_port_21",
+        "pcb_smtpad_22",
+        "pcb_port_22",
+        "pcb_smtpad_38",
+        "pcb_port_42",
+        "pcb_smtpad_47",
+        "pcb_port_51",
+        "pcb_smtpad_59",
+        "pcb_port_63",
+        "pcb_smtpad_70",
+        "pcb_port_74",
+        "pcb_smtpad_79",
+        "pcb_port_83",
+        "pcb_smtpad_81",
+        "pcb_port_85",
+        "pcb_smtpad_85",
+        "pcb_port_89",
+        "pcb_smtpad_86",
+        "pcb_port_90",
+        "pcb_smtpad_108",
+        "pcb_port_112",
+        "pcb_smtpad_126",
+        "pcb_port_130",
+        "pcb_smtpad_129",
+        "pcb_port_133",
+        "pcb_smtpad_141",
+        "pcb_port_145",
+        "pcb_smtpad_145",
+        "pcb_port_149",
+        "pcb_smtpad_151",
+        "pcb_port_155",
+        "pcb_smtpad_156",
+        "pcb_port_160"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_13",
+        "pcb_port_id": "pcb_port_13"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -11,
+        "y": -7.51
+      },
+      "width": 0.64,
+      "height": 0.54,
+      "connectedTo": [
+        "pcb_smtpad_13",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_smtpad_5",
+        "pcb_port_5",
+        "pcb_smtpad_7",
+        "pcb_port_7",
+        "pcb_smtpad_9",
+        "pcb_port_9",
+        "pcb_smtpad_11",
+        "pcb_port_11",
+        "pcb_port_13",
+        "pcb_smtpad_15",
+        "pcb_port_15",
+        "pcb_smtpad_19",
+        "pcb_port_19",
+        "pcb_smtpad_23",
+        "pcb_port_23",
+        "pcb_smtpad_25",
+        "pcb_port_25",
+        "pcb_plated_hole_0",
+        "pcb_port_26",
+        "pcb_plated_hole_1",
+        "pcb_port_27",
+        "pcb_plated_hole_2",
+        "pcb_port_28",
+        "pcb_plated_hole_3",
+        "pcb_port_29",
+        "pcb_smtpad_26",
+        "pcb_port_30",
+        "pcb_smtpad_37",
+        "pcb_port_41",
+        "pcb_smtpad_56",
+        "pcb_port_60",
+        "pcb_smtpad_94",
+        "pcb_port_98",
+        "pcb_smtpad_101",
+        "pcb_port_102",
+        "pcb_smtpad_103",
+        "pcb_port_107",
+        "pcb_smtpad_105",
+        "pcb_port_109",
+        "pcb_smtpad_112",
+        "pcb_port_113",
+        "pcb_smtpad_110",
+        "pcb_port_114",
+        "pcb_smtpad_115",
+        "pcb_port_119",
+        "pcb_smtpad_120",
+        "pcb_port_124",
+        "pcb_smtpad_121",
+        "pcb_port_126",
+        "pcb_smtpad_123",
+        "pcb_port_128",
+        "pcb_smtpad_132",
+        "pcb_port_136",
+        "pcb_smtpad_134",
+        "pcb_port_138",
+        "pcb_smtpad_140",
+        "pcb_port_144",
+        "pcb_smtpad_142",
+        "pcb_port_146",
+        "pcb_smtpad_144",
+        "pcb_port_148",
+        "pcb_smtpad_146",
+        "pcb_port_150",
+        "pcb_smtpad_148",
+        "pcb_port_152",
+        "pcb_smtpad_150",
+        "pcb_port_154",
+        "pcb_smtpad_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_0"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_14",
+        "pcb_port_id": "pcb_port_14"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -18.51,
+        "y": 6.1
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_14",
+        "source_trace_106",
+        "source_trace_100",
+        "source_trace_94",
+        "source_trace_83",
+        "source_trace_78",
+        "source_trace_76",
+        "source_trace_72",
+        "source_trace_70",
+        "source_trace_50",
+        "source_trace_48",
+        "source_trace_46",
+        "source_trace_43",
+        "source_trace_42",
+        "source_trace_41",
+        "source_trace_40",
+        "source_trace_39",
+        "source_trace_38",
+        "source_trace_25",
+        "source_trace_23",
+        "source_trace_21",
+        "source_trace_17",
+        "source_trace_14",
+        "source_trace_12",
+        "source_trace_10",
+        "source_trace_8",
+        "source_net_16",
+        "pcb_smtpad_4",
+        "pcb_port_4",
+        "pcb_smtpad_6",
+        "pcb_port_6",
+        "pcb_smtpad_8",
+        "pcb_port_8",
+        "pcb_smtpad_10",
+        "pcb_port_10",
+        "pcb_smtpad_12",
+        "pcb_port_12",
+        "pcb_port_14",
+        "pcb_smtpad_17",
+        "pcb_port_17",
+        "pcb_smtpad_21",
+        "pcb_port_21",
+        "pcb_smtpad_22",
+        "pcb_port_22",
+        "pcb_smtpad_38",
+        "pcb_port_42",
+        "pcb_smtpad_47",
+        "pcb_port_51",
+        "pcb_smtpad_59",
+        "pcb_port_63",
+        "pcb_smtpad_70",
+        "pcb_port_74",
+        "pcb_smtpad_79",
+        "pcb_port_83",
+        "pcb_smtpad_81",
+        "pcb_port_85",
+        "pcb_smtpad_85",
+        "pcb_port_89",
+        "pcb_smtpad_86",
+        "pcb_port_90",
+        "pcb_smtpad_108",
+        "pcb_port_112",
+        "pcb_smtpad_126",
+        "pcb_port_130",
+        "pcb_smtpad_129",
+        "pcb_port_133",
+        "pcb_smtpad_141",
+        "pcb_port_145",
+        "pcb_smtpad_145",
+        "pcb_port_149",
+        "pcb_smtpad_151",
+        "pcb_port_155",
+        "pcb_smtpad_156",
+        "pcb_port_160"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_15",
+        "pcb_port_id": "pcb_port_15"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -17.49,
+        "y": 6.1
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_15",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_smtpad_5",
+        "pcb_port_5",
+        "pcb_smtpad_7",
+        "pcb_port_7",
+        "pcb_smtpad_9",
+        "pcb_port_9",
+        "pcb_smtpad_11",
+        "pcb_port_11",
+        "pcb_smtpad_13",
+        "pcb_port_13",
+        "pcb_port_15",
+        "pcb_smtpad_19",
+        "pcb_port_19",
+        "pcb_smtpad_23",
+        "pcb_port_23",
+        "pcb_smtpad_25",
+        "pcb_port_25",
+        "pcb_plated_hole_0",
+        "pcb_port_26",
+        "pcb_plated_hole_1",
+        "pcb_port_27",
+        "pcb_plated_hole_2",
+        "pcb_port_28",
+        "pcb_plated_hole_3",
+        "pcb_port_29",
+        "pcb_smtpad_26",
+        "pcb_port_30",
+        "pcb_smtpad_37",
+        "pcb_port_41",
+        "pcb_smtpad_56",
+        "pcb_port_60",
+        "pcb_smtpad_94",
+        "pcb_port_98",
+        "pcb_smtpad_101",
+        "pcb_port_102",
+        "pcb_smtpad_103",
+        "pcb_port_107",
+        "pcb_smtpad_105",
+        "pcb_port_109",
+        "pcb_smtpad_112",
+        "pcb_port_113",
+        "pcb_smtpad_110",
+        "pcb_port_114",
+        "pcb_smtpad_115",
+        "pcb_port_119",
+        "pcb_smtpad_120",
+        "pcb_port_124",
+        "pcb_smtpad_121",
+        "pcb_port_126",
+        "pcb_smtpad_123",
+        "pcb_port_128",
+        "pcb_smtpad_132",
+        "pcb_port_136",
+        "pcb_smtpad_134",
+        "pcb_port_138",
+        "pcb_smtpad_140",
+        "pcb_port_144",
+        "pcb_smtpad_142",
+        "pcb_port_146",
+        "pcb_smtpad_144",
+        "pcb_port_148",
+        "pcb_smtpad_146",
+        "pcb_port_150",
+        "pcb_smtpad_148",
+        "pcb_port_152",
+        "pcb_smtpad_150",
+        "pcb_port_154",
+        "pcb_smtpad_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_0"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_16",
+        "pcb_port_id": "pcb_port_16"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -0.10999999999999965,
+        "y": -1
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_16",
+        "source_trace_95",
+        "source_trace_16",
+        "pcb_port_16",
+        "pcb_smtpad_63",
+        "pcb_port_67",
+        "pcb_smtpad_117",
+        "pcb_port_121"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_3"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_17",
+        "pcb_port_id": "pcb_port_17"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": 0.9100000000000004,
+        "y": -1
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_17",
+        "source_trace_106",
+        "source_trace_100",
+        "source_trace_94",
+        "source_trace_83",
+        "source_trace_78",
+        "source_trace_76",
+        "source_trace_72",
+        "source_trace_70",
+        "source_trace_50",
+        "source_trace_48",
+        "source_trace_46",
+        "source_trace_43",
+        "source_trace_42",
+        "source_trace_41",
+        "source_trace_40",
+        "source_trace_39",
+        "source_trace_38",
+        "source_trace_25",
+        "source_trace_23",
+        "source_trace_21",
+        "source_trace_17",
+        "source_trace_14",
+        "source_trace_12",
+        "source_trace_10",
+        "source_trace_8",
+        "source_net_16",
+        "pcb_smtpad_4",
+        "pcb_port_4",
+        "pcb_smtpad_6",
+        "pcb_port_6",
+        "pcb_smtpad_8",
+        "pcb_port_8",
+        "pcb_smtpad_10",
+        "pcb_port_10",
+        "pcb_smtpad_12",
+        "pcb_port_12",
+        "pcb_smtpad_14",
+        "pcb_port_14",
+        "pcb_port_17",
+        "pcb_smtpad_21",
+        "pcb_port_21",
+        "pcb_smtpad_22",
+        "pcb_port_22",
+        "pcb_smtpad_38",
+        "pcb_port_42",
+        "pcb_smtpad_47",
+        "pcb_port_51",
+        "pcb_smtpad_59",
+        "pcb_port_63",
+        "pcb_smtpad_70",
+        "pcb_port_74",
+        "pcb_smtpad_79",
+        "pcb_port_83",
+        "pcb_smtpad_81",
+        "pcb_port_85",
+        "pcb_smtpad_85",
+        "pcb_port_89",
+        "pcb_smtpad_86",
+        "pcb_port_90",
+        "pcb_smtpad_108",
+        "pcb_port_112",
+        "pcb_smtpad_126",
+        "pcb_port_130",
+        "pcb_smtpad_129",
+        "pcb_port_133",
+        "pcb_smtpad_141",
+        "pcb_port_145",
+        "pcb_smtpad_145",
+        "pcb_port_149",
+        "pcb_smtpad_151",
+        "pcb_port_155",
+        "pcb_smtpad_156",
+        "pcb_port_160"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_18",
+        "pcb_port_id": "pcb_port_18"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -8.69,
+        "y": 15.7
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_18",
+        "source_trace_82",
+        "source_trace_19",
+        "pcb_port_18",
+        "pcb_smtpad_20",
+        "pcb_port_20",
+        "pcb_smtpad_96",
+        "pcb_port_106"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_19",
+        "pcb_port_id": "pcb_port_19"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -9.709999999999999,
+        "y": 15.7
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_19",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_smtpad_5",
+        "pcb_port_5",
+        "pcb_smtpad_7",
+        "pcb_port_7",
+        "pcb_smtpad_9",
+        "pcb_port_9",
+        "pcb_smtpad_11",
+        "pcb_port_11",
+        "pcb_smtpad_13",
+        "pcb_port_13",
+        "pcb_smtpad_15",
+        "pcb_port_15",
+        "pcb_port_19",
+        "pcb_smtpad_23",
+        "pcb_port_23",
+        "pcb_smtpad_25",
+        "pcb_port_25",
+        "pcb_plated_hole_0",
+        "pcb_port_26",
+        "pcb_plated_hole_1",
+        "pcb_port_27",
+        "pcb_plated_hole_2",
+        "pcb_port_28",
+        "pcb_plated_hole_3",
+        "pcb_port_29",
+        "pcb_smtpad_26",
+        "pcb_port_30",
+        "pcb_smtpad_37",
+        "pcb_port_41",
+        "pcb_smtpad_56",
+        "pcb_port_60",
+        "pcb_smtpad_94",
+        "pcb_port_98",
+        "pcb_smtpad_101",
+        "pcb_port_102",
+        "pcb_smtpad_103",
+        "pcb_port_107",
+        "pcb_smtpad_105",
+        "pcb_port_109",
+        "pcb_smtpad_112",
+        "pcb_port_113",
+        "pcb_smtpad_110",
+        "pcb_port_114",
+        "pcb_smtpad_115",
+        "pcb_port_119",
+        "pcb_smtpad_120",
+        "pcb_port_124",
+        "pcb_smtpad_121",
+        "pcb_port_126",
+        "pcb_smtpad_123",
+        "pcb_port_128",
+        "pcb_smtpad_132",
+        "pcb_port_136",
+        "pcb_smtpad_134",
+        "pcb_port_138",
+        "pcb_smtpad_140",
+        "pcb_port_144",
+        "pcb_smtpad_142",
+        "pcb_port_146",
+        "pcb_smtpad_144",
+        "pcb_port_148",
+        "pcb_smtpad_146",
+        "pcb_port_150",
+        "pcb_smtpad_148",
+        "pcb_port_152",
+        "pcb_smtpad_150",
+        "pcb_port_154",
+        "pcb_smtpad_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_0"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_20",
+        "pcb_port_id": "pcb_port_20"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -8.69,
+        "y": 14.25
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_20",
+        "source_trace_82",
+        "source_trace_19",
+        "pcb_smtpad_18",
+        "pcb_port_18",
+        "pcb_port_20",
+        "pcb_smtpad_96",
+        "pcb_port_106"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_21",
+        "pcb_port_id": "pcb_port_21"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -9.709999999999999,
+        "y": 14.25
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_21",
+        "source_trace_106",
+        "source_trace_100",
+        "source_trace_94",
+        "source_trace_83",
+        "source_trace_78",
+        "source_trace_76",
+        "source_trace_72",
+        "source_trace_70",
+        "source_trace_50",
+        "source_trace_48",
+        "source_trace_46",
+        "source_trace_43",
+        "source_trace_42",
+        "source_trace_41",
+        "source_trace_40",
+        "source_trace_39",
+        "source_trace_38",
+        "source_trace_25",
+        "source_trace_23",
+        "source_trace_21",
+        "source_trace_17",
+        "source_trace_14",
+        "source_trace_12",
+        "source_trace_10",
+        "source_trace_8",
+        "source_net_16",
+        "pcb_smtpad_4",
+        "pcb_port_4",
+        "pcb_smtpad_6",
+        "pcb_port_6",
+        "pcb_smtpad_8",
+        "pcb_port_8",
+        "pcb_smtpad_10",
+        "pcb_port_10",
+        "pcb_smtpad_12",
+        "pcb_port_12",
+        "pcb_smtpad_14",
+        "pcb_port_14",
+        "pcb_smtpad_17",
+        "pcb_port_17",
+        "pcb_port_21",
+        "pcb_smtpad_22",
+        "pcb_port_22",
+        "pcb_smtpad_38",
+        "pcb_port_42",
+        "pcb_smtpad_47",
+        "pcb_port_51",
+        "pcb_smtpad_59",
+        "pcb_port_63",
+        "pcb_smtpad_70",
+        "pcb_port_74",
+        "pcb_smtpad_79",
+        "pcb_port_83",
+        "pcb_smtpad_81",
+        "pcb_port_85",
+        "pcb_smtpad_85",
+        "pcb_port_89",
+        "pcb_smtpad_86",
+        "pcb_port_90",
+        "pcb_smtpad_108",
+        "pcb_port_112",
+        "pcb_smtpad_126",
+        "pcb_port_130",
+        "pcb_smtpad_129",
+        "pcb_port_133",
+        "pcb_smtpad_141",
+        "pcb_port_145",
+        "pcb_smtpad_145",
+        "pcb_port_149",
+        "pcb_smtpad_151",
+        "pcb_port_155",
+        "pcb_smtpad_156",
+        "pcb_port_160"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_22",
+        "pcb_port_id": "pcb_port_22"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -3.3099999999999996,
+        "y": 19
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_22",
+        "source_trace_106",
+        "source_trace_100",
+        "source_trace_94",
+        "source_trace_83",
+        "source_trace_78",
+        "source_trace_76",
+        "source_trace_72",
+        "source_trace_70",
+        "source_trace_50",
+        "source_trace_48",
+        "source_trace_46",
+        "source_trace_43",
+        "source_trace_42",
+        "source_trace_41",
+        "source_trace_40",
+        "source_trace_39",
+        "source_trace_38",
+        "source_trace_25",
+        "source_trace_23",
+        "source_trace_21",
+        "source_trace_17",
+        "source_trace_14",
+        "source_trace_12",
+        "source_trace_10",
+        "source_trace_8",
+        "source_net_16",
+        "pcb_smtpad_4",
+        "pcb_port_4",
+        "pcb_smtpad_6",
+        "pcb_port_6",
+        "pcb_smtpad_8",
+        "pcb_port_8",
+        "pcb_smtpad_10",
+        "pcb_port_10",
+        "pcb_smtpad_12",
+        "pcb_port_12",
+        "pcb_smtpad_14",
+        "pcb_port_14",
+        "pcb_smtpad_17",
+        "pcb_port_17",
+        "pcb_smtpad_21",
+        "pcb_port_21",
+        "pcb_port_22",
+        "pcb_smtpad_38",
+        "pcb_port_42",
+        "pcb_smtpad_47",
+        "pcb_port_51",
+        "pcb_smtpad_59",
+        "pcb_port_63",
+        "pcb_smtpad_70",
+        "pcb_port_74",
+        "pcb_smtpad_79",
+        "pcb_port_83",
+        "pcb_smtpad_81",
+        "pcb_port_85",
+        "pcb_smtpad_85",
+        "pcb_port_89",
+        "pcb_smtpad_86",
+        "pcb_port_90",
+        "pcb_smtpad_108",
+        "pcb_port_112",
+        "pcb_smtpad_126",
+        "pcb_port_130",
+        "pcb_smtpad_129",
+        "pcb_port_133",
+        "pcb_smtpad_141",
+        "pcb_port_145",
+        "pcb_smtpad_145",
+        "pcb_port_149",
+        "pcb_smtpad_151",
+        "pcb_port_155",
+        "pcb_smtpad_156",
+        "pcb_port_160"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_23",
+        "pcb_port_id": "pcb_port_23"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -2.29,
+        "y": 19
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_23",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_smtpad_5",
+        "pcb_port_5",
+        "pcb_smtpad_7",
+        "pcb_port_7",
+        "pcb_smtpad_9",
+        "pcb_port_9",
+        "pcb_smtpad_11",
+        "pcb_port_11",
+        "pcb_smtpad_13",
+        "pcb_port_13",
+        "pcb_smtpad_15",
+        "pcb_port_15",
+        "pcb_smtpad_19",
+        "pcb_port_19",
+        "pcb_port_23",
+        "pcb_smtpad_25",
+        "pcb_port_25",
+        "pcb_plated_hole_0",
+        "pcb_port_26",
+        "pcb_plated_hole_1",
+        "pcb_port_27",
+        "pcb_plated_hole_2",
+        "pcb_port_28",
+        "pcb_plated_hole_3",
+        "pcb_port_29",
+        "pcb_smtpad_26",
+        "pcb_port_30",
+        "pcb_smtpad_37",
+        "pcb_port_41",
+        "pcb_smtpad_56",
+        "pcb_port_60",
+        "pcb_smtpad_94",
+        "pcb_port_98",
+        "pcb_smtpad_101",
+        "pcb_port_102",
+        "pcb_smtpad_103",
+        "pcb_port_107",
+        "pcb_smtpad_105",
+        "pcb_port_109",
+        "pcb_smtpad_112",
+        "pcb_port_113",
+        "pcb_smtpad_110",
+        "pcb_port_114",
+        "pcb_smtpad_115",
+        "pcb_port_119",
+        "pcb_smtpad_120",
+        "pcb_port_124",
+        "pcb_smtpad_121",
+        "pcb_port_126",
+        "pcb_smtpad_123",
+        "pcb_port_128",
+        "pcb_smtpad_132",
+        "pcb_port_136",
+        "pcb_smtpad_134",
+        "pcb_port_138",
+        "pcb_smtpad_140",
+        "pcb_port_144",
+        "pcb_smtpad_142",
+        "pcb_port_146",
+        "pcb_smtpad_144",
+        "pcb_port_148",
+        "pcb_smtpad_146",
+        "pcb_port_150",
+        "pcb_smtpad_148",
+        "pcb_port_152",
+        "pcb_smtpad_150",
+        "pcb_port_154",
+        "pcb_smtpad_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_0"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_24",
+        "pcb_port_id": "pcb_port_24"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -2.51,
+        "y": 0.09999999999999964
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_24",
+        "source_trace_80",
+        "source_trace_79",
+        "source_trace_27",
+        "source_net_17",
+        "pcb_port_24",
+        "pcb_smtpad_80",
+        "pcb_port_84",
+        "pcb_smtpad_152",
+        "pcb_port_156"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_25",
+        "pcb_port_id": "pcb_port_25"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -1.49,
+        "y": 0.09999999999999964
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_25",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_smtpad_5",
+        "pcb_port_5",
+        "pcb_smtpad_7",
+        "pcb_port_7",
+        "pcb_smtpad_9",
+        "pcb_port_9",
+        "pcb_smtpad_11",
+        "pcb_port_11",
+        "pcb_smtpad_13",
+        "pcb_port_13",
+        "pcb_smtpad_15",
+        "pcb_port_15",
+        "pcb_smtpad_19",
+        "pcb_port_19",
+        "pcb_smtpad_23",
+        "pcb_port_23",
+        "pcb_port_25",
+        "pcb_plated_hole_0",
+        "pcb_port_26",
+        "pcb_plated_hole_1",
+        "pcb_port_27",
+        "pcb_plated_hole_2",
+        "pcb_port_28",
+        "pcb_plated_hole_3",
+        "pcb_port_29",
+        "pcb_smtpad_26",
+        "pcb_port_30",
+        "pcb_smtpad_37",
+        "pcb_port_41",
+        "pcb_smtpad_56",
+        "pcb_port_60",
+        "pcb_smtpad_94",
+        "pcb_port_98",
+        "pcb_smtpad_101",
+        "pcb_port_102",
+        "pcb_smtpad_103",
+        "pcb_port_107",
+        "pcb_smtpad_105",
+        "pcb_port_109",
+        "pcb_smtpad_112",
+        "pcb_port_113",
+        "pcb_smtpad_110",
+        "pcb_port_114",
+        "pcb_smtpad_115",
+        "pcb_port_119",
+        "pcb_smtpad_120",
+        "pcb_port_124",
+        "pcb_smtpad_121",
+        "pcb_port_126",
+        "pcb_smtpad_123",
+        "pcb_port_128",
+        "pcb_smtpad_132",
+        "pcb_port_136",
+        "pcb_smtpad_134",
+        "pcb_port_138",
+        "pcb_smtpad_140",
+        "pcb_port_144",
+        "pcb_smtpad_142",
+        "pcb_port_146",
+        "pcb_smtpad_144",
+        "pcb_port_148",
+        "pcb_smtpad_146",
+        "pcb_port_150",
+        "pcb_smtpad_148",
+        "pcb_port_152",
+        "pcb_smtpad_150",
+        "pcb_port_154",
+        "pcb_smtpad_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_0"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_26",
+        "pcb_port_id": "pcb_port_30"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -6.800000000000001,
+        "y": 33.375
+      },
+      "width": 0.55,
+      "height": 1.1,
+      "connectedTo": [
+        "pcb_smtpad_26",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_smtpad_5",
+        "pcb_port_5",
+        "pcb_smtpad_7",
+        "pcb_port_7",
+        "pcb_smtpad_9",
+        "pcb_port_9",
+        "pcb_smtpad_11",
+        "pcb_port_11",
+        "pcb_smtpad_13",
+        "pcb_port_13",
+        "pcb_smtpad_15",
+        "pcb_port_15",
+        "pcb_smtpad_19",
+        "pcb_port_19",
+        "pcb_smtpad_23",
+        "pcb_port_23",
+        "pcb_smtpad_25",
+        "pcb_port_25",
+        "pcb_plated_hole_0",
+        "pcb_port_26",
+        "pcb_plated_hole_1",
+        "pcb_port_27",
+        "pcb_plated_hole_2",
+        "pcb_port_28",
+        "pcb_plated_hole_3",
+        "pcb_port_29",
+        "pcb_port_30",
+        "pcb_smtpad_37",
+        "pcb_port_41",
+        "pcb_smtpad_56",
+        "pcb_port_60",
+        "pcb_smtpad_94",
+        "pcb_port_98",
+        "pcb_smtpad_101",
+        "pcb_port_102",
+        "pcb_smtpad_103",
+        "pcb_port_107",
+        "pcb_smtpad_105",
+        "pcb_port_109",
+        "pcb_smtpad_112",
+        "pcb_port_113",
+        "pcb_smtpad_110",
+        "pcb_port_114",
+        "pcb_smtpad_115",
+        "pcb_port_119",
+        "pcb_smtpad_120",
+        "pcb_port_124",
+        "pcb_smtpad_121",
+        "pcb_port_126",
+        "pcb_smtpad_123",
+        "pcb_port_128",
+        "pcb_smtpad_132",
+        "pcb_port_136",
+        "pcb_smtpad_134",
+        "pcb_port_138",
+        "pcb_smtpad_140",
+        "pcb_port_144",
+        "pcb_smtpad_142",
+        "pcb_port_146",
+        "pcb_smtpad_144",
+        "pcb_port_148",
+        "pcb_smtpad_146",
+        "pcb_port_150",
+        "pcb_smtpad_148",
+        "pcb_port_152",
+        "pcb_smtpad_150",
+        "pcb_port_154",
+        "pcb_smtpad_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_0"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_27",
+        "pcb_port_id": "pcb_port_31"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -7.6000000000000005,
+        "y": 33.375
+      },
+      "width": 0.55,
+      "height": 1.1,
+      "connectedTo": [
+        "pcb_smtpad_27",
+        "source_trace_67",
+        "source_trace_52",
+        "source_trace_51",
+        "source_trace_4",
+        "source_net_14",
+        "pcb_smtpad_1",
+        "pcb_port_1",
+        "pcb_port_31",
+        "pcb_smtpad_36",
+        "pcb_port_40",
+        "pcb_smtpad_139",
+        "pcb_port_143"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_28",
+        "pcb_port_id": "pcb_port_32"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -8.25,
+        "y": 33.375
+      },
+      "width": 0.3,
+      "height": 1.1,
+      "connectedTo": [
+        "pcb_smtpad_28",
+        "pcb_port_32"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_29",
+        "pcb_port_id": "pcb_port_33"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -8.75,
+        "y": 33.375
+      },
+      "width": 0.3,
+      "height": 1.1,
+      "connectedTo": [
+        "pcb_smtpad_29",
+        "source_trace_57",
+        "pcb_port_33",
+        "pcb_smtpad_131",
+        "pcb_port_135"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_30",
+        "pcb_port_id": "pcb_port_34"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -9.25,
+        "y": 33.375
+      },
+      "width": 0.3,
+      "height": 1.1,
+      "connectedTo": [
+        "pcb_smtpad_30",
+        "source_trace_53",
+        "source_trace_2",
+        "pcb_port_34",
+        "pcb_smtpad_32",
+        "pcb_port_36",
+        "pcb_smtpad_135",
+        "pcb_port_139"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_31",
+        "pcb_port_id": "pcb_port_35"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -9.75,
+        "y": 33.375
+      },
+      "width": 0.3,
+      "height": 1.1,
+      "connectedTo": [
+        "pcb_smtpad_31",
+        "source_trace_55",
+        "source_trace_3",
+        "pcb_port_35",
+        "pcb_smtpad_33",
+        "pcb_port_37",
+        "pcb_smtpad_137",
+        "pcb_port_141"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_32",
+        "pcb_port_id": "pcb_port_36"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -10.25,
+        "y": 33.375
+      },
+      "width": 0.3,
+      "height": 1.1,
+      "connectedTo": [
+        "pcb_smtpad_32",
+        "source_trace_53",
+        "source_trace_2",
+        "pcb_smtpad_30",
+        "pcb_port_34",
+        "pcb_port_36",
+        "pcb_smtpad_135",
+        "pcb_port_139"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_33",
+        "pcb_port_id": "pcb_port_37"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -10.75,
+        "y": 33.375
+      },
+      "width": 0.3,
+      "height": 1.1,
+      "connectedTo": [
+        "pcb_smtpad_33",
+        "source_trace_55",
+        "source_trace_3",
+        "pcb_smtpad_31",
+        "pcb_port_35",
+        "pcb_port_37",
+        "pcb_smtpad_137",
+        "pcb_port_141"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_34",
+        "pcb_port_id": "pcb_port_38"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -11.25,
+        "y": 33.375
+      },
+      "width": 0.3,
+      "height": 1.1,
+      "connectedTo": [
+        "pcb_smtpad_34",
+        "pcb_port_38"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_35",
+        "pcb_port_id": "pcb_port_39"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -11.75,
+        "y": 33.375
+      },
+      "width": 0.3,
+      "height": 1.1,
+      "connectedTo": [
+        "pcb_smtpad_35",
+        "source_trace_58",
+        "pcb_port_39",
+        "pcb_smtpad_133",
+        "pcb_port_137"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_36",
+        "pcb_port_id": "pcb_port_40"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -12.4,
+        "y": 33.375
+      },
+      "width": 0.55,
+      "height": 1.1,
+      "connectedTo": [
+        "pcb_smtpad_36",
+        "source_trace_67",
+        "source_trace_52",
+        "source_trace_51",
+        "source_trace_4",
+        "source_net_14",
+        "pcb_smtpad_1",
+        "pcb_port_1",
+        "pcb_smtpad_27",
+        "pcb_port_31",
+        "pcb_port_40",
+        "pcb_smtpad_139",
+        "pcb_port_143"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_37",
+        "pcb_port_id": "pcb_port_41"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -13.200000000000001,
+        "y": 33.375
+      },
+      "width": 0.55,
+      "height": 1.1,
+      "connectedTo": [
+        "pcb_smtpad_37",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_smtpad_5",
+        "pcb_port_5",
+        "pcb_smtpad_7",
+        "pcb_port_7",
+        "pcb_smtpad_9",
+        "pcb_port_9",
+        "pcb_smtpad_11",
+        "pcb_port_11",
+        "pcb_smtpad_13",
+        "pcb_port_13",
+        "pcb_smtpad_15",
+        "pcb_port_15",
+        "pcb_smtpad_19",
+        "pcb_port_19",
+        "pcb_smtpad_23",
+        "pcb_port_23",
+        "pcb_smtpad_25",
+        "pcb_port_25",
+        "pcb_plated_hole_0",
+        "pcb_port_26",
+        "pcb_plated_hole_1",
+        "pcb_port_27",
+        "pcb_plated_hole_2",
+        "pcb_port_28",
+        "pcb_plated_hole_3",
+        "pcb_port_29",
+        "pcb_smtpad_26",
+        "pcb_port_30",
+        "pcb_port_41",
+        "pcb_smtpad_56",
+        "pcb_port_60",
+        "pcb_smtpad_94",
+        "pcb_port_98",
+        "pcb_smtpad_101",
+        "pcb_port_102",
+        "pcb_smtpad_103",
+        "pcb_port_107",
+        "pcb_smtpad_105",
+        "pcb_port_109",
+        "pcb_smtpad_112",
+        "pcb_port_113",
+        "pcb_smtpad_110",
+        "pcb_port_114",
+        "pcb_smtpad_115",
+        "pcb_port_119",
+        "pcb_smtpad_120",
+        "pcb_port_124",
+        "pcb_smtpad_121",
+        "pcb_port_126",
+        "pcb_smtpad_123",
+        "pcb_port_128",
+        "pcb_smtpad_132",
+        "pcb_port_136",
+        "pcb_smtpad_134",
+        "pcb_port_138",
+        "pcb_smtpad_140",
+        "pcb_port_144",
+        "pcb_smtpad_142",
+        "pcb_port_146",
+        "pcb_smtpad_144",
+        "pcb_port_148",
+        "pcb_smtpad_146",
+        "pcb_port_150",
+        "pcb_smtpad_148",
+        "pcb_port_152",
+        "pcb_smtpad_150",
+        "pcb_port_154",
+        "pcb_smtpad_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_0"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_38",
+        "pcb_port_id": "pcb_port_42"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -13.424949999999999,
+        "y": 7.60065
+      },
+      "width": 0.85,
+      "height": 0.2,
+      "connectedTo": [
+        "pcb_smtpad_38",
+        "source_trace_106",
+        "source_trace_100",
+        "source_trace_94",
+        "source_trace_83",
+        "source_trace_78",
+        "source_trace_76",
+        "source_trace_72",
+        "source_trace_70",
+        "source_trace_50",
+        "source_trace_48",
+        "source_trace_46",
+        "source_trace_43",
+        "source_trace_42",
+        "source_trace_41",
+        "source_trace_40",
+        "source_trace_39",
+        "source_trace_38",
+        "source_trace_25",
+        "source_trace_23",
+        "source_trace_21",
+        "source_trace_17",
+        "source_trace_14",
+        "source_trace_12",
+        "source_trace_10",
+        "source_trace_8",
+        "source_net_16",
+        "pcb_smtpad_4",
+        "pcb_port_4",
+        "pcb_smtpad_6",
+        "pcb_port_6",
+        "pcb_smtpad_8",
+        "pcb_port_8",
+        "pcb_smtpad_10",
+        "pcb_port_10",
+        "pcb_smtpad_12",
+        "pcb_port_12",
+        "pcb_smtpad_14",
+        "pcb_port_14",
+        "pcb_smtpad_17",
+        "pcb_port_17",
+        "pcb_smtpad_21",
+        "pcb_port_21",
+        "pcb_smtpad_22",
+        "pcb_port_22",
+        "pcb_port_42",
+        "pcb_smtpad_47",
+        "pcb_port_51",
+        "pcb_smtpad_59",
+        "pcb_port_63",
+        "pcb_smtpad_70",
+        "pcb_port_74",
+        "pcb_smtpad_79",
+        "pcb_port_83",
+        "pcb_smtpad_81",
+        "pcb_port_85",
+        "pcb_smtpad_85",
+        "pcb_port_89",
+        "pcb_smtpad_86",
+        "pcb_port_90",
+        "pcb_smtpad_108",
+        "pcb_port_112",
+        "pcb_smtpad_126",
+        "pcb_port_130",
+        "pcb_smtpad_129",
+        "pcb_port_133",
+        "pcb_smtpad_141",
+        "pcb_port_145",
+        "pcb_smtpad_145",
+        "pcb_port_149",
+        "pcb_smtpad_151",
+        "pcb_port_155",
+        "pcb_smtpad_156",
+        "pcb_port_160"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_39",
+        "pcb_port_id": "pcb_port_43"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -13.424949999999999,
+        "y": 7.20055
+      },
+      "width": 0.85,
+      "height": 0.2,
+      "connectedTo": [
+        "pcb_smtpad_39",
+        "pcb_port_43"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_40",
+        "pcb_port_id": "pcb_port_44"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -13.424949999999999,
+        "y": 6.80045
+      },
+      "width": 0.85,
+      "height": 0.2,
+      "connectedTo": [
+        "pcb_smtpad_40",
+        "pcb_port_44"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_41",
+        "pcb_port_id": "pcb_port_45"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -13.424949999999999,
+        "y": 6.4003499999999995
+      },
+      "width": 0.85,
+      "height": 0.2,
+      "connectedTo": [
+        "pcb_smtpad_41",
+        "pcb_port_45"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_42",
+        "pcb_port_id": "pcb_port_46"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -13.424949999999999,
+        "y": 6.000249999999999
+      },
+      "width": 0.85,
+      "height": 0.2,
+      "connectedTo": [
+        "pcb_smtpad_42",
+        "pcb_port_46"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_43",
+        "pcb_port_id": "pcb_port_47"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -13.424949999999999,
+        "y": 5.600149999999999
+      },
+      "width": 0.85,
+      "height": 0.2,
+      "connectedTo": [
+        "pcb_smtpad_43",
+        "source_trace_29",
+        "source_net_18",
+        "pcb_port_47"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_44",
+        "pcb_port_id": "pcb_port_48"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -13.424949999999999,
+        "y": 5.20005
+      },
+      "width": 0.85,
+      "height": 0.2,
+      "connectedTo": [
+        "pcb_smtpad_44",
+        "source_trace_30",
+        "source_net_19",
+        "pcb_port_48"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_45",
+        "pcb_port_id": "pcb_port_49"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -13.424949999999999,
+        "y": 4.79995
+      },
+      "width": 0.85,
+      "height": 0.2,
+      "connectedTo": [
+        "pcb_smtpad_45",
+        "pcb_port_49"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_46",
+        "pcb_port_id": "pcb_port_50"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -13.424949999999999,
+        "y": 4.39985
+      },
+      "width": 0.85,
+      "height": 0.2,
+      "connectedTo": [
+        "pcb_smtpad_46",
+        "pcb_port_50"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_47",
+        "pcb_port_id": "pcb_port_51"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -13.424949999999999,
+        "y": 3.9997499999999997
+      },
+      "width": 0.85,
+      "height": 0.2,
+      "connectedTo": [
+        "pcb_smtpad_47",
+        "source_trace_106",
+        "source_trace_100",
+        "source_trace_94",
+        "source_trace_83",
+        "source_trace_78",
+        "source_trace_76",
+        "source_trace_72",
+        "source_trace_70",
+        "source_trace_50",
+        "source_trace_48",
+        "source_trace_46",
+        "source_trace_43",
+        "source_trace_42",
+        "source_trace_41",
+        "source_trace_40",
+        "source_trace_39",
+        "source_trace_38",
+        "source_trace_25",
+        "source_trace_23",
+        "source_trace_21",
+        "source_trace_17",
+        "source_trace_14",
+        "source_trace_12",
+        "source_trace_10",
+        "source_trace_8",
+        "source_net_16",
+        "pcb_smtpad_4",
+        "pcb_port_4",
+        "pcb_smtpad_6",
+        "pcb_port_6",
+        "pcb_smtpad_8",
+        "pcb_port_8",
+        "pcb_smtpad_10",
+        "pcb_port_10",
+        "pcb_smtpad_12",
+        "pcb_port_12",
+        "pcb_smtpad_14",
+        "pcb_port_14",
+        "pcb_smtpad_17",
+        "pcb_port_17",
+        "pcb_smtpad_21",
+        "pcb_port_21",
+        "pcb_smtpad_22",
+        "pcb_port_22",
+        "pcb_smtpad_38",
+        "pcb_port_42",
+        "pcb_port_51",
+        "pcb_smtpad_59",
+        "pcb_port_63",
+        "pcb_smtpad_70",
+        "pcb_port_74",
+        "pcb_smtpad_79",
+        "pcb_port_83",
+        "pcb_smtpad_81",
+        "pcb_port_85",
+        "pcb_smtpad_85",
+        "pcb_port_89",
+        "pcb_smtpad_86",
+        "pcb_port_90",
+        "pcb_smtpad_108",
+        "pcb_port_112",
+        "pcb_smtpad_126",
+        "pcb_port_130",
+        "pcb_smtpad_129",
+        "pcb_port_133",
+        "pcb_smtpad_141",
+        "pcb_port_145",
+        "pcb_smtpad_145",
+        "pcb_port_149",
+        "pcb_smtpad_151",
+        "pcb_port_155",
+        "pcb_smtpad_156",
+        "pcb_port_160"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_48",
+        "pcb_port_id": "pcb_port_52"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -13.424949999999999,
+        "y": 3.5996499999999996
+      },
+      "width": 0.85,
+      "height": 0.2,
+      "connectedTo": [
+        "pcb_smtpad_48",
+        "pcb_port_52"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_49",
+        "pcb_port_id": "pcb_port_53"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -13.424949999999999,
+        "y": 3.1995499999999995
+      },
+      "width": 0.85,
+      "height": 0.2,
+      "connectedTo": [
+        "pcb_smtpad_49",
+        "pcb_port_53"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_50",
+        "pcb_port_id": "pcb_port_54"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -13.424949999999999,
+        "y": 2.79945
+      },
+      "width": 0.85,
+      "height": 0.2,
+      "connectedTo": [
+        "pcb_smtpad_50",
+        "pcb_port_54"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_51",
+        "pcb_port_id": "pcb_port_55"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -13.424949999999999,
+        "y": 2.39935
+      },
+      "width": 0.85,
+      "height": 0.2,
+      "connectedTo": [
+        "pcb_smtpad_51",
+        "pcb_port_55"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_52",
+        "pcb_port_id": "pcb_port_56"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -12.60065,
+        "y": 1.5749499999999999
+      },
+      "width": 0.2,
+      "height": 0.85,
+      "connectedTo": [
+        "pcb_smtpad_52",
+        "pcb_port_56"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_53",
+        "pcb_port_id": "pcb_port_57"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -12.20055,
+        "y": 1.5749499999999999
+      },
+      "width": 0.2,
+      "height": 0.85,
+      "connectedTo": [
+        "pcb_smtpad_53",
+        "pcb_port_57"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_54",
+        "pcb_port_id": "pcb_port_58"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -11.80045,
+        "y": 1.5749499999999999
+      },
+      "width": 0.2,
+      "height": 0.85,
+      "connectedTo": [
+        "pcb_smtpad_54",
+        "pcb_port_58"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_55",
+        "pcb_port_id": "pcb_port_59"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -11.40035,
+        "y": 1.5749499999999999
+      },
+      "width": 0.2,
+      "height": 0.85,
+      "connectedTo": [
+        "pcb_smtpad_55",
+        "pcb_port_59"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_56",
+        "pcb_port_id": "pcb_port_60"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -11.00025,
+        "y": 1.5749499999999999
+      },
+      "width": 0.2,
+      "height": 0.85,
+      "connectedTo": [
+        "pcb_smtpad_56",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_smtpad_5",
+        "pcb_port_5",
+        "pcb_smtpad_7",
+        "pcb_port_7",
+        "pcb_smtpad_9",
+        "pcb_port_9",
+        "pcb_smtpad_11",
+        "pcb_port_11",
+        "pcb_smtpad_13",
+        "pcb_port_13",
+        "pcb_smtpad_15",
+        "pcb_port_15",
+        "pcb_smtpad_19",
+        "pcb_port_19",
+        "pcb_smtpad_23",
+        "pcb_port_23",
+        "pcb_smtpad_25",
+        "pcb_port_25",
+        "pcb_plated_hole_0",
+        "pcb_port_26",
+        "pcb_plated_hole_1",
+        "pcb_port_27",
+        "pcb_plated_hole_2",
+        "pcb_port_28",
+        "pcb_plated_hole_3",
+        "pcb_port_29",
+        "pcb_smtpad_26",
+        "pcb_port_30",
+        "pcb_smtpad_37",
+        "pcb_port_41",
+        "pcb_port_60",
+        "pcb_smtpad_94",
+        "pcb_port_98",
+        "pcb_smtpad_101",
+        "pcb_port_102",
+        "pcb_smtpad_103",
+        "pcb_port_107",
+        "pcb_smtpad_105",
+        "pcb_port_109",
+        "pcb_smtpad_112",
+        "pcb_port_113",
+        "pcb_smtpad_110",
+        "pcb_port_114",
+        "pcb_smtpad_115",
+        "pcb_port_119",
+        "pcb_smtpad_120",
+        "pcb_port_124",
+        "pcb_smtpad_121",
+        "pcb_port_126",
+        "pcb_smtpad_123",
+        "pcb_port_128",
+        "pcb_smtpad_132",
+        "pcb_port_136",
+        "pcb_smtpad_134",
+        "pcb_port_138",
+        "pcb_smtpad_140",
+        "pcb_port_144",
+        "pcb_smtpad_142",
+        "pcb_port_146",
+        "pcb_smtpad_144",
+        "pcb_port_148",
+        "pcb_smtpad_146",
+        "pcb_port_150",
+        "pcb_smtpad_148",
+        "pcb_port_152",
+        "pcb_smtpad_150",
+        "pcb_port_154",
+        "pcb_smtpad_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_0"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_57",
+        "pcb_port_id": "pcb_port_61"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -10.60015,
+        "y": 1.5749499999999999
+      },
+      "width": 0.2,
+      "height": 0.85,
+      "connectedTo": [
+        "pcb_smtpad_57",
+        "source_trace_87",
+        "source_trace_85",
+        "pcb_port_61",
+        "pcb_smtpad_109",
+        "pcb_port_115",
+        "pcb_smtpad_147",
+        "pcb_port_151"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_58",
+        "pcb_port_id": "pcb_port_62"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -10.200050000000001,
+        "y": 1.5749499999999999
+      },
+      "width": 0.2,
+      "height": 0.85,
+      "connectedTo": [
+        "pcb_smtpad_58",
+        "source_trace_89",
+        "source_trace_86",
+        "pcb_port_62",
+        "pcb_smtpad_111",
+        "pcb_port_116",
+        "pcb_smtpad_149",
+        "pcb_port_153"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_59",
+        "pcb_port_id": "pcb_port_63"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -9.799949999999999,
+        "y": 1.5749499999999999
+      },
+      "width": 0.2,
+      "height": 0.85,
+      "connectedTo": [
+        "pcb_smtpad_59",
+        "source_trace_106",
+        "source_trace_100",
+        "source_trace_94",
+        "source_trace_83",
+        "source_trace_78",
+        "source_trace_76",
+        "source_trace_72",
+        "source_trace_70",
+        "source_trace_50",
+        "source_trace_48",
+        "source_trace_46",
+        "source_trace_43",
+        "source_trace_42",
+        "source_trace_41",
+        "source_trace_40",
+        "source_trace_39",
+        "source_trace_38",
+        "source_trace_25",
+        "source_trace_23",
+        "source_trace_21",
+        "source_trace_17",
+        "source_trace_14",
+        "source_trace_12",
+        "source_trace_10",
+        "source_trace_8",
+        "source_net_16",
+        "pcb_smtpad_4",
+        "pcb_port_4",
+        "pcb_smtpad_6",
+        "pcb_port_6",
+        "pcb_smtpad_8",
+        "pcb_port_8",
+        "pcb_smtpad_10",
+        "pcb_port_10",
+        "pcb_smtpad_12",
+        "pcb_port_12",
+        "pcb_smtpad_14",
+        "pcb_port_14",
+        "pcb_smtpad_17",
+        "pcb_port_17",
+        "pcb_smtpad_21",
+        "pcb_port_21",
+        "pcb_smtpad_22",
+        "pcb_port_22",
+        "pcb_smtpad_38",
+        "pcb_port_42",
+        "pcb_smtpad_47",
+        "pcb_port_51",
+        "pcb_port_63",
+        "pcb_smtpad_70",
+        "pcb_port_74",
+        "pcb_smtpad_79",
+        "pcb_port_83",
+        "pcb_smtpad_81",
+        "pcb_port_85",
+        "pcb_smtpad_85",
+        "pcb_port_89",
+        "pcb_smtpad_86",
+        "pcb_port_90",
+        "pcb_smtpad_108",
+        "pcb_port_112",
+        "pcb_smtpad_126",
+        "pcb_port_130",
+        "pcb_smtpad_129",
+        "pcb_port_133",
+        "pcb_smtpad_141",
+        "pcb_port_145",
+        "pcb_smtpad_145",
+        "pcb_port_149",
+        "pcb_smtpad_151",
+        "pcb_port_155",
+        "pcb_smtpad_156",
+        "pcb_port_160"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_60",
+        "pcb_port_id": "pcb_port_64"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -9.39985,
+        "y": 1.5749499999999999
+      },
+      "width": 0.2,
+      "height": 0.85,
+      "connectedTo": [
+        "pcb_smtpad_60",
+        "source_trace_74",
+        "source_trace_47",
+        "source_trace_45",
+        "source_trace_44",
+        "source_net_21",
+        "pcb_port_64",
+        "pcb_smtpad_82",
+        "pcb_port_86",
+        "pcb_smtpad_87",
+        "pcb_port_91",
+        "pcb_smtpad_143",
+        "pcb_port_147"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_61",
+        "pcb_port_id": "pcb_port_65"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -8.999749999999999,
+        "y": 1.5749499999999999
+      },
+      "width": 0.2,
+      "height": 0.85,
+      "connectedTo": [
+        "pcb_smtpad_61",
+        "source_trace_103",
+        "pcb_port_65",
+        "pcb_smtpad_153",
+        "pcb_port_157"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_62",
+        "pcb_port_id": "pcb_port_66"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -8.59965,
+        "y": 1.5749499999999999
+      },
+      "width": 0.2,
+      "height": 0.85,
+      "connectedTo": [
+        "pcb_smtpad_62",
+        "source_trace_104",
+        "pcb_port_66",
+        "pcb_smtpad_155",
+        "pcb_port_159"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_63",
+        "pcb_port_id": "pcb_port_67"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -8.199549999999999,
+        "y": 1.5749499999999999
+      },
+      "width": 0.2,
+      "height": 0.85,
+      "connectedTo": [
+        "pcb_smtpad_63",
+        "source_trace_95",
+        "source_trace_16",
+        "pcb_smtpad_16",
+        "pcb_port_16",
+        "pcb_port_67",
+        "pcb_smtpad_117",
+        "pcb_port_121"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_3"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_64",
+        "pcb_port_id": "pcb_port_68"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -7.79945,
+        "y": 1.5749499999999999
+      },
+      "width": 0.2,
+      "height": 0.85,
+      "connectedTo": [
+        "pcb_smtpad_64",
+        "pcb_port_68"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_65",
+        "pcb_port_id": "pcb_port_69"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -7.39935,
+        "y": 1.5749499999999999
+      },
+      "width": 0.2,
+      "height": 0.85,
+      "connectedTo": [
+        "pcb_smtpad_65",
+        "pcb_port_69"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_66",
+        "pcb_port_id": "pcb_port_70"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -6.57505,
+        "y": 2.39935
+      },
+      "width": 0.85,
+      "height": 0.2,
+      "connectedTo": [
+        "pcb_smtpad_66",
+        "pcb_port_70"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_67",
+        "pcb_port_id": "pcb_port_71"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -6.57505,
+        "y": 2.79945
+      },
+      "width": 0.85,
+      "height": 0.2,
+      "connectedTo": [
+        "pcb_smtpad_67",
+        "pcb_port_71"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_68",
+        "pcb_port_id": "pcb_port_72"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -6.57505,
+        "y": 3.1995500000000003
+      },
+      "width": 0.85,
+      "height": 0.2,
+      "connectedTo": [
+        "pcb_smtpad_68",
+        "pcb_port_72"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_69",
+        "pcb_port_id": "pcb_port_73"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -6.57505,
+        "y": 3.59965
+      },
+      "width": 0.85,
+      "height": 0.2,
+      "connectedTo": [
+        "pcb_smtpad_69",
+        "pcb_port_73"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_70",
+        "pcb_port_id": "pcb_port_74"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -6.57505,
+        "y": 3.99975
+      },
+      "width": 0.85,
+      "height": 0.2,
+      "connectedTo": [
+        "pcb_smtpad_70",
+        "source_trace_106",
+        "source_trace_100",
+        "source_trace_94",
+        "source_trace_83",
+        "source_trace_78",
+        "source_trace_76",
+        "source_trace_72",
+        "source_trace_70",
+        "source_trace_50",
+        "source_trace_48",
+        "source_trace_46",
+        "source_trace_43",
+        "source_trace_42",
+        "source_trace_41",
+        "source_trace_40",
+        "source_trace_39",
+        "source_trace_38",
+        "source_trace_25",
+        "source_trace_23",
+        "source_trace_21",
+        "source_trace_17",
+        "source_trace_14",
+        "source_trace_12",
+        "source_trace_10",
+        "source_trace_8",
+        "source_net_16",
+        "pcb_smtpad_4",
+        "pcb_port_4",
+        "pcb_smtpad_6",
+        "pcb_port_6",
+        "pcb_smtpad_8",
+        "pcb_port_8",
+        "pcb_smtpad_10",
+        "pcb_port_10",
+        "pcb_smtpad_12",
+        "pcb_port_12",
+        "pcb_smtpad_14",
+        "pcb_port_14",
+        "pcb_smtpad_17",
+        "pcb_port_17",
+        "pcb_smtpad_21",
+        "pcb_port_21",
+        "pcb_smtpad_22",
+        "pcb_port_22",
+        "pcb_smtpad_38",
+        "pcb_port_42",
+        "pcb_smtpad_47",
+        "pcb_port_51",
+        "pcb_smtpad_59",
+        "pcb_port_63",
+        "pcb_port_74",
+        "pcb_smtpad_79",
+        "pcb_port_83",
+        "pcb_smtpad_81",
+        "pcb_port_85",
+        "pcb_smtpad_85",
+        "pcb_port_89",
+        "pcb_smtpad_86",
+        "pcb_port_90",
+        "pcb_smtpad_108",
+        "pcb_port_112",
+        "pcb_smtpad_126",
+        "pcb_port_130",
+        "pcb_smtpad_129",
+        "pcb_port_133",
+        "pcb_smtpad_141",
+        "pcb_port_145",
+        "pcb_smtpad_145",
+        "pcb_port_149",
+        "pcb_smtpad_151",
+        "pcb_port_155",
+        "pcb_smtpad_156",
+        "pcb_port_160"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_71",
+        "pcb_port_id": "pcb_port_75"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -6.57505,
+        "y": 4.399850000000001
+      },
+      "width": 0.85,
+      "height": 0.2,
+      "connectedTo": [
+        "pcb_smtpad_71",
+        "pcb_port_75"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_72",
+        "pcb_port_id": "pcb_port_76"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -6.57505,
+        "y": 4.79995
+      },
+      "width": 0.85,
+      "height": 0.2,
+      "connectedTo": [
+        "pcb_smtpad_72",
+        "pcb_port_76"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_73",
+        "pcb_port_id": "pcb_port_77"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -6.57505,
+        "y": 5.20005
+      },
+      "width": 0.85,
+      "height": 0.2,
+      "connectedTo": [
+        "pcb_smtpad_73",
+        "pcb_port_77"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_74",
+        "pcb_port_id": "pcb_port_78"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -6.57505,
+        "y": 5.60015
+      },
+      "width": 0.85,
+      "height": 0.2,
+      "connectedTo": [
+        "pcb_smtpad_74",
+        "source_trace_97",
+        "pcb_port_78",
+        "pcb_smtpad_127",
+        "pcb_port_131"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_75",
+        "pcb_port_id": "pcb_port_79"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -6.57505,
+        "y": 6.00025
+      },
+      "width": 0.85,
+      "height": 0.2,
+      "connectedTo": [
+        "pcb_smtpad_75",
+        "source_trace_31",
+        "source_net_20",
+        "pcb_port_79"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_76",
+        "pcb_port_id": "pcb_port_80"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -6.57505,
+        "y": 6.40035
+      },
+      "width": 0.85,
+      "height": 0.2,
+      "connectedTo": [
+        "pcb_smtpad_76",
+        "pcb_port_80"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_77",
+        "pcb_port_id": "pcb_port_81"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -6.57505,
+        "y": 6.8004500000000005
+      },
+      "width": 0.85,
+      "height": 0.2,
+      "connectedTo": [
+        "pcb_smtpad_77",
+        "pcb_port_81"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_78",
+        "pcb_port_id": "pcb_port_82"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -6.57505,
+        "y": 7.20055
+      },
+      "width": 0.85,
+      "height": 0.2,
+      "connectedTo": [
+        "pcb_smtpad_78",
+        "pcb_port_82"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_79",
+        "pcb_port_id": "pcb_port_83"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -6.57505,
+        "y": 7.60065
+      },
+      "width": 0.85,
+      "height": 0.2,
+      "connectedTo": [
+        "pcb_smtpad_79",
+        "source_trace_106",
+        "source_trace_100",
+        "source_trace_94",
+        "source_trace_83",
+        "source_trace_78",
+        "source_trace_76",
+        "source_trace_72",
+        "source_trace_70",
+        "source_trace_50",
+        "source_trace_48",
+        "source_trace_46",
+        "source_trace_43",
+        "source_trace_42",
+        "source_trace_41",
+        "source_trace_40",
+        "source_trace_39",
+        "source_trace_38",
+        "source_trace_25",
+        "source_trace_23",
+        "source_trace_21",
+        "source_trace_17",
+        "source_trace_14",
+        "source_trace_12",
+        "source_trace_10",
+        "source_trace_8",
+        "source_net_16",
+        "pcb_smtpad_4",
+        "pcb_port_4",
+        "pcb_smtpad_6",
+        "pcb_port_6",
+        "pcb_smtpad_8",
+        "pcb_port_8",
+        "pcb_smtpad_10",
+        "pcb_port_10",
+        "pcb_smtpad_12",
+        "pcb_port_12",
+        "pcb_smtpad_14",
+        "pcb_port_14",
+        "pcb_smtpad_17",
+        "pcb_port_17",
+        "pcb_smtpad_21",
+        "pcb_port_21",
+        "pcb_smtpad_22",
+        "pcb_port_22",
+        "pcb_smtpad_38",
+        "pcb_port_42",
+        "pcb_smtpad_47",
+        "pcb_port_51",
+        "pcb_smtpad_59",
+        "pcb_port_63",
+        "pcb_smtpad_70",
+        "pcb_port_74",
+        "pcb_port_83",
+        "pcb_smtpad_81",
+        "pcb_port_85",
+        "pcb_smtpad_85",
+        "pcb_port_89",
+        "pcb_smtpad_86",
+        "pcb_port_90",
+        "pcb_smtpad_108",
+        "pcb_port_112",
+        "pcb_smtpad_126",
+        "pcb_port_130",
+        "pcb_smtpad_129",
+        "pcb_port_133",
+        "pcb_smtpad_141",
+        "pcb_port_145",
+        "pcb_smtpad_145",
+        "pcb_port_149",
+        "pcb_smtpad_151",
+        "pcb_port_155",
+        "pcb_smtpad_156",
+        "pcb_port_160"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_80",
+        "pcb_port_id": "pcb_port_84"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -7.39935,
+        "y": 8.42505
+      },
+      "width": 0.2,
+      "height": 0.85,
+      "connectedTo": [
+        "pcb_smtpad_80",
+        "source_trace_80",
+        "source_trace_79",
+        "source_trace_27",
+        "source_net_17",
+        "pcb_smtpad_24",
+        "pcb_port_24",
+        "pcb_port_84",
+        "pcb_smtpad_152",
+        "pcb_port_156"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_81",
+        "pcb_port_id": "pcb_port_85"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -7.79945,
+        "y": 8.42505
+      },
+      "width": 0.2,
+      "height": 0.85,
+      "connectedTo": [
+        "pcb_smtpad_81",
+        "source_trace_106",
+        "source_trace_100",
+        "source_trace_94",
+        "source_trace_83",
+        "source_trace_78",
+        "source_trace_76",
+        "source_trace_72",
+        "source_trace_70",
+        "source_trace_50",
+        "source_trace_48",
+        "source_trace_46",
+        "source_trace_43",
+        "source_trace_42",
+        "source_trace_41",
+        "source_trace_40",
+        "source_trace_39",
+        "source_trace_38",
+        "source_trace_25",
+        "source_trace_23",
+        "source_trace_21",
+        "source_trace_17",
+        "source_trace_14",
+        "source_trace_12",
+        "source_trace_10",
+        "source_trace_8",
+        "source_net_16",
+        "pcb_smtpad_4",
+        "pcb_port_4",
+        "pcb_smtpad_6",
+        "pcb_port_6",
+        "pcb_smtpad_8",
+        "pcb_port_8",
+        "pcb_smtpad_10",
+        "pcb_port_10",
+        "pcb_smtpad_12",
+        "pcb_port_12",
+        "pcb_smtpad_14",
+        "pcb_port_14",
+        "pcb_smtpad_17",
+        "pcb_port_17",
+        "pcb_smtpad_21",
+        "pcb_port_21",
+        "pcb_smtpad_22",
+        "pcb_port_22",
+        "pcb_smtpad_38",
+        "pcb_port_42",
+        "pcb_smtpad_47",
+        "pcb_port_51",
+        "pcb_smtpad_59",
+        "pcb_port_63",
+        "pcb_smtpad_70",
+        "pcb_port_74",
+        "pcb_smtpad_79",
+        "pcb_port_83",
+        "pcb_port_85",
+        "pcb_smtpad_85",
+        "pcb_port_89",
+        "pcb_smtpad_86",
+        "pcb_port_90",
+        "pcb_smtpad_108",
+        "pcb_port_112",
+        "pcb_smtpad_126",
+        "pcb_port_130",
+        "pcb_smtpad_129",
+        "pcb_port_133",
+        "pcb_smtpad_141",
+        "pcb_port_145",
+        "pcb_smtpad_145",
+        "pcb_port_149",
+        "pcb_smtpad_151",
+        "pcb_port_155",
+        "pcb_smtpad_156",
+        "pcb_port_160"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_82",
+        "pcb_port_id": "pcb_port_86"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -8.19955,
+        "y": 8.42505
+      },
+      "width": 0.2,
+      "height": 0.85,
+      "connectedTo": [
+        "pcb_smtpad_82",
+        "source_trace_74",
+        "source_trace_47",
+        "source_trace_45",
+        "source_trace_44",
+        "source_net_21",
+        "pcb_smtpad_60",
+        "pcb_port_64",
+        "pcb_port_86",
+        "pcb_smtpad_87",
+        "pcb_port_91",
+        "pcb_smtpad_143",
+        "pcb_port_147"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_83",
+        "pcb_port_id": "pcb_port_87"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -8.59965,
+        "y": 8.42505
+      },
+      "width": 0.2,
+      "height": 0.85,
+      "connectedTo": [
+        "pcb_smtpad_83",
+        "source_trace_54",
+        "pcb_port_87",
+        "pcb_smtpad_136",
+        "pcb_port_140"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_84",
+        "pcb_port_id": "pcb_port_88"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -8.99975,
+        "y": 8.42505
+      },
+      "width": 0.2,
+      "height": 0.85,
+      "connectedTo": [
+        "pcb_smtpad_84",
+        "source_trace_56",
+        "pcb_port_88",
+        "pcb_smtpad_138",
+        "pcb_port_142"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_85",
+        "pcb_port_id": "pcb_port_89"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -9.39985,
+        "y": 8.42505
+      },
+      "width": 0.2,
+      "height": 0.85,
+      "connectedTo": [
+        "pcb_smtpad_85",
+        "source_trace_106",
+        "source_trace_100",
+        "source_trace_94",
+        "source_trace_83",
+        "source_trace_78",
+        "source_trace_76",
+        "source_trace_72",
+        "source_trace_70",
+        "source_trace_50",
+        "source_trace_48",
+        "source_trace_46",
+        "source_trace_43",
+        "source_trace_42",
+        "source_trace_41",
+        "source_trace_40",
+        "source_trace_39",
+        "source_trace_38",
+        "source_trace_25",
+        "source_trace_23",
+        "source_trace_21",
+        "source_trace_17",
+        "source_trace_14",
+        "source_trace_12",
+        "source_trace_10",
+        "source_trace_8",
+        "source_net_16",
+        "pcb_smtpad_4",
+        "pcb_port_4",
+        "pcb_smtpad_6",
+        "pcb_port_6",
+        "pcb_smtpad_8",
+        "pcb_port_8",
+        "pcb_smtpad_10",
+        "pcb_port_10",
+        "pcb_smtpad_12",
+        "pcb_port_12",
+        "pcb_smtpad_14",
+        "pcb_port_14",
+        "pcb_smtpad_17",
+        "pcb_port_17",
+        "pcb_smtpad_21",
+        "pcb_port_21",
+        "pcb_smtpad_22",
+        "pcb_port_22",
+        "pcb_smtpad_38",
+        "pcb_port_42",
+        "pcb_smtpad_47",
+        "pcb_port_51",
+        "pcb_smtpad_59",
+        "pcb_port_63",
+        "pcb_smtpad_70",
+        "pcb_port_74",
+        "pcb_smtpad_79",
+        "pcb_port_83",
+        "pcb_smtpad_81",
+        "pcb_port_85",
+        "pcb_port_89",
+        "pcb_smtpad_86",
+        "pcb_port_90",
+        "pcb_smtpad_108",
+        "pcb_port_112",
+        "pcb_smtpad_126",
+        "pcb_port_130",
+        "pcb_smtpad_129",
+        "pcb_port_133",
+        "pcb_smtpad_141",
+        "pcb_port_145",
+        "pcb_smtpad_145",
+        "pcb_port_149",
+        "pcb_smtpad_151",
+        "pcb_port_155",
+        "pcb_smtpad_156",
+        "pcb_port_160"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_86",
+        "pcb_port_id": "pcb_port_90"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -9.799949999999999,
+        "y": 8.42505
+      },
+      "width": 0.2,
+      "height": 0.85,
+      "connectedTo": [
+        "pcb_smtpad_86",
+        "source_trace_106",
+        "source_trace_100",
+        "source_trace_94",
+        "source_trace_83",
+        "source_trace_78",
+        "source_trace_76",
+        "source_trace_72",
+        "source_trace_70",
+        "source_trace_50",
+        "source_trace_48",
+        "source_trace_46",
+        "source_trace_43",
+        "source_trace_42",
+        "source_trace_41",
+        "source_trace_40",
+        "source_trace_39",
+        "source_trace_38",
+        "source_trace_25",
+        "source_trace_23",
+        "source_trace_21",
+        "source_trace_17",
+        "source_trace_14",
+        "source_trace_12",
+        "source_trace_10",
+        "source_trace_8",
+        "source_net_16",
+        "pcb_smtpad_4",
+        "pcb_port_4",
+        "pcb_smtpad_6",
+        "pcb_port_6",
+        "pcb_smtpad_8",
+        "pcb_port_8",
+        "pcb_smtpad_10",
+        "pcb_port_10",
+        "pcb_smtpad_12",
+        "pcb_port_12",
+        "pcb_smtpad_14",
+        "pcb_port_14",
+        "pcb_smtpad_17",
+        "pcb_port_17",
+        "pcb_smtpad_21",
+        "pcb_port_21",
+        "pcb_smtpad_22",
+        "pcb_port_22",
+        "pcb_smtpad_38",
+        "pcb_port_42",
+        "pcb_smtpad_47",
+        "pcb_port_51",
+        "pcb_smtpad_59",
+        "pcb_port_63",
+        "pcb_smtpad_70",
+        "pcb_port_74",
+        "pcb_smtpad_79",
+        "pcb_port_83",
+        "pcb_smtpad_81",
+        "pcb_port_85",
+        "pcb_smtpad_85",
+        "pcb_port_89",
+        "pcb_port_90",
+        "pcb_smtpad_108",
+        "pcb_port_112",
+        "pcb_smtpad_126",
+        "pcb_port_130",
+        "pcb_smtpad_129",
+        "pcb_port_133",
+        "pcb_smtpad_141",
+        "pcb_port_145",
+        "pcb_smtpad_145",
+        "pcb_port_149",
+        "pcb_smtpad_151",
+        "pcb_port_155",
+        "pcb_smtpad_156",
+        "pcb_port_160"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_87",
+        "pcb_port_id": "pcb_port_91"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -10.200050000000001,
+        "y": 8.42505
+      },
+      "width": 0.2,
+      "height": 0.85,
+      "connectedTo": [
+        "pcb_smtpad_87",
+        "source_trace_74",
+        "source_trace_47",
+        "source_trace_45",
+        "source_trace_44",
+        "source_net_21",
+        "pcb_smtpad_60",
+        "pcb_port_64",
+        "pcb_smtpad_82",
+        "pcb_port_86",
+        "pcb_port_91",
+        "pcb_smtpad_143",
+        "pcb_port_147"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_88",
+        "pcb_port_id": "pcb_port_92"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -10.60015,
+        "y": 8.42505
+      },
+      "width": 0.2,
+      "height": 0.85,
+      "connectedTo": [
+        "pcb_smtpad_88",
+        "source_trace_36",
+        "pcb_port_92",
+        "pcb_smtpad_98",
+        "pcb_port_105"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_89",
+        "pcb_port_id": "pcb_port_93"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -11.000250000000001,
+        "y": 8.42505
+      },
+      "width": 0.2,
+      "height": 0.85,
+      "connectedTo": [
+        "pcb_smtpad_89",
+        "source_trace_37",
+        "pcb_port_93",
+        "pcb_smtpad_100",
+        "pcb_port_104"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_90",
+        "pcb_port_id": "pcb_port_94"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -11.40035,
+        "y": 8.42505
+      },
+      "width": 0.2,
+      "height": 0.85,
+      "connectedTo": [
+        "pcb_smtpad_90",
+        "source_trace_33",
+        "pcb_port_94",
+        "pcb_smtpad_102",
+        "pcb_port_103"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_91",
+        "pcb_port_id": "pcb_port_95"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -11.800450000000001,
+        "y": 8.42505
+      },
+      "width": 0.2,
+      "height": 0.85,
+      "connectedTo": [
+        "pcb_smtpad_91",
+        "source_trace_35",
+        "pcb_port_95",
+        "pcb_smtpad_99",
+        "pcb_port_101"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_92",
+        "pcb_port_id": "pcb_port_96"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -12.20055,
+        "y": 8.42505
+      },
+      "width": 0.2,
+      "height": 0.85,
+      "connectedTo": [
+        "pcb_smtpad_92",
+        "source_trace_34",
+        "pcb_port_96",
+        "pcb_smtpad_97",
+        "pcb_port_100"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_93",
+        "pcb_port_id": "pcb_port_97"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -12.60065,
+        "y": 8.42505
+      },
+      "width": 0.2,
+      "height": 0.85,
+      "connectedTo": [
+        "pcb_smtpad_93",
+        "source_trace_93",
+        "source_trace_91",
+        "source_trace_32",
+        "pcb_port_97",
+        "pcb_smtpad_95",
+        "pcb_port_99",
+        "pcb_smtpad_113",
+        "pcb_port_117",
+        "pcb_smtpad_125",
+        "pcb_port_129"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_1"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_94",
+        "pcb_port_id": "pcb_port_98"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -10,
+        "y": 5
+      },
+      "width": 3.1,
+      "height": 3.1,
+      "connectedTo": [
+        "pcb_smtpad_94",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_smtpad_5",
+        "pcb_port_5",
+        "pcb_smtpad_7",
+        "pcb_port_7",
+        "pcb_smtpad_9",
+        "pcb_port_9",
+        "pcb_smtpad_11",
+        "pcb_port_11",
+        "pcb_smtpad_13",
+        "pcb_port_13",
+        "pcb_smtpad_15",
+        "pcb_port_15",
+        "pcb_smtpad_19",
+        "pcb_port_19",
+        "pcb_smtpad_23",
+        "pcb_port_23",
+        "pcb_smtpad_25",
+        "pcb_port_25",
+        "pcb_plated_hole_0",
+        "pcb_port_26",
+        "pcb_plated_hole_1",
+        "pcb_port_27",
+        "pcb_plated_hole_2",
+        "pcb_port_28",
+        "pcb_plated_hole_3",
+        "pcb_port_29",
+        "pcb_smtpad_26",
+        "pcb_port_30",
+        "pcb_smtpad_37",
+        "pcb_port_41",
+        "pcb_smtpad_56",
+        "pcb_port_60",
+        "pcb_port_98",
+        "pcb_smtpad_101",
+        "pcb_port_102",
+        "pcb_smtpad_103",
+        "pcb_port_107",
+        "pcb_smtpad_105",
+        "pcb_port_109",
+        "pcb_smtpad_112",
+        "pcb_port_113",
+        "pcb_smtpad_110",
+        "pcb_port_114",
+        "pcb_smtpad_115",
+        "pcb_port_119",
+        "pcb_smtpad_120",
+        "pcb_port_124",
+        "pcb_smtpad_121",
+        "pcb_port_126",
+        "pcb_smtpad_123",
+        "pcb_port_128",
+        "pcb_smtpad_132",
+        "pcb_port_136",
+        "pcb_smtpad_134",
+        "pcb_port_138",
+        "pcb_smtpad_140",
+        "pcb_port_144",
+        "pcb_smtpad_142",
+        "pcb_port_146",
+        "pcb_smtpad_144",
+        "pcb_port_148",
+        "pcb_smtpad_146",
+        "pcb_port_150",
+        "pcb_smtpad_148",
+        "pcb_port_152",
+        "pcb_smtpad_150",
+        "pcb_port_154",
+        "pcb_smtpad_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_0"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_95",
+        "pcb_port_id": "pcb_port_99"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -4.4925,
+        "y": 14.25
+      },
+      "width": 0.6,
+      "height": 0.28,
+      "connectedTo": [
+        "pcb_smtpad_95",
+        "source_trace_93",
+        "source_trace_91",
+        "source_trace_32",
+        "pcb_smtpad_93",
+        "pcb_port_97",
+        "pcb_port_99",
+        "pcb_smtpad_113",
+        "pcb_port_117",
+        "pcb_smtpad_125",
+        "pcb_port_129"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_1"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_96",
+        "pcb_port_id": "pcb_port_106"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -7.5075,
+        "y": 14.25
+      },
+      "width": 0.6,
+      "height": 0.28,
+      "connectedTo": [
+        "pcb_smtpad_96",
+        "source_trace_82",
+        "source_trace_19",
+        "pcb_smtpad_18",
+        "pcb_port_18",
+        "pcb_smtpad_20",
+        "pcb_port_20",
+        "pcb_port_106"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_97",
+        "pcb_port_id": "pcb_port_100"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -4.4925,
+        "y": 14.75
+      },
+      "width": 0.6,
+      "height": 0.28,
+      "connectedTo": [
+        "pcb_smtpad_97",
+        "source_trace_34",
+        "pcb_smtpad_92",
+        "pcb_port_96",
+        "pcb_port_100"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_98",
+        "pcb_port_id": "pcb_port_105"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -7.5075,
+        "y": 14.75
+      },
+      "width": 0.6,
+      "height": 0.28,
+      "connectedTo": [
+        "pcb_smtpad_98",
+        "source_trace_36",
+        "pcb_smtpad_88",
+        "pcb_port_92",
+        "pcb_port_105"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_99",
+        "pcb_port_id": "pcb_port_101"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -4.4925,
+        "y": 15.25
+      },
+      "width": 0.6,
+      "height": 0.28,
+      "connectedTo": [
+        "pcb_smtpad_99",
+        "source_trace_35",
+        "pcb_smtpad_91",
+        "pcb_port_95",
+        "pcb_port_101"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_100",
+        "pcb_port_id": "pcb_port_104"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -7.5075,
+        "y": 15.25
+      },
+      "width": 0.6,
+      "height": 0.28,
+      "connectedTo": [
+        "pcb_smtpad_100",
+        "source_trace_37",
+        "pcb_smtpad_89",
+        "pcb_port_93",
+        "pcb_port_104"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_101",
+        "pcb_port_id": "pcb_port_102"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -4.4925,
+        "y": 15.75
+      },
+      "width": 0.6,
+      "height": 0.28,
+      "connectedTo": [
+        "pcb_smtpad_101",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_smtpad_5",
+        "pcb_port_5",
+        "pcb_smtpad_7",
+        "pcb_port_7",
+        "pcb_smtpad_9",
+        "pcb_port_9",
+        "pcb_smtpad_11",
+        "pcb_port_11",
+        "pcb_smtpad_13",
+        "pcb_port_13",
+        "pcb_smtpad_15",
+        "pcb_port_15",
+        "pcb_smtpad_19",
+        "pcb_port_19",
+        "pcb_smtpad_23",
+        "pcb_port_23",
+        "pcb_smtpad_25",
+        "pcb_port_25",
+        "pcb_plated_hole_0",
+        "pcb_port_26",
+        "pcb_plated_hole_1",
+        "pcb_port_27",
+        "pcb_plated_hole_2",
+        "pcb_port_28",
+        "pcb_plated_hole_3",
+        "pcb_port_29",
+        "pcb_smtpad_26",
+        "pcb_port_30",
+        "pcb_smtpad_37",
+        "pcb_port_41",
+        "pcb_smtpad_56",
+        "pcb_port_60",
+        "pcb_smtpad_94",
+        "pcb_port_98",
+        "pcb_port_102",
+        "pcb_smtpad_103",
+        "pcb_port_107",
+        "pcb_smtpad_105",
+        "pcb_port_109",
+        "pcb_smtpad_112",
+        "pcb_port_113",
+        "pcb_smtpad_110",
+        "pcb_port_114",
+        "pcb_smtpad_115",
+        "pcb_port_119",
+        "pcb_smtpad_120",
+        "pcb_port_124",
+        "pcb_smtpad_121",
+        "pcb_port_126",
+        "pcb_smtpad_123",
+        "pcb_port_128",
+        "pcb_smtpad_132",
+        "pcb_port_136",
+        "pcb_smtpad_134",
+        "pcb_port_138",
+        "pcb_smtpad_140",
+        "pcb_port_144",
+        "pcb_smtpad_142",
+        "pcb_port_146",
+        "pcb_smtpad_144",
+        "pcb_port_148",
+        "pcb_smtpad_146",
+        "pcb_port_150",
+        "pcb_smtpad_148",
+        "pcb_port_152",
+        "pcb_smtpad_150",
+        "pcb_port_154",
+        "pcb_smtpad_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_0"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_102",
+        "pcb_port_id": "pcb_port_103"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -7.5075,
+        "y": 15.75
+      },
+      "width": 0.6,
+      "height": 0.28,
+      "connectedTo": [
+        "pcb_smtpad_102",
+        "source_trace_33",
+        "pcb_smtpad_90",
+        "pcb_port_94",
+        "pcb_port_103"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_103",
+        "pcb_port_id": "pcb_port_107"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -6,
+        "y": 15
+      },
+      "width": 0.3,
+      "height": 1.7,
+      "connectedTo": [
+        "pcb_smtpad_103",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_smtpad_5",
+        "pcb_port_5",
+        "pcb_smtpad_7",
+        "pcb_port_7",
+        "pcb_smtpad_9",
+        "pcb_port_9",
+        "pcb_smtpad_11",
+        "pcb_port_11",
+        "pcb_smtpad_13",
+        "pcb_port_13",
+        "pcb_smtpad_15",
+        "pcb_port_15",
+        "pcb_smtpad_19",
+        "pcb_port_19",
+        "pcb_smtpad_23",
+        "pcb_port_23",
+        "pcb_smtpad_25",
+        "pcb_port_25",
+        "pcb_plated_hole_0",
+        "pcb_port_26",
+        "pcb_plated_hole_1",
+        "pcb_port_27",
+        "pcb_plated_hole_2",
+        "pcb_port_28",
+        "pcb_plated_hole_3",
+        "pcb_port_29",
+        "pcb_smtpad_26",
+        "pcb_port_30",
+        "pcb_smtpad_37",
+        "pcb_port_41",
+        "pcb_smtpad_56",
+        "pcb_port_60",
+        "pcb_smtpad_94",
+        "pcb_port_98",
+        "pcb_smtpad_101",
+        "pcb_port_102",
+        "pcb_port_107",
+        "pcb_smtpad_105",
+        "pcb_port_109",
+        "pcb_smtpad_112",
+        "pcb_port_113",
+        "pcb_smtpad_110",
+        "pcb_port_114",
+        "pcb_smtpad_115",
+        "pcb_port_119",
+        "pcb_smtpad_120",
+        "pcb_port_124",
+        "pcb_smtpad_121",
+        "pcb_port_126",
+        "pcb_smtpad_123",
+        "pcb_port_128",
+        "pcb_smtpad_132",
+        "pcb_port_136",
+        "pcb_smtpad_134",
+        "pcb_port_138",
+        "pcb_smtpad_140",
+        "pcb_port_144",
+        "pcb_smtpad_142",
+        "pcb_port_146",
+        "pcb_smtpad_144",
+        "pcb_port_148",
+        "pcb_smtpad_146",
+        "pcb_port_150",
+        "pcb_smtpad_148",
+        "pcb_port_152",
+        "pcb_smtpad_150",
+        "pcb_port_154",
+        "pcb_smtpad_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_0"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_104",
+        "pcb_port_id": "pcb_port_108"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -18.30005,
+        "y": 25.65
+      },
+      "width": 1,
+      "height": 0.6,
+      "connectedTo": [
+        "pcb_smtpad_104",
+        "source_trace_69",
+        "source_trace_6",
+        "source_trace_5",
+        "source_net_15",
+        "pcb_smtpad_0",
+        "pcb_port_0",
+        "pcb_smtpad_2",
+        "pcb_port_2",
+        "pcb_port_108"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_105",
+        "pcb_port_id": "pcb_port_109"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -18.30005,
+        "y": 24.7
+      },
+      "width": 1,
+      "height": 0.6,
+      "connectedTo": [
+        "pcb_smtpad_105",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_smtpad_5",
+        "pcb_port_5",
+        "pcb_smtpad_7",
+        "pcb_port_7",
+        "pcb_smtpad_9",
+        "pcb_port_9",
+        "pcb_smtpad_11",
+        "pcb_port_11",
+        "pcb_smtpad_13",
+        "pcb_port_13",
+        "pcb_smtpad_15",
+        "pcb_port_15",
+        "pcb_smtpad_19",
+        "pcb_port_19",
+        "pcb_smtpad_23",
+        "pcb_port_23",
+        "pcb_smtpad_25",
+        "pcb_port_25",
+        "pcb_plated_hole_0",
+        "pcb_port_26",
+        "pcb_plated_hole_1",
+        "pcb_port_27",
+        "pcb_plated_hole_2",
+        "pcb_port_28",
+        "pcb_plated_hole_3",
+        "pcb_port_29",
+        "pcb_smtpad_26",
+        "pcb_port_30",
+        "pcb_smtpad_37",
+        "pcb_port_41",
+        "pcb_smtpad_56",
+        "pcb_port_60",
+        "pcb_smtpad_94",
+        "pcb_port_98",
+        "pcb_smtpad_101",
+        "pcb_port_102",
+        "pcb_smtpad_103",
+        "pcb_port_107",
+        "pcb_port_109",
+        "pcb_smtpad_112",
+        "pcb_port_113",
+        "pcb_smtpad_110",
+        "pcb_port_114",
+        "pcb_smtpad_115",
+        "pcb_port_119",
+        "pcb_smtpad_120",
+        "pcb_port_124",
+        "pcb_smtpad_121",
+        "pcb_port_126",
+        "pcb_smtpad_123",
+        "pcb_port_128",
+        "pcb_smtpad_132",
+        "pcb_port_136",
+        "pcb_smtpad_134",
+        "pcb_port_138",
+        "pcb_smtpad_140",
+        "pcb_port_144",
+        "pcb_smtpad_142",
+        "pcb_port_146",
+        "pcb_smtpad_144",
+        "pcb_port_148",
+        "pcb_smtpad_146",
+        "pcb_port_150",
+        "pcb_smtpad_148",
+        "pcb_port_152",
+        "pcb_smtpad_150",
+        "pcb_port_154",
+        "pcb_smtpad_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_0"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_106",
+        "pcb_port_id": "pcb_port_110"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -18.30005,
+        "y": 23.75
+      },
+      "width": 1,
+      "height": 0.6,
+      "connectedTo": [
+        "pcb_smtpad_106",
+        "source_trace_7",
+        "pcb_smtpad_3",
+        "pcb_port_3",
+        "pcb_port_110"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_107",
+        "pcb_port_id": "pcb_port_111"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -16.09995,
+        "y": 23.75
+      },
+      "width": 1,
+      "height": 0.6,
+      "connectedTo": [
+        "pcb_smtpad_107",
+        "pcb_port_111"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_108",
+        "pcb_port_id": "pcb_port_112"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -16.09995,
+        "y": 25.65
+      },
+      "width": 1,
+      "height": 0.6,
+      "connectedTo": [
+        "pcb_smtpad_108",
+        "source_trace_106",
+        "source_trace_100",
+        "source_trace_94",
+        "source_trace_83",
+        "source_trace_78",
+        "source_trace_76",
+        "source_trace_72",
+        "source_trace_70",
+        "source_trace_50",
+        "source_trace_48",
+        "source_trace_46",
+        "source_trace_43",
+        "source_trace_42",
+        "source_trace_41",
+        "source_trace_40",
+        "source_trace_39",
+        "source_trace_38",
+        "source_trace_25",
+        "source_trace_23",
+        "source_trace_21",
+        "source_trace_17",
+        "source_trace_14",
+        "source_trace_12",
+        "source_trace_10",
+        "source_trace_8",
+        "source_net_16",
+        "pcb_smtpad_4",
+        "pcb_port_4",
+        "pcb_smtpad_6",
+        "pcb_port_6",
+        "pcb_smtpad_8",
+        "pcb_port_8",
+        "pcb_smtpad_10",
+        "pcb_port_10",
+        "pcb_smtpad_12",
+        "pcb_port_12",
+        "pcb_smtpad_14",
+        "pcb_port_14",
+        "pcb_smtpad_17",
+        "pcb_port_17",
+        "pcb_smtpad_21",
+        "pcb_port_21",
+        "pcb_smtpad_22",
+        "pcb_port_22",
+        "pcb_smtpad_38",
+        "pcb_port_42",
+        "pcb_smtpad_47",
+        "pcb_port_51",
+        "pcb_smtpad_59",
+        "pcb_port_63",
+        "pcb_smtpad_70",
+        "pcb_port_74",
+        "pcb_smtpad_79",
+        "pcb_port_83",
+        "pcb_smtpad_81",
+        "pcb_port_85",
+        "pcb_smtpad_85",
+        "pcb_port_89",
+        "pcb_smtpad_86",
+        "pcb_port_90",
+        "pcb_port_112",
+        "pcb_smtpad_126",
+        "pcb_port_130",
+        "pcb_smtpad_129",
+        "pcb_port_133",
+        "pcb_smtpad_141",
+        "pcb_port_145",
+        "pcb_smtpad_145",
+        "pcb_port_149",
+        "pcb_smtpad_151",
+        "pcb_port_155",
+        "pcb_smtpad_156",
+        "pcb_port_160"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_109",
+        "pcb_port_id": "pcb_port_115"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -11.6,
+        "y": -2.35
+      },
+      "width": 1.4,
+      "height": 1.2,
+      "connectedTo": [
+        "pcb_smtpad_109",
+        "source_trace_87",
+        "source_trace_85",
+        "pcb_smtpad_57",
+        "pcb_port_61",
+        "pcb_port_115",
+        "pcb_smtpad_147",
+        "pcb_port_151"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_110",
+        "pcb_port_id": "pcb_port_114"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -9.4,
+        "y": -2.35
+      },
+      "width": 1.4,
+      "height": 1.2,
+      "connectedTo": [
+        "pcb_smtpad_110",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_smtpad_5",
+        "pcb_port_5",
+        "pcb_smtpad_7",
+        "pcb_port_7",
+        "pcb_smtpad_9",
+        "pcb_port_9",
+        "pcb_smtpad_11",
+        "pcb_port_11",
+        "pcb_smtpad_13",
+        "pcb_port_13",
+        "pcb_smtpad_15",
+        "pcb_port_15",
+        "pcb_smtpad_19",
+        "pcb_port_19",
+        "pcb_smtpad_23",
+        "pcb_port_23",
+        "pcb_smtpad_25",
+        "pcb_port_25",
+        "pcb_plated_hole_0",
+        "pcb_port_26",
+        "pcb_plated_hole_1",
+        "pcb_port_27",
+        "pcb_plated_hole_2",
+        "pcb_port_28",
+        "pcb_plated_hole_3",
+        "pcb_port_29",
+        "pcb_smtpad_26",
+        "pcb_port_30",
+        "pcb_smtpad_37",
+        "pcb_port_41",
+        "pcb_smtpad_56",
+        "pcb_port_60",
+        "pcb_smtpad_94",
+        "pcb_port_98",
+        "pcb_smtpad_101",
+        "pcb_port_102",
+        "pcb_smtpad_103",
+        "pcb_port_107",
+        "pcb_smtpad_105",
+        "pcb_port_109",
+        "pcb_smtpad_112",
+        "pcb_port_113",
+        "pcb_port_114",
+        "pcb_smtpad_115",
+        "pcb_port_119",
+        "pcb_smtpad_120",
+        "pcb_port_124",
+        "pcb_smtpad_121",
+        "pcb_port_126",
+        "pcb_smtpad_123",
+        "pcb_port_128",
+        "pcb_smtpad_132",
+        "pcb_port_136",
+        "pcb_smtpad_134",
+        "pcb_port_138",
+        "pcb_smtpad_140",
+        "pcb_port_144",
+        "pcb_smtpad_142",
+        "pcb_port_146",
+        "pcb_smtpad_144",
+        "pcb_port_148",
+        "pcb_smtpad_146",
+        "pcb_port_150",
+        "pcb_smtpad_148",
+        "pcb_port_152",
+        "pcb_smtpad_150",
+        "pcb_port_154",
+        "pcb_smtpad_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_0"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_111",
+        "pcb_port_id": "pcb_port_116"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -9.4,
+        "y": -0.65
+      },
+      "width": 1.4,
+      "height": 1.2,
+      "connectedTo": [
+        "pcb_smtpad_111",
+        "source_trace_89",
+        "source_trace_86",
+        "pcb_smtpad_58",
+        "pcb_port_62",
+        "pcb_port_116",
+        "pcb_smtpad_149",
+        "pcb_port_153"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_112",
+        "pcb_port_id": "pcb_port_113"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -11.6,
+        "y": -0.65
+      },
+      "width": 1.4,
+      "height": 1.2,
+      "connectedTo": [
+        "pcb_smtpad_112",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_smtpad_5",
+        "pcb_port_5",
+        "pcb_smtpad_7",
+        "pcb_port_7",
+        "pcb_smtpad_9",
+        "pcb_port_9",
+        "pcb_smtpad_11",
+        "pcb_port_11",
+        "pcb_smtpad_13",
+        "pcb_port_13",
+        "pcb_smtpad_15",
+        "pcb_port_15",
+        "pcb_smtpad_19",
+        "pcb_port_19",
+        "pcb_smtpad_23",
+        "pcb_port_23",
+        "pcb_smtpad_25",
+        "pcb_port_25",
+        "pcb_plated_hole_0",
+        "pcb_port_26",
+        "pcb_plated_hole_1",
+        "pcb_port_27",
+        "pcb_plated_hole_2",
+        "pcb_port_28",
+        "pcb_plated_hole_3",
+        "pcb_port_29",
+        "pcb_smtpad_26",
+        "pcb_port_30",
+        "pcb_smtpad_37",
+        "pcb_port_41",
+        "pcb_smtpad_56",
+        "pcb_port_60",
+        "pcb_smtpad_94",
+        "pcb_port_98",
+        "pcb_smtpad_101",
+        "pcb_port_102",
+        "pcb_smtpad_103",
+        "pcb_port_107",
+        "pcb_smtpad_105",
+        "pcb_port_109",
+        "pcb_port_113",
+        "pcb_smtpad_110",
+        "pcb_port_114",
+        "pcb_smtpad_115",
+        "pcb_port_119",
+        "pcb_smtpad_120",
+        "pcb_port_124",
+        "pcb_smtpad_121",
+        "pcb_port_126",
+        "pcb_smtpad_123",
+        "pcb_port_128",
+        "pcb_smtpad_132",
+        "pcb_port_136",
+        "pcb_smtpad_134",
+        "pcb_port_138",
+        "pcb_smtpad_140",
+        "pcb_port_144",
+        "pcb_smtpad_142",
+        "pcb_port_146",
+        "pcb_smtpad_144",
+        "pcb_port_148",
+        "pcb_smtpad_146",
+        "pcb_port_150",
+        "pcb_smtpad_148",
+        "pcb_port_152",
+        "pcb_smtpad_150",
+        "pcb_port_154",
+        "pcb_smtpad_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_0"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_113",
+        "pcb_port_id": "pcb_port_117"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -3.5000000000000004,
+        "y": 27.375
+      },
+      "width": 1.05,
+      "height": 0.7,
+      "connectedTo": [
+        "pcb_smtpad_113",
+        "source_trace_93",
+        "source_trace_91",
+        "source_trace_32",
+        "pcb_smtpad_93",
+        "pcb_port_97",
+        "pcb_smtpad_95",
+        "pcb_port_99",
+        "pcb_port_117",
+        "pcb_smtpad_125",
+        "pcb_port_129"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_1"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_114",
+        "pcb_port_id": "pcb_port_118"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": 0.6999999999999997,
+        "y": 27.375
+      },
+      "width": 1.05,
+      "height": 0.7,
+      "connectedTo": [
+        "pcb_smtpad_114",
+        "pcb_port_118"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_1"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_115",
+        "pcb_port_id": "pcb_port_119"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -3.5000000000000004,
+        "y": 25.225
+      },
+      "width": 1.05,
+      "height": 0.7,
+      "connectedTo": [
+        "pcb_smtpad_115",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_smtpad_5",
+        "pcb_port_5",
+        "pcb_smtpad_7",
+        "pcb_port_7",
+        "pcb_smtpad_9",
+        "pcb_port_9",
+        "pcb_smtpad_11",
+        "pcb_port_11",
+        "pcb_smtpad_13",
+        "pcb_port_13",
+        "pcb_smtpad_15",
+        "pcb_port_15",
+        "pcb_smtpad_19",
+        "pcb_port_19",
+        "pcb_smtpad_23",
+        "pcb_port_23",
+        "pcb_smtpad_25",
+        "pcb_port_25",
+        "pcb_plated_hole_0",
+        "pcb_port_26",
+        "pcb_plated_hole_1",
+        "pcb_port_27",
+        "pcb_plated_hole_2",
+        "pcb_port_28",
+        "pcb_plated_hole_3",
+        "pcb_port_29",
+        "pcb_smtpad_26",
+        "pcb_port_30",
+        "pcb_smtpad_37",
+        "pcb_port_41",
+        "pcb_smtpad_56",
+        "pcb_port_60",
+        "pcb_smtpad_94",
+        "pcb_port_98",
+        "pcb_smtpad_101",
+        "pcb_port_102",
+        "pcb_smtpad_103",
+        "pcb_port_107",
+        "pcb_smtpad_105",
+        "pcb_port_109",
+        "pcb_smtpad_112",
+        "pcb_port_113",
+        "pcb_smtpad_110",
+        "pcb_port_114",
+        "pcb_port_119",
+        "pcb_smtpad_120",
+        "pcb_port_124",
+        "pcb_smtpad_121",
+        "pcb_port_126",
+        "pcb_smtpad_123",
+        "pcb_port_128",
+        "pcb_smtpad_132",
+        "pcb_port_136",
+        "pcb_smtpad_134",
+        "pcb_port_138",
+        "pcb_smtpad_140",
+        "pcb_port_144",
+        "pcb_smtpad_142",
+        "pcb_port_146",
+        "pcb_smtpad_144",
+        "pcb_port_148",
+        "pcb_smtpad_146",
+        "pcb_port_150",
+        "pcb_smtpad_148",
+        "pcb_port_152",
+        "pcb_smtpad_150",
+        "pcb_port_154",
+        "pcb_smtpad_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_2"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_116",
+        "pcb_port_id": "pcb_port_120"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": 0.6999999999999997,
+        "y": 25.225
+      },
+      "width": 1.05,
+      "height": 0.7,
+      "connectedTo": [
+        "pcb_smtpad_116",
+        "pcb_port_120"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_2"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_117",
+        "pcb_port_id": "pcb_port_121"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -5.575,
+        "y": -10.1
+      },
+      "width": 0.7,
+      "height": 1.05,
+      "connectedTo": [
+        "pcb_smtpad_117",
+        "source_trace_95",
+        "source_trace_16",
+        "pcb_smtpad_16",
+        "pcb_port_16",
+        "pcb_smtpad_63",
+        "pcb_port_67",
+        "pcb_port_121"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_3"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_118",
+        "pcb_port_id": "pcb_port_122"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -5.574999999999999,
+        "y": -5.9
+      },
+      "width": 0.7,
+      "height": 1.05,
+      "connectedTo": [
+        "pcb_smtpad_118",
+        "pcb_port_122"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_3"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_119",
+        "pcb_port_id": "pcb_port_123"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -3.4250000000000003,
+        "y": -10.1
+      },
+      "width": 0.7,
+      "height": 1.05,
+      "connectedTo": [
+        "pcb_smtpad_119",
+        "pcb_port_123"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_4"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_120",
+        "pcb_port_id": "pcb_port_124"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -3.425,
+        "y": -5.9
+      },
+      "width": 0.7,
+      "height": 1.05,
+      "connectedTo": [
+        "pcb_smtpad_120",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_smtpad_5",
+        "pcb_port_5",
+        "pcb_smtpad_7",
+        "pcb_port_7",
+        "pcb_smtpad_9",
+        "pcb_port_9",
+        "pcb_smtpad_11",
+        "pcb_port_11",
+        "pcb_smtpad_13",
+        "pcb_port_13",
+        "pcb_smtpad_15",
+        "pcb_port_15",
+        "pcb_smtpad_19",
+        "pcb_port_19",
+        "pcb_smtpad_23",
+        "pcb_port_23",
+        "pcb_smtpad_25",
+        "pcb_port_25",
+        "pcb_plated_hole_0",
+        "pcb_port_26",
+        "pcb_plated_hole_1",
+        "pcb_port_27",
+        "pcb_plated_hole_2",
+        "pcb_port_28",
+        "pcb_plated_hole_3",
+        "pcb_port_29",
+        "pcb_smtpad_26",
+        "pcb_port_30",
+        "pcb_smtpad_37",
+        "pcb_port_41",
+        "pcb_smtpad_56",
+        "pcb_port_60",
+        "pcb_smtpad_94",
+        "pcb_port_98",
+        "pcb_smtpad_101",
+        "pcb_port_102",
+        "pcb_smtpad_103",
+        "pcb_port_107",
+        "pcb_smtpad_105",
+        "pcb_port_109",
+        "pcb_smtpad_112",
+        "pcb_port_113",
+        "pcb_smtpad_110",
+        "pcb_port_114",
+        "pcb_smtpad_115",
+        "pcb_port_119",
+        "pcb_port_124",
+        "pcb_smtpad_121",
+        "pcb_port_126",
+        "pcb_smtpad_123",
+        "pcb_port_128",
+        "pcb_smtpad_132",
+        "pcb_port_136",
+        "pcb_smtpad_134",
+        "pcb_port_138",
+        "pcb_smtpad_140",
+        "pcb_port_144",
+        "pcb_smtpad_142",
+        "pcb_port_146",
+        "pcb_smtpad_144",
+        "pcb_port_148",
+        "pcb_smtpad_146",
+        "pcb_port_150",
+        "pcb_smtpad_148",
+        "pcb_port_152",
+        "pcb_smtpad_150",
+        "pcb_port_154",
+        "pcb_smtpad_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_4"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_121",
+        "pcb_port_id": "pcb_port_126"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -4.5863022628068375e-17,
+        "y": 7.951
+      },
+      "width": 0.8,
+      "height": 0.8,
+      "connectedTo": [
+        "pcb_smtpad_121",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_smtpad_5",
+        "pcb_port_5",
+        "pcb_smtpad_7",
+        "pcb_port_7",
+        "pcb_smtpad_9",
+        "pcb_port_9",
+        "pcb_smtpad_11",
+        "pcb_port_11",
+        "pcb_smtpad_13",
+        "pcb_port_13",
+        "pcb_smtpad_15",
+        "pcb_port_15",
+        "pcb_smtpad_19",
+        "pcb_port_19",
+        "pcb_smtpad_23",
+        "pcb_port_23",
+        "pcb_smtpad_25",
+        "pcb_port_25",
+        "pcb_plated_hole_0",
+        "pcb_port_26",
+        "pcb_plated_hole_1",
+        "pcb_port_27",
+        "pcb_plated_hole_2",
+        "pcb_port_28",
+        "pcb_plated_hole_3",
+        "pcb_port_29",
+        "pcb_smtpad_26",
+        "pcb_port_30",
+        "pcb_smtpad_37",
+        "pcb_port_41",
+        "pcb_smtpad_56",
+        "pcb_port_60",
+        "pcb_smtpad_94",
+        "pcb_port_98",
+        "pcb_smtpad_101",
+        "pcb_port_102",
+        "pcb_smtpad_103",
+        "pcb_port_107",
+        "pcb_smtpad_105",
+        "pcb_port_109",
+        "pcb_smtpad_112",
+        "pcb_port_113",
+        "pcb_smtpad_110",
+        "pcb_port_114",
+        "pcb_smtpad_115",
+        "pcb_port_119",
+        "pcb_smtpad_120",
+        "pcb_port_124",
+        "pcb_port_126",
+        "pcb_smtpad_123",
+        "pcb_port_128",
+        "pcb_smtpad_132",
+        "pcb_port_136",
+        "pcb_smtpad_134",
+        "pcb_port_138",
+        "pcb_smtpad_140",
+        "pcb_port_144",
+        "pcb_smtpad_142",
+        "pcb_port_146",
+        "pcb_smtpad_144",
+        "pcb_port_148",
+        "pcb_smtpad_146",
+        "pcb_port_150",
+        "pcb_smtpad_148",
+        "pcb_port_152",
+        "pcb_smtpad_150",
+        "pcb_port_154",
+        "pcb_smtpad_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_0"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_122",
+        "pcb_port_id": "pcb_port_125"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": 4.5863022628068375e-17,
+        "y": 9.449
+      },
+      "width": 0.8,
+      "height": 0.8,
+      "connectedTo": [
+        "pcb_smtpad_122",
+        "source_trace_98",
+        "pcb_port_125",
+        "pcb_smtpad_128",
+        "pcb_port_132"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_123",
+        "pcb_port_id": "pcb_port_128"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -19.8,
+        "y": 28.551000000000002
+      },
+      "width": 0.8,
+      "height": 0.8,
+      "connectedTo": [
+        "pcb_smtpad_123",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_smtpad_5",
+        "pcb_port_5",
+        "pcb_smtpad_7",
+        "pcb_port_7",
+        "pcb_smtpad_9",
+        "pcb_port_9",
+        "pcb_smtpad_11",
+        "pcb_port_11",
+        "pcb_smtpad_13",
+        "pcb_port_13",
+        "pcb_smtpad_15",
+        "pcb_port_15",
+        "pcb_smtpad_19",
+        "pcb_port_19",
+        "pcb_smtpad_23",
+        "pcb_port_23",
+        "pcb_smtpad_25",
+        "pcb_port_25",
+        "pcb_plated_hole_0",
+        "pcb_port_26",
+        "pcb_plated_hole_1",
+        "pcb_port_27",
+        "pcb_plated_hole_2",
+        "pcb_port_28",
+        "pcb_plated_hole_3",
+        "pcb_port_29",
+        "pcb_smtpad_26",
+        "pcb_port_30",
+        "pcb_smtpad_37",
+        "pcb_port_41",
+        "pcb_smtpad_56",
+        "pcb_port_60",
+        "pcb_smtpad_94",
+        "pcb_port_98",
+        "pcb_smtpad_101",
+        "pcb_port_102",
+        "pcb_smtpad_103",
+        "pcb_port_107",
+        "pcb_smtpad_105",
+        "pcb_port_109",
+        "pcb_smtpad_112",
+        "pcb_port_113",
+        "pcb_smtpad_110",
+        "pcb_port_114",
+        "pcb_smtpad_115",
+        "pcb_port_119",
+        "pcb_smtpad_120",
+        "pcb_port_124",
+        "pcb_smtpad_121",
+        "pcb_port_126",
+        "pcb_port_128",
+        "pcb_smtpad_132",
+        "pcb_port_136",
+        "pcb_smtpad_134",
+        "pcb_port_138",
+        "pcb_smtpad_140",
+        "pcb_port_144",
+        "pcb_smtpad_142",
+        "pcb_port_146",
+        "pcb_smtpad_144",
+        "pcb_port_148",
+        "pcb_smtpad_146",
+        "pcb_port_150",
+        "pcb_smtpad_148",
+        "pcb_port_152",
+        "pcb_smtpad_150",
+        "pcb_port_154",
+        "pcb_smtpad_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_0"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_124",
+        "pcb_port_id": "pcb_port_127"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -19.8,
+        "y": 30.049
+      },
+      "width": 0.8,
+      "height": 0.8,
+      "connectedTo": [
+        "pcb_smtpad_124",
+        "source_trace_101",
+        "pcb_port_127",
+        "pcb_smtpad_130",
+        "pcb_port_134"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_125",
+        "pcb_port_id": "pcb_port_129"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": 2,
+        "y": 21.79
+      },
+      "width": 0.64,
+      "height": 0.54,
+      "connectedTo": [
+        "pcb_smtpad_125",
+        "source_trace_93",
+        "source_trace_91",
+        "source_trace_32",
+        "pcb_smtpad_93",
+        "pcb_port_97",
+        "pcb_smtpad_95",
+        "pcb_port_99",
+        "pcb_smtpad_113",
+        "pcb_port_117",
+        "pcb_port_129"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_1"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_126",
+        "pcb_port_id": "pcb_port_130"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": 2,
+        "y": 22.810000000000002
+      },
+      "width": 0.64,
+      "height": 0.54,
+      "connectedTo": [
+        "pcb_smtpad_126",
+        "source_trace_106",
+        "source_trace_100",
+        "source_trace_94",
+        "source_trace_83",
+        "source_trace_78",
+        "source_trace_76",
+        "source_trace_72",
+        "source_trace_70",
+        "source_trace_50",
+        "source_trace_48",
+        "source_trace_46",
+        "source_trace_43",
+        "source_trace_42",
+        "source_trace_41",
+        "source_trace_40",
+        "source_trace_39",
+        "source_trace_38",
+        "source_trace_25",
+        "source_trace_23",
+        "source_trace_21",
+        "source_trace_17",
+        "source_trace_14",
+        "source_trace_12",
+        "source_trace_10",
+        "source_trace_8",
+        "source_net_16",
+        "pcb_smtpad_4",
+        "pcb_port_4",
+        "pcb_smtpad_6",
+        "pcb_port_6",
+        "pcb_smtpad_8",
+        "pcb_port_8",
+        "pcb_smtpad_10",
+        "pcb_port_10",
+        "pcb_smtpad_12",
+        "pcb_port_12",
+        "pcb_smtpad_14",
+        "pcb_port_14",
+        "pcb_smtpad_17",
+        "pcb_port_17",
+        "pcb_smtpad_21",
+        "pcb_port_21",
+        "pcb_smtpad_22",
+        "pcb_port_22",
+        "pcb_smtpad_38",
+        "pcb_port_42",
+        "pcb_smtpad_47",
+        "pcb_port_51",
+        "pcb_smtpad_59",
+        "pcb_port_63",
+        "pcb_smtpad_70",
+        "pcb_port_74",
+        "pcb_smtpad_79",
+        "pcb_port_83",
+        "pcb_smtpad_81",
+        "pcb_port_85",
+        "pcb_smtpad_85",
+        "pcb_port_89",
+        "pcb_smtpad_86",
+        "pcb_port_90",
+        "pcb_smtpad_108",
+        "pcb_port_112",
+        "pcb_port_130",
+        "pcb_smtpad_129",
+        "pcb_port_133",
+        "pcb_smtpad_141",
+        "pcb_port_145",
+        "pcb_smtpad_145",
+        "pcb_port_149",
+        "pcb_smtpad_151",
+        "pcb_port_155",
+        "pcb_smtpad_156",
+        "pcb_port_160"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_127",
+        "pcb_port_id": "pcb_port_131"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -2.8,
+        "y": 5.19
+      },
+      "width": 0.64,
+      "height": 0.54,
+      "connectedTo": [
+        "pcb_smtpad_127",
+        "source_trace_97",
+        "pcb_smtpad_74",
+        "pcb_port_78",
+        "pcb_port_131"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_128",
+        "pcb_port_id": "pcb_port_132"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -2.8,
+        "y": 6.21
+      },
+      "width": 0.64,
+      "height": 0.54,
+      "connectedTo": [
+        "pcb_smtpad_128",
+        "source_trace_98",
+        "pcb_smtpad_122",
+        "pcb_port_125",
+        "pcb_port_132"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_129",
+        "pcb_port_id": "pcb_port_133"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -16.2,
+        "y": 28.79
+      },
+      "width": 0.64,
+      "height": 0.54,
+      "connectedTo": [
+        "pcb_smtpad_129",
+        "source_trace_106",
+        "source_trace_100",
+        "source_trace_94",
+        "source_trace_83",
+        "source_trace_78",
+        "source_trace_76",
+        "source_trace_72",
+        "source_trace_70",
+        "source_trace_50",
+        "source_trace_48",
+        "source_trace_46",
+        "source_trace_43",
+        "source_trace_42",
+        "source_trace_41",
+        "source_trace_40",
+        "source_trace_39",
+        "source_trace_38",
+        "source_trace_25",
+        "source_trace_23",
+        "source_trace_21",
+        "source_trace_17",
+        "source_trace_14",
+        "source_trace_12",
+        "source_trace_10",
+        "source_trace_8",
+        "source_net_16",
+        "pcb_smtpad_4",
+        "pcb_port_4",
+        "pcb_smtpad_6",
+        "pcb_port_6",
+        "pcb_smtpad_8",
+        "pcb_port_8",
+        "pcb_smtpad_10",
+        "pcb_port_10",
+        "pcb_smtpad_12",
+        "pcb_port_12",
+        "pcb_smtpad_14",
+        "pcb_port_14",
+        "pcb_smtpad_17",
+        "pcb_port_17",
+        "pcb_smtpad_21",
+        "pcb_port_21",
+        "pcb_smtpad_22",
+        "pcb_port_22",
+        "pcb_smtpad_38",
+        "pcb_port_42",
+        "pcb_smtpad_47",
+        "pcb_port_51",
+        "pcb_smtpad_59",
+        "pcb_port_63",
+        "pcb_smtpad_70",
+        "pcb_port_74",
+        "pcb_smtpad_79",
+        "pcb_port_83",
+        "pcb_smtpad_81",
+        "pcb_port_85",
+        "pcb_smtpad_85",
+        "pcb_port_89",
+        "pcb_smtpad_86",
+        "pcb_port_90",
+        "pcb_smtpad_108",
+        "pcb_port_112",
+        "pcb_smtpad_126",
+        "pcb_port_130",
+        "pcb_port_133",
+        "pcb_smtpad_141",
+        "pcb_port_145",
+        "pcb_smtpad_145",
+        "pcb_port_149",
+        "pcb_smtpad_151",
+        "pcb_port_155",
+        "pcb_smtpad_156",
+        "pcb_port_160"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_130",
+        "pcb_port_id": "pcb_port_134"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -16.2,
+        "y": 29.810000000000002
+      },
+      "width": 0.64,
+      "height": 0.54,
+      "connectedTo": [
+        "pcb_smtpad_130",
+        "source_trace_101",
+        "pcb_smtpad_124",
+        "pcb_port_127",
+        "pcb_port_134"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_131",
+        "pcb_port_id": "pcb_port_135"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -10.709999999999999,
+        "y": 30.1
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_131",
+        "source_trace_57",
+        "pcb_smtpad_29",
+        "pcb_port_33",
+        "pcb_port_135"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_132",
+        "pcb_port_id": "pcb_port_136"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -9.69,
+        "y": 30.1
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_132",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_smtpad_5",
+        "pcb_port_5",
+        "pcb_smtpad_7",
+        "pcb_port_7",
+        "pcb_smtpad_9",
+        "pcb_port_9",
+        "pcb_smtpad_11",
+        "pcb_port_11",
+        "pcb_smtpad_13",
+        "pcb_port_13",
+        "pcb_smtpad_15",
+        "pcb_port_15",
+        "pcb_smtpad_19",
+        "pcb_port_19",
+        "pcb_smtpad_23",
+        "pcb_port_23",
+        "pcb_smtpad_25",
+        "pcb_port_25",
+        "pcb_plated_hole_0",
+        "pcb_port_26",
+        "pcb_plated_hole_1",
+        "pcb_port_27",
+        "pcb_plated_hole_2",
+        "pcb_port_28",
+        "pcb_plated_hole_3",
+        "pcb_port_29",
+        "pcb_smtpad_26",
+        "pcb_port_30",
+        "pcb_smtpad_37",
+        "pcb_port_41",
+        "pcb_smtpad_56",
+        "pcb_port_60",
+        "pcb_smtpad_94",
+        "pcb_port_98",
+        "pcb_smtpad_101",
+        "pcb_port_102",
+        "pcb_smtpad_103",
+        "pcb_port_107",
+        "pcb_smtpad_105",
+        "pcb_port_109",
+        "pcb_smtpad_112",
+        "pcb_port_113",
+        "pcb_smtpad_110",
+        "pcb_port_114",
+        "pcb_smtpad_115",
+        "pcb_port_119",
+        "pcb_smtpad_120",
+        "pcb_port_124",
+        "pcb_smtpad_121",
+        "pcb_port_126",
+        "pcb_smtpad_123",
+        "pcb_port_128",
+        "pcb_port_136",
+        "pcb_smtpad_134",
+        "pcb_port_138",
+        "pcb_smtpad_140",
+        "pcb_port_144",
+        "pcb_smtpad_142",
+        "pcb_port_146",
+        "pcb_smtpad_144",
+        "pcb_port_148",
+        "pcb_smtpad_146",
+        "pcb_port_150",
+        "pcb_smtpad_148",
+        "pcb_port_152",
+        "pcb_smtpad_150",
+        "pcb_port_154",
+        "pcb_smtpad_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_0"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_133",
+        "pcb_port_id": "pcb_port_137"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -6.91,
+        "y": 31
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_133",
+        "source_trace_58",
+        "pcb_smtpad_35",
+        "pcb_port_39",
+        "pcb_port_137"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_134",
+        "pcb_port_id": "pcb_port_138"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -5.890000000000001,
+        "y": 31
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_134",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_smtpad_5",
+        "pcb_port_5",
+        "pcb_smtpad_7",
+        "pcb_port_7",
+        "pcb_smtpad_9",
+        "pcb_port_9",
+        "pcb_smtpad_11",
+        "pcb_port_11",
+        "pcb_smtpad_13",
+        "pcb_port_13",
+        "pcb_smtpad_15",
+        "pcb_port_15",
+        "pcb_smtpad_19",
+        "pcb_port_19",
+        "pcb_smtpad_23",
+        "pcb_port_23",
+        "pcb_smtpad_25",
+        "pcb_port_25",
+        "pcb_plated_hole_0",
+        "pcb_port_26",
+        "pcb_plated_hole_1",
+        "pcb_port_27",
+        "pcb_plated_hole_2",
+        "pcb_port_28",
+        "pcb_plated_hole_3",
+        "pcb_port_29",
+        "pcb_smtpad_26",
+        "pcb_port_30",
+        "pcb_smtpad_37",
+        "pcb_port_41",
+        "pcb_smtpad_56",
+        "pcb_port_60",
+        "pcb_smtpad_94",
+        "pcb_port_98",
+        "pcb_smtpad_101",
+        "pcb_port_102",
+        "pcb_smtpad_103",
+        "pcb_port_107",
+        "pcb_smtpad_105",
+        "pcb_port_109",
+        "pcb_smtpad_112",
+        "pcb_port_113",
+        "pcb_smtpad_110",
+        "pcb_port_114",
+        "pcb_smtpad_115",
+        "pcb_port_119",
+        "pcb_smtpad_120",
+        "pcb_port_124",
+        "pcb_smtpad_121",
+        "pcb_port_126",
+        "pcb_smtpad_123",
+        "pcb_port_128",
+        "pcb_smtpad_132",
+        "pcb_port_136",
+        "pcb_port_138",
+        "pcb_smtpad_140",
+        "pcb_port_144",
+        "pcb_smtpad_142",
+        "pcb_port_146",
+        "pcb_smtpad_144",
+        "pcb_port_148",
+        "pcb_smtpad_146",
+        "pcb_port_150",
+        "pcb_smtpad_148",
+        "pcb_port_152",
+        "pcb_smtpad_150",
+        "pcb_port_154",
+        "pcb_smtpad_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_0"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_135",
+        "pcb_port_id": "pcb_port_139"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -8.3,
+        "y": 11.2
+      },
+      "width": 0.7,
+      "height": 0.6,
+      "connectedTo": [
+        "pcb_smtpad_135",
+        "source_trace_53",
+        "source_trace_2",
+        "pcb_smtpad_30",
+        "pcb_port_34",
+        "pcb_smtpad_32",
+        "pcb_port_36",
+        "pcb_port_139"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_136",
+        "pcb_port_id": "pcb_port_140"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -8.3,
+        "y": 10.2
+      },
+      "width": 0.7,
+      "height": 0.6,
+      "connectedTo": [
+        "pcb_smtpad_136",
+        "source_trace_54",
+        "pcb_smtpad_83",
+        "pcb_port_87",
+        "pcb_port_140"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_137",
+        "pcb_port_id": "pcb_port_141"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -9.3,
+        "y": 11.2
+      },
+      "width": 0.7,
+      "height": 0.6,
+      "connectedTo": [
+        "pcb_smtpad_137",
+        "source_trace_55",
+        "source_trace_3",
+        "pcb_smtpad_31",
+        "pcb_port_35",
+        "pcb_smtpad_33",
+        "pcb_port_37",
+        "pcb_port_141"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_138",
+        "pcb_port_id": "pcb_port_142"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -9.3,
+        "y": 10.2
+      },
+      "width": 0.7,
+      "height": 0.6,
+      "connectedTo": [
+        "pcb_smtpad_138",
+        "source_trace_56",
+        "pcb_smtpad_84",
+        "pcb_port_88",
+        "pcb_port_142"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_139",
+        "pcb_port_id": "pcb_port_143"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -12.8,
+        "y": 29.975
+      },
+      "width": 0.95,
+      "height": 0.8,
+      "connectedTo": [
+        "pcb_smtpad_139",
+        "source_trace_67",
+        "source_trace_52",
+        "source_trace_51",
+        "source_trace_4",
+        "source_net_14",
+        "pcb_smtpad_1",
+        "pcb_port_1",
+        "pcb_smtpad_27",
+        "pcb_port_31",
+        "pcb_smtpad_36",
+        "pcb_port_40",
+        "pcb_port_143"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_140",
+        "pcb_port_id": "pcb_port_144"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -12.8,
+        "y": 31.625
+      },
+      "width": 0.95,
+      "height": 0.8,
+      "connectedTo": [
+        "pcb_smtpad_140",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_smtpad_5",
+        "pcb_port_5",
+        "pcb_smtpad_7",
+        "pcb_port_7",
+        "pcb_smtpad_9",
+        "pcb_port_9",
+        "pcb_smtpad_11",
+        "pcb_port_11",
+        "pcb_smtpad_13",
+        "pcb_port_13",
+        "pcb_smtpad_15",
+        "pcb_port_15",
+        "pcb_smtpad_19",
+        "pcb_port_19",
+        "pcb_smtpad_23",
+        "pcb_port_23",
+        "pcb_smtpad_25",
+        "pcb_port_25",
+        "pcb_plated_hole_0",
+        "pcb_port_26",
+        "pcb_plated_hole_1",
+        "pcb_port_27",
+        "pcb_plated_hole_2",
+        "pcb_port_28",
+        "pcb_plated_hole_3",
+        "pcb_port_29",
+        "pcb_smtpad_26",
+        "pcb_port_30",
+        "pcb_smtpad_37",
+        "pcb_port_41",
+        "pcb_smtpad_56",
+        "pcb_port_60",
+        "pcb_smtpad_94",
+        "pcb_port_98",
+        "pcb_smtpad_101",
+        "pcb_port_102",
+        "pcb_smtpad_103",
+        "pcb_port_107",
+        "pcb_smtpad_105",
+        "pcb_port_109",
+        "pcb_smtpad_112",
+        "pcb_port_113",
+        "pcb_smtpad_110",
+        "pcb_port_114",
+        "pcb_smtpad_115",
+        "pcb_port_119",
+        "pcb_smtpad_120",
+        "pcb_port_124",
+        "pcb_smtpad_121",
+        "pcb_port_126",
+        "pcb_smtpad_123",
+        "pcb_port_128",
+        "pcb_smtpad_132",
+        "pcb_port_136",
+        "pcb_smtpad_134",
+        "pcb_port_138",
+        "pcb_port_144",
+        "pcb_smtpad_142",
+        "pcb_port_146",
+        "pcb_smtpad_144",
+        "pcb_port_148",
+        "pcb_smtpad_146",
+        "pcb_port_150",
+        "pcb_smtpad_148",
+        "pcb_port_152",
+        "pcb_smtpad_150",
+        "pcb_port_154",
+        "pcb_smtpad_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_0"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_141",
+        "pcb_port_id": "pcb_port_145"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -19.325,
+        "y": 8.7
+      },
+      "width": 0.8,
+      "height": 0.95,
+      "connectedTo": [
+        "pcb_smtpad_141",
+        "source_trace_106",
+        "source_trace_100",
+        "source_trace_94",
+        "source_trace_83",
+        "source_trace_78",
+        "source_trace_76",
+        "source_trace_72",
+        "source_trace_70",
+        "source_trace_50",
+        "source_trace_48",
+        "source_trace_46",
+        "source_trace_43",
+        "source_trace_42",
+        "source_trace_41",
+        "source_trace_40",
+        "source_trace_39",
+        "source_trace_38",
+        "source_trace_25",
+        "source_trace_23",
+        "source_trace_21",
+        "source_trace_17",
+        "source_trace_14",
+        "source_trace_12",
+        "source_trace_10",
+        "source_trace_8",
+        "source_net_16",
+        "pcb_smtpad_4",
+        "pcb_port_4",
+        "pcb_smtpad_6",
+        "pcb_port_6",
+        "pcb_smtpad_8",
+        "pcb_port_8",
+        "pcb_smtpad_10",
+        "pcb_port_10",
+        "pcb_smtpad_12",
+        "pcb_port_12",
+        "pcb_smtpad_14",
+        "pcb_port_14",
+        "pcb_smtpad_17",
+        "pcb_port_17",
+        "pcb_smtpad_21",
+        "pcb_port_21",
+        "pcb_smtpad_22",
+        "pcb_port_22",
+        "pcb_smtpad_38",
+        "pcb_port_42",
+        "pcb_smtpad_47",
+        "pcb_port_51",
+        "pcb_smtpad_59",
+        "pcb_port_63",
+        "pcb_smtpad_70",
+        "pcb_port_74",
+        "pcb_smtpad_79",
+        "pcb_port_83",
+        "pcb_smtpad_81",
+        "pcb_port_85",
+        "pcb_smtpad_85",
+        "pcb_port_89",
+        "pcb_smtpad_86",
+        "pcb_port_90",
+        "pcb_smtpad_108",
+        "pcb_port_112",
+        "pcb_smtpad_126",
+        "pcb_port_130",
+        "pcb_smtpad_129",
+        "pcb_port_133",
+        "pcb_port_145",
+        "pcb_smtpad_145",
+        "pcb_port_149",
+        "pcb_smtpad_151",
+        "pcb_port_155",
+        "pcb_smtpad_156",
+        "pcb_port_160"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_142",
+        "pcb_port_id": "pcb_port_146"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -17.675,
+        "y": 8.7
+      },
+      "width": 0.8,
+      "height": 0.95,
+      "connectedTo": [
+        "pcb_smtpad_142",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_smtpad_5",
+        "pcb_port_5",
+        "pcb_smtpad_7",
+        "pcb_port_7",
+        "pcb_smtpad_9",
+        "pcb_port_9",
+        "pcb_smtpad_11",
+        "pcb_port_11",
+        "pcb_smtpad_13",
+        "pcb_port_13",
+        "pcb_smtpad_15",
+        "pcb_port_15",
+        "pcb_smtpad_19",
+        "pcb_port_19",
+        "pcb_smtpad_23",
+        "pcb_port_23",
+        "pcb_smtpad_25",
+        "pcb_port_25",
+        "pcb_plated_hole_0",
+        "pcb_port_26",
+        "pcb_plated_hole_1",
+        "pcb_port_27",
+        "pcb_plated_hole_2",
+        "pcb_port_28",
+        "pcb_plated_hole_3",
+        "pcb_port_29",
+        "pcb_smtpad_26",
+        "pcb_port_30",
+        "pcb_smtpad_37",
+        "pcb_port_41",
+        "pcb_smtpad_56",
+        "pcb_port_60",
+        "pcb_smtpad_94",
+        "pcb_port_98",
+        "pcb_smtpad_101",
+        "pcb_port_102",
+        "pcb_smtpad_103",
+        "pcb_port_107",
+        "pcb_smtpad_105",
+        "pcb_port_109",
+        "pcb_smtpad_112",
+        "pcb_port_113",
+        "pcb_smtpad_110",
+        "pcb_port_114",
+        "pcb_smtpad_115",
+        "pcb_port_119",
+        "pcb_smtpad_120",
+        "pcb_port_124",
+        "pcb_smtpad_121",
+        "pcb_port_126",
+        "pcb_smtpad_123",
+        "pcb_port_128",
+        "pcb_smtpad_132",
+        "pcb_port_136",
+        "pcb_smtpad_134",
+        "pcb_port_138",
+        "pcb_smtpad_140",
+        "pcb_port_144",
+        "pcb_port_146",
+        "pcb_smtpad_144",
+        "pcb_port_148",
+        "pcb_smtpad_146",
+        "pcb_port_150",
+        "pcb_smtpad_148",
+        "pcb_port_152",
+        "pcb_smtpad_150",
+        "pcb_port_154",
+        "pcb_smtpad_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_0"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_143",
+        "pcb_port_id": "pcb_port_147"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -6.71,
+        "y": -1
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_143",
+        "source_trace_74",
+        "source_trace_47",
+        "source_trace_45",
+        "source_trace_44",
+        "source_net_21",
+        "pcb_smtpad_60",
+        "pcb_port_64",
+        "pcb_smtpad_82",
+        "pcb_port_86",
+        "pcb_smtpad_87",
+        "pcb_port_91",
+        "pcb_port_147"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_144",
+        "pcb_port_id": "pcb_port_148"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -5.69,
+        "y": -1
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_144",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_smtpad_5",
+        "pcb_port_5",
+        "pcb_smtpad_7",
+        "pcb_port_7",
+        "pcb_smtpad_9",
+        "pcb_port_9",
+        "pcb_smtpad_11",
+        "pcb_port_11",
+        "pcb_smtpad_13",
+        "pcb_port_13",
+        "pcb_smtpad_15",
+        "pcb_port_15",
+        "pcb_smtpad_19",
+        "pcb_port_19",
+        "pcb_smtpad_23",
+        "pcb_port_23",
+        "pcb_smtpad_25",
+        "pcb_port_25",
+        "pcb_plated_hole_0",
+        "pcb_port_26",
+        "pcb_plated_hole_1",
+        "pcb_port_27",
+        "pcb_plated_hole_2",
+        "pcb_port_28",
+        "pcb_plated_hole_3",
+        "pcb_port_29",
+        "pcb_smtpad_26",
+        "pcb_port_30",
+        "pcb_smtpad_37",
+        "pcb_port_41",
+        "pcb_smtpad_56",
+        "pcb_port_60",
+        "pcb_smtpad_94",
+        "pcb_port_98",
+        "pcb_smtpad_101",
+        "pcb_port_102",
+        "pcb_smtpad_103",
+        "pcb_port_107",
+        "pcb_smtpad_105",
+        "pcb_port_109",
+        "pcb_smtpad_112",
+        "pcb_port_113",
+        "pcb_smtpad_110",
+        "pcb_port_114",
+        "pcb_smtpad_115",
+        "pcb_port_119",
+        "pcb_smtpad_120",
+        "pcb_port_124",
+        "pcb_smtpad_121",
+        "pcb_port_126",
+        "pcb_smtpad_123",
+        "pcb_port_128",
+        "pcb_smtpad_132",
+        "pcb_port_136",
+        "pcb_smtpad_134",
+        "pcb_port_138",
+        "pcb_smtpad_140",
+        "pcb_port_144",
+        "pcb_smtpad_142",
+        "pcb_port_146",
+        "pcb_port_148",
+        "pcb_smtpad_146",
+        "pcb_port_150",
+        "pcb_smtpad_148",
+        "pcb_port_152",
+        "pcb_smtpad_150",
+        "pcb_port_154",
+        "pcb_smtpad_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_0"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_145",
+        "pcb_port_id": "pcb_port_149"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -0.7099999999999993,
+        "y": 22.9
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_145",
+        "source_trace_106",
+        "source_trace_100",
+        "source_trace_94",
+        "source_trace_83",
+        "source_trace_78",
+        "source_trace_76",
+        "source_trace_72",
+        "source_trace_70",
+        "source_trace_50",
+        "source_trace_48",
+        "source_trace_46",
+        "source_trace_43",
+        "source_trace_42",
+        "source_trace_41",
+        "source_trace_40",
+        "source_trace_39",
+        "source_trace_38",
+        "source_trace_25",
+        "source_trace_23",
+        "source_trace_21",
+        "source_trace_17",
+        "source_trace_14",
+        "source_trace_12",
+        "source_trace_10",
+        "source_trace_8",
+        "source_net_16",
+        "pcb_smtpad_4",
+        "pcb_port_4",
+        "pcb_smtpad_6",
+        "pcb_port_6",
+        "pcb_smtpad_8",
+        "pcb_port_8",
+        "pcb_smtpad_10",
+        "pcb_port_10",
+        "pcb_smtpad_12",
+        "pcb_port_12",
+        "pcb_smtpad_14",
+        "pcb_port_14",
+        "pcb_smtpad_17",
+        "pcb_port_17",
+        "pcb_smtpad_21",
+        "pcb_port_21",
+        "pcb_smtpad_22",
+        "pcb_port_22",
+        "pcb_smtpad_38",
+        "pcb_port_42",
+        "pcb_smtpad_47",
+        "pcb_port_51",
+        "pcb_smtpad_59",
+        "pcb_port_63",
+        "pcb_smtpad_70",
+        "pcb_port_74",
+        "pcb_smtpad_79",
+        "pcb_port_83",
+        "pcb_smtpad_81",
+        "pcb_port_85",
+        "pcb_smtpad_85",
+        "pcb_port_89",
+        "pcb_smtpad_86",
+        "pcb_port_90",
+        "pcb_smtpad_108",
+        "pcb_port_112",
+        "pcb_smtpad_126",
+        "pcb_port_130",
+        "pcb_smtpad_129",
+        "pcb_port_133",
+        "pcb_smtpad_141",
+        "pcb_port_145",
+        "pcb_port_149",
+        "pcb_smtpad_151",
+        "pcb_port_155",
+        "pcb_smtpad_156",
+        "pcb_port_160"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_146",
+        "pcb_port_id": "pcb_port_150"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": 0.3100000000000007,
+        "y": 22.9
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_146",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_smtpad_5",
+        "pcb_port_5",
+        "pcb_smtpad_7",
+        "pcb_port_7",
+        "pcb_smtpad_9",
+        "pcb_port_9",
+        "pcb_smtpad_11",
+        "pcb_port_11",
+        "pcb_smtpad_13",
+        "pcb_port_13",
+        "pcb_smtpad_15",
+        "pcb_port_15",
+        "pcb_smtpad_19",
+        "pcb_port_19",
+        "pcb_smtpad_23",
+        "pcb_port_23",
+        "pcb_smtpad_25",
+        "pcb_port_25",
+        "pcb_plated_hole_0",
+        "pcb_port_26",
+        "pcb_plated_hole_1",
+        "pcb_port_27",
+        "pcb_plated_hole_2",
+        "pcb_port_28",
+        "pcb_plated_hole_3",
+        "pcb_port_29",
+        "pcb_smtpad_26",
+        "pcb_port_30",
+        "pcb_smtpad_37",
+        "pcb_port_41",
+        "pcb_smtpad_56",
+        "pcb_port_60",
+        "pcb_smtpad_94",
+        "pcb_port_98",
+        "pcb_smtpad_101",
+        "pcb_port_102",
+        "pcb_smtpad_103",
+        "pcb_port_107",
+        "pcb_smtpad_105",
+        "pcb_port_109",
+        "pcb_smtpad_112",
+        "pcb_port_113",
+        "pcb_smtpad_110",
+        "pcb_port_114",
+        "pcb_smtpad_115",
+        "pcb_port_119",
+        "pcb_smtpad_120",
+        "pcb_port_124",
+        "pcb_smtpad_121",
+        "pcb_port_126",
+        "pcb_smtpad_123",
+        "pcb_port_128",
+        "pcb_smtpad_132",
+        "pcb_port_136",
+        "pcb_smtpad_134",
+        "pcb_port_138",
+        "pcb_smtpad_140",
+        "pcb_port_144",
+        "pcb_smtpad_142",
+        "pcb_port_146",
+        "pcb_smtpad_144",
+        "pcb_port_148",
+        "pcb_port_150",
+        "pcb_smtpad_148",
+        "pcb_port_152",
+        "pcb_smtpad_150",
+        "pcb_port_154",
+        "pcb_smtpad_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_0"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_147",
+        "pcb_port_id": "pcb_port_151"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -13.709999999999999,
+        "y": -4.5
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_147",
+        "source_trace_87",
+        "source_trace_85",
+        "pcb_smtpad_57",
+        "pcb_port_61",
+        "pcb_smtpad_109",
+        "pcb_port_115",
+        "pcb_port_151"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_148",
+        "pcb_port_id": "pcb_port_152"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -12.69,
+        "y": -4.5
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_148",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_smtpad_5",
+        "pcb_port_5",
+        "pcb_smtpad_7",
+        "pcb_port_7",
+        "pcb_smtpad_9",
+        "pcb_port_9",
+        "pcb_smtpad_11",
+        "pcb_port_11",
+        "pcb_smtpad_13",
+        "pcb_port_13",
+        "pcb_smtpad_15",
+        "pcb_port_15",
+        "pcb_smtpad_19",
+        "pcb_port_19",
+        "pcb_smtpad_23",
+        "pcb_port_23",
+        "pcb_smtpad_25",
+        "pcb_port_25",
+        "pcb_plated_hole_0",
+        "pcb_port_26",
+        "pcb_plated_hole_1",
+        "pcb_port_27",
+        "pcb_plated_hole_2",
+        "pcb_port_28",
+        "pcb_plated_hole_3",
+        "pcb_port_29",
+        "pcb_smtpad_26",
+        "pcb_port_30",
+        "pcb_smtpad_37",
+        "pcb_port_41",
+        "pcb_smtpad_56",
+        "pcb_port_60",
+        "pcb_smtpad_94",
+        "pcb_port_98",
+        "pcb_smtpad_101",
+        "pcb_port_102",
+        "pcb_smtpad_103",
+        "pcb_port_107",
+        "pcb_smtpad_105",
+        "pcb_port_109",
+        "pcb_smtpad_112",
+        "pcb_port_113",
+        "pcb_smtpad_110",
+        "pcb_port_114",
+        "pcb_smtpad_115",
+        "pcb_port_119",
+        "pcb_smtpad_120",
+        "pcb_port_124",
+        "pcb_smtpad_121",
+        "pcb_port_126",
+        "pcb_smtpad_123",
+        "pcb_port_128",
+        "pcb_smtpad_132",
+        "pcb_port_136",
+        "pcb_smtpad_134",
+        "pcb_port_138",
+        "pcb_smtpad_140",
+        "pcb_port_144",
+        "pcb_smtpad_142",
+        "pcb_port_146",
+        "pcb_smtpad_144",
+        "pcb_port_148",
+        "pcb_smtpad_146",
+        "pcb_port_150",
+        "pcb_port_152",
+        "pcb_smtpad_150",
+        "pcb_port_154",
+        "pcb_smtpad_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_0"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_149",
+        "pcb_port_id": "pcb_port_153"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -7.71,
+        "y": -4.5
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_149",
+        "source_trace_89",
+        "source_trace_86",
+        "pcb_smtpad_58",
+        "pcb_port_62",
+        "pcb_smtpad_111",
+        "pcb_port_116",
+        "pcb_port_153"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_150",
+        "pcb_port_id": "pcb_port_154"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -6.69,
+        "y": -4.5
+      },
+      "width": 0.54,
+      "height": 0.64,
+      "connectedTo": [
+        "pcb_smtpad_150",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_smtpad_5",
+        "pcb_port_5",
+        "pcb_smtpad_7",
+        "pcb_port_7",
+        "pcb_smtpad_9",
+        "pcb_port_9",
+        "pcb_smtpad_11",
+        "pcb_port_11",
+        "pcb_smtpad_13",
+        "pcb_port_13",
+        "pcb_smtpad_15",
+        "pcb_port_15",
+        "pcb_smtpad_19",
+        "pcb_port_19",
+        "pcb_smtpad_23",
+        "pcb_port_23",
+        "pcb_smtpad_25",
+        "pcb_port_25",
+        "pcb_plated_hole_0",
+        "pcb_port_26",
+        "pcb_plated_hole_1",
+        "pcb_port_27",
+        "pcb_plated_hole_2",
+        "pcb_port_28",
+        "pcb_plated_hole_3",
+        "pcb_port_29",
+        "pcb_smtpad_26",
+        "pcb_port_30",
+        "pcb_smtpad_37",
+        "pcb_port_41",
+        "pcb_smtpad_56",
+        "pcb_port_60",
+        "pcb_smtpad_94",
+        "pcb_port_98",
+        "pcb_smtpad_101",
+        "pcb_port_102",
+        "pcb_smtpad_103",
+        "pcb_port_107",
+        "pcb_smtpad_105",
+        "pcb_port_109",
+        "pcb_smtpad_112",
+        "pcb_port_113",
+        "pcb_smtpad_110",
+        "pcb_port_114",
+        "pcb_smtpad_115",
+        "pcb_port_119",
+        "pcb_smtpad_120",
+        "pcb_port_124",
+        "pcb_smtpad_121",
+        "pcb_port_126",
+        "pcb_smtpad_123",
+        "pcb_port_128",
+        "pcb_smtpad_132",
+        "pcb_port_136",
+        "pcb_smtpad_134",
+        "pcb_port_138",
+        "pcb_smtpad_140",
+        "pcb_port_144",
+        "pcb_smtpad_142",
+        "pcb_port_146",
+        "pcb_smtpad_144",
+        "pcb_port_148",
+        "pcb_smtpad_146",
+        "pcb_port_150",
+        "pcb_smtpad_148",
+        "pcb_port_152",
+        "pcb_port_154",
+        "pcb_smtpad_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_0"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_151",
+        "pcb_port_id": "pcb_port_155"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -1.5,
+        "y": 1.8750000000000002
+      },
+      "width": 0.95,
+      "height": 0.8,
+      "connectedTo": [
+        "pcb_smtpad_151",
+        "source_trace_106",
+        "source_trace_100",
+        "source_trace_94",
+        "source_trace_83",
+        "source_trace_78",
+        "source_trace_76",
+        "source_trace_72",
+        "source_trace_70",
+        "source_trace_50",
+        "source_trace_48",
+        "source_trace_46",
+        "source_trace_43",
+        "source_trace_42",
+        "source_trace_41",
+        "source_trace_40",
+        "source_trace_39",
+        "source_trace_38",
+        "source_trace_25",
+        "source_trace_23",
+        "source_trace_21",
+        "source_trace_17",
+        "source_trace_14",
+        "source_trace_12",
+        "source_trace_10",
+        "source_trace_8",
+        "source_net_16",
+        "pcb_smtpad_4",
+        "pcb_port_4",
+        "pcb_smtpad_6",
+        "pcb_port_6",
+        "pcb_smtpad_8",
+        "pcb_port_8",
+        "pcb_smtpad_10",
+        "pcb_port_10",
+        "pcb_smtpad_12",
+        "pcb_port_12",
+        "pcb_smtpad_14",
+        "pcb_port_14",
+        "pcb_smtpad_17",
+        "pcb_port_17",
+        "pcb_smtpad_21",
+        "pcb_port_21",
+        "pcb_smtpad_22",
+        "pcb_port_22",
+        "pcb_smtpad_38",
+        "pcb_port_42",
+        "pcb_smtpad_47",
+        "pcb_port_51",
+        "pcb_smtpad_59",
+        "pcb_port_63",
+        "pcb_smtpad_70",
+        "pcb_port_74",
+        "pcb_smtpad_79",
+        "pcb_port_83",
+        "pcb_smtpad_81",
+        "pcb_port_85",
+        "pcb_smtpad_85",
+        "pcb_port_89",
+        "pcb_smtpad_86",
+        "pcb_port_90",
+        "pcb_smtpad_108",
+        "pcb_port_112",
+        "pcb_smtpad_126",
+        "pcb_port_130",
+        "pcb_smtpad_129",
+        "pcb_port_133",
+        "pcb_smtpad_141",
+        "pcb_port_145",
+        "pcb_smtpad_145",
+        "pcb_port_149",
+        "pcb_port_155",
+        "pcb_smtpad_156",
+        "pcb_port_160"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_152",
+        "pcb_port_id": "pcb_port_156"
+      },
+      "type": "rect",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -1.5,
+        "y": 3.5250000000000004
+      },
+      "width": 0.95,
+      "height": 0.8,
+      "connectedTo": [
+        "pcb_smtpad_152",
+        "source_trace_80",
+        "source_trace_79",
+        "source_trace_27",
+        "source_net_17",
+        "pcb_smtpad_24",
+        "pcb_port_24",
+        "pcb_smtpad_80",
+        "pcb_port_84",
+        "pcb_port_156"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_153",
+        "pcb_port_id": "pcb_port_157"
+      },
+      "type": "rect",
+      "shape": "circle",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -12,
+        "y": -26.5
+      },
+      "width": 1.1,
+      "height": 1.1,
+      "connectedTo": [
+        "pcb_smtpad_153",
+        "source_trace_103",
+        "pcb_smtpad_61",
+        "pcb_port_65",
+        "pcb_port_157"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_154",
+        "pcb_port_id": "pcb_port_158"
+      },
+      "type": "rect",
+      "shape": "circle",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -8,
+        "y": -26.5
+      },
+      "width": 1.1,
+      "height": 1.1,
+      "connectedTo": [
+        "pcb_smtpad_154",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_smtpad_5",
+        "pcb_port_5",
+        "pcb_smtpad_7",
+        "pcb_port_7",
+        "pcb_smtpad_9",
+        "pcb_port_9",
+        "pcb_smtpad_11",
+        "pcb_port_11",
+        "pcb_smtpad_13",
+        "pcb_port_13",
+        "pcb_smtpad_15",
+        "pcb_port_15",
+        "pcb_smtpad_19",
+        "pcb_port_19",
+        "pcb_smtpad_23",
+        "pcb_port_23",
+        "pcb_smtpad_25",
+        "pcb_port_25",
+        "pcb_plated_hole_0",
+        "pcb_port_26",
+        "pcb_plated_hole_1",
+        "pcb_port_27",
+        "pcb_plated_hole_2",
+        "pcb_port_28",
+        "pcb_plated_hole_3",
+        "pcb_port_29",
+        "pcb_smtpad_26",
+        "pcb_port_30",
+        "pcb_smtpad_37",
+        "pcb_port_41",
+        "pcb_smtpad_56",
+        "pcb_port_60",
+        "pcb_smtpad_94",
+        "pcb_port_98",
+        "pcb_smtpad_101",
+        "pcb_port_102",
+        "pcb_smtpad_103",
+        "pcb_port_107",
+        "pcb_smtpad_105",
+        "pcb_port_109",
+        "pcb_smtpad_112",
+        "pcb_port_113",
+        "pcb_smtpad_110",
+        "pcb_port_114",
+        "pcb_smtpad_115",
+        "pcb_port_119",
+        "pcb_smtpad_120",
+        "pcb_port_124",
+        "pcb_smtpad_121",
+        "pcb_port_126",
+        "pcb_smtpad_123",
+        "pcb_port_128",
+        "pcb_smtpad_132",
+        "pcb_port_136",
+        "pcb_smtpad_134",
+        "pcb_port_138",
+        "pcb_smtpad_140",
+        "pcb_port_144",
+        "pcb_smtpad_142",
+        "pcb_port_146",
+        "pcb_smtpad_144",
+        "pcb_port_148",
+        "pcb_smtpad_146",
+        "pcb_port_150",
+        "pcb_smtpad_148",
+        "pcb_port_152",
+        "pcb_smtpad_150",
+        "pcb_port_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_0"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_155",
+        "pcb_port_id": "pcb_port_159"
+      },
+      "type": "rect",
+      "shape": "circle",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": -4,
+        "y": -26.5
+      },
+      "width": 1.1,
+      "height": 1.1,
+      "connectedTo": [
+        "pcb_smtpad_155",
+        "source_trace_104",
+        "pcb_smtpad_62",
+        "pcb_port_66",
+        "pcb_port_159"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_smtpad_id": "pcb_smtpad_156",
+        "pcb_port_id": "pcb_port_160"
+      },
+      "type": "rect",
+      "shape": "circle",
+      "layers": [
+        "top"
+      ],
+      "center": {
+        "x": 0,
+        "y": -26.5
+      },
+      "width": 1.1,
+      "height": 1.1,
+      "connectedTo": [
+        "pcb_smtpad_156",
+        "source_trace_106",
+        "source_trace_100",
+        "source_trace_94",
+        "source_trace_83",
+        "source_trace_78",
+        "source_trace_76",
+        "source_trace_72",
+        "source_trace_70",
+        "source_trace_50",
+        "source_trace_48",
+        "source_trace_46",
+        "source_trace_43",
+        "source_trace_42",
+        "source_trace_41",
+        "source_trace_40",
+        "source_trace_39",
+        "source_trace_38",
+        "source_trace_25",
+        "source_trace_23",
+        "source_trace_21",
+        "source_trace_17",
+        "source_trace_14",
+        "source_trace_12",
+        "source_trace_10",
+        "source_trace_8",
+        "source_net_16",
+        "pcb_smtpad_4",
+        "pcb_port_4",
+        "pcb_smtpad_6",
+        "pcb_port_6",
+        "pcb_smtpad_8",
+        "pcb_port_8",
+        "pcb_smtpad_10",
+        "pcb_port_10",
+        "pcb_smtpad_12",
+        "pcb_port_12",
+        "pcb_smtpad_14",
+        "pcb_port_14",
+        "pcb_smtpad_17",
+        "pcb_port_17",
+        "pcb_smtpad_21",
+        "pcb_port_21",
+        "pcb_smtpad_22",
+        "pcb_port_22",
+        "pcb_smtpad_38",
+        "pcb_port_42",
+        "pcb_smtpad_47",
+        "pcb_port_51",
+        "pcb_smtpad_59",
+        "pcb_port_63",
+        "pcb_smtpad_70",
+        "pcb_port_74",
+        "pcb_smtpad_79",
+        "pcb_port_83",
+        "pcb_smtpad_81",
+        "pcb_port_85",
+        "pcb_smtpad_85",
+        "pcb_port_89",
+        "pcb_smtpad_86",
+        "pcb_port_90",
+        "pcb_smtpad_108",
+        "pcb_port_112",
+        "pcb_smtpad_126",
+        "pcb_port_130",
+        "pcb_smtpad_129",
+        "pcb_port_133",
+        "pcb_smtpad_141",
+        "pcb_port_145",
+        "pcb_smtpad_145",
+        "pcb_port_149",
+        "pcb_smtpad_151",
+        "pcb_port_155",
+        "pcb_port_160"
+      ]
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_plated_hole_id": "pcb_plated_hole_0",
+        "pcb_port_id": "pcb_port_26"
+      },
+      "type": "rect",
+      "layers": [
+        "top",
+        "inner1",
+        "inner2",
+        "bottom"
+      ],
+      "center": {
+        "x": -5.675,
+        "y": 33.925
+      },
+      "width": 1.1,
+      "height": 2,
+      "ccwRotationDegrees": 180,
+      "connectedTo": [
+        "pcb_plated_hole_0",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_smtpad_5",
+        "pcb_port_5",
+        "pcb_smtpad_7",
+        "pcb_port_7",
+        "pcb_smtpad_9",
+        "pcb_port_9",
+        "pcb_smtpad_11",
+        "pcb_port_11",
+        "pcb_smtpad_13",
+        "pcb_port_13",
+        "pcb_smtpad_15",
+        "pcb_port_15",
+        "pcb_smtpad_19",
+        "pcb_port_19",
+        "pcb_smtpad_23",
+        "pcb_port_23",
+        "pcb_smtpad_25",
+        "pcb_port_25",
+        "pcb_port_26",
+        "pcb_plated_hole_1",
+        "pcb_port_27",
+        "pcb_plated_hole_2",
+        "pcb_port_28",
+        "pcb_plated_hole_3",
+        "pcb_port_29",
+        "pcb_smtpad_26",
+        "pcb_port_30",
+        "pcb_smtpad_37",
+        "pcb_port_41",
+        "pcb_smtpad_56",
+        "pcb_port_60",
+        "pcb_smtpad_94",
+        "pcb_port_98",
+        "pcb_smtpad_101",
+        "pcb_port_102",
+        "pcb_smtpad_103",
+        "pcb_port_107",
+        "pcb_smtpad_105",
+        "pcb_port_109",
+        "pcb_smtpad_112",
+        "pcb_port_113",
+        "pcb_smtpad_110",
+        "pcb_port_114",
+        "pcb_smtpad_115",
+        "pcb_port_119",
+        "pcb_smtpad_120",
+        "pcb_port_124",
+        "pcb_smtpad_121",
+        "pcb_port_126",
+        "pcb_smtpad_123",
+        "pcb_port_128",
+        "pcb_smtpad_132",
+        "pcb_port_136",
+        "pcb_smtpad_134",
+        "pcb_port_138",
+        "pcb_smtpad_140",
+        "pcb_port_144",
+        "pcb_smtpad_142",
+        "pcb_port_146",
+        "pcb_smtpad_144",
+        "pcb_port_148",
+        "pcb_smtpad_146",
+        "pcb_port_150",
+        "pcb_smtpad_148",
+        "pcb_port_152",
+        "pcb_smtpad_150",
+        "pcb_port_154",
+        "pcb_smtpad_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_0"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_plated_hole_id": "pcb_plated_hole_1",
+        "pcb_port_id": "pcb_port_27"
+      },
+      "type": "rect",
+      "layers": [
+        "top",
+        "inner1",
+        "inner2",
+        "bottom"
+      ],
+      "center": {
+        "x": -14.325,
+        "y": 33.925
+      },
+      "width": 1.1,
+      "height": 2,
+      "ccwRotationDegrees": 180,
+      "connectedTo": [
+        "pcb_plated_hole_1",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_smtpad_5",
+        "pcb_port_5",
+        "pcb_smtpad_7",
+        "pcb_port_7",
+        "pcb_smtpad_9",
+        "pcb_port_9",
+        "pcb_smtpad_11",
+        "pcb_port_11",
+        "pcb_smtpad_13",
+        "pcb_port_13",
+        "pcb_smtpad_15",
+        "pcb_port_15",
+        "pcb_smtpad_19",
+        "pcb_port_19",
+        "pcb_smtpad_23",
+        "pcb_port_23",
+        "pcb_smtpad_25",
+        "pcb_port_25",
+        "pcb_plated_hole_0",
+        "pcb_port_26",
+        "pcb_port_27",
+        "pcb_plated_hole_2",
+        "pcb_port_28",
+        "pcb_plated_hole_3",
+        "pcb_port_29",
+        "pcb_smtpad_26",
+        "pcb_port_30",
+        "pcb_smtpad_37",
+        "pcb_port_41",
+        "pcb_smtpad_56",
+        "pcb_port_60",
+        "pcb_smtpad_94",
+        "pcb_port_98",
+        "pcb_smtpad_101",
+        "pcb_port_102",
+        "pcb_smtpad_103",
+        "pcb_port_107",
+        "pcb_smtpad_105",
+        "pcb_port_109",
+        "pcb_smtpad_112",
+        "pcb_port_113",
+        "pcb_smtpad_110",
+        "pcb_port_114",
+        "pcb_smtpad_115",
+        "pcb_port_119",
+        "pcb_smtpad_120",
+        "pcb_port_124",
+        "pcb_smtpad_121",
+        "pcb_port_126",
+        "pcb_smtpad_123",
+        "pcb_port_128",
+        "pcb_smtpad_132",
+        "pcb_port_136",
+        "pcb_smtpad_134",
+        "pcb_port_138",
+        "pcb_smtpad_140",
+        "pcb_port_144",
+        "pcb_smtpad_142",
+        "pcb_port_146",
+        "pcb_smtpad_144",
+        "pcb_port_148",
+        "pcb_smtpad_146",
+        "pcb_port_150",
+        "pcb_smtpad_148",
+        "pcb_port_152",
+        "pcb_smtpad_150",
+        "pcb_port_154",
+        "pcb_smtpad_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_0"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_plated_hole_id": "pcb_plated_hole_2",
+        "pcb_port_id": "pcb_port_28"
+      },
+      "type": "rect",
+      "layers": [
+        "top",
+        "inner1",
+        "inner2",
+        "bottom"
+      ],
+      "center": {
+        "x": -5.675,
+        "y": 38.125
+      },
+      "width": 1.2,
+      "height": 1.7999999999999998,
+      "ccwRotationDegrees": 180,
+      "connectedTo": [
+        "pcb_plated_hole_2",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_smtpad_5",
+        "pcb_port_5",
+        "pcb_smtpad_7",
+        "pcb_port_7",
+        "pcb_smtpad_9",
+        "pcb_port_9",
+        "pcb_smtpad_11",
+        "pcb_port_11",
+        "pcb_smtpad_13",
+        "pcb_port_13",
+        "pcb_smtpad_15",
+        "pcb_port_15",
+        "pcb_smtpad_19",
+        "pcb_port_19",
+        "pcb_smtpad_23",
+        "pcb_port_23",
+        "pcb_smtpad_25",
+        "pcb_port_25",
+        "pcb_plated_hole_0",
+        "pcb_port_26",
+        "pcb_plated_hole_1",
+        "pcb_port_27",
+        "pcb_port_28",
+        "pcb_plated_hole_3",
+        "pcb_port_29",
+        "pcb_smtpad_26",
+        "pcb_port_30",
+        "pcb_smtpad_37",
+        "pcb_port_41",
+        "pcb_smtpad_56",
+        "pcb_port_60",
+        "pcb_smtpad_94",
+        "pcb_port_98",
+        "pcb_smtpad_101",
+        "pcb_port_102",
+        "pcb_smtpad_103",
+        "pcb_port_107",
+        "pcb_smtpad_105",
+        "pcb_port_109",
+        "pcb_smtpad_112",
+        "pcb_port_113",
+        "pcb_smtpad_110",
+        "pcb_port_114",
+        "pcb_smtpad_115",
+        "pcb_port_119",
+        "pcb_smtpad_120",
+        "pcb_port_124",
+        "pcb_smtpad_121",
+        "pcb_port_126",
+        "pcb_smtpad_123",
+        "pcb_port_128",
+        "pcb_smtpad_132",
+        "pcb_port_136",
+        "pcb_smtpad_134",
+        "pcb_port_138",
+        "pcb_smtpad_140",
+        "pcb_port_144",
+        "pcb_smtpad_142",
+        "pcb_port_146",
+        "pcb_smtpad_144",
+        "pcb_port_148",
+        "pcb_smtpad_146",
+        "pcb_port_150",
+        "pcb_smtpad_148",
+        "pcb_port_152",
+        "pcb_smtpad_150",
+        "pcb_port_154",
+        "pcb_smtpad_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_0"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "circuitJsonMetadata": {
+        "pcb_plated_hole_id": "pcb_plated_hole_3",
+        "pcb_port_id": "pcb_port_29"
+      },
+      "type": "rect",
+      "layers": [
+        "top",
+        "inner1",
+        "inner2",
+        "bottom"
+      ],
+      "center": {
+        "x": -14.325,
+        "y": 38.125
+      },
+      "width": 1.2,
+      "height": 1.7999999999999998,
+      "ccwRotationDegrees": 180,
+      "connectedTo": [
+        "pcb_plated_hole_3",
+        "source_trace_105",
+        "source_trace_102",
+        "source_trace_99",
+        "source_trace_96",
+        "source_trace_92",
+        "source_trace_90",
+        "source_trace_88",
+        "source_trace_84",
+        "source_trace_81",
+        "source_trace_77",
+        "source_trace_75",
+        "source_trace_73",
+        "source_trace_71",
+        "source_trace_68",
+        "source_trace_66",
+        "source_trace_65",
+        "source_trace_64",
+        "source_trace_63",
+        "source_trace_62",
+        "source_trace_61",
+        "source_trace_60",
+        "source_trace_59",
+        "source_trace_49",
+        "source_trace_28",
+        "source_trace_26",
+        "source_trace_24",
+        "source_trace_22",
+        "source_trace_20",
+        "source_trace_18",
+        "source_trace_15",
+        "source_trace_13",
+        "source_trace_11",
+        "source_trace_9",
+        "source_trace_1",
+        "source_trace_0",
+        "source_net_13",
+        "pcb_smtpad_5",
+        "pcb_port_5",
+        "pcb_smtpad_7",
+        "pcb_port_7",
+        "pcb_smtpad_9",
+        "pcb_port_9",
+        "pcb_smtpad_11",
+        "pcb_port_11",
+        "pcb_smtpad_13",
+        "pcb_port_13",
+        "pcb_smtpad_15",
+        "pcb_port_15",
+        "pcb_smtpad_19",
+        "pcb_port_19",
+        "pcb_smtpad_23",
+        "pcb_port_23",
+        "pcb_smtpad_25",
+        "pcb_port_25",
+        "pcb_plated_hole_0",
+        "pcb_port_26",
+        "pcb_plated_hole_1",
+        "pcb_port_27",
+        "pcb_plated_hole_2",
+        "pcb_port_28",
+        "pcb_port_29",
+        "pcb_smtpad_26",
+        "pcb_port_30",
+        "pcb_smtpad_37",
+        "pcb_port_41",
+        "pcb_smtpad_56",
+        "pcb_port_60",
+        "pcb_smtpad_94",
+        "pcb_port_98",
+        "pcb_smtpad_101",
+        "pcb_port_102",
+        "pcb_smtpad_103",
+        "pcb_port_107",
+        "pcb_smtpad_105",
+        "pcb_port_109",
+        "pcb_smtpad_112",
+        "pcb_port_113",
+        "pcb_smtpad_110",
+        "pcb_port_114",
+        "pcb_smtpad_115",
+        "pcb_port_119",
+        "pcb_smtpad_120",
+        "pcb_port_124",
+        "pcb_smtpad_121",
+        "pcb_port_126",
+        "pcb_smtpad_123",
+        "pcb_port_128",
+        "pcb_smtpad_132",
+        "pcb_port_136",
+        "pcb_smtpad_134",
+        "pcb_port_138",
+        "pcb_smtpad_140",
+        "pcb_port_144",
+        "pcb_smtpad_142",
+        "pcb_port_146",
+        "pcb_smtpad_144",
+        "pcb_port_148",
+        "pcb_smtpad_146",
+        "pcb_port_150",
+        "pcb_smtpad_148",
+        "pcb_port_152",
+        "pcb_smtpad_150",
+        "pcb_port_154",
+        "pcb_smtpad_154",
+        "pcb_port_158"
+      ],
+      "offBoardConnectsTo": [
+        "source_component_internal_connection_0"
+      ],
+      "netIsAssignable": true
+    },
+    {
+      "type": "rect",
+      "layers": [
+        "top",
+        "inner1",
+        "inner2",
+        "bottom"
+      ],
+      "center": {
+        "x": -7.109999999999999,
+        "y": 34.445
+      },
+      "width": 0.7,
+      "height": 0.7,
+      "connectedTo": []
+    },
+    {
+      "type": "rect",
+      "layers": [
+        "top",
+        "inner1",
+        "inner2",
+        "bottom"
+      ],
+      "center": {
+        "x": -12.89,
+        "y": 34.445
+      },
+      "width": 0.7,
+      "height": 0.7,
+      "connectedTo": []
+    }
+  ],
+  "connections": [
+    {
+      "name": "source_trace_2",
+      "source_trace_id": "source_trace_2",
+      "nominalTraceWidth": 0.15,
+      "width": 0.15,
+      "pointsToConnect": [
+        {
+          "x": -9.25,
+          "y": 33.375,
+          "layer": "top",
+          "pointId": "pcb_port_34",
+          "pcb_port_id": "pcb_port_34"
+        },
+        {
+          "x": -8.3,
+          "y": 11.2,
+          "layer": "top",
+          "pointId": "pcb_port_139",
+          "pcb_port_id": "pcb_port_139"
+        }
+      ]
+    },
+    {
+      "name": "source_trace_3",
+      "source_trace_id": "source_trace_3",
+      "nominalTraceWidth": 0.15,
+      "width": 0.15,
+      "pointsToConnect": [
+        {
+          "x": -10.75,
+          "y": 33.375,
+          "layer": "top",
+          "pointId": "pcb_port_37",
+          "pcb_port_id": "pcb_port_37"
+        },
+        {
+          "x": -9.3,
+          "y": 11.2,
+          "layer": "top",
+          "pointId": "pcb_port_141",
+          "pcb_port_id": "pcb_port_141"
+        }
+      ]
+    },
+    {
+      "name": "source_trace_7",
+      "source_trace_id": "source_trace_7",
+      "nominalTraceWidth": 0.15,
+      "width": 0.15,
+      "pointsToConnect": [
+        {
+          "x": -14.7,
+          "y": 22.310000000000002,
+          "layer": "top",
+          "pointId": "pcb_port_3",
+          "pcb_port_id": "pcb_port_3"
+        },
+        {
+          "x": -18.30005,
+          "y": 23.75,
+          "layer": "top",
+          "pointId": "pcb_port_110",
+          "pcb_port_id": "pcb_port_110"
+        }
+      ]
+    },
+    {
+      "name": "source_trace_16",
+      "source_trace_id": "source_trace_16",
+      "nominalTraceWidth": 0.1,
+      "width": 0.1,
+      "pointsToConnect": [
+        {
+          "x": -0.10999999999999965,
+          "y": -1,
+          "layer": "top",
+          "pointId": "pcb_port_16",
+          "pcb_port_id": "pcb_port_16"
+        },
+        {
+          "x": -8.199549999999999,
+          "y": 1.5749499999999999,
+          "layer": "top",
+          "pointId": "pcb_port_67",
+          "pcb_port_id": "pcb_port_67"
+        }
+      ]
+    },
+    {
+      "name": "source_trace_19",
+      "source_trace_id": "source_trace_19",
+      "nominalTraceWidth": 0.15,
+      "width": 0.15,
+      "pointsToConnect": [
+        {
+          "x": -8.69,
+          "y": 15.7,
+          "layer": "top",
+          "pointId": "pcb_port_18",
+          "pcb_port_id": "pcb_port_18"
+        },
+        {
+          "x": -8.69,
+          "y": 14.25,
+          "layer": "top",
+          "pointId": "pcb_port_20",
+          "pcb_port_id": "pcb_port_20"
+        }
+      ]
+    },
+    {
+      "name": "source_trace_32",
+      "source_trace_id": "source_trace_32",
+      "nominalTraceWidth": 0.1,
+      "width": 0.1,
+      "pointsToConnect": [
+        {
+          "x": -12.60065,
+          "y": 8.42505,
+          "layer": "top",
+          "pointId": "pcb_port_97",
+          "pcb_port_id": "pcb_port_97"
+        },
+        {
+          "x": -4.4925,
+          "y": 14.25,
+          "layer": "top",
+          "pointId": "pcb_port_99",
+          "pcb_port_id": "pcb_port_99"
+        }
+      ]
+    },
+    {
+      "name": "source_trace_33",
+      "source_trace_id": "source_trace_33",
+      "nominalTraceWidth": 0.1,
+      "width": 0.1,
+      "pointsToConnect": [
+        {
+          "x": -11.40035,
+          "y": 8.42505,
+          "layer": "top",
+          "pointId": "pcb_port_94",
+          "pcb_port_id": "pcb_port_94"
+        },
+        {
+          "x": -7.5075,
+          "y": 15.75,
+          "layer": "top",
+          "pointId": "pcb_port_103",
+          "pcb_port_id": "pcb_port_103"
+        }
+      ]
+    },
+    {
+      "name": "source_trace_34",
+      "source_trace_id": "source_trace_34",
+      "nominalTraceWidth": 0.1,
+      "width": 0.1,
+      "pointsToConnect": [
+        {
+          "x": -12.20055,
+          "y": 8.42505,
+          "layer": "top",
+          "pointId": "pcb_port_96",
+          "pcb_port_id": "pcb_port_96"
+        },
+        {
+          "x": -4.4925,
+          "y": 14.75,
+          "layer": "top",
+          "pointId": "pcb_port_100",
+          "pcb_port_id": "pcb_port_100"
+        }
+      ]
+    },
+    {
+      "name": "source_trace_35",
+      "source_trace_id": "source_trace_35",
+      "nominalTraceWidth": 0.1,
+      "width": 0.1,
+      "pointsToConnect": [
+        {
+          "x": -11.800450000000001,
+          "y": 8.42505,
+          "layer": "top",
+          "pointId": "pcb_port_95",
+          "pcb_port_id": "pcb_port_95"
+        },
+        {
+          "x": -4.4925,
+          "y": 15.25,
+          "layer": "top",
+          "pointId": "pcb_port_101",
+          "pcb_port_id": "pcb_port_101"
+        }
+      ]
+    },
+    {
+      "name": "source_trace_36",
+      "source_trace_id": "source_trace_36",
+      "nominalTraceWidth": 0.1,
+      "width": 0.1,
+      "pointsToConnect": [
+        {
+          "x": -10.60015,
+          "y": 8.42505,
+          "layer": "top",
+          "pointId": "pcb_port_92",
+          "pcb_port_id": "pcb_port_92"
+        },
+        {
+          "x": -7.5075,
+          "y": 14.75,
+          "layer": "top",
+          "pointId": "pcb_port_105",
+          "pcb_port_id": "pcb_port_105"
+        }
+      ]
+    },
+    {
+      "name": "source_trace_37",
+      "source_trace_id": "source_trace_37",
+      "nominalTraceWidth": 0.1,
+      "width": 0.1,
+      "pointsToConnect": [
+        {
+          "x": -11.000250000000001,
+          "y": 8.42505,
+          "layer": "top",
+          "pointId": "pcb_port_93",
+          "pcb_port_id": "pcb_port_93"
+        },
+        {
+          "x": -7.5075,
+          "y": 15.25,
+          "layer": "top",
+          "pointId": "pcb_port_104",
+          "pcb_port_id": "pcb_port_104"
+        }
+      ]
+    },
+    {
+      "name": "source_trace_50",
+      "source_trace_id": "source_trace_50",
+      "nominalTraceWidth": 0.1,
+      "width": 0.1,
+      "pointsToConnect": [
+        {
+          "x": -9.39985,
+          "y": 8.42505,
+          "layer": "top",
+          "pointId": "pcb_port_89",
+          "pcb_port_id": "pcb_port_89"
+        },
+        {
+          "x": -9.799949999999999,
+          "y": 8.42505,
+          "layer": "top",
+          "pointId": "pcb_port_90",
+          "pcb_port_id": "pcb_port_90"
+        }
+      ]
+    },
+    {
+      "name": "source_trace_53",
+      "source_trace_id": "source_trace_53",
+      "nominalTraceWidth": 0.15,
+      "width": 0.15,
+      "pointsToConnect": [
+        {
+          "x": -10.25,
+          "y": 33.375,
+          "layer": "top",
+          "pointId": "pcb_port_36",
+          "pcb_port_id": "pcb_port_36"
+        },
+        {
+          "x": -8.3,
+          "y": 11.2,
+          "layer": "top",
+          "pointId": "pcb_port_139",
+          "pcb_port_id": "pcb_port_139"
+        }
+      ]
+    },
+    {
+      "name": "source_trace_54",
+      "source_trace_id": "source_trace_54",
+      "nominalTraceWidth": 0.1,
+      "width": 0.1,
+      "pointsToConnect": [
+        {
+          "x": -8.3,
+          "y": 10.2,
+          "layer": "top",
+          "pointId": "pcb_port_140",
+          "pcb_port_id": "pcb_port_140"
+        },
+        {
+          "x": -8.59965,
+          "y": 8.42505,
+          "layer": "top",
+          "pointId": "pcb_port_87",
+          "pcb_port_id": "pcb_port_87"
+        }
+      ]
+    },
+    {
+      "name": "source_trace_55",
+      "source_trace_id": "source_trace_55",
+      "nominalTraceWidth": 0.15,
+      "width": 0.15,
+      "pointsToConnect": [
+        {
+          "x": -9.75,
+          "y": 33.375,
+          "layer": "top",
+          "pointId": "pcb_port_35",
+          "pcb_port_id": "pcb_port_35"
+        },
+        {
+          "x": -9.3,
+          "y": 11.2,
+          "layer": "top",
+          "pointId": "pcb_port_141",
+          "pcb_port_id": "pcb_port_141"
+        }
+      ]
+    },
+    {
+      "name": "source_trace_56",
+      "source_trace_id": "source_trace_56",
+      "nominalTraceWidth": 0.1,
+      "width": 0.1,
+      "pointsToConnect": [
+        {
+          "x": -9.3,
+          "y": 10.2,
+          "layer": "top",
+          "pointId": "pcb_port_142",
+          "pcb_port_id": "pcb_port_142"
+        },
+        {
+          "x": -8.99975,
+          "y": 8.42505,
+          "layer": "top",
+          "pointId": "pcb_port_88",
+          "pcb_port_id": "pcb_port_88"
+        }
+      ]
+    },
+    {
+      "name": "source_trace_57",
+      "source_trace_id": "source_trace_57",
+      "nominalTraceWidth": 0.1,
+      "width": 0.1,
+      "pointsToConnect": [
+        {
+          "x": -8.75,
+          "y": 33.375,
+          "layer": "top",
+          "pointId": "pcb_port_33",
+          "pcb_port_id": "pcb_port_33"
+        },
+        {
+          "x": -10.709999999999999,
+          "y": 30.1,
+          "layer": "top",
+          "pointId": "pcb_port_135",
+          "pcb_port_id": "pcb_port_135"
+        }
+      ]
+    },
+    {
+      "name": "source_trace_58",
+      "source_trace_id": "source_trace_58",
+      "nominalTraceWidth": 0.1,
+      "width": 0.1,
+      "pointsToConnect": [
+        {
+          "x": -11.75,
+          "y": 33.375,
+          "layer": "top",
+          "pointId": "pcb_port_39",
+          "pcb_port_id": "pcb_port_39"
+        },
+        {
+          "x": -6.91,
+          "y": 31,
+          "layer": "top",
+          "pointId": "pcb_port_137",
+          "pcb_port_id": "pcb_port_137"
+        }
+      ]
+    },
+    {
+      "name": "source_trace_82",
+      "source_trace_id": "source_trace_82",
+      "nominalTraceWidth": 0.15,
+      "width": 0.15,
+      "pointsToConnect": [
+        {
+          "x": -7.5075,
+          "y": 14.25,
+          "layer": "top",
+          "pointId": "pcb_port_106",
+          "pcb_port_id": "pcb_port_106"
+        },
+        {
+          "x": -8.69,
+          "y": 14.25,
+          "layer": "top",
+          "pointId": "pcb_port_20",
+          "pcb_port_id": "pcb_port_20"
+        }
+      ]
+    },
+    {
+      "name": "source_trace_85",
+      "source_trace_id": "source_trace_85",
+      "nominalTraceWidth": 0.15,
+      "width": 0.15,
+      "pointsToConnect": [
+        {
+          "x": -11.6,
+          "y": -2.35,
+          "layer": "top",
+          "pointId": "pcb_port_115",
+          "pcb_port_id": "pcb_port_115"
+        },
+        {
+          "x": -10.60015,
+          "y": 1.5749499999999999,
+          "layer": "top",
+          "pointId": "pcb_port_61",
+          "pcb_port_id": "pcb_port_61"
+        }
+      ]
+    },
+    {
+      "name": "source_trace_86",
+      "source_trace_id": "source_trace_86",
+      "nominalTraceWidth": 0.15,
+      "width": 0.15,
+      "pointsToConnect": [
+        {
+          "x": -9.4,
+          "y": -0.65,
+          "layer": "top",
+          "pointId": "pcb_port_116",
+          "pcb_port_id": "pcb_port_116"
+        },
+        {
+          "x": -10.200050000000001,
+          "y": 1.5749499999999999,
+          "layer": "top",
+          "pointId": "pcb_port_62",
+          "pcb_port_id": "pcb_port_62"
+        }
+      ]
+    },
+    {
+      "name": "source_trace_87",
+      "source_trace_id": "source_trace_87",
+      "nominalTraceWidth": 0.15,
+      "width": 0.15,
+      "pointsToConnect": [
+        {
+          "x": -13.709999999999999,
+          "y": -4.5,
+          "layer": "top",
+          "pointId": "pcb_port_151",
+          "pcb_port_id": "pcb_port_151"
+        },
+        {
+          "x": -11.6,
+          "y": -2.35,
+          "layer": "top",
+          "pointId": "pcb_port_115",
+          "pcb_port_id": "pcb_port_115"
+        }
+      ]
+    },
+    {
+      "name": "source_trace_89",
+      "source_trace_id": "source_trace_89",
+      "nominalTraceWidth": 0.15,
+      "width": 0.15,
+      "pointsToConnect": [
+        {
+          "x": -7.71,
+          "y": -4.5,
+          "layer": "top",
+          "pointId": "pcb_port_153",
+          "pcb_port_id": "pcb_port_153"
+        },
+        {
+          "x": -9.4,
+          "y": -0.65,
+          "layer": "top",
+          "pointId": "pcb_port_116",
+          "pcb_port_id": "pcb_port_116"
+        }
+      ]
+    },
+    {
+      "name": "source_trace_91",
+      "source_trace_id": "source_trace_91",
+      "nominalTraceWidth": 0.15,
+      "width": 0.15,
+      "pointsToConnect": [
+        {
+          "x": -3.5000000000000004,
+          "y": 27.375,
+          "layer": "top",
+          "pointId": "pcb_port_117",
+          "pcb_port_id": "pcb_port_117"
+        },
+        {
+          "x": -12.60065,
+          "y": 8.42505,
+          "layer": "top",
+          "pointId": "pcb_port_97",
+          "pcb_port_id": "pcb_port_97"
+        }
+      ]
+    },
+    {
+      "name": "source_trace_93",
+      "source_trace_id": "source_trace_93",
+      "nominalTraceWidth": 0.15,
+      "width": 0.15,
+      "pointsToConnect": [
+        {
+          "x": 2,
+          "y": 21.79,
+          "layer": "top",
+          "pointId": "pcb_port_129",
+          "pcb_port_id": "pcb_port_129"
+        },
+        {
+          "x": -12.60065,
+          "y": 8.42505,
+          "layer": "top",
+          "pointId": "pcb_port_97",
+          "pcb_port_id": "pcb_port_97"
+        }
+      ]
+    },
+    {
+      "name": "source_trace_95",
+      "source_trace_id": "source_trace_95",
+      "nominalTraceWidth": 0.15,
+      "width": 0.15,
+      "pointsToConnect": [
+        {
+          "x": -5.575,
+          "y": -10.1,
+          "layer": "top",
+          "pointId": "pcb_port_121",
+          "pcb_port_id": "pcb_port_121"
+        },
+        {
+          "x": -8.199549999999999,
+          "y": 1.5749499999999999,
+          "layer": "top",
+          "pointId": "pcb_port_67",
+          "pcb_port_id": "pcb_port_67"
+        }
+      ]
+    },
+    {
+      "name": "source_trace_97",
+      "source_trace_id": "source_trace_97",
+      "nominalTraceWidth": 0.15,
+      "width": 0.15,
+      "pointsToConnect": [
+        {
+          "x": -6.57505,
+          "y": 5.60015,
+          "layer": "top",
+          "pointId": "pcb_port_78",
+          "pcb_port_id": "pcb_port_78"
+        },
+        {
+          "x": -2.8,
+          "y": 5.19,
+          "layer": "top",
+          "pointId": "pcb_port_131",
+          "pcb_port_id": "pcb_port_131"
+        }
+      ]
+    },
+    {
+      "name": "source_trace_98",
+      "source_trace_id": "source_trace_98",
+      "nominalTraceWidth": 0.15,
+      "width": 0.15,
+      "pointsToConnect": [
+        {
+          "x": -2.8,
+          "y": 6.21,
+          "layer": "top",
+          "pointId": "pcb_port_132",
+          "pcb_port_id": "pcb_port_132"
+        },
+        {
+          "x": 4.5863022628068375e-17,
+          "y": 9.449,
+          "layer": "top",
+          "pointId": "pcb_port_125",
+          "pcb_port_id": "pcb_port_125"
+        }
+      ]
+    },
+    {
+      "name": "source_trace_101",
+      "source_trace_id": "source_trace_101",
+      "nominalTraceWidth": 0.15,
+      "width": 0.15,
+      "pointsToConnect": [
+        {
+          "x": -16.2,
+          "y": 29.810000000000002,
+          "layer": "top",
+          "pointId": "pcb_port_134",
+          "pcb_port_id": "pcb_port_134"
+        },
+        {
+          "x": -19.8,
+          "y": 30.049,
+          "layer": "top",
+          "pointId": "pcb_port_127",
+          "pcb_port_id": "pcb_port_127"
+        }
+      ]
+    },
+    {
+      "name": "source_trace_103",
+      "source_trace_id": "source_trace_103",
+      "nominalTraceWidth": 0.15,
+      "width": 0.15,
+      "pointsToConnect": [
+        {
+          "x": -8.999749999999999,
+          "y": 1.5749499999999999,
+          "layer": "top",
+          "pointId": "pcb_port_65",
+          "pcb_port_id": "pcb_port_65"
+        },
+        {
+          "x": -12,
+          "y": -26.5,
+          "layer": "top",
+          "pointId": "pcb_port_157",
+          "pcb_port_id": "pcb_port_157"
+        }
+      ]
+    },
+    {
+      "name": "source_trace_104",
+      "source_trace_id": "source_trace_104",
+      "nominalTraceWidth": 0.15,
+      "width": 0.15,
+      "pointsToConnect": [
+        {
+          "x": -8.59965,
+          "y": 1.5749499999999999,
+          "layer": "top",
+          "pointId": "pcb_port_66",
+          "pcb_port_id": "pcb_port_66"
+        },
+        {
+          "x": -4,
+          "y": -26.5,
+          "layer": "top",
+          "pointId": "pcb_port_159",
+          "pcb_port_id": "pcb_port_159"
+        }
+      ]
+    },
+    {
+      "name": "source_net_13",
+      "nominalTraceWidth": 0.1,
+      "width": 0.1,
+      "pointsToConnect": [
+        {
+          "x": -9.4,
+          "y": -2.35,
+          "layer": "top",
+          "pointId": "pcb_port_114",
+          "pcb_port_id": "pcb_port_114"
+        },
+        {
+          "x": -11.6,
+          "y": -0.65,
+          "layer": "top",
+          "pointId": "pcb_port_113",
+          "pcb_port_id": "pcb_port_113"
+        },
+        {
+          "x": -11,
+          "y": -7.51,
+          "layer": "top",
+          "pointId": "pcb_port_13",
+          "pcb_port_id": "pcb_port_13"
+        },
+        {
+          "x": -17.49,
+          "y": 6.1,
+          "layer": "top",
+          "pointId": "pcb_port_15",
+          "pcb_port_id": "pcb_port_15"
+        },
+        {
+          "x": -18,
+          "y": 2.99,
+          "layer": "top",
+          "pointId": "pcb_port_9",
+          "pcb_port_id": "pcb_port_9"
+        },
+        {
+          "x": -13.49,
+          "y": -1.5,
+          "layer": "top",
+          "pointId": "pcb_port_11",
+          "pcb_port_id": "pcb_port_11"
+        },
+        {
+          "x": -11.00025,
+          "y": 1.5749499999999999,
+          "layer": "top",
+          "pointId": "pcb_port_60",
+          "pcb_port_id": "pcb_port_60"
+        },
+        {
+          "x": -9.709999999999999,
+          "y": 15.7,
+          "layer": "top",
+          "pointId": "pcb_port_19",
+          "pcb_port_id": "pcb_port_19"
+        },
+        {
+          "x": -13.49,
+          "y": -0.5,
+          "layer": "top",
+          "pointId": "pcb_port_5",
+          "pcb_port_id": "pcb_port_5"
+        },
+        {
+          "x": -12.49,
+          "y": 10.5,
+          "layer": "top",
+          "pointId": "pcb_port_7",
+          "pcb_port_id": "pcb_port_7"
+        },
+        {
+          "x": -2.29,
+          "y": 19,
+          "layer": "top",
+          "pointId": "pcb_port_23",
+          "pcb_port_id": "pcb_port_23"
+        },
+        {
+          "x": -1.49,
+          "y": 0.09999999999999964,
+          "layer": "top",
+          "pointId": "pcb_port_25",
+          "pcb_port_id": "pcb_port_25"
+        },
+        {
+          "x": -10,
+          "y": 5,
+          "layer": "top",
+          "pointId": "pcb_port_98",
+          "pcb_port_id": "pcb_port_98"
+        },
+        {
+          "x": -6.800000000000001,
+          "y": 33.375,
+          "layer": "top",
+          "pointId": "pcb_port_30",
+          "pcb_port_id": "pcb_port_30"
+        },
+        {
+          "x": -13.200000000000001,
+          "y": 33.375,
+          "layer": "top",
+          "pointId": "pcb_port_41",
+          "pcb_port_id": "pcb_port_41"
+        },
+        {
+          "x": -5.675,
+          "y": 33.925,
+          "layer": "top",
+          "pointId": "pcb_port_26",
+          "pcb_port_id": "pcb_port_26"
+        },
+        {
+          "x": -5.675,
+          "y": 38.125,
+          "layer": "top",
+          "pointId": "pcb_port_28",
+          "pcb_port_id": "pcb_port_28"
+        },
+        {
+          "x": -14.325,
+          "y": 33.925,
+          "layer": "top",
+          "pointId": "pcb_port_27",
+          "pcb_port_id": "pcb_port_27"
+        },
+        {
+          "x": -14.325,
+          "y": 38.125,
+          "layer": "top",
+          "pointId": "pcb_port_29",
+          "pcb_port_id": "pcb_port_29"
+        },
+        {
+          "x": -9.69,
+          "y": 30.1,
+          "layer": "top",
+          "pointId": "pcb_port_136",
+          "pcb_port_id": "pcb_port_136"
+        },
+        {
+          "x": -5.890000000000001,
+          "y": 31,
+          "layer": "top",
+          "pointId": "pcb_port_138",
+          "pcb_port_id": "pcb_port_138"
+        },
+        {
+          "x": -12.8,
+          "y": 31.625,
+          "layer": "top",
+          "pointId": "pcb_port_144",
+          "pcb_port_id": "pcb_port_144"
+        },
+        {
+          "x": -18.30005,
+          "y": 24.7,
+          "layer": "top",
+          "pointId": "pcb_port_109",
+          "pcb_port_id": "pcb_port_109"
+        },
+        {
+          "x": -17.675,
+          "y": 8.7,
+          "layer": "top",
+          "pointId": "pcb_port_146",
+          "pcb_port_id": "pcb_port_146"
+        },
+        {
+          "x": -5.69,
+          "y": -1,
+          "layer": "top",
+          "pointId": "pcb_port_148",
+          "pcb_port_id": "pcb_port_148"
+        },
+        {
+          "x": 0.3100000000000007,
+          "y": 22.9,
+          "layer": "top",
+          "pointId": "pcb_port_150",
+          "pcb_port_id": "pcb_port_150"
+        },
+        {
+          "x": -4.4925,
+          "y": 15.75,
+          "layer": "top",
+          "pointId": "pcb_port_102",
+          "pcb_port_id": "pcb_port_102"
+        },
+        {
+          "x": -6,
+          "y": 15,
+          "layer": "top",
+          "pointId": "pcb_port_107",
+          "pcb_port_id": "pcb_port_107"
+        },
+        {
+          "x": -12.69,
+          "y": -4.5,
+          "layer": "top",
+          "pointId": "pcb_port_152",
+          "pcb_port_id": "pcb_port_152"
+        },
+        {
+          "x": -6.69,
+          "y": -4.5,
+          "layer": "top",
+          "pointId": "pcb_port_154",
+          "pcb_port_id": "pcb_port_154"
+        },
+        {
+          "x": -3.5000000000000004,
+          "y": 25.225,
+          "layer": "top",
+          "pointId": "pcb_port_119",
+          "pcb_port_id": "pcb_port_119"
+        },
+        {
+          "x": -3.425,
+          "y": -5.9,
+          "layer": "top",
+          "pointId": "pcb_port_124",
+          "pcb_port_id": "pcb_port_124"
+        },
+        {
+          "x": -4.5863022628068375e-17,
+          "y": 7.951,
+          "layer": "top",
+          "pointId": "pcb_port_126",
+          "pcb_port_id": "pcb_port_126"
+        },
+        {
+          "x": -19.8,
+          "y": 28.551000000000002,
+          "layer": "top",
+          "pointId": "pcb_port_128",
+          "pcb_port_id": "pcb_port_128"
+        },
+        {
+          "x": -8,
+          "y": -26.5,
+          "layer": "top",
+          "pointId": "pcb_port_158",
+          "pcb_port_id": "pcb_port_158"
+        }
+      ]
+    },
+    {
+      "name": "source_net_14",
+      "nominalTraceWidth": 0.15,
+      "width": 0.15,
+      "pointsToConnect": [
+        {
+          "x": -12,
+          "y": 27.2,
+          "layer": "top",
+          "pointId": "pcb_port_1",
+          "pcb_port_id": "pcb_port_1"
+        },
+        {
+          "x": -7.6000000000000005,
+          "y": 33.375,
+          "layer": "top",
+          "pointId": "pcb_port_31",
+          "pcb_port_id": "pcb_port_31"
+        },
+        {
+          "x": -12.4,
+          "y": 33.375,
+          "layer": "top",
+          "pointId": "pcb_port_40",
+          "pcb_port_id": "pcb_port_40"
+        },
+        {
+          "x": -12.8,
+          "y": 29.975,
+          "layer": "top",
+          "pointId": "pcb_port_143",
+          "pcb_port_id": "pcb_port_143"
+        }
+      ]
+    },
+    {
+      "name": "source_net_15",
+      "nominalTraceWidth": 0.15,
+      "width": 0.15,
+      "pointsToConnect": [
+        {
+          "x": -12,
+          "y": 23.8,
+          "layer": "top",
+          "pointId": "pcb_port_0",
+          "pcb_port_id": "pcb_port_0"
+        },
+        {
+          "x": -14.7,
+          "y": 21.29,
+          "layer": "top",
+          "pointId": "pcb_port_2",
+          "pcb_port_id": "pcb_port_2"
+        },
+        {
+          "x": -18.30005,
+          "y": 25.65,
+          "layer": "top",
+          "pointId": "pcb_port_108",
+          "pcb_port_id": "pcb_port_108"
+        }
+      ]
+    },
+    {
+      "name": "source_net_16",
+      "nominalTraceWidth": 0.1,
+      "width": 0.1,
+      "pointsToConnect": [
+        {
+          "x": -11,
+          "y": -6.49,
+          "layer": "top",
+          "pointId": "pcb_port_12",
+          "pcb_port_id": "pcb_port_12"
+        },
+        {
+          "x": -18.51,
+          "y": 6.1,
+          "layer": "top",
+          "pointId": "pcb_port_14",
+          "pcb_port_id": "pcb_port_14"
+        },
+        {
+          "x": -18,
+          "y": 4.01,
+          "layer": "top",
+          "pointId": "pcb_port_8",
+          "pcb_port_id": "pcb_port_8"
+        },
+        {
+          "x": -14.51,
+          "y": -1.5,
+          "layer": "top",
+          "pointId": "pcb_port_10",
+          "pcb_port_id": "pcb_port_10"
+        },
+        {
+          "x": 0.9100000000000004,
+          "y": -1,
+          "layer": "top",
+          "pointId": "pcb_port_17",
+          "pcb_port_id": "pcb_port_17"
+        },
+        {
+          "x": -14.51,
+          "y": -0.5,
+          "layer": "top",
+          "pointId": "pcb_port_4",
+          "pcb_port_id": "pcb_port_4"
+        },
+        {
+          "x": -13.51,
+          "y": 10.5,
+          "layer": "top",
+          "pointId": "pcb_port_6",
+          "pcb_port_id": "pcb_port_6"
+        },
+        {
+          "x": -3.3099999999999996,
+          "y": 19,
+          "layer": "top",
+          "pointId": "pcb_port_22",
+          "pcb_port_id": "pcb_port_22"
+        },
+        {
+          "x": -9.799949999999999,
+          "y": 8.42505,
+          "layer": "top",
+          "pointId": "pcb_port_90",
+          "pcb_port_id": "pcb_port_90"
+        },
+        {
+          "x": -6.57505,
+          "y": 7.60065,
+          "layer": "top",
+          "pointId": "pcb_port_83",
+          "pcb_port_id": "pcb_port_83"
+        },
+        {
+          "x": -6.57505,
+          "y": 3.99975,
+          "layer": "top",
+          "pointId": "pcb_port_74",
+          "pcb_port_id": "pcb_port_74"
+        },
+        {
+          "x": -9.799949999999999,
+          "y": 1.5749499999999999,
+          "layer": "top",
+          "pointId": "pcb_port_63",
+          "pcb_port_id": "pcb_port_63"
+        },
+        {
+          "x": -13.424949999999999,
+          "y": 3.9997499999999997,
+          "layer": "top",
+          "pointId": "pcb_port_51",
+          "pcb_port_id": "pcb_port_51"
+        },
+        {
+          "x": -13.424949999999999,
+          "y": 7.60065,
+          "layer": "top",
+          "pointId": "pcb_port_42",
+          "pcb_port_id": "pcb_port_42"
+        },
+        {
+          "x": -7.79945,
+          "y": 8.42505,
+          "layer": "top",
+          "pointId": "pcb_port_85",
+          "pcb_port_id": "pcb_port_85"
+        },
+        {
+          "x": -9.39985,
+          "y": 8.42505,
+          "layer": "top",
+          "pointId": "pcb_port_89",
+          "pcb_port_id": "pcb_port_89"
+        },
+        {
+          "x": -16.09995,
+          "y": 25.65,
+          "layer": "top",
+          "pointId": "pcb_port_112",
+          "pcb_port_id": "pcb_port_112"
+        },
+        {
+          "x": -19.325,
+          "y": 8.7,
+          "layer": "top",
+          "pointId": "pcb_port_145",
+          "pcb_port_id": "pcb_port_145"
+        },
+        {
+          "x": -0.7099999999999993,
+          "y": 22.9,
+          "layer": "top",
+          "pointId": "pcb_port_149",
+          "pcb_port_id": "pcb_port_149"
+        },
+        {
+          "x": -1.5,
+          "y": 1.8750000000000002,
+          "layer": "top",
+          "pointId": "pcb_port_155",
+          "pcb_port_id": "pcb_port_155"
+        },
+        {
+          "x": -9.709999999999999,
+          "y": 14.25,
+          "layer": "top",
+          "pointId": "pcb_port_21",
+          "pcb_port_id": "pcb_port_21"
+        },
+        {
+          "x": 2,
+          "y": 22.810000000000002,
+          "layer": "top",
+          "pointId": "pcb_port_130",
+          "pcb_port_id": "pcb_port_130"
+        },
+        {
+          "x": -16.2,
+          "y": 28.79,
+          "layer": "top",
+          "pointId": "pcb_port_133",
+          "pcb_port_id": "pcb_port_133"
+        },
+        {
+          "x": 0,
+          "y": -26.5,
+          "layer": "top",
+          "pointId": "pcb_port_160",
+          "pcb_port_id": "pcb_port_160"
+        }
+      ]
+    },
+    {
+      "name": "source_net_17",
+      "nominalTraceWidth": 0.15,
+      "width": 0.15,
+      "pointsToConnect": [
+        {
+          "x": -2.51,
+          "y": 0.09999999999999964,
+          "layer": "top",
+          "pointId": "pcb_port_24",
+          "pcb_port_id": "pcb_port_24"
+        },
+        {
+          "x": -1.5,
+          "y": 3.5250000000000004,
+          "layer": "top",
+          "pointId": "pcb_port_156",
+          "pcb_port_id": "pcb_port_156"
+        },
+        {
+          "x": -7.39935,
+          "y": 8.42505,
+          "layer": "top",
+          "pointId": "pcb_port_84",
+          "pcb_port_id": "pcb_port_84"
+        }
+      ]
+    },
+    {
+      "name": "source_net_18",
+      "nominalTraceWidth": 0.15,
+      "width": 0.15,
+      "pointsToConnect": [
+        {
+          "x": -13.424949999999999,
+          "y": 5.600149999999999,
+          "layer": "top",
+          "pointId": "pcb_port_47",
+          "pcb_port_id": "pcb_port_47"
+        }
+      ]
+    },
+    {
+      "name": "source_net_19",
+      "nominalTraceWidth": 0.15,
+      "width": 0.15,
+      "pointsToConnect": [
+        {
+          "x": -13.424949999999999,
+          "y": 5.20005,
+          "layer": "top",
+          "pointId": "pcb_port_48",
+          "pcb_port_id": "pcb_port_48"
+        }
+      ]
+    },
+    {
+      "name": "source_net_20",
+      "nominalTraceWidth": 0.15,
+      "width": 0.15,
+      "pointsToConnect": [
+        {
+          "x": -6.57505,
+          "y": 6.00025,
+          "layer": "top",
+          "pointId": "pcb_port_79",
+          "pcb_port_id": "pcb_port_79"
+        }
+      ]
+    },
+    {
+      "name": "source_net_21",
+      "nominalTraceWidth": 0.1,
+      "width": 0.1,
+      "pointsToConnect": [
+        {
+          "x": -10.200050000000001,
+          "y": 8.42505,
+          "layer": "top",
+          "pointId": "pcb_port_91",
+          "pcb_port_id": "pcb_port_91"
+        },
+        {
+          "x": -9.39985,
+          "y": 1.5749499999999999,
+          "layer": "top",
+          "pointId": "pcb_port_64",
+          "pcb_port_id": "pcb_port_64"
+        },
+        {
+          "x": -8.19955,
+          "y": 8.42505,
+          "layer": "top",
+          "pointId": "pcb_port_86",
+          "pcb_port_id": "pcb_port_86"
+        },
+        {
+          "x": -6.71,
+          "y": -1,
+          "layer": "top",
+          "pointId": "pcb_port_147",
+          "pcb_port_id": "pcb_port_147"
+        }
+      ]
+    }
+  ],
+  "layerCount": 4,
+  "minTraceWidth": 0.1,
+  "minViaDiameter": 0.6,
+  "minViaHoleDiameter": 0.3,
+  "minViaPadDiameter": 0.6,
+  "min_via_hole_diameter": 0.3,
+  "min_via_pad_diameter": 0.6,
+  "minTraceToPadEdgeClearance": 0.1,
+  "minViaHoleEdgeToViaHoleEdgeClearance": 0.1,
+  "minPlatedHoleDrillEdgeToDrillEdgeClearance": 0.15,
+  "minPadEdgeToPadEdgeClearance": 0.1,
+  "minBoardEdgeClearance": 0.2,
+  "nominalTraceWidth": 0.15
+}

--- a/tests/bugs/bugreport91-rp2040-usbc-clearance.test.ts
+++ b/tests/bugs/bugreport91-rp2040-usbc-clearance.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver } from "lib"
+import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
+import type { SimpleRouteJson } from "lib/types"
+import srjJson from "../../fixtures/bug-reports/bugreport91-rp2040-usbc-clearance/bugreport91-rp2040-usbc-clearance.srj.json" with {
+  type: "json",
+}
+
+const srj = srjJson as SimpleRouteJson
+
+// The exact-geometry repair portfolio currently leaves one 0.089998 mm
+// pad/trace clearance for a board that requires 0.1 mm.
+test.skip("pipeline7 clears the RP2040 board USB-C pad/trace DRC error", () => {
+  const solver = new AutoroutingPipelineSolver(structuredClone(srj))
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  if (!solver.srjWithPointPairs) {
+    throw new Error("Solver did not produce point-pair SRJ")
+  }
+
+  const { errors } = evaluateRelaxedDrc({
+    inputSrj: srj,
+    srjWithPointPairs: solver.srjWithPointPairs,
+    routedTraces: solver.getOutputSimplifiedPcbTraces(),
+  })
+
+  expect(errors).toHaveLength(0)
+})


### PR DESCRIPTION
## Summary

Adds an unresolved Pipeline 7 regression fixture captured from the public `seveibar/rp2040-lipo-charger` board and a skipped test expressing the desired zero-DRC result.

The input was emitted directly from the board's `MCU` subcircuit while building with `tscircuit@0.0.2285`. The failure also reproduces on this repository's current `main` (`@tscircuit/capacity-autorouter@0.0.791`), so it is not limited to the older 0.0.785 transitive release.

## Observed behavior

Pipeline 7 reports `solved: true`, but the relaxed DRC evaluator returns one `pcb_pad_trace_clearance_error`:

- pad: `pcb_smtpad_31` / `pcb_port_35` (USB-C A6)
- trace: `source_trace_2__source_trace_53_mst0_0` between `pcb_port_36` and `pcb_port_34`
- required clearance: `0.1 mm`
- actual clearance: `0.08999816906738829 mm`

Stage diagnostics from current `main`:

- trace-width output: 31 DRC errors
- global repair output: 1 DRC error
- exact-geometry repair output: 1 DRC error
- exact repair attempted 6 candidates, accepted no broad or targeted force improvement, and rejected the safe trace-layer branch

This indicates the remaining error is produced by the autorouter and the exact-geometry repair portfolio currently cannot clear the final 0.01 mm deficit.

## Reproduction

The test is skipped to match the repository's convention for unresolved bug reports. Remove `.skip` from:

`tests/bugs/bugreport91-rp2040-usbc-clearance.test.ts`

Then run:

```sh
bun test tests/bugs/bugreport91-rp2040-usbc-clearance.test.ts --timeout 9999999
```

The assertion fails with `Expected length: 0; Received length: 1` after approximately 14 seconds.

## Validation

- focused test with the desired assertion enabled: reproduces the single clearance error
- focused test in committed skipped state: passes test collection
- `bun run build`: passes
- `git diff --check`: passes