### PR TITLE
Improve benchmark comparison comments

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -487,6 +487,11 @@ jobs:
           github-token: ${{ secrets.TSCIRCUIT_BOT_GITHUB_TOKEN }}
           script: |
             const fs = require('node:fs')
+            const { pathToFileURL } = require('node:url')
+            const comparisonUrl = pathToFileURL(
+              `${process.env.GITHUB_WORKSPACE}/scripts/benchmark/benchmark-comment-comparison.js`,
+            ).href
+            const { renderBenchmarkComparison } = await import(comparisonUrl)
             const maxLength = 60000
             const truncate = (s, max) => s.length > max ? `${s.slice(0, max)}\n\n...truncated...` : s
             const formatTime = (timeMs) => {
@@ -724,9 +729,14 @@ jobs:
                     '',
                   ]
                 : []),
-              '### Previous main run',
+              '### Main vs PR',
               '',
-              ...renderPreviousMainSummary(mainDatasetReport, benchmarkDatasetName),
+              ...renderBenchmarkComparison({
+                mainReport: mainDatasetReport,
+                prReport,
+                fallbackText: prText ?? '(benchmark results were not produced)',
+                maxLength,
+              }),
               '',
               ...renderReport(mainDatasetReport, '', {
                 detailsLabel: 'Previous main run details',
@@ -735,6 +745,7 @@ jobs:
               '',
               ...renderReport(prReport, prText ?? '(benchmark results were not produced)', {
                 detailsLabel: 'PR run details',
+                omitSummary: true,
                 includeDelta: true,
                 mainIndex,
                 viaCellIndex,
@@ -970,6 +981,11 @@ jobs:
           github-token: ${{ secrets.TSCIRCUIT_BOT_GITHUB_TOKEN }}
           script: |
             const fs = require('node:fs')
+            const { pathToFileURL } = require('node:url')
+            const comparisonUrl = pathToFileURL(
+              `${process.env.GITHUB_WORKSPACE}/scripts/benchmark/benchmark-comment-comparison.js`,
+            ).href
+            const { renderBenchmarkComparison } = await import(comparisonUrl)
             const maxLength = 60000
             const truncate = (s, max) => s.length > max ? `${s.slice(0, max)}\n\n...truncated...` : s
             const formatTime = (timeMs) => {
@@ -1328,9 +1344,14 @@ jobs:
                     '',
                   ]
                 : []),
-              '### Previous main run',
+              '### Main vs PR',
               '',
-              ...renderPreviousMainSummary(mainDatasetReport, benchmarkDatasetName),
+              ...renderBenchmarkComparison({
+                mainReport: mainDatasetReport,
+                prReport,
+                fallbackText: prText ?? '(benchmark results were not produced)',
+                maxLength,
+              }),
               '',
               ...renderReport(mainDatasetReport, '', {
                 detailsLabel: 'Previous main run details',
@@ -1345,6 +1366,7 @@ jobs:
               '',
               ...renderReport(prReport, prText ?? '(benchmark results were not produced)', {
                 detailsLabel: 'PR run details',
+                omitSummary: true,
                 includeDelta: true,
                 mainIndex,
                 viaCellIndex,

--- a/scripts/benchmark/benchmark-comment-comparison.d.ts
+++ b/scripts/benchmark/benchmark-comment-comparison.d.ts
@@ -1,0 +1,12 @@
+import type { BenchmarkReport } from "./benchmark-types"
+
+export type BenchmarkComparisonInput = {
+  mainReport: BenchmarkReport | null
+  prReport: BenchmarkReport | null
+  fallbackText?: string
+  maxLength?: number
+}
+
+export function renderBenchmarkComparison(
+  input: BenchmarkComparisonInput,
+): string[]

--- a/scripts/benchmark/benchmark-comment-comparison.js
+++ b/scripts/benchmark/benchmark-comment-comparison.js
@@ -1,0 +1,158 @@
+const formatTime = (timeMs) => {
+  if (typeof timeMs !== "number" || !Number.isFinite(timeMs)) {
+    return "n/a"
+  }
+  return timeMs < 1_000
+    ? `${Math.round(timeMs)}ms`
+    : `${(timeMs / 1_000).toFixed(1)}s`
+}
+
+const formatAverage = (value) => {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return "n/a"
+  }
+  return value.toFixed(2)
+}
+
+const formatSolverDisplayName = (solverName, effortLabel) => {
+  const solver = String(solverName ?? "").replace(
+    /^AutoroutingPipelineSolver(\d+).*$/,
+    "Pipeline$1",
+  )
+  const match = String(effortLabel ?? "").match(/^(\d+)x effort$/)
+  if (!match) return `${solver}${effortLabel === "mixed effort" ? "(mixed)" : ""}`
+  const effort = Number.parseInt(match[1], 10)
+  return `${solver}${Number.isFinite(effort) && effort > 1 ? `(${effort}x)` : ""}`
+}
+
+const parsePercentLabel = (label) => {
+  const match = String(label ?? "")
+    .trim()
+    .match(/^(-?\d+(?:\.\d+)?)%/)
+  if (!match) return null
+  const value = Number(match[1])
+  return Number.isFinite(value) ? value : null
+}
+
+const formatPercentPointDelta = (mainLabel, prLabel) => {
+  const mainValue = parsePercentLabel(mainLabel)
+  const prValue = parsePercentLabel(prLabel)
+  if (mainValue === null || prValue === null) return "n/a"
+  const delta = prValue - mainValue
+  return `${delta > 0 ? "+" : ""}${delta.toFixed(1)} pp`
+}
+
+const formatRelativeDelta = (mainValue, prValue) => {
+  if (
+    typeof mainValue !== "number" ||
+    typeof prValue !== "number" ||
+    !Number.isFinite(mainValue) ||
+    !Number.isFinite(prValue) ||
+    mainValue === 0
+  ) {
+    return "n/a"
+  }
+  const delta = ((prValue - mainValue) / mainValue) * 100
+  return `${delta > 0 ? "+" : ""}${delta.toFixed(1)}%`
+}
+
+const getTimeoutCount = (report, solverName) => {
+  if (!Array.isArray(report?.tests)) return null
+  return report.tests.filter(
+    (test) => test.solverName === solverName && test.didTimeout,
+  ).length
+}
+
+const getTimePercentile = (report, solverName, percentile) => {
+  if (!Array.isArray(report?.tests)) return null
+  const elapsedTimes = report.tests
+    .filter(
+      (test) =>
+        test.solverName === solverName &&
+        (test.didSolve || test.didTimeout) &&
+        typeof test.elapsedTimeMs === "number" &&
+        Number.isFinite(test.elapsedTimeMs),
+    )
+    .map((test) => test.elapsedTimeMs)
+    .sort((a, b) => a - b)
+  if (elapsedTimes.length === 0) return null
+
+  const index = (elapsedTimes.length - 1) * percentile
+  const lowerIndex = Math.floor(index)
+  const upperIndex = Math.ceil(index)
+  const lowerValue = elapsedTimes[lowerIndex]
+  const upperValue = elapsedTimes[upperIndex]
+  return lowerValue + (upperValue - lowerValue) * (index - lowerIndex)
+}
+
+const formatCountDelta = (mainValue, prValue) => {
+  if (typeof mainValue !== "number" || typeof prValue !== "number") {
+    return "n/a"
+  }
+  const delta = prValue - mainValue
+  return `${delta > 0 ? "+" : ""}${delta}`
+}
+
+export const renderBenchmarkComparison = ({
+  mainReport,
+  prReport,
+  fallbackText = "(benchmark results were not produced)",
+  maxLength = 60_000,
+}) => {
+  if (!Array.isArray(prReport?.summary) || prReport.summary.length === 0) {
+    const truncated =
+      fallbackText.length > maxLength
+        ? `${fallbackText.slice(0, maxLength)}\n\n...truncated...`
+        : fallbackText
+    return ["```", truncated, "```"]
+  }
+
+  const mainSummaries = new Map(
+    Array.isArray(mainReport?.summary)
+      ? mainReport.summary.map((row) => [row.solverName, row])
+      : [],
+  )
+  const rows = []
+  for (const prSummary of prReport.summary) {
+    const mainSummary = mainSummaries.get(prSummary.solverName)
+    const solver = formatSolverDisplayName(
+      prSummary.solverName,
+      prReport.effortLabel,
+    )
+    const mainTimeouts = getTimeoutCount(mainReport, prSummary.solverName)
+    const prTimeouts = getTimeoutCount(prReport, prSummary.solverName)
+    rows.push(
+      `| ${solver} | Completion | ${mainSummary?.completedRateLabel ?? "n/a"} | ${prSummary.completedRateLabel} | ${formatPercentPointDelta(mainSummary?.completedRateLabel, prSummary.completedRateLabel)} |`,
+      `| ${solver} | Relaxed DRC pass | ${mainSummary?.relaxedDrcRateLabel ?? "n/a"} | ${prSummary.relaxedDrcRateLabel} | ${formatPercentPointDelta(mainSummary?.relaxedDrcRateLabel, prSummary.relaxedDrcRateLabel)} |`,
+      `| ${solver} | Timeouts | ${mainTimeouts ?? "n/a"} | ${prTimeouts ?? "n/a"} | ${formatCountDelta(mainTimeouts, prTimeouts)} |`,
+    )
+    for (const percentile of [50, 60, 70, 80, 90, 95]) {
+      const mainTime = getTimePercentile(
+        mainReport,
+        prSummary.solverName,
+        percentile / 100,
+      )
+      const prTime = getTimePercentile(
+        prReport,
+        prSummary.solverName,
+        percentile / 100,
+      )
+      rows.push(
+        `| ${solver} | P${percentile} time | ${formatTime(mainTime)} | ${formatTime(prTime)} | ${formatRelativeDelta(mainTime, prTime)} |`,
+      )
+    }
+    rows.push(
+      `| ${solver} | Average vias | ${formatAverage(mainSummary?.avgVia)} | ${formatAverage(prSummary.avgVia)} | ${formatRelativeDelta(mainSummary?.avgVia, prSummary.avgVia)} |`,
+    )
+  }
+
+  return [
+    `Dataset: ${prReport.datasetName} · Scenarios: ${prReport.scenarioCount} · Effort: ${prReport.effortLabel}`,
+    "",
+    "| Solver | Metric | Main | PR | Change |",
+    "| --- | --- | ---: | ---: | ---: |",
+    ...rows,
+    "",
+    "_Timing percentiles include solved and timed-out samples. Negative timing changes are faster._",
+  ]
+}

--- a/scripts/benchmark/benchmark-comment-comparison.js
+++ b/scripts/benchmark/benchmark-comment-comparison.js
@@ -20,7 +20,8 @@ const formatSolverDisplayName = (solverName, effortLabel) => {
     "Pipeline$1",
   )
   const match = String(effortLabel ?? "").match(/^(\d+)x effort$/)
-  if (!match) return `${solver}${effortLabel === "mixed effort" ? "(mixed)" : ""}`
+  if (!match)
+    return `${solver}${effortLabel === "mixed effort" ? "(mixed)" : ""}`
   const effort = Number.parseInt(match[1], 10)
   return `${solver}${Number.isFinite(effort) && effort > 1 ? `(${effort}x)` : ""}`
 }

--- a/scripts/benchmark/benchmark-types.ts
+++ b/scripts/benchmark/benchmark-types.ts
@@ -128,6 +128,11 @@ export type SolverRunSummary = {
   relaxedDrcRateLabel: string
   timedOutLabel: string
   p50TimeMs: number | null
+  // Optional so previously published version 1 artifacts remain readable.
+  p60TimeMs?: number | null
+  p70TimeMs?: number | null
+  p80TimeMs?: number | null
+  p90TimeMs?: number | null
   p95TimeMs: number | null
   avgVia: number | null
 }

--- a/scripts/benchmark/index.ts
+++ b/scripts/benchmark/index.ts
@@ -836,6 +836,10 @@ const formatTable = (rows: SolverRunSummary[]) => {
     "Relaxed DRC Pass %",
     "Timed Out",
     "P50 Time",
+    "P60 Time",
+    "P70 Time",
+    "P80 Time",
+    "P90 Time",
     "P95 Time",
     "Avg Via",
   ]
@@ -846,6 +850,10 @@ const formatTable = (rows: SolverRunSummary[]) => {
     row.relaxedDrcRateLabel,
     row.timedOutLabel,
     formatTime(row.p50TimeMs),
+    formatTime(row.p60TimeMs ?? null),
+    formatTime(row.p70TimeMs ?? null),
+    formatTime(row.p80TimeMs ?? null),
+    formatTime(row.p90TimeMs ?? null),
     formatTime(row.p95TimeMs),
     formatAverage(row.avgVia),
   ])
@@ -1433,13 +1441,15 @@ const runBenchmarkTasks = async (
   return results
 }
 
-const summarizeSolverResults = (
+export const summarizeSolverResults = (
   solverName: string,
   results: WorkerResult[],
 ): SolverRunSummary => {
   const timedOut = results.filter((result) => result.didTimeout)
   const succeeded = results.filter((result) => result.didSolve)
-  const elapsedForSucceeded = succeeded.map((result) => result.elapsedTimeMs)
+  const elapsedForSolvedAndTimedOut = results
+    .filter((result) => result.didSolve || result.didTimeout)
+    .map((result) => result.elapsedTimeMs)
   const viaCounts = succeeded
     .map((result) => result.viaCount)
     .filter((viaCount): viaCount is number => typeof viaCount === "number")
@@ -1465,8 +1475,12 @@ const summarizeSolverResults = (
       timedOut.length,
     ),
     timedOutLabel: `${timedOut.length}/${results.length}`,
-    p50TimeMs: getPercentileMs(elapsedForSucceeded, 0.5),
-    p95TimeMs: getPercentileMs(elapsedForSucceeded, 0.95),
+    p50TimeMs: getPercentileMs(elapsedForSolvedAndTimedOut, 0.5),
+    p60TimeMs: getPercentileMs(elapsedForSolvedAndTimedOut, 0.6),
+    p70TimeMs: getPercentileMs(elapsedForSolvedAndTimedOut, 0.7),
+    p80TimeMs: getPercentileMs(elapsedForSolvedAndTimedOut, 0.8),
+    p90TimeMs: getPercentileMs(elapsedForSolvedAndTimedOut, 0.9),
+    p95TimeMs: getPercentileMs(elapsedForSolvedAndTimedOut, 0.95),
     avgVia,
   } satisfies SolverRunSummary
 }

--- a/scripts/benchmark/same-machine-results.ts
+++ b/scripts/benchmark/same-machine-results.ts
@@ -53,6 +53,29 @@ const formatRelativeDelta = (
   return formatSigned(((prValue - mainValue) / mainValue) * 100, "%")
 }
 
+const getTimePercentile = (
+  report: BenchmarkReport,
+  solverName: string,
+  percentile: number,
+): number | null => {
+  const elapsedTimes = report.tests
+    .filter(
+      (test) =>
+        test.solverName === solverName && (test.didSolve || test.didTimeout),
+    )
+    .map((test) => test.elapsedTimeMs)
+    .sort((a, b) => a - b)
+  if (elapsedTimes.length === 0) return null
+
+  const index = (elapsedTimes.length - 1) * percentile
+  const lowerIndex = Math.floor(index)
+  const upperIndex = Math.ceil(index)
+  const lowerValue = elapsedTimes[lowerIndex]
+  const upperValue = elapsedTimes[upperIndex]
+  if (lowerValue === undefined || upperValue === undefined) return null
+  return lowerValue + (upperValue - lowerValue) * (index - lowerIndex)
+}
+
 const outcomeScore = (test: WorkerResult): number => {
   if (!test.didSolve) return 0
   return test.relaxedDrcPassed ? 2 : 1
@@ -142,13 +165,25 @@ export const renderSameMachineBenchmarkResults = ({
     const prTimeouts = prReport.tests.filter(
       (test) => test.solverName === prSummary.solverName && test.didTimeout,
     ).length
+    const timePercentiles = [50, 60, 70, 80, 90, 95].map((percentile) => {
+      const mainTime = getTimePercentile(
+        mainReport,
+        prSummary.solverName,
+        percentile / 100,
+      )
+      const prTime = getTimePercentile(
+        prReport,
+        prSummary.solverName,
+        percentile / 100,
+      )
+      return `| ${solver} | P${percentile} time | ${formatTime(mainTime)} | ${formatTime(prTime)} | ${formatRelativeDelta(mainTime, prTime)} |`
+    })
 
     lines.push(
       `| ${solver} | Completion | ${mainSummary.completedRateLabel} | ${prSummary.completedRateLabel} | ${formatPercentPointDelta(mainSummary.completedRateLabel, prSummary.completedRateLabel)} |`,
       `| ${solver} | Relaxed DRC pass | ${mainSummary.relaxedDrcRateLabel} | ${prSummary.relaxedDrcRateLabel} | ${formatPercentPointDelta(mainSummary.relaxedDrcRateLabel, prSummary.relaxedDrcRateLabel)} |`,
       `| ${solver} | Timeouts | ${mainTimeouts} | ${prTimeouts} | ${prTimeouts - mainTimeouts > 0 ? "+" : ""}${prTimeouts - mainTimeouts} |`,
-      `| ${solver} | P50 time | ${formatTime(mainSummary.p50TimeMs)} | ${formatTime(prSummary.p50TimeMs)} | ${formatRelativeDelta(mainSummary.p50TimeMs, prSummary.p50TimeMs)} |`,
-      `| ${solver} | P95 time | ${formatTime(mainSummary.p95TimeMs)} | ${formatTime(prSummary.p95TimeMs)} | ${formatRelativeDelta(mainSummary.p95TimeMs, prSummary.p95TimeMs)} |`,
+      ...timePercentiles,
       `| ${solver} | Average vias | ${formatAverage(mainSummary.avgVia)} | ${formatAverage(prSummary.avgVia)} | ${formatRelativeDelta(mainSummary.avgVia, prSummary.avgVia)} |`,
     )
   }
@@ -159,7 +194,7 @@ export const renderSameMachineBenchmarkResults = ({
   const regressionCount = changedOutcomes.length - improvementCount
   lines.push(
     "",
-    `Outcome changes: **${improvementCount} improved**, **${regressionCount} regressed**. Negative timing deltas are faster.`,
+    `Outcome changes: **${improvementCount} improved**, **${regressionCount} regressed**. Timing percentiles include solved and timed-out samples; negative timing deltas are faster.`,
   )
 
   if (changedOutcomes.length > 0) {

--- a/tests/benchmark-comment-comparison.test.ts
+++ b/tests/benchmark-comment-comparison.test.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "bun:test"
+import type {
+  BenchmarkReport,
+  WorkerResult,
+} from "../scripts/benchmark/benchmark-types"
+import { renderBenchmarkComparison } from "../scripts/benchmark/benchmark-comment-comparison.js"
+
+test("PR benchmark comments render one main-versus-PR comparison table", () => {
+  const solverName = "AutoroutingPipelineSolver7_MultiGraph"
+  const makeTest = (
+    sampleNumber: number,
+    elapsedTimeMs: number,
+    overrides: Partial<WorkerResult> = {},
+  ): WorkerResult => ({
+    solverName,
+    scenarioName: `sample${sampleNumber}`,
+    sampleNumber,
+    elapsedTimeMs,
+    didSolve: true,
+    didTimeout: false,
+    relaxedDrcPassed: true,
+    ...overrides,
+  })
+  const makeReport = (
+    summary: BenchmarkReport["summary"],
+    tests: WorkerResult[],
+  ): BenchmarkReport => ({
+    version: 1,
+    datasetName: "srj18",
+    scenarioCount: 2,
+    effortLabel: "1x effort",
+    summary,
+    solverFailureSummary: [],
+    timeoutSummary: [],
+    failureSummary: [],
+    snapshots: [],
+    tests,
+  })
+  const mainReport = makeReport(
+    [
+      {
+        solverName,
+        completedRateLabel: "50.0% (🕒50.0%)",
+        relaxedDrcRateLabel: "50.0% (🕒50.0%)",
+        timedOutLabel: "1/2",
+        p50TimeMs: 1_000,
+        p95TimeMs: 1_000,
+        avgVia: 2,
+      },
+    ],
+    [
+      makeTest(1, 1_000),
+      makeTest(2, 2_000, {
+        didSolve: false,
+        didTimeout: true,
+        relaxedDrcPassed: false,
+      }),
+    ],
+  )
+  const prReport = makeReport(
+    [
+      {
+        solverName,
+        completedRateLabel: "100.0%",
+        relaxedDrcRateLabel: "100.0%",
+        timedOutLabel: "0/2",
+        p50TimeMs: 1_350,
+        p95TimeMs: 1_755,
+        avgVia: 2.2,
+      },
+    ],
+    [makeTest(1, 900), makeTest(2, 1_800)],
+  )
+
+  expect(
+    renderBenchmarkComparison({ mainReport, prReport }).join("\n"),
+  ).toBe(`Dataset: srj18 · Scenarios: 2 · Effort: 1x effort
+
+| Solver | Metric | Main | PR | Change |
+| --- | --- | ---: | ---: | ---: |
+| Pipeline7 | Completion | 50.0% (🕒50.0%) | 100.0% | +50.0 pp |
+| Pipeline7 | Relaxed DRC pass | 50.0% (🕒50.0%) | 100.0% | +50.0 pp |
+| Pipeline7 | Timeouts | 1 | 0 | -1 |
+| Pipeline7 | P50 time | 1.5s | 1.4s | -10.0% |
+| Pipeline7 | P60 time | 1.6s | 1.4s | -10.0% |
+| Pipeline7 | P70 time | 1.7s | 1.5s | -10.0% |
+| Pipeline7 | P80 time | 1.8s | 1.6s | -10.0% |
+| Pipeline7 | P90 time | 1.9s | 1.7s | -10.0% |
+| Pipeline7 | P95 time | 1.9s | 1.8s | -10.0% |
+| Pipeline7 | Average vias | 2.00 | 2.20 | +10.0% |
+
+_Timing percentiles include solved and timed-out samples. Negative timing changes are faster._`)
+})

--- a/tests/benchmark-summary-percentiles.test.ts
+++ b/tests/benchmark-summary-percentiles.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "bun:test"
+import type { WorkerResult } from "../scripts/benchmark/benchmark-types"
+import { summarizeSolverResults } from "../scripts/benchmark/index"
+
+test("benchmark timing percentiles include solved and timed-out samples", () => {
+  const solverName = "AutoroutingPipelineSolver7_MultiGraph"
+  const makeResult = (
+    sampleNumber: number,
+    elapsedTimeMs: number,
+    overrides: Partial<WorkerResult> = {},
+  ): WorkerResult => ({
+    solverName,
+    scenarioName: `sample${sampleNumber}`,
+    sampleNumber,
+    elapsedTimeMs,
+    didSolve: true,
+    didTimeout: false,
+    relaxedDrcPassed: true,
+    ...overrides,
+  })
+  const results = [
+    makeResult(1, 100),
+    makeResult(2, 200),
+    makeResult(3, 300),
+    makeResult(4, 400),
+    makeResult(5, 1_000, {
+      didSolve: false,
+      didTimeout: true,
+      relaxedDrcPassed: false,
+    }),
+    makeResult(6, 10, {
+      didSolve: false,
+      relaxedDrcPassed: false,
+      error: "failed before routing",
+    }),
+  ]
+
+  const summary = summarizeSolverResults(solverName, results)
+  expect(summary.p50TimeMs).toBe(300)
+  expect(summary.p60TimeMs).toBeCloseTo(340)
+  expect(summary.p70TimeMs).toBeCloseTo(380)
+  expect(summary.p80TimeMs).toBeCloseTo(520)
+  expect(summary.p90TimeMs).toBeCloseTo(760)
+  expect(summary.p95TimeMs).toBeCloseTo(880)
+})

--- a/tests/pr-benchmark-command.test.ts
+++ b/tests/pr-benchmark-command.test.ts
@@ -118,6 +118,10 @@ test("PR benchmark commands preserve arguments and fan-out behavior", () => {
   expect(benchmarkWorkflow).toContain("same_machine_compare:")
   expect(benchmarkWorkflow).toContain("inputs.same_machine_compare == true")
   expect(benchmarkWorkflow).toContain("## Same Machine Benchmark Results")
+  expect(benchmarkWorkflow.match(/### Main vs PR/g)).toHaveLength(2)
+  expect(
+    benchmarkWorkflow.match(/benchmark-comment-comparison\.js/g),
+  ).toHaveLength(2)
   expect(benchmarkWorkflow).toContain("Checkout benchmark controller")
   expect(benchmarkWorkflow).toContain(
     "working-directory: same-machine-controller",

--- a/tests/same-machine-benchmark-results.test.ts
+++ b/tests/same-machine-benchmark-results.test.ts
@@ -89,8 +89,16 @@ test("same-machine benchmark comments compare matching reports", () => {
     "| Pipeline7 | Completion | 50.0% (🕒50.0%) | 100.0% (🕒0.0%) | +50.0 pp |",
   )
   expect(markdown).toContain("| Pipeline7 | Timeouts | 1 | 0 | -1 |")
-  expect(markdown).toContain("| Pipeline7 | P50 time | 1.0s | 900ms | -10.0% |")
+  expect(markdown).toContain("| Pipeline7 | P50 time | 1.5s | 1.4s | -6.7% |")
+  expect(markdown).toContain("| Pipeline7 | P60 time |")
+  expect(markdown).toContain("| Pipeline7 | P70 time |")
+  expect(markdown).toContain("| Pipeline7 | P80 time |")
+  expect(markdown).toContain("| Pipeline7 | P90 time |")
+  expect(markdown).toContain("| Pipeline7 | P95 time |")
   expect(markdown).toContain("Outcome changes: **1 improved**, **0 regressed**")
+  expect(markdown).toContain(
+    "Timing percentiles include solved and timed-out samples",
+  )
   expect(markdown).toContain("| Pipeline7 | 1 | Timeout | DRC passed |")
   expect(() =>
     renderSameMachineBenchmarkResults({


### PR DESCRIPTION
## What changed

- Replace the separate main and PR benchmark summary tables with one compact `Solver / Metric / Main / PR / Change` comparison table.
- Add P60, P70, P80, and P90 timing rows alongside P50 and P95.
- Calculate timing percentiles from solved and timed-out samples, while continuing to exclude non-timeout failures.
- Apply the same percentile behavior to same-machine benchmark comments.
- Keep previous-main and PR per-sample results available in collapsed details.

## Why

The previous comment layout made readers scan between separate tables to compare a metric. Timing percentiles also excluded timeout durations, which could make a slower or less reliable run appear faster.

## Example

| Solver | Metric | Main | PR | Change |
| --- | --- | ---: | ---: | ---: |
| Pipeline7 | Completion | 50.0% (🕒50.0%) | 100.0% | +50.0 pp |
| Pipeline7 | Relaxed DRC pass | 50.0% (🕒50.0%) | 100.0% | +50.0 pp |
| Pipeline7 | Timeouts | 1 | 0 | -1 |
| Pipeline7 | P50 time | 1.5s | 1.4s | -10.0% |
| Pipeline7 | P60 time | 1.6s | 1.4s | -10.0% |
| Pipeline7 | P70 time | 1.7s | 1.5s | -10.0% |
| Pipeline7 | P80 time | 1.8s | 1.6s | -10.0% |
| Pipeline7 | P90 time | 1.9s | 1.7s | -10.0% |
| Pipeline7 | P95 time | 1.9s | 1.8s | -10.0% |
| Pipeline7 | Average vias | 2.00 | 2.20 | +10.0% |

_Timing percentiles include solved and timed-out samples. Negative timing changes are faster._

## Validation

- `bun test tests/benchmark-comment-comparison.test.ts tests/benchmark-summary-percentiles.test.ts tests/same-machine-benchmark-results.test.ts tests/pr-benchmark-command.test.ts --timeout 9999999`
- `bunx tsc --noEmit`
- `bun run build`
- Parsed the workflow YAML and compiled both embedded benchmark-comment scripts as async JavaScript functions.
