### PR TITLE
Add CI check for string ID hacks

### DIFF
--- a/.github/workflows/no-string-id-hacks.yml
+++ b/.github/workflows/no-string-id-hacks.yml
@@ -1,0 +1,31 @@
+name: No String ID Hacks
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  check-added-code:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.3.8
+
+      - name: Check added production code
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: bun scripts/check-no-string-id-hacks.ts "$BASE_SHA" "$HEAD_SHA"

--- a/.github/workflows/no-string-id-hacks.yml
+++ b/.github/workflows/no-string-id-hacks.yml
@@ -15,12 +15,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.8
 

--- a/scripts/check-no-string-id-hacks.ts
+++ b/scripts/check-no-string-id-hacks.ts
@@ -32,7 +32,8 @@ export const findStringIdPrefixHacks = (
     /\.startsWith\s*\(\s*(["'`])([^"'`\r\n]*_[^"'`\r\n]*)\1/g
 
   for (const match of source.matchAll(hardCodedPrefixPattern)) {
-    if (match.index === undefined || isInsideComment(source, match.index)) continue
+    if (match.index === undefined || isInsideComment(source, match.index))
+      continue
     const prefix = match[2]!
     if (prefix.includes("${")) continue
 
@@ -57,9 +58,7 @@ export const getAddedProductionLines = (diff: string): AddedLine[] => {
       continue
     }
 
-    const hunk = diffLine.match(
-      /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/,
-    )
+    const hunk = diffLine.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/)
     if (hunk) {
       currentNewLine = Number(hunk[1])
       continue
@@ -81,15 +80,7 @@ export const getAddedProductionLines = (diff: string): AddedLine[] => {
 const getAddedLines = (baseSha: string, headSha: string): AddedLine[] => {
   const diff = spawnSync(
     "git",
-    [
-      "diff",
-      "--unified=0",
-      "--no-ext-diff",
-      baseSha,
-      headSha,
-      "--",
-      "lib",
-    ],
+    ["diff", "--unified=0", "--no-ext-diff", baseSha, headSha, "--", "lib"],
     { encoding: "utf8" },
   )
   if (diff.status !== 0) {

--- a/scripts/check-no-string-id-hacks.ts
+++ b/scripts/check-no-string-id-hacks.ts
@@ -1,0 +1,160 @@
+import { spawnSync } from "node:child_process"
+
+export type AddedLine = {
+  file: string
+  line: number
+}
+
+export type StringIdPrefixHack = {
+  prefix: string
+  startLine: number
+  endLine: number
+}
+
+const EMPTY_TREE_SHA = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
+const getLineNumber = (source: string, index: number): number =>
+  source.slice(0, index).split("\n").length
+
+const isInsideComment = (source: string, index: number): boolean => {
+  const beforeMatch = source.slice(0, index)
+  const currentLine = beforeMatch.slice(beforeMatch.lastIndexOf("\n") + 1)
+  if (currentLine.trimStart().startsWith("//")) return true
+
+  return beforeMatch.lastIndexOf("/*") > beforeMatch.lastIndexOf("*/")
+}
+
+export const findStringIdPrefixHacks = (
+  source: string,
+): StringIdPrefixHack[] => {
+  const findings: StringIdPrefixHack[] = []
+  const hardCodedPrefixPattern =
+    /\.startsWith\s*\(\s*(["'`])([^"'`\r\n]*_[^"'`\r\n]*)\1/g
+
+  for (const match of source.matchAll(hardCodedPrefixPattern)) {
+    if (match.index === undefined || isInsideComment(source, match.index)) continue
+    const prefix = match[2]!
+    if (prefix.includes("${")) continue
+
+    findings.push({
+      prefix,
+      startLine: getLineNumber(source, match.index),
+      endLine: getLineNumber(source, match.index + match[0].length),
+    })
+  }
+
+  return findings
+}
+
+export const getAddedProductionLines = (diff: string): AddedLine[] => {
+  const addedLines: AddedLine[] = []
+  let currentFile = ""
+  let currentNewLine = 0
+
+  for (const diffLine of diff.split("\n")) {
+    if (diffLine.startsWith("+++ b/")) {
+      currentFile = diffLine.slice("+++ b/".length)
+      continue
+    }
+
+    const hunk = diffLine.match(
+      /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/,
+    )
+    if (hunk) {
+      currentNewLine = Number(hunk[1])
+      continue
+    }
+
+    if (diffLine.startsWith("+") && !diffLine.startsWith("+++")) {
+      if (/^lib\/.*\.[cm]?[jt]sx?$/.test(currentFile)) {
+        addedLines.push({ file: currentFile, line: currentNewLine })
+      }
+      currentNewLine += 1
+    } else if (!diffLine.startsWith("-") && !diffLine.startsWith("\\")) {
+      currentNewLine += 1
+    }
+  }
+
+  return addedLines
+}
+
+const getAddedLines = (baseSha: string, headSha: string): AddedLine[] => {
+  const diff = spawnSync(
+    "git",
+    [
+      "diff",
+      "--unified=0",
+      "--no-ext-diff",
+      baseSha,
+      headSha,
+      "--",
+      "lib",
+    ],
+    { encoding: "utf8" },
+  )
+  if (diff.status !== 0) {
+    throw new Error(diff.stderr || "git diff failed")
+  }
+
+  return getAddedProductionLines(diff.stdout)
+}
+
+const getFileAtRevision = (revision: string, file: string): string => {
+  const result = spawnSync("git", ["show", `${revision}:${file}`], {
+    encoding: "utf8",
+  })
+  if (result.status !== 0) {
+    throw new Error(result.stderr || `Unable to read ${file} at ${revision}`)
+  }
+  return result.stdout
+}
+
+const escapeAnnotation = (value: string): string =>
+  value.replaceAll("%", "%25").replaceAll("\r", "%0D").replaceAll("\n", "%0A")
+
+const main = (): void => {
+  const [rawBaseSha, headSha] = process.argv.slice(2)
+  if (!rawBaseSha || !headSha) {
+    throw new Error(
+      "Usage: bun scripts/check-no-string-id-hacks.ts <base-sha> <head-sha>",
+    )
+  }
+
+  const baseSha = /^0+$/.test(rawBaseSha) ? EMPTY_TREE_SHA : rawBaseSha
+  const addedLinesByFile = new Map<string, Set<number>>()
+  for (const addedLine of getAddedLines(baseSha, headSha)) {
+    const lines = addedLinesByFile.get(addedLine.file) ?? new Set<number>()
+    lines.add(addedLine.line)
+    addedLinesByFile.set(addedLine.file, lines)
+  }
+
+  let findingCount = 0
+  for (const [file, addedLines] of addedLinesByFile) {
+    const source = getFileAtRevision(headSha, file)
+    for (const finding of findStringIdPrefixHacks(source)) {
+      const touchesAddedLine = [...addedLines].some(
+        (line) => line >= finding.startLine && line <= finding.endLine,
+      )
+      if (!touchesAddedLine) continue
+
+      findingCount += 1
+      const message =
+        `Do not infer a circuit entity's type from the hard-coded ID prefix ` +
+        `\"${finding.prefix}\". Use explicit metadata or a discriminated union instead.`
+      console.error(
+        `::error file=${escapeAnnotation(file)},line=${finding.startLine},title=String ID hack::${escapeAnnotation(message)}`,
+      )
+    }
+  }
+
+  if (findingCount > 0) {
+    console.error(
+      `Found ${findingCount} newly added hard-coded string ID prefix check(s).`,
+    )
+    process.exit(1)
+  }
+
+  console.log("No newly added string ID prefix hacks found.")
+}
+
+if (import.meta.main) main()

--- a/tests/scripts/check-no-string-id-hacks.test.ts
+++ b/tests/scripts/check-no-string-id-hacks.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "bun:test"
+import {
+  findStringIdPrefixHacks,
+  getAddedProductionLines,
+} from "../../scripts/check-no-string-id-hacks"
+
+test("finds hard-coded ID prefixes without flagging ordinary string checks", () => {
+  const source = `
+const hasSourceTrace = connectionId.startsWith("source_trace_")
+const hasPcbTrace = connectionId.startsWith(
+  "pcb_trace_",
+)
+const cacheEntry = key.startsWith(CACHE_PREFIX)
+const prose = message.startsWith("Route failed")
+// example.startsWith("comment_prefix_")
+/*
+ * example.startsWith("block_comment_prefix_")
+ */
+`
+
+  expect(findStringIdPrefixHacks(source)).toEqual([
+    { prefix: "source_trace_", startLine: 2, endLine: 2 },
+    { prefix: "pcb_trace_", startLine: 3, endLine: 4 },
+  ])
+
+  const diff = `diff --git a/lib/example.ts b/lib/example.ts
++++ b/lib/example.ts
+@@ -10,0 +11,2 @@
++const safe = true
++const hacked = connectionId.startsWith("source_trace_")
+diff --git a/tests/example.test.ts b/tests/example.test.ts
++++ b/tests/example.test.ts
+@@ -0,0 +1 @@
++expect(connectionId.startsWith("source_trace_")).toBe(true)
+`
+
+  expect(getAddedProductionLines(diff)).toEqual([
+    { file: "lib/example.ts", line: 11 },
+    { file: "lib/example.ts", line: 12 },
+  ])
+})


### PR DESCRIPTION
## What changed

- add a `No String ID Hacks` workflow for pull requests and pushes to `main`
- inspect only newly added production lines under `lib/`
- reject hard-coded underscore-delimited prefixes passed to `startsWith(...)`, including multiline calls
- emit an inline GitHub Actions annotation directing contributors to explicit metadata or discriminated unions
- add focused coverage for expression detection, comment handling, multiline calls, and unified-diff parsing

## Why

Inferring circuit entity types from encoded ID strings (for example, checking `source_trace_`, `pcb_trace_`, or `source_net_`) couples solver behavior to naming conventions and can silently break when IDs change. A deterministic diff check catches this precise anti-pattern without requiring an API key or nondeterministic AI review.

Existing code is not grandfathered into every run: the scanner checks only newly added `lib` lines, so this introduces no repository-wide cleanup requirement.

## Validation

- `bunx tsc --noEmit`
- focused unit test: 1 pass, 0 failures
- checker against `main..HEAD`: passes
- checker against historical commit `4fdce4f4`, which introduced `startsWith("missing_connection_")`: fails with the expected file/line annotation
- `git diff --check`