### PR TITLE
Eliminate false disconnected-pad DRC failures for preloaded traces

### DIFF
--- a/lib/testing/AutoroutingPipelineDebugger.tsx
+++ b/lib/testing/AutoroutingPipelineDebugger.tsx
@@ -809,6 +809,7 @@ export const AutoroutingPipelineDebugger = ({
           inputSrj: srj,
           srjWithPointPairs: solver.srjWithPointPairs ?? srj,
           routedTraces: traces,
+          normalizePreloadedTracePadEdgeEndpoints: true,
         })
       } else {
         const circuitJson =

--- a/lib/testing/evaluate-relaxed-drc.ts
+++ b/lib/testing/evaluate-relaxed-drc.ts
@@ -1,7 +1,7 @@
 import type { AnyCircuitElement } from "circuit-json"
 import type { SimpleRouteJson, SimplifiedPcbTrace } from "lib/types"
 import { RELAXED_DRC_OPTIONS } from "./drcPresets"
-import { getDrcErrors, type GetDrcErrorsResult } from "./getDrcErrors"
+import { type GetDrcErrorsResult, getDrcErrors } from "./getDrcErrors"
 import { convertToCircuitJson } from "./utils/convertToCircuitJson"
 
 /** Inputs used by the benchmark's relaxed DRC evaluation. */
@@ -10,6 +10,8 @@ export interface EvaluateRelaxedDrcInput {
   srjWithPointPairs: SimpleRouteJson
   /** Newly routed traces. Input traces are always included automatically. */
   routedTraces: SimplifiedPcbTrace[]
+  /** Treat physically touching preloaded pad-edge endpoints as connected. */
+  normalizePreloadedTracePadEdgeEndpoints?: boolean
 }
 
 /** Benchmark relaxed DRC errors and the Circuit JSON evaluated to produce them. */
@@ -43,6 +45,7 @@ export const evaluateRelaxedDrc = ({
   inputSrj,
   srjWithPointPairs,
   routedTraces,
+  normalizePreloadedTracePadEdgeEndpoints = false,
 }: EvaluateRelaxedDrcInput): EvaluateRelaxedDrcResult => {
   const preloadedTraces = inputSrj.traces ?? []
   const jointTraces = combinePreloadedAndRoutedTraces(
@@ -54,6 +57,7 @@ export const evaluateRelaxedDrc = ({
     minViaDiameter: inputSrj.minViaDiameter,
     originalSrj: inputSrj,
     includeOriginalConnections: true,
+    normalizePreloadedTracePadEdgeEndpoints,
   })
 
   return {

--- a/lib/testing/utils/convertToCircuitJson.ts
+++ b/lib/testing/utils/convertToCircuitJson.ts
@@ -15,29 +15,49 @@ import { mapZToLayerName } from "lib/utils/mapZToLayerName"
 function convertSimplifiedPcbTraceToCircuitJson(
   simplifiedTrace: SimplifiedPcbTrace,
   connectionName: string,
+  inferredEndpointPcbPortIds: {
+    start?: { pcbPortId: string; x: number; y: number }
+    end?: { pcbPortId: string; x: number; y: number }
+  } = {},
 ): PcbTrace {
+  const firstWireIndex = simplifiedTrace.route.findIndex(
+    (segment) => segment.route_type === "wire" && isLayerName(segment.layer),
+  )
+  const lastWireIndex = simplifiedTrace.route.findLastIndex(
+    (segment) => segment.route_type === "wire" && isLayerName(segment.layer),
+  )
+
   return {
     type: "pcb_trace",
     pcb_trace_id: simplifiedTrace.pcb_trace_id,
     source_trace_id: connectionName,
     route: simplifiedTrace.route
-      .map((segment) => {
+      .map((segment, segmentIndex) => {
         if (segment.route_type === "wire") {
           if (!isLayerName(segment.layer)) return null
+          const inferredStart =
+            segmentIndex === firstWireIndex
+              ? inferredEndpointPcbPortIds.start
+              : undefined
+          const inferredEnd =
+            segmentIndex === lastWireIndex
+              ? inferredEndpointPcbPortIds.end
+              : undefined
           const startPcbPortId =
             "start_pcb_port_id" in segment &&
             typeof segment.start_pcb_port_id === "string"
               ? segment.start_pcb_port_id
-              : undefined
+              : inferredStart?.pcbPortId
           const endPcbPortId =
             "end_pcb_port_id" in segment &&
             typeof segment.end_pcb_port_id === "string"
               ? segment.end_pcb_port_id
-              : undefined
+              : inferredEnd?.pcbPortId
+          const inferredEndpoint = inferredStart ?? inferredEnd
           return {
             route_type: "wire" as const,
-            x: segment.x,
-            y: segment.y,
+            x: inferredEndpoint?.x ?? segment.x,
+            y: inferredEndpoint?.y ?? segment.y,
             width: segment.width,
             layer: segment.layer,
             ...(startPcbPortId ? { start_pcb_port_id: startPcbPortId } : {}),
@@ -233,6 +253,90 @@ const getSrjDeclaredPcbPortIds = ({
       return pcbPortId ? [pcbPortId] : []
     }),
   ])
+
+const PRELOADED_TRACE_PAD_EDGE_TOLERANCE = 1e-6
+
+/**
+ * SRJ preloaded traces may stop exactly at a pad edge while declaring the pad
+ * through `connectsTo`. Preserve that terminal metadata for Circuit JSON DRC,
+ * but only when the copper endpoint physically touches the declared pad.
+ */
+const inferTraceEndpointPcbPortIds = (
+  trace: SimplifiedPcbTrace,
+  srj: SimpleRouteJson,
+): {
+  start?: { pcbPortId: string; x: number; y: number }
+  end?: { pcbPortId: string; x: number; y: number }
+} => {
+  const declaredPcbPortIds = getSrjDeclaredPcbPortIds(srj)
+  const connectedPcbPortIds = [
+    ...new Set(
+      (trace.connectsTo ?? []).filter((id) => declaredPcbPortIds.has(id)),
+    ),
+  ]
+  if (connectedPcbPortIds.length === 0) return {}
+
+  const obstaclesByPcbPortId = new Map<string, Obstacle[]>()
+  for (const obstacle of srj.obstacles) {
+    const metadataPcbPortId = obstacle.circuitJsonMetadata?.pcb_port_id
+    const obstaclePcbPortIds = metadataPcbPortId
+      ? [metadataPcbPortId]
+      : obstacle.connectedTo.filter((id) => declaredPcbPortIds.has(id))
+    for (const pcbPortId of obstaclePcbPortIds) {
+      const obstacles = obstaclesByPcbPortId.get(pcbPortId) ?? []
+      obstacles.push(obstacle)
+      obstaclesByPcbPortId.set(pcbPortId, obstacles)
+    }
+  }
+
+  const wirePoints = trace.route.filter(
+    (segment) => segment.route_type === "wire" && isLayerName(segment.layer),
+  )
+  const startPoint = wirePoints[0]
+  const endPoint = wirePoints.at(-1)
+
+  const findTouchingPcbPortId = (
+    point: (typeof wirePoints)[number] | undefined,
+  ): { pcbPortId: string; x: number; y: number } | undefined => {
+    if (!point || point.route_type !== "wire") return undefined
+    const match = connectedPcbPortIds
+      .flatMap((pcbPortId) =>
+        (obstaclesByPcbPortId.get(pcbPortId) ?? []).map((obstacle) => ({
+          pcbPortId,
+          obstacle,
+        })),
+      )
+      .filter(
+        ({ obstacle }) =>
+          obstacle.type === "rect" &&
+          obstacle.layers.includes(point.layer) &&
+          pointToBoxDistance(point, obstacle) <=
+            PRELOADED_TRACE_PAD_EDGE_TOLERANCE,
+      )
+      .sort(
+        (a, b) =>
+          Math.hypot(
+            point.x - a.obstacle.center.x,
+            point.y - a.obstacle.center.y,
+          ) -
+          Math.hypot(
+            point.x - b.obstacle.center.x,
+            point.y - b.obstacle.center.y,
+          ),
+      )[0]
+    if (!match) return undefined
+    return {
+      pcbPortId: match.pcbPortId,
+      x: match.obstacle.center.x,
+      y: match.obstacle.center.y,
+    }
+  }
+
+  return {
+    start: findTouchingPcbPortId(startPoint),
+    end: findTouchingPcbPortId(endPoint),
+  }
+}
 
 declare const connectivityNetIdBrand: unique symbol
 type ConnectivityNetId = string & {
@@ -888,6 +992,7 @@ export type ConvertToCircuitJsonOptions = {
   minViaHoleDiameter?: number
   originalSrj?: SimpleRouteJson
   includeOriginalConnections?: boolean
+  normalizePreloadedTracePadEdgeEndpoints?: boolean
 }
 
 export function convertToCircuitJson(
@@ -901,6 +1006,7 @@ export function convertToCircuitJson(
     minViaHoleDiameter,
     originalSrj,
     includeOriginalConnections = false,
+    normalizePreloadedTracePadEdgeEndpoints = false,
   } = options
   const viaDimensions = getViaDimensions(srjWithPointPairs)
   const resolvedMinViaDiameter = minViaDiameter ?? viaDimensions.padDiameter
@@ -979,6 +1085,10 @@ export function convertToCircuitJson(
           convertSimplifiedPcbTraceToCircuitJson(
             trace,
             connectionName,
+            normalizePreloadedTracePadEdgeEndpoints &&
+              originalSrj?.traces?.includes(trace)
+              ? inferTraceEndpointPcbPortIds(trace, originalSrj)
+              : undefined,
           ) as AnyCircuitElement,
         )
       })

--- a/scripts/benchmark/benchmark-run-task.ts
+++ b/scripts/benchmark/benchmark-run-task.ts
@@ -447,6 +447,7 @@ export const runTask = async (
       inputSrj: task.scenario,
       srjWithPointPairs: solver.srjWithPointPairs ?? task.scenario,
       routedTraces: traces,
+      normalizePreloadedTracePadEdgeEndpoints: true,
     })
     const relaxedDrcPassed = errors.length === 0
     const drcSummary = summarizeDrcErrors(errors as object[])

--- a/tests/evaluate-relaxed-drc-preloaded-trace-connects-to.test.ts
+++ b/tests/evaluate-relaxed-drc-preloaded-trace-connects-to.test.ts
@@ -74,3 +74,111 @@ test("relaxed DRC connects a preloaded fanout trace to its own pad", () => {
   })
   expect(errors).toHaveLength(0)
 })
+
+test("relaxed DRC accepts preloaded trace endpoints on their declared pad edges", () => {
+  const padHeight = 0.6604
+  const firstPadY = 0
+  const secondPadY = 1.0414
+  const edgeTrace: SimplifiedPcbTrace = {
+    type: "pcb_trace",
+    pcb_trace_id: "pcb_trace_edge_to_edge",
+    connection_name: "source_net_0",
+    connectsTo: ["pcb_port_0", "pcb_port_1"],
+    route: [
+      {
+        route_type: "wire",
+        x: 0,
+        y: firstPadY + padHeight / 2,
+        width: 0.3175,
+        layer: "bottom",
+      },
+      {
+        route_type: "wire",
+        x: 0,
+        y: secondPadY - padHeight / 2,
+        width: 0.3175,
+        layer: "bottom",
+      },
+    ],
+  }
+  const inputSrj: SimpleRouteJson = {
+    layerCount: 2,
+    minTraceWidth: 0.1,
+    bounds: { minX: -2, minY: -2, maxX: 2, maxY: 2 },
+    obstacles: [
+      {
+        type: "rect",
+        layers: ["bottom"],
+        center: { x: 0, y: firstPadY },
+        width: 1.27,
+        height: padHeight,
+        connectedTo: ["pcb_smtpad_0", "pcb_port_0", "source_net_0"],
+        circuitJsonMetadata: { pcb_port_id: "pcb_port_0" },
+      },
+      {
+        type: "rect",
+        layers: ["bottom"],
+        center: { x: 0, y: secondPadY },
+        width: 1.27,
+        height: padHeight,
+        connectedTo: ["pcb_smtpad_1", "pcb_port_1", "source_net_0"],
+        circuitJsonMetadata: { pcb_port_id: "pcb_port_1" },
+      },
+    ],
+    connections: [
+      {
+        name: "source_net_0",
+        pointsToConnect: [
+          {
+            x: 0,
+            y: firstPadY,
+            layer: "bottom",
+            pcb_port_id: "pcb_port_0",
+          },
+          {
+            x: 0,
+            y: secondPadY,
+            layer: "bottom",
+            pcb_port_id: "pcb_port_1",
+          },
+        ],
+      },
+    ],
+    traces: [edgeTrace],
+  }
+
+  const { errors } = evaluateRelaxedDrc({
+    inputSrj,
+    srjWithPointPairs: inputSrj,
+    routedTraces: [],
+    normalizePreloadedTracePadEdgeEndpoints: true,
+  })
+
+  expect(errors).toHaveLength(0)
+
+  const separatedTrace: SimplifiedPcbTrace = {
+    ...edgeTrace,
+    route: edgeTrace.route.map((point, index) =>
+      index === 0 && point.route_type === "wire"
+        ? { ...point, y: point.y + 0.01 }
+        : point,
+    ),
+  }
+  const separatedInputSrj = {
+    ...inputSrj,
+    traces: [separatedTrace],
+  }
+  const separatedResult = evaluateRelaxedDrc({
+    inputSrj: separatedInputSrj,
+    srjWithPointPairs: separatedInputSrj,
+    routedTraces: [],
+    normalizePreloadedTracePadEdgeEndpoints: true,
+  })
+  expect(
+    separatedResult.errors.some(
+      (error) =>
+        error.type === "pcb_trace_error" &&
+        error.message.includes("pcb_port_0"),
+    ),
+  ).toBe(true)
+})


### PR DESCRIPTION
## Scope

This PR contains only the DRC evaluator fix. The dataset01 dependency update is isolated in [PR #2099](https://github.com/tscircuit/tscircuit-autorouter/pull/2099), and the source dataset corrections remain in [dataset PR #127](https://github.com/tscircuit/autorouting-dataset-01/pull/127).

## Problem

After dataset PR #127 regenerates the complete circuit018 board, a valid preloaded solder-jumper trace between `pcb_port_27` and `pcb_port_28` ends exactly on the rectangular pad edge. The copper is connected, but Circuit JSON DRC reports:

> Trace `pcb_port_27 → pcb_port_28` is missing a connection to `pcb_port_27`.

## What this PR fixes

For benchmark/debugger DRC conversion only, an original preloaded trace endpoint is attached to a pad when all of these are true:

1. The trace declares that pad in `connectsTo`.
2. The endpoint physically touches the rectangular pad within `1e-6`.
3. The endpoint is on the pad's layer.

The DRC-only endpoint is then normalized to the pad center with its `pcb_port_id`. The real route is not changed, and internal repair scoring keeps the old behavior by default. A regression test proves a real 0.01 mm gap still fails.

## Visual proof — same board and same route

<img width="1000" alt="Circuit018 relaxed DRC before and after on the same corrected board and route" src="https://github.com/user-attachments/assets/73ed255b-09cc-4693-b0e1-53df4c720047" />

- Before: main evaluator + corrected dataset circuit018 → 1 false missing-pad DRC.
- After: this PR + the same circuit and route → 0 DRC errors.
- Both runs used 16 vias; the copper geometry did not change.

## Why the GitHub same-machine comment shows 0 improved

That bot run installed the currently published dataset, not dataset PR #127. Its old circuit018 fails for a different reason: two routed traces have only a **0.079 mm clearance gap**. Both main and this PR correctly report that same old-data failure, so **98.8% → 98.8% and 0 improved is expected**. PR #2099 supplies the corrected dataset revision separately.

## Validation

- Focused corrected circuit018: 1 false DRC before → 0 after.
- Full dataset01 with PR #2099: 85/85 complete, 100% relaxed DRC, 0 timeouts.
- Positive pad-edge regression and negative 0.01 mm real-gap regression pass.
- Relevant relaxed-DRC and Pipeline9 tests pass.
- `bunx tsc --noEmit`
- `bun run build`
- No benchmark snapshots are committed.
