### PR TITLE
Add XIAO clad routing fixtures

### DIFF
--- a/fixtures/prefab-clad/create-xiao-clad-srj.ts
+++ b/fixtures/prefab-clad/create-xiao-clad-srj.ts
@@ -1,0 +1,104 @@
+import type { Obstacle, SimpleRouteJson } from "lib/types"
+
+export const XIAO_CLAD_WIDTH = 21
+export const XIAO_CLAD_HEIGHT = 17.8
+export const XIAO_HEADER_PITCH = 2.54
+export const XIAO_HEADER_ROW_X = 8.25
+
+const PIN_COUNT_PER_ROW = 7
+const HEADER_PAD_SIZE = 1.7
+const CASTELLATED_PAD_WIDTH = 3
+const CASTELLATED_PAD_HEIGHT = 2
+
+const pinY = (pinIndex: number): number =>
+  (PIN_COUNT_PER_ROW - 1) * (XIAO_HEADER_PITCH / 2) -
+  pinIndex * XIAO_HEADER_PITCH
+
+const createPinObstacle = (
+  side: "left" | "right",
+  pinIndex: number,
+  withPinHeaders: boolean,
+): Obstacle => {
+  const connectionName = `xiao_pin_pair_${pinIndex + 1}`
+
+  return {
+    obstacleId: `obstacle_xiao_${side}_pin_${pinIndex + 1}`,
+    componentId: withPinHeaders
+      ? `pcb_component_xiao_${side}_header`
+      : `pcb_component_xiao_${side}_castellations`,
+    type: "rect",
+    layers: withPinHeaders ? ["top", "bottom"] : ["top"],
+    center: {
+      x: side === "left" ? -XIAO_HEADER_ROW_X : XIAO_HEADER_ROW_X,
+      y: pinY(pinIndex),
+    },
+    width: withPinHeaders ? HEADER_PAD_SIZE : CASTELLATED_PAD_WIDTH,
+    height: withPinHeaders ? HEADER_PAD_SIZE : CASTELLATED_PAD_HEIGHT,
+    connectedTo: [connectionName],
+  }
+}
+
+const PREFAB_VIA_POSITIONS = [-5.5, -2.75, 0, 2.75, 5.5].flatMap((y) =>
+  [-3.5, 0, 3.5].map((x) => ({ x, y })),
+)
+
+export const createXiaoCladSrj = (
+  withPinHeaders: boolean,
+): SimpleRouteJson => {
+  const pinObstacles = Array.from(
+    { length: PIN_COUNT_PER_ROW },
+    (_, pinIndex) => [
+      createPinObstacle("left", pinIndex, withPinHeaders),
+      createPinObstacle("right", pinIndex, withPinHeaders),
+    ],
+  ).flat()
+
+  const prefabViaObstacles: Obstacle[] = PREFAB_VIA_POSITIONS.map(
+    (position, index) => ({
+      obstacleId: `obstacle_xiao_prefab_via_${index + 1}`,
+      type: "rect",
+      layers: ["top", "bottom"],
+      center: position,
+      width: 1.2,
+      height: 1.2,
+      connectedTo: [],
+      netIsAssignable: true,
+    }),
+  )
+
+  return {
+    layerCount: 2,
+    minTraceWidth: 0.15,
+    nominalTraceWidth: 0.2,
+    defaultObstacleMargin: 0.15,
+    minTraceToPadEdgeClearance: 0.15,
+    minBoardEdgeClearance: 0.2,
+    bounds: {
+      minX: -XIAO_CLAD_WIDTH / 2,
+      maxX: XIAO_CLAD_WIDTH / 2,
+      minY: -XIAO_CLAD_HEIGHT / 2,
+      maxY: XIAO_CLAD_HEIGHT / 2,
+    },
+    obstacles: [...pinObstacles, ...prefabViaObstacles],
+    connections: Array.from(
+      { length: PIN_COUNT_PER_ROW },
+      (_, pinIndex) => ({
+        name: `xiao_pin_pair_${pinIndex + 1}`,
+        pointsToConnect: [
+          {
+            x: -XIAO_HEADER_ROW_X,
+            y: pinY(pinIndex),
+            layer: "top",
+            pointId: `xiao_left_pin_${pinIndex + 1}`,
+          },
+          {
+            x: XIAO_HEADER_ROW_X,
+            y: pinY(pinIndex),
+            layer: "top",
+            pointId: `xiao_right_pin_${pinIndex + 1}`,
+          },
+        ],
+      }),
+    ),
+  }
+}

--- a/fixtures/prefab-clad/xiao-clad-with-pin-headers.fixture.tsx
+++ b/fixtures/prefab-clad/xiao-clad-with-pin-headers.fixture.tsx
@@ -1,0 +1,6 @@
+import { AutoroutingPipelineDebugger } from "lib/testing/AutoroutingPipelineDebugger"
+import { createXiaoCladSrj } from "./create-xiao-clad-srj"
+
+export default () => (
+  <AutoroutingPipelineDebugger srj={createXiaoCladSrj(true)} />
+)

--- a/fixtures/prefab-clad/xiao-clad-without-pin-headers.fixture.tsx
+++ b/fixtures/prefab-clad/xiao-clad-without-pin-headers.fixture.tsx
@@ -1,0 +1,6 @@
+import { AutoroutingPipelineDebugger } from "lib/testing/AutoroutingPipelineDebugger"
+import { createXiaoCladSrj } from "./create-xiao-clad-srj"
+
+export default () => (
+  <AutoroutingPipelineDebugger srj={createXiaoCladSrj(false)} />
+)

--- a/tests/prefab-clad/xiao-clad-with-pin-headers.test.ts
+++ b/tests/prefab-clad/xiao-clad-with-pin-headers.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test"
+import { AssignableAutoroutingPipeline2 } from "lib/autorouter-pipelines/AssignableAutoroutingPipeline2/AssignableAutoroutingPipeline2"
+import {
+  createXiaoCladSrj,
+  XIAO_CLAD_HEIGHT,
+  XIAO_CLAD_WIDTH,
+} from "../../fixtures/prefab-clad/create-xiao-clad-srj"
+
+test("XIAO clad with pin headers uses plated through-hole pads", () => {
+  const srj = createXiaoCladSrj(true)
+  const pinObstacles = srj.obstacles.filter((obstacle) =>
+    obstacle.obstacleId?.startsWith("obstacle_xiao_left_pin_") ||
+    obstacle.obstacleId?.startsWith("obstacle_xiao_right_pin_"),
+  )
+  const prefabVias = srj.obstacles.filter(
+    (obstacle) => obstacle.netIsAssignable === true,
+  )
+
+  expect(srj.bounds.maxX - srj.bounds.minX).toBe(XIAO_CLAD_WIDTH)
+  expect(srj.bounds.maxY - srj.bounds.minY).toBe(XIAO_CLAD_HEIGHT)
+  expect(pinObstacles).toHaveLength(14)
+  expect(
+    pinObstacles.every(
+      (obstacle) =>
+        obstacle.layers.includes("top") && obstacle.layers.includes("bottom"),
+    ),
+  ).toBe(true)
+  expect(pinObstacles.every((obstacle) => obstacle.width === 1.7)).toBe(true)
+  expect(prefabVias).toHaveLength(15)
+
+  const solver = new AssignableAutoroutingPipeline2(srj)
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+})

--- a/tests/prefab-clad/xiao-clad-without-pin-headers.test.ts
+++ b/tests/prefab-clad/xiao-clad-without-pin-headers.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test"
+import { AssignableAutoroutingPipeline2 } from "lib/autorouter-pipelines/AssignableAutoroutingPipeline2/AssignableAutoroutingPipeline2"
+import {
+  createXiaoCladSrj,
+  XIAO_CLAD_HEIGHT,
+  XIAO_CLAD_WIDTH,
+} from "../../fixtures/prefab-clad/create-xiao-clad-srj"
+
+test("XIAO clad without pin headers uses castellated top pads", () => {
+  const srj = createXiaoCladSrj(false)
+  const pinObstacles = srj.obstacles.filter((obstacle) =>
+    obstacle.obstacleId?.startsWith("obstacle_xiao_left_pin_") ||
+    obstacle.obstacleId?.startsWith("obstacle_xiao_right_pin_"),
+  )
+  const prefabVias = srj.obstacles.filter(
+    (obstacle) => obstacle.netIsAssignable === true,
+  )
+
+  expect(srj.bounds.maxX - srj.bounds.minX).toBe(XIAO_CLAD_WIDTH)
+  expect(srj.bounds.maxY - srj.bounds.minY).toBe(XIAO_CLAD_HEIGHT)
+  expect(pinObstacles).toHaveLength(14)
+  expect(pinObstacles.every((obstacle) => obstacle.layers.length === 1)).toBe(
+    true,
+  )
+  expect(pinObstacles.every((obstacle) => obstacle.width === 3)).toBe(true)
+  expect(prefabVias).toHaveLength(15)
+
+  const solver = new AssignableAutoroutingPipeline2(srj)
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+})


### PR DESCRIPTION
## Summary

- add a shared 21 × 17.8 mm XIAO-form-factor Simple Route JSON fixture generator
- expose debugger fixtures for headerless castellated pads and plated pin-header pads
- retain the same two-row, 2.54 mm pin geometry and 15 assignable prefabricated vias in both variants
- add focused geometry and Pipeline 2 solve coverage for each form

## Why

The prefab-CLAD fixtures only covered the large Clad1 reproduction. These smaller fixtures make it easy to exercise routing on the XIAO footprint and compare the castellated/SMD form with the through-hole pin-header form without changing the logical routing problem.

## Impact

Developers can select either XIAO clad in the Cosmos autorouting debugger. Both fixtures provide seven routed pin-pair nets and validate that Assignable Pipeline 2 completes successfully.

## Validation

- `bun test tests/prefab-clad --timeout 9999999` (3 passed, 422 assertions)
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`
