### PR TITLE
Add repro for preloaded via transition drift

### DIFF
--- a/tests/repro/__snapshots__/preloaded-via-transition-layers.snap.svg
+++ b/tests/repro/__snapshots__/preloaded-via-transition-layers.snap.svg
@@ -1,0 +1,44 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="-0.5,0 0,0" data-type="line" data-label="route-a (z=0)" points="40,320 239.94287346472439,320" fill="none" stroke="rgba(255, 0, 0, 0.5)" stroke-linejoin="round" stroke-width="59.98286203941731"/></g><g><polyline data-points="0,0 0.5,0" data-type="line" data-label="route-a (z=1)" points="239.94287346472439,320 439.88574692944877,320" fill="none" stroke="rgba(0, 0, 255, 0.5)" stroke-linejoin="round" stroke-width="59.98286203941731"/></g><g><polyline data-points="-0.09960000000000002,0 0.4004,0" data-type="line" data-label="preloaded-route-b (z=0)" points="200.11425307055129,320 400.05712653527564,320" fill="none" stroke="rgba(255, 0, 0, 0.5)" stroke-linejoin="round" stroke-width="59.98286203941731"/></g><g><polyline data-points="0.4004,0 0.9004,0" data-type="line" data-label="preloaded-route-b (z=1)" points="400.05712653527564,320 600,320" fill="none" stroke="rgba(0, 0, 255, 0.5)" stroke-linejoin="round" stroke-width="59.98286203941731"/></g><circle data-type="circle" data-label="" data-x="0" data-y="0" cx="239.94287346472439" cy="320" r="59.98286203941731" fill="rgba(255, 0, 255, 0.5)" stroke="black" stroke-width="0.0025007142857142854"/><circle data-type="circle" data-label="" data-x="0.4" data-y="0" cx="399.89717223650393" cy="320" r="59.98286203941731" fill="rgba(255, 0, 255, 0.5)" stroke="black" stroke-width="0.0025007142857142854"/><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":399.88574692944877,"c":0,"e":239.94287346472439,"b":0,"d":-399.88574692944877,"f":320};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/repro/preloaded-via-transition-layers.test.ts
+++ b/tests/repro/preloaded-via-transition-layers.test.ts
@@ -1,0 +1,61 @@
+import { expect, spyOn, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { SameNetViaMergerSolver } from "lib/solvers/SameNetViaMergerSolver/SameNetViaMergerSolver"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+
+const makeViaRoute = ({
+  connectionName,
+  viaX,
+  transitionX = viaX,
+}: {
+  connectionName: string
+  viaX: number
+  transitionX?: number
+}): HighDensityRoute => ({
+  connectionName,
+  traceThickness: 0.15,
+  viaDiameter: 0.3,
+  route: [
+    { x: transitionX - 0.5, y: 0, z: 0 },
+    { x: transitionX, y: 0, z: 0 },
+    { x: transitionX, y: 0, z: 1 },
+    { x: transitionX + 0.5, y: 0, z: 1 },
+  ],
+  vias: [{ x: viaX, y: 0 }],
+})
+
+test("repro: preloaded via rounding hides valid transition layers", () => {
+  const solver = new SameNetViaMergerSolver({
+    inputHdRoutes: [
+      makeViaRoute({ connectionName: "route-a", viaX: 0 }),
+      makeViaRoute({
+        connectionName: "preloaded-route-b",
+        viaX: 0.4,
+        transitionX: 0.4004,
+      }),
+    ],
+    obstacles: [],
+    colorMap: {
+      "route-a": "#ef4444",
+      "preloaded-route-b": "#3b82f6",
+    },
+    layerCount: 2,
+    connMap: new ConnectivityMap({
+      net0: ["route-a", "preloaded-route-b"],
+    }),
+  })
+
+  const consoleError = spyOn(console, "error").mockImplementation(() => {})
+  try {
+    expect(() => solver.solve()).toThrow(
+      "could not find transition layers for via at (0.4, 0)",
+    )
+  } finally {
+    consoleError.mockRestore()
+  }
+  expect(solver.failed).toBe(true)
+  expect(String(solver.error)).toContain(
+    "could not find transition layers for via at (0.4, 0)",
+  )
+  expect(solver.visualize()).toMatchGraphicsSvg(import.meta.path)
+})


### PR DESCRIPTION
## Summary

- reproduce `SameNetViaMergerSolver could not find transition layers for via`
- model a preloaded via whose serialized center differs from its valid route transition by 0.4 µm
- snapshot the overlapping same-net routes and via centers before the merger fails

## Distinction from open work

Open PR #2077 addresses chained traces that change position and layer without an explicit via. This reproduction already has an explicit via and a valid coincident outer-layer transition; the failure is exact coordinate matching between preloaded via metadata and route topology.

## Validation

- `bun test tests/repro/preloaded-via-transition-layers.test.ts --timeout 9999999`
- visual SVG snapshot rendered and inspected

This is the passing reproduction PR. The tolerance-scoped topology fix is isolated in the next PR in the stack.
