### PR TITLE
Track DRC issues in benchmark comments

### DIFF
--- a/scripts/benchmark/benchmark-comment-comparison.js
+++ b/scripts/benchmark/benchmark-comment-comparison.js
@@ -64,6 +64,27 @@ const getTimeoutCount = (report, solverName) => {
   ).length
 }
 
+const getDrcIssueCount = (report, solverName) => {
+  if (!Array.isArray(report?.tests)) return null
+  const completedTests = report.tests.filter(
+    (test) => test.solverName === solverName && test.didSolve,
+  )
+  if (
+    completedTests.length === 0 ||
+    completedTests.some(
+      (test) =>
+        typeof test.drcErrorCount !== "number" ||
+        !Number.isFinite(test.drcErrorCount),
+    )
+  ) {
+    return null
+  }
+  return completedTests.reduce(
+    (total, test) => total + test.drcErrorCount,
+    0,
+  )
+}
+
 const getTimePercentile = (report, solverName, percentile) => {
   if (!Array.isArray(report?.tests)) return null
   const elapsedTimes = report.tests
@@ -122,9 +143,12 @@ export const renderBenchmarkComparison = ({
     )
     const mainTimeouts = getTimeoutCount(mainReport, prSummary.solverName)
     const prTimeouts = getTimeoutCount(prReport, prSummary.solverName)
+    const mainDrcIssues = getDrcIssueCount(mainReport, prSummary.solverName)
+    const prDrcIssues = getDrcIssueCount(prReport, prSummary.solverName)
     rows.push(
       `| ${solver} | Completion | ${mainSummary?.completedRateLabel ?? "n/a"} | ${prSummary.completedRateLabel} | ${formatPercentPointDelta(mainSummary?.completedRateLabel, prSummary.completedRateLabel)} |`,
       `| ${solver} | Relaxed DRC pass | ${mainSummary?.relaxedDrcRateLabel ?? "n/a"} | ${prSummary.relaxedDrcRateLabel} | ${formatPercentPointDelta(mainSummary?.relaxedDrcRateLabel, prSummary.relaxedDrcRateLabel)} |`,
+      `| ${solver} | DRC issues | ${mainDrcIssues ?? "n/a"} | ${prDrcIssues ?? "n/a"} | ${formatCountDelta(mainDrcIssues, prDrcIssues)} |`,
       `| ${solver} | Timeouts | ${mainTimeouts ?? "n/a"} | ${prTimeouts ?? "n/a"} | ${formatCountDelta(mainTimeouts, prTimeouts)} |`,
     )
     for (const percentile of [50, 60, 70, 80, 90, 95]) {
@@ -153,6 +177,8 @@ export const renderBenchmarkComparison = ({
     "| Solver | Metric | Main | PR | Change |",
     "| --- | --- | ---: | ---: | ---: |",
     ...rows,
+    "",
+    "_DRC issue totals include completed samples; fewer is better._",
     "",
     "_Timing percentiles include solved and timed-out samples. Negative timing changes are faster._",
   ]

--- a/scripts/benchmark/benchmark-comment-comparison.js
+++ b/scripts/benchmark/benchmark-comment-comparison.js
@@ -79,10 +79,7 @@ const getDrcIssueCount = (report, solverName) => {
   ) {
     return null
   }
-  return completedTests.reduce(
-    (total, test) => total + test.drcErrorCount,
-    0,
-  )
+  return completedTests.reduce((total, test) => total + test.drcErrorCount, 0)
 }
 
 const getTimePercentile = (report, solverName, percentile) => {

--- a/scripts/benchmark/same-machine-results.ts
+++ b/scripts/benchmark/same-machine-results.ts
@@ -188,10 +188,7 @@ export const renderSameMachineBenchmarkResults = ({
     const prTimeouts = prReport.tests.filter(
       (test) => test.solverName === prSummary.solverName && test.didTimeout,
     ).length
-    const mainDrcIssues = getDrcIssueCount(
-      mainReport,
-      prSummary.solverName,
-    )
+    const mainDrcIssues = getDrcIssueCount(mainReport, prSummary.solverName)
     const prDrcIssues = getDrcIssueCount(prReport, prSummary.solverName)
     const timePercentiles = [50, 60, 70, 80, 90, 95].map((percentile) => {
       const mainTime = getTimePercentile(

--- a/scripts/benchmark/same-machine-results.ts
+++ b/scripts/benchmark/same-machine-results.ts
@@ -76,6 +76,29 @@ const getTimePercentile = (
   return lowerValue + (upperValue - lowerValue) * (index - lowerIndex)
 }
 
+const getDrcIssueCount = (
+  report: BenchmarkReport,
+  solverName: string,
+): number | null => {
+  const completedTests = report.tests.filter(
+    (test) => test.solverName === solverName && test.didSolve,
+  )
+  if (
+    completedTests.length === 0 ||
+    completedTests.some(
+      (test) =>
+        typeof test.drcErrorCount !== "number" ||
+        !Number.isFinite(test.drcErrorCount),
+    )
+  ) {
+    return null
+  }
+  return completedTests.reduce(
+    (total, test) => total + (test.drcErrorCount ?? 0),
+    0,
+  )
+}
+
 const outcomeScore = (test: WorkerResult): number => {
   if (!test.didSolve) return 0
   return test.relaxedDrcPassed ? 2 : 1
@@ -165,6 +188,11 @@ export const renderSameMachineBenchmarkResults = ({
     const prTimeouts = prReport.tests.filter(
       (test) => test.solverName === prSummary.solverName && test.didTimeout,
     ).length
+    const mainDrcIssues = getDrcIssueCount(
+      mainReport,
+      prSummary.solverName,
+    )
+    const prDrcIssues = getDrcIssueCount(prReport, prSummary.solverName)
     const timePercentiles = [50, 60, 70, 80, 90, 95].map((percentile) => {
       const mainTime = getTimePercentile(
         mainReport,
@@ -182,6 +210,7 @@ export const renderSameMachineBenchmarkResults = ({
     lines.push(
       `| ${solver} | Completion | ${mainSummary.completedRateLabel} | ${prSummary.completedRateLabel} | ${formatPercentPointDelta(mainSummary.completedRateLabel, prSummary.completedRateLabel)} |`,
       `| ${solver} | Relaxed DRC pass | ${mainSummary.relaxedDrcRateLabel} | ${prSummary.relaxedDrcRateLabel} | ${formatPercentPointDelta(mainSummary.relaxedDrcRateLabel, prSummary.relaxedDrcRateLabel)} |`,
+      `| ${solver} | DRC issues | ${mainDrcIssues ?? "n/a"} | ${prDrcIssues ?? "n/a"} | ${mainDrcIssues === null || prDrcIssues === null ? "n/a" : `${prDrcIssues - mainDrcIssues > 0 ? "+" : ""}${prDrcIssues - mainDrcIssues}`} |`,
       `| ${solver} | Timeouts | ${mainTimeouts} | ${prTimeouts} | ${prTimeouts - mainTimeouts > 0 ? "+" : ""}${prTimeouts - mainTimeouts} |`,
       ...timePercentiles,
       `| ${solver} | Average vias | ${formatAverage(mainSummary.avgVia)} | ${formatAverage(prSummary.avgVia)} | ${formatRelativeDelta(mainSummary.avgVia, prSummary.avgVia)} |`,
@@ -194,7 +223,7 @@ export const renderSameMachineBenchmarkResults = ({
   const regressionCount = changedOutcomes.length - improvementCount
   lines.push(
     "",
-    `Outcome changes: **${improvementCount} improved**, **${regressionCount} regressed**. Timing percentiles include solved and timed-out samples; negative timing deltas are faster.`,
+    `Outcome changes: **${improvementCount} improved**, **${regressionCount} regressed**. DRC issue totals include completed samples; fewer is better. Timing percentiles include solved and timed-out samples; negative timing deltas are faster.`,
   )
 
   if (changedOutcomes.length > 0) {

--- a/tests/benchmark-comment-comparison.test.ts
+++ b/tests/benchmark-comment-comparison.test.ts
@@ -19,6 +19,7 @@ test("PR benchmark comments render one main-versus-PR comparison table", () => {
     didSolve: true,
     didTimeout: false,
     relaxedDrcPassed: true,
+    drcErrorCount: 0,
     ...overrides,
   })
   const makeReport = (
@@ -62,14 +63,20 @@ test("PR benchmark comments render one main-versus-PR comparison table", () => {
       {
         solverName,
         completedRateLabel: "100.0%",
-        relaxedDrcRateLabel: "100.0%",
+        relaxedDrcRateLabel: "50.0%",
         timedOutLabel: "0/2",
         p50TimeMs: 1_350,
         p95TimeMs: 1_755,
         avgVia: 2.2,
       },
     ],
-    [makeTest(1, 900), makeTest(2, 1_800)],
+    [
+      makeTest(1, 900),
+      makeTest(2, 1_800, {
+        relaxedDrcPassed: false,
+        drcErrorCount: 3,
+      }),
+    ],
   )
 
   expect(
@@ -79,7 +86,8 @@ test("PR benchmark comments render one main-versus-PR comparison table", () => {
 | Solver | Metric | Main | PR | Change |
 | --- | --- | ---: | ---: | ---: |
 | Pipeline7 | Completion | 50.0% (🕒50.0%) | 100.0% | +50.0 pp |
-| Pipeline7 | Relaxed DRC pass | 50.0% (🕒50.0%) | 100.0% | +50.0 pp |
+| Pipeline7 | Relaxed DRC pass | 50.0% (🕒50.0%) | 50.0% | 0.0 pp |
+| Pipeline7 | DRC issues | 0 | 3 | +3 |
 | Pipeline7 | Timeouts | 1 | 0 | -1 |
 | Pipeline7 | P50 time | 1.5s | 1.4s | -10.0% |
 | Pipeline7 | P60 time | 1.6s | 1.4s | -10.0% |
@@ -88,6 +96,8 @@ test("PR benchmark comments render one main-versus-PR comparison table", () => {
 | Pipeline7 | P90 time | 1.9s | 1.7s | -10.0% |
 | Pipeline7 | P95 time | 1.9s | 1.8s | -10.0% |
 | Pipeline7 | Average vias | 2.00 | 2.20 | +10.0% |
+
+_DRC issue totals include completed samples; fewer is better._
 
 _Timing percentiles include solved and timed-out samples. Negative timing changes are faster._`)
 })

--- a/tests/same-machine-benchmark-results.test.ts
+++ b/tests/same-machine-benchmark-results.test.ts
@@ -18,6 +18,7 @@ test("same-machine benchmark comments compare matching reports", () => {
     didSolve: true,
     didTimeout: false,
     relaxedDrcPassed: true,
+    drcErrorCount: 0,
     ...overrides,
   })
   const makeReport = (
@@ -62,14 +63,21 @@ test("same-machine benchmark comments compare matching reports", () => {
       {
         solverName,
         completedRateLabel: "100.0% (🕒0.0%)",
-        relaxedDrcRateLabel: "100.0% (🕒0.0%)",
+        relaxedDrcRateLabel: "50.0% (🕒0.0%)",
         timedOutLabel: "0/2",
         p50TimeMs: 900,
         p95TimeMs: 1_800,
         avgVia: 2.2,
       },
     ],
-    tests: [makeTest(1, { elapsedTimeMs: 1_800 }), makeTest(2, {})],
+    tests: [
+      makeTest(1, {
+        elapsedTimeMs: 1_800,
+        relaxedDrcPassed: false,
+        drcErrorCount: 3,
+      }),
+      makeTest(2, {}),
+    ],
   })
 
   const markdown = renderSameMachineBenchmarkResults({
@@ -88,6 +96,7 @@ test("same-machine benchmark comments compare matching reports", () => {
   expect(markdown).toContain(
     "| Pipeline7 | Completion | 50.0% (🕒50.0%) | 100.0% (🕒0.0%) | +50.0 pp |",
   )
+  expect(markdown).toContain("| Pipeline7 | DRC issues | 0 | 3 | +3 |")
   expect(markdown).toContain("| Pipeline7 | Timeouts | 1 | 0 | -1 |")
   expect(markdown).toContain("| Pipeline7 | P50 time | 1.5s | 1.4s | -6.7% |")
   expect(markdown).toContain("| Pipeline7 | P60 time |")
@@ -97,9 +106,14 @@ test("same-machine benchmark comments compare matching reports", () => {
   expect(markdown).toContain("| Pipeline7 | P95 time |")
   expect(markdown).toContain("Outcome changes: **1 improved**, **0 regressed**")
   expect(markdown).toContain(
+    "DRC issue totals include completed samples; fewer is better",
+  )
+  expect(markdown).toContain(
     "Timing percentiles include solved and timed-out samples",
   )
-  expect(markdown).toContain("| Pipeline7 | 1 | Timeout | DRC passed |")
+  expect(markdown).toContain(
+    "| Pipeline7 | 1 | Timeout | Solved (DRC failed) |",
+  )
   expect(() =>
     renderSameMachineBenchmarkResults({
       mainReport,


### PR DESCRIPTION
## Summary

- add a `DRC issues` metric to regular Main-vs-PR benchmark comments
- add the same metric to paired same-machine benchmark comments
- total per-sample `drcErrorCount` values for completed samples and show the signed delta
- render `n/a` when a report does not contain complete DRC issue-count data

## Why

Relaxed DRC pass rate only shows whether each completed sample passed. Tracking the total issue count makes partial DRC improvements and regressions visible even when the pass rate is unchanged.

## Validation

- `bun test --config=/dev/null tests/same-machine-benchmark-results.test.ts tests/benchmark-comment-comparison.test.ts --timeout 9999999`
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`