### PR TITLE
Remove hypergraph pathing exception fallback

### DIFF
--- a/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
+++ b/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
@@ -896,17 +896,7 @@ class TinyHyperGraphSectionPipelineWithTerminalNetIds extends TinyHyperGraphSect
   }
 
   override _step() {
-    try {
-      super._step()
-    } catch (error) {
-      if (this.tryAcceptSolveGraphWithoutSerializedOutput(error)) {
-        return
-      }
-      if (this.trySkipOptimizeSection(error)) {
-        return
-      }
-      throw error
-    }
+    super._step()
     this.configureSolver(this.activeSubSolver)
   }
 
@@ -961,58 +951,6 @@ class TinyHyperGraphSectionPipelineWithTerminalNetIds extends TinyHyperGraphSect
     }
 
     this.configuredSolvers.add(solver)
-  }
-
-  private trySkipOptimizeSection(error: unknown) {
-    if (this.getCurrentStageName() !== "optimizeSection") {
-      return false
-    }
-
-    const solveGraphOutput =
-      this.getStageOutput<SerializedHyperGraph>("solveGraph")
-
-    if (!solveGraphOutput) {
-      return false
-    }
-
-    this.pipelineOutputs.optimizeSection = solveGraphOutput
-    this.finishWithExistingSolverState({
-      sectionOptimizationSkipped: true,
-      sectionOptimizationError:
-        error instanceof Error ? error.message : String(error),
-    })
-    return true
-  }
-
-  private tryAcceptSolveGraphWithoutSerializedOutput(error: unknown) {
-    if (this.getCurrentStageName() !== "solveGraph") {
-      return false
-    }
-
-    const solveGraphSolver = this.getSolver<TinyHyperGraphSolver>("solveGraph")
-    if (!solveGraphSolver?.solved || solveGraphSolver.failed) {
-      return false
-    }
-
-    this.finishWithExistingSolverState({
-      solveGraphSerializationSkipped: true,
-      sectionOptimizationSkipped: true,
-      sectionOptimizationError:
-        error instanceof Error ? error.message : String(error),
-    })
-    return true
-  }
-
-  private finishWithExistingSolverState(extraStats: Record<string, unknown>) {
-    this.currentPipelineStageIndex = this.pipelineDef.length
-    this.activeSubSolver = null
-    this.solved = true
-    this.failed = false
-    this.error = null
-    this.stats = {
-      ...this.stats,
-      ...extraStats,
-    }
   }
 }
 
@@ -1322,13 +1260,7 @@ export class TinyHypergraphPortPointPathingSolver extends BaseSolver {
   }
 
   _step() {
-    try {
-      this.tinyPipelineSolver.step()
-    } catch (error) {
-      this.error = `${this.getSolverName()} error: ${error}`
-      this.failed = true
-      throw error
-    }
+    this.tinyPipelineSolver.step()
 
     if (
       this.candidatePortfolioPhase === "primary" &&

--- a/tests/tinyhypergraph-pipeline-error-propagation.test.ts
+++ b/tests/tinyhypergraph-pipeline-error-propagation.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test"
+import input from "../fixtures/features/portpointpathing/tinyhypergraph-port-bridge-repro-input.json"
+import { TinyHypergraphPortPointPathingSolver } from "lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver"
+
+type TinyPipelineTestHarness = {
+  activeSubSolver?: { step(): void } | null
+  failed: boolean
+  solved: boolean
+  getCurrentStageName(): string
+  step(): void
+}
+
+type TinyHypergraphParams = ConstructorParameters<
+  typeof TinyHypergraphPortPointPathingSolver
+>[0]
+
+test("TinyHypergraph port-point pathing propagates pipeline errors", () => {
+  const solver = new TinyHypergraphPortPointPathingSolver(
+    structuredClone(input) as TinyHypergraphParams,
+  )
+  const pipeline = (
+    solver as unknown as { tinyPipelineSolver: TinyPipelineTestHarness }
+  ).tinyPipelineSolver
+
+  while (pipeline.getCurrentStageName() !== "optimizeSection") {
+    if (pipeline.solved || pipeline.failed) {
+      throw new Error("Pipeline ended before reaching optimizeSection")
+    }
+    pipeline.step()
+  }
+
+  pipeline.step()
+  const optimizeSectionSolver = pipeline.activeSubSolver
+  if (!optimizeSectionSolver) {
+    throw new Error("optimizeSection solver was not initialized")
+  }
+
+  optimizeSectionSolver.step = () => {
+    throw new Error("forced optimize-section failure")
+  }
+
+  expect(() => solver.step()).toThrow("forced optimize-section failure")
+  expect(pipeline.solved).toBe(false)
+  expect(pipeline.failed).toBe(true)
+  expect(solver.solved).toBe(false)
+  expect(solver.failed).toBe(true)
+})


### PR DESCRIPTION
## Summary

- let tiny-hypergraph section-pipeline errors propagate instead of silently accepting the solve-graph state or skipping section optimization
- remove the redundant public solver catch/rethrow wrapper and rely on `BaseSolver.step()` to record and rethrow failures
- add a regression test proving an optimizer-stage exception leaves both the inner pipeline and public port-point pathing solver failed rather than solved

## Root cause

`TinyHyperGraphSectionPipelineWithTerminalNetIds._step()` caught errors from `solveGraph` serialization and `optimizeSection`, then called `finishWithExistingSolverState()`. That helper advanced the pipeline to completion, set `solved = true`, cleared `failed` and `error`, and allowed downstream routing to consume a graph produced by an incomplete pipeline.

The public `TinyHypergraphPortPointPathingSolver._step()` also wrapped the child step only to annotate and rethrow the same error, even though the inherited `BaseSolver.step()` already performs that bookkeeping.

## Impact

Unexpected hypergraph pipeline states now fail loudly at their source. Normal successful routing keeps the existing solver-configuration hook and output behavior.

This is a standalone PR based directly on `main`; it is not stacked on any region-optimization or unravel PR.

## Validation

- `bun test tests/tinyhypergraph-pipeline-error-propagation.test.ts tests/tinyhypergraph-terminal-port-ids.test.ts --timeout 9999999`
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`