### PR TITLE
Preserve shared benchmark dashboard history

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1632,6 +1632,14 @@ jobs:
           name: benchmark-result
           path: ./benchmark-artifact
 
+      - name: Checkout benchmark dashboard
+        uses: actions/checkout@v4
+        with:
+          repository: tscircuit/autorouter-benchmark-dashboard
+          ref: main
+          token: ${{ secrets.TSCIRCUIT_BOT_GITHUB_TOKEN }}
+          path: .benchmark-dashboard
+
       - name: Checkout or create benchmark history branch
         env:
           GH_TOKEN: ${{ github.token }}
@@ -1663,6 +1671,7 @@ jobs:
             --report ./benchmark-artifact/benchmark-result.json \
             --history-dir ./.benchmark-history/history \
             --out-dir benchmark-dashboard \
+            --published-history-dir ./.benchmark-dashboard/data \
             --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             --metadata ./benchmark-artifact/benchmark-run-metadata.json
 
@@ -1684,14 +1693,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: git config --global --unset-all url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf
-
-      - name: Checkout benchmark dashboard
-        uses: actions/checkout@v4
-        with:
-          repository: tscircuit/autorouter-benchmark-dashboard
-          ref: main
-          token: ${{ secrets.TSCIRCUIT_BOT_GITHUB_TOKEN }}
-          path: .benchmark-dashboard
 
       - name: Publish benchmark history dashboard
         run: |

--- a/scripts/benchmark/benchmark-history.ts
+++ b/scripts/benchmark/benchmark-history.ts
@@ -735,7 +735,9 @@ export const mergePublishedHistoryRuns = async ({
       existsSync(publishedRunsDirectory) &&
       (await readdir(publishedRunsDirectory)).length > 0
     ) {
-      throw new Error(`Published benchmark history index is missing: ${indexPath}`)
+      throw new Error(
+        `Published benchmark history index is missing: ${indexPath}`,
+      )
     }
     return historyRuns
   }

--- a/scripts/benchmark/benchmark-history.ts
+++ b/scripts/benchmark/benchmark-history.ts
@@ -120,6 +120,7 @@ type RecordCommand = {
   command: "record"
   historyDirectory: string
   outputDirectory: string
+  publishedHistoryDirectory?: string
   reportPath: string
   metadataPath: string
   runUrl: string
@@ -716,16 +717,150 @@ export const readHistoryRuns = async (
   return runs
 }
 
+export const mergePublishedHistoryRuns = async ({
+  historyDirectory,
+  publishedHistoryDirectory,
+}: {
+  historyDirectory: string
+  publishedHistoryDirectory: string
+}): Promise<BenchmarkHistoryRun[]> => {
+  const historyRuns = await readHistoryRuns(historyDirectory)
+  const indexPath = join(publishedHistoryDirectory, HISTORY_INDEX_NAME)
+  const publishedRunsDirectory = join(
+    publishedHistoryDirectory,
+    HISTORY_RUNS_DIRECTORY,
+  )
+  if (!existsSync(indexPath)) {
+    if (
+      existsSync(publishedRunsDirectory) &&
+      (await readdir(publishedRunsDirectory)).length > 0
+    ) {
+      throw new Error(`Published benchmark history index is missing: ${indexPath}`)
+    }
+    return historyRuns
+  }
+  const value = await readJsonFileOrThrow(indexPath)
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value) ||
+    !("kind" in value) ||
+    value.kind !== "benchmark-history-dashboard-index" ||
+    !("runs" in value)
+  ) {
+    throw new Error(`Invalid published benchmark history index: ${indexPath}`)
+  }
+  const publishedIndex = parseHistoryIndexOrThrow(
+    { version: 1, runs: value.runs },
+    indexPath,
+  )
+  if (existsSync(publishedRunsDirectory)) {
+    const indexedFileNames = new Set(
+      publishedIndex.runs.map((entry) => `${entry.runId}.json`),
+    )
+    const unindexedFileName = (await readdir(publishedRunsDirectory)).find(
+      (fileName) => !indexedFileNames.has(fileName),
+    )
+    if (unindexedFileName) {
+      throw new Error(
+        `Published benchmark history contains unindexed run file: ${join(publishedRunsDirectory, unindexedFileName)}`,
+      )
+    }
+  }
+  const runsById = new Map(historyRuns.map((run) => [run.runId, run]))
+  const importedRuns: BenchmarkHistoryRun[] = []
+  for (const entry of publishedIndex.runs) {
+    const publishedRunPath = join(publishedHistoryDirectory, entry.path)
+    const historyRun = runsById.get(entry.runId)
+    if (historyRun) {
+      if (historyRun.createdAt !== entry.createdAt) {
+        throw new Error(
+          `Published benchmark history index entry ${entry.runId} does not match ${publishedRunPath}`,
+        )
+      }
+      const [historyContents, publishedContents] = await Promise.all([
+        readFile(
+          join(
+            historyDirectory,
+            HISTORY_RUNS_DIRECTORY,
+            `${historyRun.runId}.json`,
+          ),
+        ),
+        readFile(publishedRunPath),
+      ])
+      if (
+        historyContents.toString("utf8") !== publishedContents.toString("utf8")
+      ) {
+        const publishedRun = parseBenchmarkHistoryRunOrThrow(
+          JSON.parse(publishedContents.toString("utf8")),
+          publishedRunPath,
+        )
+        if (stableStringify(historyRun) !== stableStringify(publishedRun)) {
+          throw new Error(
+            `Published benchmark history conflicts with workflow run ${publishedRun.runId}`,
+          )
+        }
+      }
+      continue
+    }
+    const publishedRun = parseBenchmarkHistoryRunOrThrow(
+      await readJsonFileOrThrow(publishedRunPath),
+      publishedRunPath,
+    )
+    if (
+      publishedRun.runId !== entry.runId ||
+      publishedRun.createdAt !== entry.createdAt
+    ) {
+      throw new Error(
+        `Published benchmark history index entry ${entry.runId} does not match ${publishedRunPath}`,
+      )
+    }
+    getDashboardPoints([publishedRun])
+    runsById.set(publishedRun.runId, publishedRun)
+    importedRuns.push(publishedRun)
+  }
+  if (importedRuns.length === 0) return historyRuns
+  const sortedRuns = [...runsById.values()].sort((left, right) =>
+    left.createdAt.localeCompare(right.createdAt),
+  )
+  await mkdir(join(historyDirectory, HISTORY_RUNS_DIRECTORY), {
+    recursive: true,
+  })
+  await Promise.all(
+    importedRuns.map((run) =>
+      writeJsonFileAtomically(
+        join(historyDirectory, HISTORY_RUNS_DIRECTORY, `${run.runId}.json`),
+        run,
+      ),
+    ),
+  )
+  const index: BenchmarkHistoryIndex = {
+    version: 1,
+    runs: sortedRuns.map((run) => ({
+      runId: run.runId,
+      createdAt: run.createdAt,
+      path: join(HISTORY_RUNS_DIRECTORY, `${run.runId}.json`),
+    })),
+  }
+  await writeJsonFileAtomically(
+    join(historyDirectory, HISTORY_INDEX_NAME),
+    index,
+  )
+  return sortedRuns
+}
+
 export const appendHistoryRun = async ({
   historyDirectory,
+  historyRuns,
   run,
 }: {
   historyDirectory: string
+  historyRuns?: BenchmarkHistoryRun[]
   run: BenchmarkHistoryRun
 }): Promise<BenchmarkHistoryRun[]> => {
   const validatedRun = parseBenchmarkHistoryRunOrThrow(run, "new history run")
   getDashboardPoints([validatedRun])
-  const runs = await readHistoryRuns(historyDirectory)
+  const runs = historyRuns ?? (await readHistoryRuns(historyDirectory))
   const existingRun = runs.find((entry) => entry.runId === validatedRun.runId)
   if (existingRun) {
     if (stableStringify(existingRun) !== stableStringify(validatedRun)) {
@@ -951,6 +1086,7 @@ const parseHistoryIndexOrThrow = (
 const parseFlagValuesOrThrow = (
   args: string[],
   expectedFlags: string[],
+  requiredFlags = expectedFlags,
 ): Map<string, string> => {
   const expected = new Set(expectedFlags)
   const values = new Map<string, string>()
@@ -967,7 +1103,7 @@ const parseFlagValuesOrThrow = (
     }
     values.set(flag, value)
   }
-  for (const flag of expectedFlags) {
+  for (const flag of requiredFlags) {
     if (!values.has(flag)) throw new Error(`Missing ${flag}`)
   }
   return values
@@ -984,8 +1120,18 @@ const parseCommandOrThrow = (args: string[]): BenchmarkHistoryCommand => {
   const expectedFlags =
     command === "render"
       ? commonFlags
+      : [
+          ...commonFlags,
+          "--report",
+          "--metadata",
+          "--run-url",
+          "--published-history-dir",
+        ]
+  const requiredFlags =
+    command === "render"
+      ? expectedFlags
       : [...commonFlags, "--report", "--metadata", "--run-url"]
-  const values = parseFlagValuesOrThrow(args, expectedFlags)
+  const values = parseFlagValuesOrThrow(args, expectedFlags, requiredFlags)
   const historyDirectory = values.get("--history-dir")
   const outputDirectory = values.get("--out-dir")
   if (!historyDirectory || !outputDirectory) {
@@ -1004,6 +1150,7 @@ const parseCommandOrThrow = (args: string[]): BenchmarkHistoryCommand => {
     command,
     historyDirectory,
     outputDirectory,
+    publishedHistoryDirectory: values.get("--published-history-dir"),
     reportPath,
     metadataPath,
     runUrl,
@@ -1027,8 +1174,15 @@ const main = async (): Promise<void> => {
     await readJsonFileOrThrow(command.metadataPath),
     command.metadataPath,
   )
+  const historyRuns = command.publishedHistoryDirectory
+    ? await mergePublishedHistoryRuns({
+        historyDirectory: command.historyDirectory,
+        publishedHistoryDirectory: command.publishedHistoryDirectory,
+      })
+    : undefined
   const runs = await appendHistoryRun({
     historyDirectory: command.historyDirectory,
+    historyRuns,
     run: {
       version: 1,
       runId: `${metadata.workflowRunId}-${metadata.workflowRunAttempt}`,

--- a/tests/benchmark-history.test.ts
+++ b/tests/benchmark-history.test.ts
@@ -195,10 +195,7 @@ test("benchmark history retains full sample records and publishes a static dashb
       runner: { name: "metadata-runner" },
     }),
   )
-  const cliPublishedHistoryDirectory = join(
-    cliDirectory,
-    "published-dashboard",
-  )
+  const cliPublishedHistoryDirectory = join(cliDirectory, "published-dashboard")
   await writeBenchmarkHistoryDashboard({
     outputDirectory: cliPublishedHistoryDirectory,
     runs: [makeRun("20")],

--- a/tests/benchmark-history.test.ts
+++ b/tests/benchmark-history.test.ts
@@ -11,6 +11,7 @@ import {
   appendHistoryRun,
   createBenchmarkHistoryDashboardIndex,
   getDashboardPoints,
+  mergePublishedHistoryRuns,
   writeBenchmarkHistoryDashboard,
   readHistoryRuns,
   type BenchmarkHistoryRun,
@@ -136,6 +137,36 @@ test("benchmark history retains full sample records and publishes a static dashb
     outputDirectory: fullDashboardDirectory,
     runs: Array.from({ length: 101 }, (_, index) => makeRun(String(index + 1))),
   })
+  const publishedHistoryDirectory = await mkdtemp(
+    join(tmpdir(), "benchmark-published-history-"),
+  )
+  await writeBenchmarkHistoryDashboard({
+    outputDirectory: publishedHistoryDirectory,
+    runs: [makeRun("3")],
+  })
+  const mergedRuns = await mergePublishedHistoryRuns({
+    historyDirectory: directory,
+    publishedHistoryDirectory: join(publishedHistoryDirectory, "data"),
+  })
+  const retriedMergedRuns = await mergePublishedHistoryRuns({
+    historyDirectory: directory,
+    publishedHistoryDirectory: join(publishedHistoryDirectory, "data"),
+  })
+  const conflictingPublishedHistoryDirectory = await mkdtemp(
+    join(tmpdir(), "benchmark-conflicting-published-history-"),
+  )
+  await writeBenchmarkHistoryDashboard({
+    outputDirectory: conflictingPublishedHistoryDirectory,
+    runs: [conflictingRun],
+  })
+  const missingPublishedIndexDirectory = await mkdtemp(
+    join(tmpdir(), "benchmark-missing-published-index-"),
+  )
+  await mkdir(join(missingPublishedIndexDirectory, "runs"))
+  await writeFile(
+    join(missingPublishedIndexDirectory, "runs", "4-1.json"),
+    JSON.stringify(makeRun("4")),
+  )
   const dashboard = await readFile(
     join(dashboardDirectory, "index.html"),
     "utf8",
@@ -164,6 +195,14 @@ test("benchmark history retains full sample records and publishes a static dashb
       runner: { name: "metadata-runner" },
     }),
   )
+  const cliPublishedHistoryDirectory = join(
+    cliDirectory,
+    "published-dashboard",
+  )
+  await writeBenchmarkHistoryDashboard({
+    outputDirectory: cliPublishedHistoryDirectory,
+    runs: [makeRun("20")],
+  })
   const recordProcess = Bun.spawnSync({
     cmd: [
       "bun",
@@ -175,6 +214,8 @@ test("benchmark history retains full sample records and publishes a static dashb
       join(cliDirectory, "history"),
       "--out-dir",
       join(cliDirectory, "dashboard"),
+      "--published-history-dir",
+      join(cliPublishedHistoryDirectory, "data"),
       "--run-url",
       "https://example.com/runs/987654321",
       "--metadata",
@@ -184,9 +225,10 @@ test("benchmark history retains full sample records and publishes a static dashb
     stdout: "pipe",
     stderr: "pipe",
   })
-  const recordedCliRun = (
-    await readHistoryRuns(join(cliDirectory, "history"))
-  )[0]
+  const recordedCliRuns = await readHistoryRuns(join(cliDirectory, "history"))
+  const recordedCliRun = recordedCliRuns.find(
+    (run) => run.runId === "987654321-2",
+  )
   const invalidMetadataPath = join(cliDirectory, "invalid-metadata.json")
   await writeFile(
     invalidMetadataPath,
@@ -391,6 +433,23 @@ test("benchmark history retains full sample records and publishes a static dashb
     makeRun("1").report,
   )
   expect(retriedRuns).toHaveLength(2)
+  expect(mergedRuns.map((run) => run.runId)).toEqual(["1-1", "2-1", "3-1"])
+  expect(retriedMergedRuns).toHaveLength(3)
+  await expect(
+    mergePublishedHistoryRuns({
+      historyDirectory: directory,
+      publishedHistoryDirectory: join(
+        conflictingPublishedHistoryDirectory,
+        "data",
+      ),
+    }),
+  ).rejects.toThrow("conflicts with workflow run 2-1")
+  await expect(
+    mergePublishedHistoryRuns({
+      historyDirectory: directory,
+      publishedHistoryDirectory: missingPublishedIndexDirectory,
+    }),
+  ).rejects.toThrow("Published benchmark history index is missing")
   await expect(
     appendHistoryRun({ historyDirectory: directory, run: conflictingRun }),
   ).rejects.toThrow("conflicting workflow run 2-1")
@@ -531,6 +590,7 @@ test("benchmark history retains full sample records and publishes a static dashb
     "Invalid benchmark metadata fields",
   )
   expect(recordedCliRun?.runId).toBe("987654321-2")
+  expect(recordedCliRuns.map((run) => run.runId)).toContain("20-1")
   expect(existsSync(join(cliDirectory, "dashboard", "index.html"))).toBeTrue()
   expect(
     existsSync(join(cliDirectory, "dashboard", "data", "index.json")),


### PR DESCRIPTION
## What changed

- Checkout the currently published dashboard before generating the next update.
- Add optional `--published-history-dir` support to the benchmark history recorder.
- Validate the published index and run-file set, import missing runs into the repository history branch, and reject conflicting run IDs.
- Reuse the validated merged runs when appending the new result, avoiding a second full archive parse.
- Add regression coverage for isolated publishers, idempotent imports, conflicts, missing indexes, and CLI recording.

## Root cause

The publish job treated one repository's `benchmark-history` branch as the complete source of truth, then deleted and replaced the shared dashboard's `data/` directory. An isolated publisher with one run therefore removed 662 valid runs.

## Impact

Future dashboard updates preserve all runs already present in the shared dashboard and backfill them into the publisher's own history branch before publishing. Malformed or conflicting published history fails closed instead of deleting data.

## Checks

- `bun test tests/benchmark-history.test.ts --timeout 9999999`
- `bunx tsc --noEmit`
- Full-scale import against the recovered 663-run dashboard

Companion data recovery: https://github.com/tscircuit/autorouter-benchmark-dashboard/pull/3