### PR TITLE
Preserve Circuit JSON identity through obstacle transitions

### DIFF
--- a/lib/solvers/HighDensitySolver/SingleTransitionThroughObstacleIntraNodeSolver.ts
+++ b/lib/solvers/HighDensitySolver/SingleTransitionThroughObstacleIntraNodeSolver.ts
@@ -122,7 +122,7 @@ export class SingleTransitionThroughObstacleIntraNodeSolver extends BaseSolver {
     }
 
     this.solvedRoutes.push(
-      ...this.routes.map((route) => ({
+      ...this.routes.map((route, routeIndex) => ({
         connectionName: route.connectionName,
         rootConnectionName: route.rootConnectionName,
         regionId: this.nodeWithPortPoints.capacityMeshNodeId,
@@ -132,7 +132,15 @@ export class SingleTransitionThroughObstacleIntraNodeSolver extends BaseSolver {
             y: route.A.y,
             z: route.A.z!,
             ...(route.A.z !== route.B.z
-              ? { toNextSegmentType: "through_obstacle" as const }
+              ? {
+                  toNextSegmentType: "through_obstacle" as const,
+                  ...(containingObstacles[routeIndex]!.circuitJsonMetadata
+                    ? {
+                        toNextSegmentCircuitJsonMetadata:
+                          containingObstacles[routeIndex]!.circuitJsonMetadata,
+                      }
+                    : {}),
+                }
               : {}),
           },
           { x: route.B.x, y: route.B.y, z: route.B.z! },

--- a/lib/solvers/TraceSimplificationSolver/TraceSimplificationSolver.ts
+++ b/lib/solvers/TraceSimplificationSolver/TraceSimplificationSolver.ts
@@ -169,19 +169,27 @@ export class TraceSimplificationSolver extends BaseSolver {
       ...route,
       route: route.route.map((point, index, points) => {
         const nextPoint = points[index + 1]
-        if (
+        const sameNetObstacle =
           nextPoint &&
           point.z !== nextPoint.z &&
           this.getSameNetObstacleForSegment(route, point, nextPoint)
-        ) {
+
+        if (sameNetObstacle) {
           return {
             ...point,
             toNextSegmentType: "through_obstacle" as const,
+            ...(sameNetObstacle.circuitJsonMetadata
+              ? {
+                  toNextSegmentCircuitJsonMetadata:
+                    sameNetObstacle.circuitJsonMetadata,
+                }
+              : {}),
           }
         }
 
         const finalizedPoint = { ...point }
         delete finalizedPoint.toNextSegmentType
+        delete finalizedPoint.toNextSegmentCircuitJsonMetadata
         return finalizedPoint
       }),
       vias: route.vias.filter(

--- a/lib/types/high-density-types.ts
+++ b/lib/types/high-density-types.ts
@@ -1,3 +1,5 @@
+import type { CircuitJsonMetadata } from "./srj-types"
+
 export type PortPoint = {
   connectionName: string
   rootConnectionName?: string
@@ -51,6 +53,7 @@ export type HighDensityIntraNodeRoute = {
     pcb_port_id?: string
     insideJumperPad?: boolean
     toNextSegmentType?: "through_obstacle"
+    toNextSegmentCircuitJsonMetadata?: CircuitJsonMetadata
   }>
   vias: Array<{ x: number; y: number }>
   jumpers?: Jumper[]

--- a/lib/types/srj-types.ts
+++ b/lib/types/srj-types.ts
@@ -189,6 +189,7 @@ export interface SimplifiedPcbTrace {
         from_layer: string
         to_layer: string
         width: number
+        circuitJsonMetadata?: CircuitJsonMetadata
       }
   >
 }

--- a/lib/utils/convertHdRouteToSimplifiedRoute.ts
+++ b/lib/utils/convertHdRouteToSimplifiedRoute.ts
@@ -17,6 +17,8 @@ type Point = {
   z: number
   traceThickness?: number
   toNextSegmentType?: "through_obstacle"
+  toNextSegmentCircuitJsonMetadata?:
+    HighDensityIntraNodeRoute["route"][number]["toNextSegmentCircuitJsonMetadata"]
 }
 const DEFAULT_TERMINAL_VIA_ATTACH_TOLERANCE = 0.25
 const SAME_POINT_TOLERANCE = 1e-12
@@ -289,6 +291,12 @@ export const convertHdRouteToSimplifiedRoute = (
           from_layer: layerName,
           to_layer: nextLayerName,
           width: previousPoint.traceThickness ?? hdRoute.traceThickness,
+          ...(previousPoint.toNextSegmentCircuitJsonMetadata
+            ? {
+                circuitJsonMetadata:
+                  previousPoint.toNextSegmentCircuitJsonMetadata,
+              }
+            : {}),
         })
       } else {
         // Check if a via exists at this position

--- a/lib/utils/convertHdRouteToSimplifiedRoute.ts
+++ b/lib/utils/convertHdRouteToSimplifiedRoute.ts
@@ -17,8 +17,7 @@ type Point = {
   z: number
   traceThickness?: number
   toNextSegmentType?: "through_obstacle"
-  toNextSegmentCircuitJsonMetadata?:
-    HighDensityIntraNodeRoute["route"][number]["toNextSegmentCircuitJsonMetadata"]
+  toNextSegmentCircuitJsonMetadata?: HighDensityIntraNodeRoute["route"][number]["toNextSegmentCircuitJsonMetadata"]
 }
 const DEFAULT_TERMINAL_VIA_ATTACH_TOLERANCE = 0.25
 const SAME_POINT_TOLERANCE = 1e-12

--- a/tests/utils/convert-hd-route-to-simplified-route-circuit-json-metadata.test.ts
+++ b/tests/utils/convert-hd-route-to-simplified-route-circuit-json-metadata.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { TraceSimplificationSolver } from "lib/solvers/TraceSimplificationSolver/TraceSimplificationSolver"
+import { convertHdRouteToSimplifiedRoute } from "lib/utils/convertHdRouteToSimplifiedRoute"
+
+test("preserves Circuit JSON metadata on through-obstacle route points", () => {
+  const solver = new TraceSimplificationSolver({
+    hdRoutes: [
+      {
+        connectionName: "trace_1",
+        traceThickness: 0.2,
+        viaDiameter: 0.6,
+        route: [
+          { x: 0, y: 0, z: 0 },
+          { x: 0, y: 0, z: 1 },
+        ],
+        vias: [{ x: 0, y: 0 }],
+      },
+    ],
+    obstacles: [
+      {
+        type: "rect",
+        layers: ["top", "bottom"],
+        center: { x: 0, y: 0 },
+        width: 1,
+        height: 1,
+        connectedTo: ["trace_1"],
+        circuitJsonMetadata: { pcb_via_id: "opaque-via-id" },
+      },
+    ],
+    connMap: new ConnectivityMap({}),
+    colorMap: {},
+    defaultViaDiameter: 0.6,
+    layerCount: 2,
+  })
+
+  const route = convertHdRouteToSimplifiedRoute(
+    solver.simplifiedHdRoutes[0]!,
+    2,
+  )
+  const throughObstacle = route.find(
+    (routePoint) => routePoint.route_type === "through_obstacle",
+  )
+
+  expect(throughObstacle).toMatchObject({
+    route_type: "through_obstacle",
+    circuitJsonMetadata: { pcb_via_id: "opaque-via-id" },
+  })
+})


### PR DESCRIPTION
## Summary

- carry obstacle `circuitJsonMetadata` through marked high-density route transitions
- expose that metadata on emitted Simple Route JSON `through_obstacle` points
- preserve the identity both when transitions are discovered during simplification and in the dedicated through-obstacle solver

This keeps provenance inert for routing decisions while allowing downstream consumers to bind the routed transition back to the exact Circuit JSON element.

## Validation

- `bun test tests/utils/convert-hd-route-to-simplified-route-circuit-json-metadata.test.ts --timeout 9999999`
- `bun test tests/utils/convertHdRouteToSimplifiedRoute.test.ts tests/prev-next-port-point-pairs.test.ts --timeout 9999999`
- `bun run build`

## Follow-up

The companion consumer change is tscircuit/core#3266. It reads `circuitJsonMetadata.pcb_via_id` directly and removes geometric via matching.