### PR TITLE
Restore board-edge DRC in autorouting debugger

### DIFF
--- a/lib/testing/autorouting-pipeline-debugger/getCurrentCircuitJson.ts
+++ b/lib/testing/autorouting-pipeline-debugger/getCurrentCircuitJson.ts
@@ -1,4 +1,7 @@
-import { convertToCircuitJson } from "lib/testing/utils/convertToCircuitJson"
+import {
+  convertToCircuitJson,
+  createPcbBoardElement,
+} from "lib/testing/utils/convertToCircuitJson"
 import type { SimpleRouteJson, SimplifiedPcbTrace } from "lib/types"
 
 type SolverLike = {
@@ -36,9 +39,11 @@ export const getCurrentCircuitJson = (
   const inputSrj = solver.originalSrj ?? solver.srj
   const jointTraces = [...(inputSrj.traces ?? []), ...routedTraces]
 
-  return convertToCircuitJson(srjWithPointPairs, jointTraces, {
+  const circuitJson = convertToCircuitJson(srjWithPointPairs, jointTraces, {
     minTraceWidth: inputSrj.minTraceWidth,
     originalSrj: inputSrj,
     includeOriginalConnections: (inputSrj.traces?.length ?? 0) > 0,
   })
+
+  return [createPcbBoardElement(inputSrj), ...circuitJson]
 }

--- a/lib/testing/getDrcErrors.ts
+++ b/lib/testing/getDrcErrors.ts
@@ -2,6 +2,7 @@ import {
   checkDifferentNetViaSpacing,
   checkEachPcbTraceNonOverlapping,
   checkPadTraceClearance,
+  checkPcbTracesOutOfBoard,
   checkSameNetViaSpacing,
   checkTracesAreContiguous,
   checkViaTraceClearance,
@@ -108,6 +109,7 @@ export const getDrcErrors = (
 
   const errors: DrcError[] = [
     ...traceErrors,
+    ...checkPcbTracesOutOfBoard(circuitJson),
     ...(options.includeTraceContinuity === false
       ? []
       : checkTracesAreContiguous(circuitJson)),

--- a/lib/testing/utils/convertToCircuitJson.ts
+++ b/lib/testing/utils/convertToCircuitJson.ts
@@ -1,5 +1,10 @@
 import { pointToBoxDistance } from "@tscircuit/math-utils"
-import type { AnyCircuitElement, PcbTrace, PcbVia } from "circuit-json"
+import type {
+  AnyCircuitElement,
+  PcbBoard,
+  PcbTrace,
+  PcbVia,
+} from "circuit-json"
 import type { ConnectivityMap } from "circuit-json-to-connectivity-map"
 import { Obstacle, SimpleRouteJson, SimplifiedPcbTrace } from "lib/types"
 import { HighDensityRoute } from "lib/types/high-density-types"
@@ -888,6 +893,27 @@ export type ConvertToCircuitJsonOptions = {
   minViaHoleDiameter?: number
   originalSrj?: SimpleRouteJson
   includeOriginalConnections?: boolean
+}
+
+export function createPcbBoardElement(srj: SimpleRouteJson): PcbBoard {
+  const { minX, maxX, minY, maxY } = srj.bounds
+
+  return {
+    type: "pcb_board",
+    pcb_board_id: "__autorouting_board__",
+    thickness: 1.6,
+    num_layers: srj.layerCount,
+    center: { x: (minX + maxX) / 2, y: (minY + maxY) / 2 },
+    width: maxX - minX,
+    height: maxY - minY,
+    ...(srj.outline
+      ? { outline: srj.outline, shape: "polygon" as const }
+      : { shape: "rect" as const }),
+    material: "fr4",
+    ...(srj.minBoardEdgeClearance !== undefined
+      ? { min_board_edge_clearance: srj.minBoardEdgeClearance }
+      : {}),
+  }
 }
 
 export function convertToCircuitJson(

--- a/tests/drc-board-edge-debug.test.ts
+++ b/tests/drc-board-edge-debug.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "bun:test"
+import { getCurrentCircuitJson } from "lib/testing/autorouting-pipeline-debugger/getCurrentCircuitJson"
+import { getDrcErrors } from "lib/testing/getDrcErrors"
+import type { SimpleRouteJson, SimplifiedPcbTrace } from "lib/types"
+
+test("debug DRC reports traces too close to the SRJ board edge", () => {
+  const srj: SimpleRouteJson = {
+    layerCount: 2,
+    minTraceWidth: 0.2,
+    minBoardEdgeClearance: 0.2,
+    bounds: { minX: -5, maxX: 5, minY: -5, maxY: 5 },
+    outline: [
+      { x: -4, y: -4 },
+      { x: 4, y: -4 },
+      { x: 4, y: 4 },
+      { x: -4, y: 4 },
+    ],
+    obstacles: [],
+    connections: [],
+  }
+  const traces: SimplifiedPcbTrace[] = [
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "edge_trace",
+      connection_name: "edge_trace",
+      route: [
+        { route_type: "wire", x: -1, y: 3.8, width: 0.2, layer: "top" },
+        { route_type: "wire", x: 1, y: 3.8, width: 0.2, layer: "top" },
+      ],
+    },
+  ]
+
+  const circuitJson = getCurrentCircuitJson({
+    srj,
+    srjWithPointPairs: srj,
+    getOutputSimplifiedPcbTraces: () => traces,
+  })
+  if (!circuitJson) throw new Error("Debug Circuit JSON was not created")
+  const { errors, locationAwareErrors } = getDrcErrors(circuitJson, {
+    includeTraceContinuity: false,
+  })
+
+  expect(circuitJson).toContainEqual(
+    expect.objectContaining({
+      type: "pcb_board",
+      min_board_edge_clearance: 0.2,
+    }),
+  )
+  expect(errors).toContainEqual(
+    expect.objectContaining({
+      pcb_trace_error_id: "trace_too_close_to_board_edge_trace_segment_0",
+      pcb_trace_id: "edge_trace",
+      message: expect.stringContaining("Trace too close to board edge"),
+    }),
+  )
+  expect(locationAwareErrors).toContainEqual(
+    expect.objectContaining({ center: { x: 0, y: 3.8 } }),
+  )
+})


### PR DESCRIPTION
I want the `checkPcbTracesOutOfBoard` drc check to run, for that we need reconstruct the `pcb_board` from the SRJ