### PR TITLE
Pin exact AM62L LPDDR4 SRJ29 reproduction

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@tscircuit/dataset-srj24": "git+https://github.com/tscircuit/dataset-srj24.git#0973fa8a123276ff0f5de1fc7edef31efccb9cc9",
     "@tscircuit/dataset-srj27-power-traces": "git+https://github.com/tscircuit/dataset-srj27-power-traces.git#eb24d36",
     "@tscircuit/dataset-srj28-partially-prerouted": "git+https://github.com/tscircuit/dataset-srj28-partially-prerouted.git#5b1673544b6ade4480612539ba6574ad414fddc0",
-    "@tscircuit/dataset-srj29-ddr3-bga-pairs": "git+https://github.com/ShiboSoftwareDev/dataset-srj29-ddr3-bga-pairs.git#f7fef97392872c67a40e9ce10800657144a0c57f",
+    "@tscircuit/dataset-srj29-ddr3-bga-pairs": "git+https://github.com/ShiboSoftwareDev/dataset-srj29-ddr3-bga-pairs.git#585c3abd4c6ce4be52bbc430b1d5e6dcc9b4ea30",
     "@tscircuit/fanout-solver": "^0.0.29",
     "@tscircuit/fixed-via-hypergraph-solver": "https://codeload.github.com/tscircuit/fixed-via-hypergraph-solver/tar.gz/bed37a6201b5dd07c9cc68b828917ecc20d6d049",
     "@tscircuit/hypergraph": "^0.0.71",

--- a/tests/benchmark-dataset-scenarios.test.ts
+++ b/tests/benchmark-dataset-scenarios.test.ts
@@ -73,10 +73,13 @@ test("benchmark datasets load in sample order", async () => {
   expect(srj28Scenarios[84][0]).toBe("circuit181")
   expect(srj28Scenarios[0][1].traces?.length).toBeGreaterThan(0)
 
-  expect(srj29Scenarios).toHaveLength(20)
+  expect(srj29Scenarios).toHaveLength(21)
   expect(srj29Scenarios[0][0]).toBe("sample001")
-  expect(srj29Scenarios[19][0]).toBe("sample020")
+  expect(srj29Scenarios[20][0]).toBe("sample021")
   expect(srj29Scenarios[0][1].connections.length).toBeGreaterThan(0)
+  expect(srj29Scenarios[20][1].layerCount).toBe(8)
+  expect(srj29Scenarios[20][1].connections).toHaveLength(33)
+  expect(srj29Scenarios[20][1].obstacles).toHaveLength(573)
 
   const sample11 = await loadScenarioBySampleNumber("srj11", 11)
   expect(sample11.scenarioName).toBe("sample011Circuit")
@@ -114,7 +117,7 @@ test("benchmark datasets load in sample order", async () => {
   expect(sample28.scenarioName).toBe("circuit181")
   expect(sample28.totalSamples).toBe(85)
 
-  const sample29 = await loadScenarioBySampleNumber("srj29", 20)
-  expect(sample29.scenarioName).toBe("sample020")
-  expect(sample29.totalSamples).toBe(20)
+  const sample29 = await loadScenarioBySampleNumber("srj29", 21)
+  expect(sample29.scenarioName).toBe("sample021")
+  expect(sample29.totalSamples).toBe(21)
 })


### PR DESCRIPTION
## What this changes

- pins `@tscircuit/dataset-srj29-ddr3-bga-pairs` to [`585c3abd4c6ce4be52bbc430b1d5e6dcc9b4ea30`](https://github.com/ShiboSoftwareDev/dataset-srj29-ddr3-bga-pairs/commit/585c3abd4c6ce4be52bbc430b1d5e6dcc9b4ea30)
- exposes `sample021` through the existing SRJ29 fixture and `/benchmark --pipeline 10 --dataset 29`
- updates the dataset-loader test to verify the 21st sample and its defining invariants

## New reproduction

`sample021` is the flat-SRJ reproduction of [`0hmX/am62l-lpddr4-breakout-repro`](https://tscircuit.com/0hmX/am62l-lpddr4-breakout-repro), preserving:

- 45 mm × 25 mm board and 8 copper layers
- 373-ball AM62L32 at `(-10, 0)`, rotated 180°
- 200-ball MT53E1G16D1ZW LPDDR4 at `(10.116917, -0.050917)`, rotated 90°
- all 573 published pad identities and coordinates
- all 33 DDR connections, three buses, three differential pairs, and the published routing rules
- a real [`circuit-to-svg` PCB snapshot](https://github.com/ShiboSoftwareDev/dataset-srj29-ddr3-bga-pairs/blob/585c3abd4c6ce4be52bbc430b1d5e6dcc9b4ea30/snapshots/sample021.svg)

## Current Pipeline 10 result

Component detection succeeds and identifies both BGAs. Pipeline 10 then stops before fanout because it currently requires at least 12 copper layers while the exact reproduction has 8:

```text
Pipeline 10 requires at least 12 copper layers, received 8
```

This PR intentionally pins the reproduction without changing the sample or mixing in a solver fix.

## Verification

- dataset `npm run build`: 21 generated snapshots and 21 validated samples
- source comparison: 573/573 pad geometries and 33/33 trace names match the published package Circuit JSON
- `bun test tests/benchmark-dataset-scenarios.test.ts --timeout 9999999`: 1 passed, 0 failed
- `bunx tsc --noEmit`: passed
