### PR TITLE
Pin AM62L LPDDR4 repro and allow 8-layer Pipeline 10 inputs

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline10_BgaFanout/AutoroutingPipelineSolver10_BgaFanout.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline10_BgaFanout/AutoroutingPipelineSolver10_BgaFanout.ts
@@ -30,7 +30,6 @@ import { convertSrjToGraphicsObject } from "lib/utils/convertSrjToGraphicsObject
 const MAX_FANOUT_BOUNDARY_MARGIN_MM = 4.5
 const MIN_FANOUT_BOUNDARY_MARGIN_MM = 2
 const MIN_POST_FANOUT_CORRIDOR_MM = 2
-const MIN_LAYER_COUNT = 12
 const INWARD_ESCAPE_DEPTH_MM = 1.2
 
 type AutoroutingPipeline10Input = {
@@ -166,11 +165,6 @@ function getBgaPair(
   ]
   if (first.componentId === second.componentId) {
     throw new Error("Pipeline 10 requires two distinct BGA component IDs")
-  }
-  if (inputSrj.layerCount < MIN_LAYER_COUNT) {
-    throw new Error(
-      `Pipeline 10 requires at least ${MIN_LAYER_COUNT} copper layers, received ${inputSrj.layerCount}`,
-    )
   }
 
   const fanoutBoundaryMargin = getFanoutBoundaryMargin(first, second)

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@tscircuit/dataset-srj24": "git+https://github.com/tscircuit/dataset-srj24.git#0973fa8a123276ff0f5de1fc7edef31efccb9cc9",
     "@tscircuit/dataset-srj27-power-traces": "git+https://github.com/tscircuit/dataset-srj27-power-traces.git#eb24d36",
     "@tscircuit/dataset-srj28-partially-prerouted": "git+https://github.com/tscircuit/dataset-srj28-partially-prerouted.git#5b1673544b6ade4480612539ba6574ad414fddc0",
-    "@tscircuit/dataset-srj29-ddr3-bga-pairs": "git+https://github.com/ShiboSoftwareDev/dataset-srj29-ddr3-bga-pairs.git#f7fef97392872c67a40e9ce10800657144a0c57f",
+    "@tscircuit/dataset-srj29-ddr3-bga-pairs": "git+https://github.com/ShiboSoftwareDev/dataset-srj29-ddr3-bga-pairs.git#585c3abd4c6ce4be52bbc430b1d5e6dcc9b4ea30",
     "@tscircuit/fanout-solver": "^0.0.29",
     "@tscircuit/fixed-via-hypergraph-solver": "https://codeload.github.com/tscircuit/fixed-via-hypergraph-solver/tar.gz/bed37a6201b5dd07c9cc68b828917ecc20d6d049",
     "@tscircuit/hypergraph": "^0.0.71",

--- a/tests/benchmark-dataset-scenarios.test.ts
+++ b/tests/benchmark-dataset-scenarios.test.ts
@@ -73,10 +73,13 @@ test("benchmark datasets load in sample order", async () => {
   expect(srj28Scenarios[84][0]).toBe("circuit181")
   expect(srj28Scenarios[0][1].traces?.length).toBeGreaterThan(0)
 
-  expect(srj29Scenarios).toHaveLength(20)
+  expect(srj29Scenarios).toHaveLength(21)
   expect(srj29Scenarios[0][0]).toBe("sample001")
-  expect(srj29Scenarios[19][0]).toBe("sample020")
+  expect(srj29Scenarios[20][0]).toBe("sample021")
   expect(srj29Scenarios[0][1].connections.length).toBeGreaterThan(0)
+  expect(srj29Scenarios[20][1].layerCount).toBe(8)
+  expect(srj29Scenarios[20][1].connections).toHaveLength(33)
+  expect(srj29Scenarios[20][1].obstacles).toHaveLength(573)
 
   const sample11 = await loadScenarioBySampleNumber("srj11", 11)
   expect(sample11.scenarioName).toBe("sample011Circuit")
@@ -114,7 +117,7 @@ test("benchmark datasets load in sample order", async () => {
   expect(sample28.scenarioName).toBe("circuit181")
   expect(sample28.totalSamples).toBe(85)
 
-  const sample29 = await loadScenarioBySampleNumber("srj29", 20)
-  expect(sample29.scenarioName).toBe("sample020")
-  expect(sample29.totalSamples).toBe(20)
+  const sample29 = await loadScenarioBySampleNumber("srj29", 21)
+  expect(sample29.scenarioName).toBe("sample021")
+  expect(sample29.totalSamples).toBe(21)
 })

--- a/tests/features/dataset-srj29-ddr3-bga-routing-pipeline.test.ts
+++ b/tests/features/dataset-srj29-ddr3-bga-routing-pipeline.test.ts
@@ -84,6 +84,21 @@ test("Pipeline 10 detects and fans out both SRJ29 BGAs before Pipeline 9", () =>
   ).toBe(1)
 })
 
+test("Pipeline 10 accepts an 8-layer two-BGA input", () => {
+  const inputSrj = structuredClone(sample001) as SimpleRouteJson
+  inputSrj.layerCount = 8
+  inputSrj.connections = inputSrj.connections.slice(0, 1)
+  inputSrj.buses = []
+  inputSrj.differentialPairs = []
+
+  const pipeline = new AutoroutingPipelineSolver10_BgaFanout(inputSrj)
+  pipeline.solveUntilStage("firstBgaFanoutSolver")
+  pipeline.step()
+
+  expect(pipeline.failed).toBe(false)
+  expect(pipeline.firstBgaFanoutSolver).toBeDefined()
+})
+
 test("Pipeline 10 reports its fanout traces as routed output", () => {
   const inputSrj = structuredClone(sample001) as SimpleRouteJson
   inputSrj.connections = inputSrj.connections.slice(0, 1)


### PR DESCRIPTION
## Summary

- pin `@tscircuit/dataset-srj29-ddr3-bga-pairs` to `585c3abd4c6ce4be52bbc430b1d5e6dcc9b4ea30`
- add the exact 8-layer AM62L32-to-LPDDR4 sample as SRJ29 sample 021
- remove Pipeline 10's artificial 12-layer minimum so it uses the board's actual copper-layer count

## Why

The 12-layer check came from the original roomy SRJ29 fixture, not from a fanout-solver or Pipeline 9 requirement. It rejected the real 8-layer reproduction before fanout began.

## Validation

- focused Pipeline 10 tests: 3 passed, including a 19 ms 8-layer initialization check
- `bun run format:check`
- `bunx tsc --noEmit`
- sample 021 was not solved locally; the regression check uses a one-connection variant of the existing fast fixture

This PR supersedes #2142, whose deployment coincided with transient GitHub tarball `504` errors during dependency installation.
