### PR TITLE
Fix bugreport93 overlapping via clearance

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "zdwiel-dataset": "git+https://github.com/dwiel/tscircuit-benchmark.git#be36518b5bf51755dae92c230061ab3cf4e3e063",
     "high-density-repair01": "git+https://github.com/tscircuit/high-density-repair01.git#8eaa775e7c7a2c32c12a82da4edef22477549027",
     "high-density-repair02": "https://codeload.github.com/tscircuit/high-density-repair02/tar.gz/2afc0cbba3bf2f7eb6b9cd33615d21e9ad9352d4",
-    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#d32a90310dce1132c500ecf2f97054c92f6a87be",
+    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#5ec2996bdd4a3ce1653572ef4073277f9c80e049",
     "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d",
     "@tscircuit/high-density-b01": "git+https://github.com/tscircuit/high-density-b01.git#1309684"
   },

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "zdwiel-dataset": "git+https://github.com/dwiel/tscircuit-benchmark.git#be36518b5bf51755dae92c230061ab3cf4e3e063",
     "high-density-repair01": "git+https://github.com/tscircuit/high-density-repair01.git#8eaa775e7c7a2c32c12a82da4edef22477549027",
     "high-density-repair02": "https://codeload.github.com/tscircuit/high-density-repair02/tar.gz/2afc0cbba3bf2f7eb6b9cd33615d21e9ad9352d4",
-    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#5ec2996bdd4a3ce1653572ef4073277f9c80e049",
+    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#e12df3b68985bf38a4836316b93a48416d606cc2",
     "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d",
     "@tscircuit/high-density-b01": "git+https://github.com/tscircuit/high-density-b01.git#1309684"
   },


### PR DESCRIPTION
## Summary

- update high-density-repair03 to tscircuit/high-density-repair03#73
- ensure exact targeted repair prioritizes different-net via clearance before trace-topology candidates can consume the iteration budget
- fix the overlapping via pair reproduced and snapshotted in #2150

## Validation

- replayed the complete captured routing through the pinned dependency: the reported pair is removed and zero via-clearance errors remain
- bun test tests/bugs/bugreport93-overlapping-vias.test.ts (skipped as intended)
- bunx tsc --noEmit
- bun run build

Depends on tscircuit/high-density-repair03#73.