### PR TITLE
feat: parallelize Pipeline7 high-density routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,31 @@ const solver = new CapacityMeshSolver(simpleRouteJson, {
 
 By default, the solver will automatically calculate the optimal `capacityDepth` to achieve a target minimum capacity of 0.5 based on the board dimensions. This automatic calculation ensures that the smallest subdivision cells have an appropriate capacity for routing.
 
+#### Parallel high-density routing
+
+Pipeline 7 can solve independent high-density capacity-mesh nodes in parallel:
+
+```typescript
+const solver = new AutoroutingPipelineSolver(simpleRouteJson, {
+  highDensitySolverParallelism: 4,
+})
+
+await solver.solveAsync()
+```
+
+Parallel mode uses module Web Workers by default and requires asynchronous
+`stepAsync()` or `solveAsync()` execution. The pipeline sends plain
+structured-cloneable node tasks to the workers and commits results in a stable
+order, independent of which worker finishes first.
+
+Hosts can set `highDensitySolverWorkerUrl` when the packaged worker needs a
+custom URL, or provide a runtime-local `highDensitySolverExecutor` implementing
+the exported executor interface. Keeping the executor outside the routing
+algorithm allows browser Workers, Node worker threads, and test executors to use
+the same pipeline API. Node.js hosts without a global Web Worker API must supply
+a `highDensitySolverExecutor` backed by worker threads. Hosts that cancel an
+active route can await `solver.dispose()` to terminate its worker session.
+
 ### Visualization Support
 
 For debugging or interactive applications, you can use the `visualize()` method to get a visualization of the current routing state:

--- a/lib/WebWorkerHighDensitySolverExecutor.ts
+++ b/lib/WebWorkerHighDensitySolverExecutor.ts
@@ -1,0 +1,254 @@
+import type {
+  HighDensitySolverExecutor,
+  HighDensitySolverExecutorSession,
+  HighDensityNodeSolveResult,
+  HighDensityNodeSolveTask,
+  HighDensitySolverExecutionContext,
+} from "./solvers/HighDensitySolver/high-density-parallel-types"
+import type {
+  HighDensityWorkerRequest,
+  HighDensityWorkerResponse,
+} from "./solvers/HighDensitySolver/high-density-worker-protocol"
+
+type WorkerLike = {
+  onmessage: ((event: MessageEvent<HighDensityWorkerResponse>) => void) | null
+  onerror: ((event: ErrorEvent) => void) | null
+  onmessageerror: ((event: MessageEvent<unknown>) => void) | null
+  postMessage(message: HighDensityWorkerRequest): void
+  terminate(): void | Promise<number>
+}
+
+type WorkerSlot = {
+  worker: WorkerLike
+  ready: boolean
+  resolveReady: () => void
+  rejectReady: (error: Error) => void
+  readyPromise: Promise<void>
+  currentRequest?: {
+    requestId: number
+    resolve: (result: HighDensityNodeSolveResult) => void
+    reject: (error: Error) => void
+  }
+}
+
+type QueuedTask = {
+  task: HighDensityNodeSolveTask
+  resolve: (result: HighDensityNodeSolveResult) => void
+  reject: (error: Error) => void
+}
+
+type WorkerFactory = () => WorkerLike
+
+const createDefaultWorker = (): WorkerLike => {
+  if (typeof Worker === "undefined") {
+    throw new Error(
+      "High-density parallel execution requires the Web Worker API or a custom highDensitySolverExecutor",
+    )
+  }
+  return new Worker(
+    new URL("./high-density-solver-worker.js", import.meta.url),
+    { type: "module" },
+  )
+}
+
+const createWorkerFromUrl = (workerUrl: string): WorkerLike => {
+  if (typeof Worker === "undefined") {
+    throw new Error(
+      "High-density parallel execution requires the Web Worker API or a custom highDensitySolverExecutor",
+    )
+  }
+  return new Worker(workerUrl, { type: "module" })
+}
+
+class WebWorkerHighDensitySolverSession
+  implements HighDensitySolverExecutorSession
+{
+  private readonly slots: WorkerSlot[] = []
+  private readonly queuedTasks: QueuedTask[] = []
+  private nextRequestId = 1
+  private disposed = false
+  private failure: Error | null = null
+  private readyPromise: Promise<void> = Promise.resolve()
+
+  constructor(
+    context: HighDensitySolverExecutionContext,
+    parallelism: number,
+    createWorker: WorkerFactory,
+  ) {
+    try {
+      for (let workerIndex = 0; workerIndex < parallelism; workerIndex++) {
+        let resolveReady!: () => void
+        let rejectReady!: (error: Error) => void
+        const readyPromise = new Promise<void>((resolve, reject) => {
+          resolveReady = resolve
+          rejectReady = reject
+        })
+        const slot: WorkerSlot = {
+          worker: createWorker(),
+          ready: false,
+          resolveReady,
+          rejectReady,
+          readyPromise,
+        }
+        slot.worker.onmessage = (event) => {
+          this.handleWorkerMessage(slot, event.data)
+        }
+        slot.worker.onerror = (event) => {
+          this.fail(
+            new Error(event.message || "High-density Web Worker failed"),
+          )
+        }
+        slot.worker.onmessageerror = () => {
+          this.fail(
+            new Error("High-density Web Worker message was not cloneable"),
+          )
+        }
+        this.slots.push(slot)
+      }
+    } catch (error) {
+      for (const slot of this.slots) void slot.worker.terminate()
+      throw this.toError(error)
+    }
+
+    this.readyPromise = Promise.all(
+      this.slots.map((slot) => slot.readyPromise),
+    ).then(() => undefined)
+    void this.readyPromise.catch(() => undefined)
+
+    for (const slot of this.slots) {
+      try {
+        slot.worker.postMessage({ type: "initialize", context })
+      } catch (error) {
+        this.fail(this.toError(error))
+        break
+      }
+    }
+  }
+
+  async execute(
+    task: HighDensityNodeSolveTask,
+  ): Promise<HighDensityNodeSolveResult> {
+    await this.readyPromise
+    if (this.disposed) {
+      const disposalError =
+        this.failure ?? new Error("High-density executor session is disposed")
+      throw disposalError
+    }
+
+    return await new Promise<HighDensityNodeSolveResult>((resolve, reject) => {
+      this.queuedTasks.push({ task, resolve, reject })
+      this.dispatchQueuedTasks()
+    })
+  }
+
+  dispose(): void {
+    if (this.disposed) return
+    this.disposed = true
+    const disposeError =
+      this.failure ?? new Error("High-density executor session was disposed")
+
+    for (const queuedTask of this.queuedTasks.splice(0)) {
+      queuedTask.reject(disposeError)
+    }
+    for (const slot of this.slots) {
+      if (!slot.ready) slot.rejectReady(disposeError)
+      slot.currentRequest?.reject(disposeError)
+      slot.currentRequest = undefined
+      void slot.worker.terminate()
+    }
+  }
+
+  private handleWorkerMessage(
+    slot: WorkerSlot,
+    response: HighDensityWorkerResponse,
+  ): void {
+    if (this.disposed) return
+    if (response.type === "ready") {
+      slot.ready = true
+      slot.resolveReady()
+      this.dispatchQueuedTasks()
+      return
+    }
+
+    if (response.type === "error") {
+      this.fail(new Error(response.error))
+      return
+    }
+
+    const currentRequest = slot.currentRequest
+    if (!currentRequest || currentRequest.requestId !== response.requestId) {
+      this.fail(
+        new Error(
+          `High-density Web Worker returned unexpected request ${response.requestId}`,
+        ),
+      )
+      return
+    }
+
+    slot.currentRequest = undefined
+    currentRequest.resolve(response.result)
+    this.dispatchQueuedTasks()
+  }
+
+  private dispatchQueuedTasks(): void {
+    if (this.disposed) return
+    for (const slot of this.slots) {
+      if (!slot.ready || slot.currentRequest || this.queuedTasks.length === 0) {
+        continue
+      }
+
+      const queuedTask = this.queuedTasks.shift()!
+      const requestId = this.nextRequestId
+      this.nextRequestId += 1
+      slot.currentRequest = {
+        requestId,
+        resolve: queuedTask.resolve,
+        reject: queuedTask.reject,
+      }
+      try {
+        slot.worker.postMessage({
+          type: "solve",
+          requestId,
+          task: queuedTask.task,
+        })
+      } catch (error) {
+        this.fail(this.toError(error))
+      }
+    }
+  }
+
+  private fail(error: Error): void {
+    if (this.failure) return
+    this.failure = error
+    for (const slot of this.slots) {
+      if (!slot.ready) slot.rejectReady(error)
+    }
+    this.dispose()
+  }
+
+  private toError(error: unknown): Error {
+    return error instanceof Error ? error : new Error(String(error))
+  }
+}
+
+/** Browser-compatible worker-pool implementation for the executor boundary. */
+export class WebWorkerHighDensitySolverExecutor
+  implements HighDensitySolverExecutor
+{
+  constructor(private readonly workerUrl?: string) {}
+
+  createSession(
+    context: HighDensitySolverExecutionContext,
+    { parallelism }: { parallelism: number },
+  ): HighDensitySolverExecutorSession {
+    const workerUrl = this.workerUrl
+    const createWorker = workerUrl
+      ? () => createWorkerFromUrl(workerUrl)
+      : createDefaultWorker
+    return new WebWorkerHighDensitySolverSession(
+      context,
+      parallelism,
+      createWorker,
+    )
+  }
+}

--- a/lib/autorouter-pipelines/AutoroutingPipeline5_HdCache/AutoroutingPipelineSolver5_HdCache.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline5_HdCache/AutoroutingPipelineSolver5_HdCache.ts
@@ -1,6 +1,6 @@
 import { ConnectivityMap } from "circuit-json-to-connectivity-map"
 import type { CapacityMeshNodeId } from "lib/types/capacity-mesh-types"
-import { getPendingEffectsFromSolverTree } from "lib/solvers/getPendingEffectsFromSolverTree"
+import { solveSolverAsync, stepSolverAsync } from "lib/solvers/runSolverAsync"
 import {
   AutoroutingPipelineSolver4_TinyHypergraph,
   type AutoroutingPipelineSolverOptions,
@@ -83,38 +83,12 @@ export class AutoroutingPipelineSolver5_HdCache extends AutoroutingPipelineSolve
     } as any
   }
 
-  async stepAsync() {
-    if (this.solved || this.failed) return
-
-    this.step()
-
-    const pendingEffects = getPendingEffectsFromSolverTree(this)
-    if (pendingEffects.length === 0) {
-      return
-    }
-
-    await Promise.race(
-      pendingEffects.map((effect) =>
-        effect.promise.then(
-          () => effect.name,
-          () => effect.name,
-        ),
-      ),
-    )
-
-    if (!this.solved && !this.failed) {
-      this.step()
-    }
+  async stepAsync(): Promise<void> {
+    await stepSolverAsync(this)
   }
 
-  async solveAsync() {
-    const startTime = Date.now()
-
-    while (!this.solved && !this.failed) {
-      await this.stepAsync()
-    }
-
-    this.timeToSolve = Date.now() - startTime
+  async solveAsync(): Promise<void> {
+    await solveSolverAsync(this)
   }
 
   override solve() {

--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -56,6 +56,8 @@ import { DeadEndSolver } from "../../solvers/DeadEndSolver/DeadEndSolver"
 import { EscapeViaLocationSolver } from "../../solvers/EscapeViaLocationSolver/EscapeViaLocationSolver"
 import { Pipeline4HighDensityRepairSolver } from "../../solvers/HighDensityRepairSolver/Pipeline4HighDensityRepairSolver"
 import { HighDensitySolver } from "../../solvers/HighDensitySolver/HighDensitySolver"
+import { ParallelHighDensitySolver } from "../../solvers/HighDensitySolver/ParallelHighDensitySolver"
+import type { HighDensitySolverExecutor } from "../../solvers/HighDensitySolver/high-density-parallel-types"
 import { MultiSectionPortPointOptimizer } from "../../solvers/MultiSectionPortPointOptimizer"
 import { NetToPointPairsSolver } from "../../solvers/NetToPointPairsSolver/NetToPointPairsSolver"
 import { NetToPointPairsSolver2_OffBoardConnection } from "../../solvers/NetToPointPairsSolver2_OffBoardConnection/NetToPointPairsSolver2_OffBoardConnection"
@@ -64,6 +66,7 @@ import { SingleLayerNodeMergerSolver } from "../../solvers/SingleLayerNodeMerger
 import { StrawSolver } from "../../solvers/StrawSolver/StrawSolver"
 import { TraceSimplificationSolver } from "../../solvers/TraceSimplificationSolver/TraceSimplificationSolver"
 import { TraceWidthSolver } from "../../solvers/TraceWidthSolver/TraceWidthSolver"
+import { solveSolverAsync, stepSolverAsync } from "../../solvers/runSolverAsync"
 import { PreprocessSimpleRouteJsonSolver } from "../AutoroutingPipeline4_TinyHypergraph/PreprocessSimpleRouteJsonSolver"
 import { MergedComponentTopologyView } from "./MergedComponentTopologyView"
 import { Pipeline7AdaptiveDrcBranchPortfolioSolver } from "./Pipeline7AdaptiveDrcBranchPortfolioSolver"
@@ -84,6 +87,12 @@ interface CapacityMeshSolverOptions {
   minNodeArea?: number
   visualizationTraceColorMode?: TraceColorMode
   powerTraceExpansion?: PowerTraceExpanderOptions
+  /** Number of independent high-density nodes to solve concurrently. */
+  highDensitySolverParallelism?: number
+  /** Runtime-local override for browser, Node, or test executor implementations. */
+  highDensitySolverExecutor?: HighDensitySolverExecutor
+  /** Optional module URL used by the built-in Web Worker executor. */
+  highDensitySolverWorkerUrl?: string
 }
 export type AutoroutingPipelineSolverOptions = CapacityMeshSolverOptions
 
@@ -528,41 +537,49 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
         },
       ],
     ),
-    definePipelineStep("highDensityRouteSolver", HighDensitySolver, (cms) => {
-      const uniformNodes = cms.uniformPortDistributionSolver?.getOutput() ?? []
-      const fallbackNodes =
-        cms.portPointPathingSolver?.getOutput().nodesWithPortPoints ?? []
-      const nodePortPointsSource =
-        uniformNodes.length > 0 ? uniformNodes : fallbackNodes
+    definePipelineStep(
+      "highDensityRouteSolver",
+      ParallelHighDensitySolver,
+      (cms) => {
+        const uniformNodes =
+          cms.uniformPortDistributionSolver?.getOutput() ?? []
+        const fallbackNodes =
+          cms.portPointPathingSolver?.getOutput().nodesWithPortPoints ?? []
+        const nodePortPointsSource =
+          uniformNodes.length > 0 ? uniformNodes : fallbackNodes
 
-      cms.highDensityNodePortPoints = structuredClone(nodePortPointsSource)
+        cms.highDensityNodePortPoints = structuredClone(nodePortPointsSource)
 
-      return [
-        {
-          nodePortPoints: nodePortPointsSource,
-          nodePfById: new Map(
-            (
-              cms.portPointPathingSolver?.getOutput().inputNodeWithPortPoints ??
-              []
-            ).map((node) => [
-              node.capacityMeshNodeId,
-              cms.portPointPathingSolver?.computeNodePf(node) ?? null,
-            ]),
-          ),
-          colorMap: cms.colorMap,
-          connMap: cms.connMap,
-          viaDiameter: cms.viaDiameter,
-          traceWidth: cms.minTraceWidth,
-          obstacleMargin: cms.srj.defaultObstacleMargin ?? 0.15,
-          obstacles: cms.srj.obstacles,
-          layerCount: cms.srj.layerCount,
-          useGrowShrinkHighDensityIntraNodeSolver: true,
-          preserveTerminalPcbPortIds: true,
-          growShrinkFallbackToInvalidGeometryOnFailure: true,
-          captureSearchDebug: false,
-        },
-      ]
-    }),
+        return [
+          {
+            nodePortPoints: nodePortPointsSource,
+            nodePfById: new Map(
+              (
+                cms.portPointPathingSolver?.getOutput()
+                  .inputNodeWithPortPoints ?? []
+              ).map((node) => [
+                node.capacityMeshNodeId,
+                cms.portPointPathingSolver?.computeNodePf(node) ?? null,
+              ]),
+            ),
+            colorMap: cms.colorMap,
+            connMap: cms.connMap,
+            viaDiameter: cms.viaDiameter,
+            traceWidth: cms.minTraceWidth,
+            obstacleMargin: cms.srj.defaultObstacleMargin ?? 0.15,
+            obstacles: cms.srj.obstacles,
+            layerCount: cms.srj.layerCount,
+            useGrowShrinkHighDensityIntraNodeSolver: true,
+            preserveTerminalPcbPortIds: true,
+            growShrinkFallbackToInvalidGeometryOnFailure: true,
+            captureSearchDebug: false,
+            parallelism: cms.opts.highDensitySolverParallelism,
+            executor: cms.opts.highDensitySolverExecutor,
+            workerUrl: cms.opts.highDensitySolverWorkerUrl,
+          },
+        ]
+      },
+    ),
     definePipelineStep(
       "highDensityForceImproveSolver",
       HighDensityForceImproveSolver,
@@ -821,6 +838,16 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
     this.originalSrj = srjWithBoardValidObstacleLayers
     this.opts = { ...opts }
     const mutableOpts = this.opts
+    const highDensitySolverParallelism =
+      mutableOpts.highDensitySolverParallelism ?? 1
+    if (
+      !Number.isInteger(highDensitySolverParallelism) ||
+      highDensitySolverParallelism < 1
+    ) {
+      throw new Error(
+        `highDensitySolverParallelism must be a positive integer, received ${highDensitySolverParallelism}`,
+      )
+    }
     this.effort = mutableOpts.effort ?? 1
     // scale with effort so the outer cap never decapitates inner solvers
     this.MAX_ITERATIONS = 100e6 * this.effort
@@ -909,9 +936,47 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
     this.startTimeOfPhase[pipelineStepDef.solverName] = performance.now()
   }
 
+  async stepAsync(): Promise<void> {
+    await stepSolverAsync(this)
+  }
+
+  async solveAsync(): Promise<void> {
+    await solveSolverAsync(this)
+  }
+
+  override solve(): void {
+    if ((this.opts.highDensitySolverParallelism ?? 1) > 1) {
+      throw new Error(
+        "AutoroutingPipelineSolver7_MultiGraph requires async execution when highDensitySolverParallelism is greater than 1. Use solveAsync() or stepAsync().",
+      )
+    }
+    super.solve()
+  }
+
+  async dispose(): Promise<void> {
+    const activeSolver = this.activeSubSolver as
+      | (BaseSolver & { dispose?: () => void | Promise<void> })
+      | null
+      | undefined
+    if (typeof activeSolver?.dispose === "function") {
+      await activeSolver.dispose()
+    }
+  }
+
   solveUntilPhase(phase: string) {
+    if ((this.opts.highDensitySolverParallelism ?? 1) > 1) {
+      throw new Error(
+        "Parallel Pipeline7 execution requires solveUntilPhaseAsync()",
+      )
+    }
     while (this.getCurrentPhase() !== phase) {
       this.step()
+    }
+  }
+
+  async solveUntilPhaseAsync(phase: string): Promise<void> {
+    while (this.getCurrentPhase() !== phase && !this.solved && !this.failed) {
+      await this.stepAsync()
     }
   }
 

--- a/lib/autorouter-pipelines/index.ts
+++ b/lib/autorouter-pipelines/index.ts
@@ -19,6 +19,7 @@ export {
 export {
   AutoroutingPipelineSolver7_MultiGraph,
   AutoroutingPipelineSolver7_MultiGraph as AutoroutingPipelineSolver,
+  type AutoroutingPipelineSolverOptions,
 } from "./AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph"
 export { AutoroutingPipelineSolver8 } from "./AutoroutingPipeline8/AutoroutingPipelineSolver8"
 export { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "./AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph"

--- a/lib/high-density-solver-worker.js
+++ b/lib/high-density-solver-worker.js
@@ -1,0 +1,2 @@
+// Lets source-mode bundlers resolve the same URL emitted by the package build.
+import "./high-density-solver-worker.ts"

--- a/lib/high-density-solver-worker.ts
+++ b/lib/high-density-solver-worker.ts
@@ -1,0 +1,46 @@
+import type {
+  HighDensityWorkerRequest,
+  HighDensityWorkerResponse,
+} from "./solvers/HighDensitySolver/high-density-worker-protocol"
+import { createHighDensityNodeTaskHandler } from "./solvers/HighDensitySolver/solveHighDensityNodeTask"
+
+type HighDensityWorkerScope = {
+  onmessage: ((event: MessageEvent<HighDensityWorkerRequest>) => void) | null
+  postMessage(message: HighDensityWorkerResponse): void
+}
+
+const workerScope = globalThis as unknown as HighDensityWorkerScope
+let solveNodeTask: ReturnType<typeof createHighDensityNodeTaskHandler> | null =
+  null
+
+workerScope.onmessage = (event): void => {
+  const request = event.data
+  if (request.type === "initialize") {
+    solveNodeTask = createHighDensityNodeTaskHandler(request.context)
+    workerScope.postMessage({ type: "ready" })
+    return
+  }
+
+  if (!solveNodeTask) {
+    workerScope.postMessage({
+      type: "error",
+      requestId: request.requestId,
+      error: "High-density worker received a task before initialization",
+    })
+    return
+  }
+
+  try {
+    workerScope.postMessage({
+      type: "result",
+      requestId: request.requestId,
+      result: solveNodeTask(request.task),
+    })
+  } catch (error) {
+    workerScope.postMessage({
+      type: "error",
+      requestId: request.requestId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -21,6 +21,7 @@ export {
 export {
   AutoroutingPipelineSolver7_MultiGraph,
   AutoroutingPipelineSolver7_MultiGraph as AutoroutingPipelineSolver,
+  type AutoroutingPipelineSolverOptions,
 } from "./autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph"
 export { AutoroutingPipelineSolver8 } from "./autorouter-pipelines/AutoroutingPipeline8/AutoroutingPipelineSolver8"
 export { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "./autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph"
@@ -63,6 +64,16 @@ export { PortfolioSingleIntraNodeSolver } from "./solvers/HyperHighDensitySolver
 /** @deprecated Use `PortfolioSingleIntraNodeSolver` instead. */
 export { HyperSingleIntraNodeSolver } from "./solvers/HyperHighDensitySolver/HyperSingleIntraNodeSolver"
 export { GrowShrinkHighDensityIntraNodeSolver } from "./solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver"
+export { ParallelHighDensitySolver } from "./solvers/HighDensitySolver/ParallelHighDensitySolver"
+export { createHighDensityNodeTaskHandler } from "./solvers/HighDensitySolver/solveHighDensityNodeTask"
+export type {
+  HighDensityNodeSolveResult,
+  HighDensityNodeSolveTask,
+  HighDensitySolverExecutionContext,
+  HighDensitySolverExecutor,
+  HighDensitySolverExecutorSession,
+} from "./solvers/HighDensitySolver/high-density-parallel-types"
+export { WebWorkerHighDensitySolverExecutor } from "./WebWorkerHighDensitySolverExecutor"
 export {
   GlobalDrcBranchPortfolioSolver,
   GlobalDrcForceImproveSolver,

--- a/lib/solvers/BaseSolver.ts
+++ b/lib/solvers/BaseSolver.ts
@@ -1,5 +1,6 @@
 import type { GraphicsObject } from "graphics-debug"
 import { CachableSolver, CacheProvider } from "lib/cache/types"
+import { getPendingEffectsFromSolverTree } from "./getPendingEffectsFromSolverTree"
 
 export type PendingEffect = {
   name: string
@@ -33,6 +34,7 @@ export class BaseSolver {
   step() {
     if (this.solved) return
     if (this.failed) return
+    if (getPendingEffectsFromSolverTree(this).length > 0) return
     this.iterations++
     try {
       this._step()
@@ -65,6 +67,11 @@ export class BaseSolver {
     const startTime = Date.now()
     while (!this.solved && !this.failed) {
       this.step()
+      if (getPendingEffectsFromSolverTree(this).length > 0) {
+        throw new Error(
+          `${this.getSolverName()} requires asynchronous execution while effects are pending`,
+        )
+      }
     }
     const endTime = Date.now()
     this.timeToSolve = endTime - startTime

--- a/lib/solvers/HighDensitySolver/FailedHighDensityNodeSolver.ts
+++ b/lib/solvers/HighDensitySolver/FailedHighDensityNodeSolver.ts
@@ -1,0 +1,38 @@
+import type {
+  HighDensityIntraNodeRoute,
+  NodeWithPortPoints,
+} from "../../types/high-density-types"
+import { BaseSolver } from "../BaseSolver"
+
+/** Host-side view of a failed solver whose original instance lived in a worker. */
+export class FailedHighDensityNodeSolver extends BaseSolver {
+  readonly nodeWithPortPoints: NodeWithPortPoints
+  readonly solvedRoutes: HighDensityIntraNodeRoute[]
+  private readonly solverType: string
+
+  constructor({
+    nodeWithPortPoints,
+    solvedRoutes,
+    solverType,
+    iterations,
+    error,
+  }: {
+    nodeWithPortPoints: NodeWithPortPoints
+    solvedRoutes: HighDensityIntraNodeRoute[]
+    solverType: string
+    iterations: number
+    error?: string
+  }) {
+    super()
+    this.nodeWithPortPoints = nodeWithPortPoints
+    this.solvedRoutes = solvedRoutes
+    this.solverType = solverType
+    this.iterations = iterations
+    this.error = error ?? null
+    this.failed = true
+  }
+
+  override getSolverName(): string {
+    return this.solverType
+  }
+}

--- a/lib/solvers/HighDensitySolver/HighDensitySolver.ts
+++ b/lib/solvers/HighDensitySolver/HighDensitySolver.ts
@@ -17,12 +17,14 @@ import {
 import { PortfolioSingleIntraNodeSolver } from "../HyperHighDensitySolver/PortfolioSingleIntraNodeSolver"
 import { safeTransparentize } from "../colors"
 import { CachedIntraNodeRouteSolver } from "./CachedIntraNodeRouteSolver"
+import type { FailedHighDensityNodeSolver } from "./FailedHighDensityNodeSolver"
 import { IntraNodeRouteSolver } from "./IntraNodeSolver"
 
 type HighDensityIntraNodeSolver =
   | IntraNodeRouteSolver
   | PortfolioSingleIntraNodeSolver
   | GrowShrinkHighDensityIntraNodeSolver
+  | FailedHighDensityNodeSolver
 
 const connectionLabel = (
   connectionName: string,
@@ -38,6 +40,26 @@ const connectionLabel = (
   ]
     .filter(Boolean)
     .join("\n")
+
+export interface HighDensitySolverParams {
+  nodePortPoints: NodeWithPortPoints[]
+  colorMap?: Record<string, string>
+  connMap?: ConnectivityMap
+  viaDiameter?: number
+  traceWidth?: number
+  obstacleMargin?: number
+  effort?: number
+  obstacles?: Obstacle[]
+  layerCount?: number
+  useGrowShrinkHighDensityIntraNodeSolver?: boolean
+  preserveTerminalPcbPortIds?: boolean
+  growShrinkMaxInnerIterationsPerGrowthAttempt?: number
+  growShrinkFallbackToInvalidGeometryOnFailure?: boolean
+  captureSearchDebug?: boolean
+  nodePfById?:
+    | Map<CapacityMeshNodeId, number | null>
+    | Record<string, number | null>
+}
 
 export class HighDensitySolver extends BaseSolver {
   override getSolverName(): string {
@@ -96,25 +118,7 @@ export class HighDensitySolver extends BaseSolver {
     growShrinkMaxInnerIterationsPerGrowthAttempt,
     growShrinkFallbackToInvalidGeometryOnFailure,
     captureSearchDebug,
-  }: {
-    nodePortPoints: NodeWithPortPoints[]
-    colorMap?: Record<string, string>
-    connMap?: ConnectivityMap
-    viaDiameter?: number
-    traceWidth?: number
-    obstacleMargin?: number
-    effort?: number
-    obstacles?: Obstacle[]
-    layerCount?: number
-    useGrowShrinkHighDensityIntraNodeSolver?: boolean
-    preserveTerminalPcbPortIds?: boolean
-    growShrinkMaxInnerIterationsPerGrowthAttempt?: number
-    growShrinkFallbackToInvalidGeometryOnFailure?: boolean
-    captureSearchDebug?: boolean
-    nodePfById?:
-      | Map<CapacityMeshNodeId, number | null>
-      | Record<string, number | null>
-  }) {
+  }: HighDensitySolverParams) {
     super()
     this.unsolvedNodePortPoints = nodePortPoints
     this.colorMap = colorMap ?? {}

--- a/lib/solvers/HighDensitySolver/ParallelHighDensitySolver.ts
+++ b/lib/solvers/HighDensitySolver/ParallelHighDensitySolver.ts
@@ -1,0 +1,305 @@
+import { WebWorkerHighDensitySolverExecutor } from "../../WebWorkerHighDensitySolverExecutor"
+import { executeTasksWithConcurrency } from "../../utils/executeTasksWithConcurrency"
+import type { PendingEffect } from "../BaseSolver"
+import { solveSolverAsync, stepSolverAsync } from "../runSolverAsync"
+import {
+  HighDensitySolver,
+  type HighDensitySolverParams,
+} from "./HighDensitySolver"
+import { FailedHighDensityNodeSolver } from "./FailedHighDensityNodeSolver"
+import type {
+  HighDensityNodeSolveResult,
+  HighDensityNodeSolveTask,
+  HighDensitySolverExecutionContext,
+  HighDensitySolverExecutor,
+  HighDensitySolverExecutorSession,
+} from "./high-density-parallel-types"
+
+export interface ParallelHighDensitySolverParams
+  extends HighDensitySolverParams {
+  parallelism?: number
+  executor?: HighDensitySolverExecutor
+  workerUrl?: string
+}
+
+/**
+ * Async orchestration for independent high-density nodes. The intra-node
+ * algorithms remain in HighDensitySolver and its child solvers.
+ */
+export class ParallelHighDensitySolver extends HighDensitySolver {
+  private readonly parallelism: number
+  private readonly executor: HighDensitySolverExecutor
+  private launchedParallelSolve = false
+  private completedResults: HighDensityNodeSolveResult[] | null = null
+  private parallelExecutionError: Error | null = null
+  private executorSession: HighDensitySolverExecutorSession | null = null
+  private disposeRequested = false
+  private executorSessionDisposed = false
+  private readonly parallelInputNodes: HighDensitySolverParams["nodePortPoints"]
+
+  constructor({
+    parallelism = 1,
+    executor,
+    workerUrl,
+    ...solverParams
+  }: ParallelHighDensitySolverParams) {
+    super(solverParams)
+    this.parallelInputNodes = this.unsolvedNodePortPoints.slice()
+    if (!Number.isInteger(parallelism) || parallelism < 1) {
+      throw new Error(
+        `High-density solver parallelism must be a positive integer, received ${parallelism}`,
+      )
+    }
+    this.parallelism = parallelism
+    this.executor =
+      executor ?? new WebWorkerHighDensitySolverExecutor(workerUrl)
+    this.pendingEffects = []
+  }
+
+  override getSolverName(): string {
+    return this.parallelism > 1
+      ? "ParallelHighDensitySolver"
+      : super.getSolverName()
+  }
+
+  override _step(): void {
+    if (this.parallelism === 1) {
+      super._step()
+      return
+    }
+
+    if (this.parallelExecutionError) {
+      throw this.parallelExecutionError
+    }
+
+    if (this.completedResults) {
+      this.commitResults(this.completedResults)
+      return
+    }
+
+    if (!this.launchedParallelSolve) {
+      this.launchParallelSolve()
+    }
+  }
+
+  async stepAsync(): Promise<void> {
+    await stepSolverAsync(this)
+  }
+
+  async solveAsync(): Promise<void> {
+    await solveSolverAsync(this)
+  }
+
+  override solve(): void {
+    if (this.parallelism > 1) {
+      throw new Error(
+        "ParallelHighDensitySolver requires async execution. Use solveAsync() or stepAsync().",
+      )
+    }
+    super.solve()
+  }
+
+  async dispose(): Promise<void> {
+    this.disposeRequested = true
+    if (this.executorSession) {
+      await this.disposeExecutorSession(this.executorSession)
+    }
+  }
+
+  private launchParallelSolve(): void {
+    this.launchedParallelSolve = true
+    const tasks = this.createTasksInSequentialOrder()
+    if (tasks.length === 0) {
+      this.solved = true
+      return
+    }
+
+    const pendingEffect: PendingEffect = {
+      name: `high-density-parallel:${tasks.length}`,
+      promise: Promise.resolve(),
+    }
+    pendingEffect.promise = this.executeTasks(tasks)
+      .then((results) => {
+        this.completedResults = results
+      })
+      .catch((error: unknown) => {
+        this.parallelExecutionError = this.toError(error)
+      })
+      .finally(() => {
+        this.pendingEffects = this.pendingEffects?.filter(
+          (effect) => effect !== pendingEffect,
+        )
+      })
+    this.pendingEffects = [pendingEffect]
+  }
+
+  private createTasksInSequentialOrder(): HighDensityNodeSolveTask[] {
+    const tasks = this.unsolvedNodePortPoints.map((node, nodeIndex) => ({
+      nodeIndex,
+      nodeWithPortPoints: structuredClone(node),
+      nodePf: this.nodePfById.get(node.capacityMeshNodeId) ?? null,
+    }))
+
+    // HighDensitySolver historically consumes nodes with pop(). Keep that
+    // result order stable even when workers finish in a different order.
+    tasks.reverse()
+    this.unsolvedNodePortPoints.length = 0
+    return tasks
+  }
+
+  private createExecutionContext(): HighDensitySolverExecutionContext {
+    return {
+      colorMap: structuredClone(this.colorMap),
+      connectivityNetMap: this.connMap
+        ? structuredClone(this.connMap.netMap)
+        : undefined,
+      viaDiameter: this.viaDiameter,
+      traceWidth: this.traceWidth,
+      obstacleMargin: this.obstacleMargin,
+      effort: this.effort,
+      obstacles: structuredClone(this.obstacles),
+      layerCount: this.layerCount,
+      useGrowShrinkHighDensityIntraNodeSolver:
+        this.useGrowShrinkHighDensityIntraNodeSolver,
+      preserveTerminalPcbPortIds: this.preserveTerminalPcbPortIds,
+      growShrinkMaxInnerIterationsPerGrowthAttempt:
+        this.growShrinkMaxInnerIterationsPerGrowthAttempt,
+      growShrinkFallbackToInvalidGeometryOnFailure:
+        this.growShrinkFallbackToInvalidGeometryOnFailure,
+      captureSearchDebug: this.captureSearchDebug,
+    }
+  }
+
+  private async executeTasks(
+    tasks: HighDensityNodeSolveTask[],
+  ): Promise<HighDensityNodeSolveResult[]> {
+    const activeParallelism = Math.min(this.parallelism, tasks.length)
+    const session = this.executor.createSession(this.createExecutionContext(), {
+      parallelism: activeParallelism,
+    })
+    this.executorSession = session
+
+    try {
+      if (this.disposeRequested) {
+        throw new Error(
+          "ParallelHighDensitySolver was disposed before its executor session became ready",
+        )
+      }
+      return await executeTasksWithConcurrency(
+        tasks,
+        activeParallelism,
+        async (task) => {
+          const result = await session.execute(task)
+          if (result.nodeIndex !== task.nodeIndex) {
+            throw new Error(
+              `High-density executor returned node index ${result.nodeIndex} for task ${task.nodeIndex}`,
+            )
+          }
+          return result
+        },
+      )
+    } finally {
+      await this.disposeExecutorSession(session)
+    }
+  }
+
+  private async disposeExecutorSession(
+    session: HighDensitySolverExecutorSession,
+  ): Promise<void> {
+    if (this.executorSessionDisposed) return
+    this.executorSessionDisposed = true
+    if (this.executorSession === session) {
+      this.executorSession = null
+    }
+    await session.dispose()
+  }
+
+  private commitResults(results: HighDensityNodeSolveResult[]): void {
+    const solverNodeCount: Record<string, number> = {}
+    const difficultNodePfs: Record<string, number[]> = {}
+    const failedResults: Array<{
+      nodeId: string
+      error?: string
+    }> = []
+
+    this.routes = []
+    this.nodeSolveMetadataById.clear()
+    this.stats.highDensityResizeCount = 0
+    this.stats.intraNodeCacheHits = 0
+    this.stats.intraNodeCacheMisses = 0
+
+    for (const result of results) {
+      const node = this.getInputNodeForResult(result.nodeIndex)
+      const nodePf = this.nodePfById.get(node.capacityMeshNodeId) ?? null
+      this.nodeSolveMetadataById.set(node.capacityMeshNodeId, {
+        node,
+        status: result.status,
+        solverType: result.solverType,
+        iterations: result.iterations,
+        routeCount: result.routeCount,
+        nodePf,
+        error: result.error,
+      })
+      this.stats.highDensityResizeCount += result.growthAttempts
+      this.stats.intraNodeCacheHits += result.cacheHits
+      this.stats.intraNodeCacheMisses += result.cacheMisses
+
+      if (result.status === "failed") {
+        this.failedSolvers.push(
+          new FailedHighDensityNodeSolver({
+            nodeWithPortPoints: node,
+            solvedRoutes: result.routes,
+            solverType: result.solverType,
+            iterations: result.iterations,
+            error: result.error,
+          }),
+        )
+        failedResults.push({
+          nodeId: node.capacityMeshNodeId,
+          error: result.error,
+        })
+        continue
+      }
+
+      this.routes.push(...result.routes)
+      solverNodeCount[result.solverType] =
+        (solverNodeCount[result.solverType] ?? 0) + 1
+      if (nodePf !== null && nodePf > 0.05) {
+        difficultNodePfs[result.solverType] ??= []
+        difficultNodePfs[result.solverType]!.push(nodePf)
+      }
+    }
+
+    this.stats.solverNodeCount = solverNodeCount
+    this.stats.difficultNodePfs = difficultNodePfs
+    this.stats.parallelism = Math.min(this.parallelism, results.length)
+    this.stats.parallelNodeCount = results.length
+
+    if (failedResults.length > 0) {
+      this.failed = true
+      const failedNodeIds = failedResults
+        .slice(0, 5)
+        .map((result) => result.nodeId)
+      this.error = `Failed to solve ${failedResults.length} nodes, ${failedNodeIds}. err0: ${failedResults[0]?.error}.`
+      return
+    }
+
+    this.solved = true
+  }
+
+  private getInputNodeForResult(
+    nodeIndex: number,
+  ): HighDensitySolverParams["nodePortPoints"][number] {
+    const taskNode = this.parallelInputNodes[nodeIndex]
+    if (!taskNode) {
+      throw new Error(
+        `High-density executor returned unknown node index ${nodeIndex}`,
+      )
+    }
+    return taskNode
+  }
+
+  private toError(error: unknown): Error {
+    return error instanceof Error ? error : new Error(String(error))
+  }
+}

--- a/lib/solvers/HighDensitySolver/high-density-parallel-types.ts
+++ b/lib/solvers/HighDensitySolver/high-density-parallel-types.ts
@@ -1,0 +1,63 @@
+import type {
+  HighDensityIntraNodeRoute,
+  NodeWithPortPoints,
+} from "../../types/high-density-types"
+import type { Obstacle } from "../../types/srj-types"
+
+/**
+ * Immutable inputs shared by every high-density node solve. This shape is
+ * deliberately free of class instances and functions so it can be sent to a
+ * Web Worker once when an executor session is created.
+ */
+export interface HighDensitySolverExecutionContext {
+  colorMap: Record<string, string>
+  connectivityNetMap?: Record<string, string[]>
+  viaDiameter: number
+  traceWidth: number
+  obstacleMargin: number
+  effort: number
+  obstacles: Obstacle[]
+  layerCount: number
+  useGrowShrinkHighDensityIntraNodeSolver: boolean
+  preserveTerminalPcbPortIds: boolean
+  growShrinkMaxInnerIterationsPerGrowthAttempt?: number
+  growShrinkFallbackToInvalidGeometryOnFailure: boolean
+  captureSearchDebug: boolean
+}
+
+/** One independent capacity-mesh node sent across the executor boundary. */
+export interface HighDensityNodeSolveTask {
+  nodeIndex: number
+  nodeWithPortPoints: NodeWithPortPoints
+  nodePf: number | null
+}
+
+/** Serializable data returned by an executor after solving one node. */
+export interface HighDensityNodeSolveResult {
+  nodeIndex: number
+  status: "solved" | "failed"
+  routes: HighDensityIntraNodeRoute[]
+  solverType: string
+  iterations: number
+  routeCount: number
+  growthAttempts: number
+  cacheHits: number
+  cacheMisses: number
+  error?: string
+}
+
+export interface HighDensitySolverExecutorSession {
+  execute(task: HighDensityNodeSolveTask): Promise<HighDensityNodeSolveResult>
+  dispose(): void | Promise<void>
+}
+
+/**
+ * Runtime-owned execution boundary. Implementations may use browser Workers,
+ * worker_threads, remote services, or an in-process test double.
+ */
+export interface HighDensitySolverExecutor {
+  createSession(
+    context: HighDensitySolverExecutionContext,
+    options: { parallelism: number },
+  ): HighDensitySolverExecutorSession
+}

--- a/lib/solvers/HighDensitySolver/high-density-worker-protocol.ts
+++ b/lib/solvers/HighDensitySolver/high-density-worker-protocol.ts
@@ -1,0 +1,29 @@
+import type {
+  HighDensityNodeSolveResult,
+  HighDensityNodeSolveTask,
+  HighDensitySolverExecutionContext,
+} from "./high-density-parallel-types"
+
+export type HighDensityWorkerRequest =
+  | {
+      type: "initialize"
+      context: HighDensitySolverExecutionContext
+    }
+  | {
+      type: "solve"
+      requestId: number
+      task: HighDensityNodeSolveTask
+    }
+
+export type HighDensityWorkerResponse =
+  | { type: "ready" }
+  | {
+      type: "result"
+      requestId: number
+      result: HighDensityNodeSolveResult
+    }
+  | {
+      type: "error"
+      requestId?: number
+      error: string
+    }

--- a/lib/solvers/HighDensitySolver/solveHighDensityNodeTask.ts
+++ b/lib/solvers/HighDensitySolver/solveHighDensityNodeTask.ts
@@ -1,0 +1,71 @@
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { getGlobalInMemoryCache } from "../../cache/setupGlobalCaches"
+import { HighDensitySolver } from "./HighDensitySolver"
+import type {
+  HighDensityNodeSolveResult,
+  HighDensityNodeSolveTask,
+  HighDensitySolverExecutionContext,
+} from "./high-density-parallel-types"
+
+/**
+ * Creates the pure algorithm-side handler used inside an executor session.
+ * ConnectivityMap is reconstructed in the execution realm because structured
+ * clone intentionally does not preserve its prototype.
+ */
+export const createHighDensityNodeTaskHandler = (
+  context: HighDensitySolverExecutionContext,
+): ((task: HighDensityNodeSolveTask) => HighDensityNodeSolveResult) => {
+  const connMap = context.connectivityNetMap
+    ? new ConnectivityMap(context.connectivityNetMap)
+    : undefined
+
+  return (task: HighDensityNodeSolveTask): HighDensityNodeSolveResult => {
+    const cache = getGlobalInMemoryCache()
+    const cacheHitsBefore = cache.cacheHits
+    const cacheMissesBefore = cache.cacheMisses
+    const solver = new HighDensitySolver({
+      nodePortPoints: [task.nodeWithPortPoints],
+      nodePfById: {
+        [task.nodeWithPortPoints.capacityMeshNodeId]: task.nodePf,
+      },
+      colorMap: context.colorMap,
+      connMap,
+      viaDiameter: context.viaDiameter,
+      traceWidth: context.traceWidth,
+      obstacleMargin: context.obstacleMargin,
+      effort: context.effort,
+      obstacles: context.obstacles,
+      layerCount: context.layerCount,
+      useGrowShrinkHighDensityIntraNodeSolver:
+        context.useGrowShrinkHighDensityIntraNodeSolver,
+      preserveTerminalPcbPortIds: context.preserveTerminalPcbPortIds,
+      growShrinkMaxInnerIterationsPerGrowthAttempt:
+        context.growShrinkMaxInnerIterationsPerGrowthAttempt,
+      growShrinkFallbackToInvalidGeometryOnFailure:
+        context.growShrinkFallbackToInvalidGeometryOnFailure,
+      captureSearchDebug: context.captureSearchDebug,
+    })
+
+    solver.solve()
+
+    const metadata = solver.nodeSolveMetadataById.get(
+      task.nodeWithPortPoints.capacityMeshNodeId,
+    )
+    const routes = solver.solved
+      ? solver.routes
+      : (solver.failedSolvers[0]?.solvedRoutes ?? [])
+
+    return {
+      nodeIndex: task.nodeIndex,
+      status: solver.solved ? "solved" : "failed",
+      routes,
+      solverType: metadata?.solverType ?? "unknown",
+      iterations: metadata?.iterations ?? solver.iterations,
+      routeCount: metadata?.routeCount ?? routes.length,
+      growthAttempts: solver.stats.highDensityResizeCount ?? 0,
+      cacheHits: cache.cacheHits - cacheHitsBefore,
+      cacheMisses: cache.cacheMisses - cacheMissesBefore,
+      error: metadata?.error ?? solver.error ?? undefined,
+    }
+  }
+}

--- a/lib/solvers/runSolverAsync.ts
+++ b/lib/solvers/runSolverAsync.ts
@@ -1,0 +1,38 @@
+import type { BaseSolver } from "./BaseSolver"
+import { getPendingEffectsFromSolverTree } from "./getPendingEffectsFromSolverTree"
+
+/**
+ * Advances a synchronous step-based solver and yields when the active solver
+ * tree exposes asynchronous effects.
+ */
+export async function stepSolverAsync(solver: BaseSolver): Promise<void> {
+  if (solver.solved || solver.failed) return
+
+  solver.step()
+  const pendingEffects = getPendingEffectsFromSolverTree(solver)
+  if (pendingEffects.length === 0) return
+
+  await Promise.race(
+    pendingEffects.map((effect) =>
+      effect.promise.then(
+        () => effect.name,
+        () => effect.name,
+      ),
+    ),
+  )
+
+  if (!solver.solved && !solver.failed) {
+    solver.step()
+  }
+}
+
+/** Solves a step-based solver without blocking its pending promises. */
+export async function solveSolverAsync(solver: BaseSolver): Promise<void> {
+  const startTime = Date.now()
+
+  while (!solver.solved && !solver.failed) {
+    await stepSolverAsync(solver)
+  }
+
+  solver.timeToSolve = Date.now() - startTime
+}

--- a/lib/utils/executeTasksWithConcurrency.ts
+++ b/lib/utils/executeTasksWithConcurrency.ts
@@ -1,0 +1,24 @@
+/**
+ * Executes independent tasks with a fixed concurrency limit while preserving
+ * input order in the returned results.
+ */
+export async function executeTasksWithConcurrency<Task, Result>(
+  tasks: Task[],
+  concurrency: number,
+  execute: (task: Task) => Promise<Result>,
+): Promise<Result[]> {
+  const results = new Array<Result>(tasks.length)
+  let nextTaskIndex = 0
+
+  const runNextTasks = async (): Promise<void> => {
+    while (nextTaskIndex < tasks.length) {
+      const taskIndex = nextTaskIndex
+      nextTaskIndex += 1
+      results[taskIndex] = await execute(tasks[taskIndex]!)
+    }
+  }
+
+  const workerCount = Math.min(concurrency, tasks.length)
+  await Promise.all(Array.from({ length: workerCount }, () => runNextTasks()))
+  return results
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "start": "cosmos",
-    "build": "tsup ./lib/index.ts --minify terser --external @tscircuit/core --external circuit-to-svg --format esm --dts --sourcemap",
+    "build": "tsup ./lib/index.ts ./lib/high-density-solver-worker.ts --minify terser --external @tscircuit/core --external circuit-to-svg --format esm --dts --sourcemap",
     "bench": "bun test tests/spatial-index-bench.test.ts",
     "format": "biome format --write .",
     "format:check": "biome format .",

--- a/tests/base-solver-pending-effect-sync-guard.test.ts
+++ b/tests/base-solver-pending-effect-sync-guard.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test"
+import { BaseSolver } from "lib/solvers/BaseSolver"
+
+class PendingEffectSolver extends BaseSolver {
+  override _step(): void {
+    this.pendingEffects = [
+      {
+        name: "never-settles",
+        promise: new Promise(() => undefined),
+      },
+    ]
+  }
+}
+
+test("BaseSolver synchronous solve fails loudly when an async effect starts", () => {
+  const solver = new PendingEffectSolver()
+
+  expect(() => solver.solve()).toThrow(
+    "requires asynchronous execution while effects are pending",
+  )
+  expect(solver.iterations).toBe(1)
+})

--- a/tests/parallel-high-density-dispose-before-ready.test.ts
+++ b/tests/parallel-high-density-dispose-before-ready.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "bun:test"
+import { ParallelHighDensitySolver } from "lib/solvers/HighDensitySolver/ParallelHighDensitySolver"
+import type {
+  HighDensitySolverExecutor,
+  HighDensitySolverExecutorSession,
+} from "lib/solvers/HighDensitySolver/high-density-parallel-types"
+
+test("parallel high-density disposal closes a session during task startup", async () => {
+  let markExecuteStarted!: () => void
+  const executeStarted = new Promise<void>((resolve) => {
+    markExecuteStarted = resolve
+  })
+  let rejectExecution!: (error: Error) => void
+  let executeCount = 0
+  let disposeCount = 0
+  const session: HighDensitySolverExecutorSession = {
+    async execute() {
+      executeCount += 1
+      markExecuteStarted()
+      return await new Promise<never>((_, reject) => {
+        rejectExecution = reject
+      })
+    },
+    dispose() {
+      disposeCount += 1
+      rejectExecution(new Error("Executor session disposed during startup"))
+    },
+  }
+  const executor: HighDensitySolverExecutor = {
+    createSession() {
+      return session
+    },
+  }
+  const solver = new ParallelHighDensitySolver({
+    nodePortPoints: [
+      {
+        capacityMeshNodeId: "cmn_dispose",
+        center: { x: 0, y: 0 },
+        width: 1,
+        height: 1,
+        portPoints: [],
+      },
+    ],
+    parallelism: 2,
+    executor,
+  })
+
+  solver.step()
+  const pendingEffect = solver.pendingEffects![0]!
+  await executeStarted
+  await solver.dispose()
+  await pendingEffect.promise
+
+  expect(executeCount).toBe(1)
+  expect(disposeCount).toBe(1)
+  expect(solver.pendingEffects).toEqual([])
+})

--- a/tests/parallel-high-density-failure-result.test.ts
+++ b/tests/parallel-high-density-failure-result.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "bun:test"
+import { ParallelHighDensitySolver } from "lib/solvers/HighDensitySolver/ParallelHighDensitySolver"
+import type { HighDensitySolverExecutor } from "lib/solvers/HighDensitySolver/high-density-parallel-types"
+
+test("parallel high-density failures preserve failed-solver metadata", async () => {
+  const executor: HighDensitySolverExecutor = {
+    createSession() {
+      return {
+        async execute(task) {
+          return {
+            nodeIndex: task.nodeIndex,
+            status: "failed",
+            routes: [
+              {
+                connectionName: "partial_connection",
+                traceThickness: 0.15,
+                viaDiameter: 0.3,
+                route: [],
+                vias: [],
+              },
+            ],
+            solverType: "failed-worker-solver",
+            iterations: 42,
+            routeCount: 1,
+            growthAttempts: 3,
+            cacheHits: 0,
+            cacheMisses: 1,
+            error: "worker could not route the node",
+          }
+        },
+        dispose() {},
+      }
+    },
+  }
+  const solver = new ParallelHighDensitySolver({
+    nodePortPoints: [
+      {
+        capacityMeshNodeId: "cmn_failed",
+        center: { x: 0, y: 0 },
+        width: 1,
+        height: 1,
+        portPoints: [],
+      },
+    ],
+    parallelism: 2,
+    executor,
+  })
+
+  await solver.solveAsync()
+
+  expect(solver.failed).toBe(true)
+  expect(solver.routes).toEqual([])
+  expect(solver.failedSolvers).toHaveLength(1)
+  expect(solver.failedSolvers[0]?.iterations).toBe(42)
+  expect(solver.failedSolvers[0]?.solvedRoutes).toHaveLength(1)
+  expect(solver.nodeSolveMetadataById.get("cmn_failed")?.routeCount).toBe(1)
+  expect(solver.error).toContain("worker could not route the node")
+})

--- a/tests/pipeline7-high-density-parallel-execution.test.ts
+++ b/tests/pipeline7-high-density-parallel-execution.test.ts
@@ -1,0 +1,179 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver7_MultiGraph } from "lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph"
+import type {
+  HighDensityNodeSolveResult,
+  HighDensityNodeSolveTask,
+  HighDensitySolverExecutionContext,
+  HighDensitySolverExecutor,
+  HighDensitySolverExecutorSession,
+} from "lib/solvers/HighDensitySolver/high-density-parallel-types"
+import type {
+  HighDensityIntraNodeRoute,
+  NodeWithPortPoints,
+} from "lib/types/high-density-types"
+import type { SimpleRouteJson } from "lib/types"
+
+const srj: SimpleRouteJson = {
+  layerCount: 2,
+  minTraceWidth: 0.15,
+  minViaDiameter: 0.3,
+  obstacles: [],
+  connections: [],
+  bounds: { minX: -5, minY: -5, maxX: 5, maxY: 5 },
+}
+
+const createNode = (nodeIndex: number): NodeWithPortPoints => ({
+  capacityMeshNodeId: `cmn_${nodeIndex}`,
+  center: { x: nodeIndex, y: 0 },
+  width: 1,
+  height: 1,
+  portPoints: [
+    {
+      connectionName: `connection_${nodeIndex}`,
+      x: nodeIndex - 0.25,
+      y: 0,
+      z: 0,
+    },
+    {
+      connectionName: `connection_${nodeIndex}`,
+      x: nodeIndex + 0.25,
+      y: 0,
+      z: 0,
+    },
+  ],
+})
+
+const createResult = (
+  task: HighDensityNodeSolveTask,
+): HighDensityNodeSolveResult => {
+  const [start, end] = task.nodeWithPortPoints.portPoints
+  const route: HighDensityIntraNodeRoute = {
+    connectionName: start!.connectionName,
+    traceThickness: 0.15,
+    viaDiameter: 0.3,
+    route: [
+      { x: start!.x, y: start!.y, z: start!.z },
+      { x: end!.x, y: end!.y, z: end!.z },
+    ],
+    vias: [],
+  }
+  return {
+    nodeIndex: task.nodeIndex,
+    status: "solved",
+    routes: [route],
+    solverType: "fake-worker-solver",
+    iterations: 1,
+    routeCount: 1,
+    growthAttempts: 0,
+    cacheHits: 0,
+    cacheMisses: 0,
+  }
+}
+
+test("Pipeline7 bounds parallel high-density work and preserves sequential result order", async () => {
+  const nodes = [createNode(0), createNode(1), createNode(2)]
+  const startedNodeIds: string[] = []
+  const pendingByNodeId = new Map<
+    string,
+    {
+      task: HighDensityNodeSolveTask
+      resolve: (result: HighDensityNodeSolveResult) => void
+    }
+  >()
+  let activeTaskCount = 0
+  let maximumActiveTaskCount = 0
+  let configuredParallelism = 0
+  let sessionDisposed = false
+  let markInitialTasksStarted!: () => void
+  const initialTasksStarted = new Promise<void>((resolve) => {
+    markInitialTasksStarted = resolve
+  })
+  let markThirdTaskStarted!: () => void
+  const thirdTaskStarted = new Promise<void>((resolve) => {
+    markThirdTaskStarted = resolve
+  })
+
+  const session: HighDensitySolverExecutorSession = {
+    execute(task) {
+      structuredClone(task)
+      const nodeId = task.nodeWithPortPoints.capacityMeshNodeId
+      startedNodeIds.push(nodeId)
+      activeTaskCount += 1
+      maximumActiveTaskCount = Math.max(maximumActiveTaskCount, activeTaskCount)
+      if (startedNodeIds.length === 2) markInitialTasksStarted()
+      if (startedNodeIds.length === 3) markThirdTaskStarted()
+      return new Promise((resolve) => {
+        pendingByNodeId.set(nodeId, {
+          task,
+          resolve: (result) => {
+            activeTaskCount -= 1
+            resolve(result)
+          },
+        })
+      })
+    },
+    dispose() {
+      sessionDisposed = true
+    },
+  }
+  const executor: HighDensitySolverExecutor = {
+    createSession(
+      context: HighDensitySolverExecutionContext,
+      options: { parallelism: number },
+    ) {
+      structuredClone(context)
+      configuredParallelism = options.parallelism
+      return session
+    },
+  }
+
+  const pipeline = new AutoroutingPipelineSolver7_MultiGraph(srj, {
+    highDensitySolverParallelism: 2,
+    highDensitySolverExecutor: executor,
+  })
+  const highDensityStep = pipeline.pipelineDef.find(
+    (step) => step.solverName === "highDensityRouteSolver",
+  )!
+  pipeline.pipelineDef = [highDensityStep] as typeof pipeline.pipelineDef
+  pipeline.uniformPortDistributionSolver = {
+    getOutput: () => nodes,
+  } as any
+  pipeline.portPointPathingSolver = {
+    getOutput: () => ({
+      nodesWithPortPoints: nodes,
+      inputNodeWithPortPoints: [],
+    }),
+  } as any
+
+  const solvePromise = pipeline.solveAsync()
+  await initialTasksStarted
+  expect(startedNodeIds).toEqual(["cmn_2", "cmn_1"])
+  expect(configuredParallelism).toBe(2)
+  const iterationsWhileWaiting = pipeline.iterations
+  for (let repeatedStep = 0; repeatedStep < 1_000; repeatedStep++) {
+    pipeline.step()
+  }
+  expect(pipeline.iterations).toBe(iterationsWhileWaiting)
+
+  const nodeOne = pendingByNodeId.get("cmn_1")!
+  nodeOne.resolve(createResult(nodeOne.task))
+  await thirdTaskStarted
+  expect(startedNodeIds).toEqual(["cmn_2", "cmn_1", "cmn_0"])
+
+  const nodeZero = pendingByNodeId.get("cmn_0")!
+  nodeZero.resolve(createResult(nodeZero.task))
+  const nodeTwo = pendingByNodeId.get("cmn_2")!
+  nodeTwo.resolve(createResult(nodeTwo.task))
+  await solvePromise
+
+  expect(maximumActiveTaskCount).toBe(2)
+  expect(sessionDisposed).toBe(true)
+  expect(pipeline.solved).toBe(true)
+  expect(pipeline.failed).toBe(false)
+  expect(pipeline.highDensityRouteSolver?.pendingEffects).toEqual([])
+  expect(
+    pipeline.highDensityRouteSolver?.routes.map(
+      (route) => route.connectionName,
+    ),
+  ).toEqual(["connection_2", "connection_1", "connection_0"])
+})

--- a/tests/pipeline7-high-density-parallel-sync-guard.test.ts
+++ b/tests/pipeline7-high-density-parallel-sync-guard.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver7_MultiGraph } from "lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph"
+import type { SimpleRouteJson } from "lib/types"
+
+const srj: SimpleRouteJson = {
+  layerCount: 2,
+  minTraceWidth: 0.15,
+  minViaDiameter: 0.3,
+  obstacles: [],
+  connections: [],
+  bounds: { minX: -1, minY: -1, maxX: 1, maxY: 1 },
+}
+
+test("Pipeline7 rejects synchronous solve when high-density parallelism is enabled", () => {
+  const pipeline = new AutoroutingPipelineSolver7_MultiGraph(srj, {
+    highDensitySolverParallelism: 2,
+  })
+
+  expect(() => pipeline.solve()).toThrow(
+    "requires async execution when highDensitySolverParallelism is greater than 1",
+  )
+})

--- a/tests/web-worker-high-density-solver-executor.test.ts
+++ b/tests/web-worker-high-density-solver-executor.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test"
+import { ParallelHighDensitySolver } from "lib/solvers/HighDensitySolver/ParallelHighDensitySolver"
+
+test("the Web Worker executor solves a structured-cloned high-density node", async () => {
+  const solver = new ParallelHighDensitySolver({
+    nodePortPoints: [
+      {
+        capacityMeshNodeId: "cmn_worker",
+        center: { x: 0, y: 0 },
+        width: 2,
+        height: 2,
+        portPoints: [
+          { connectionName: "worker_net", x: -0.5, y: 0, z: 0 },
+          { connectionName: "worker_net", x: 0.5, y: 0, z: 0 },
+        ],
+      },
+    ],
+    parallelism: 2,
+    workerUrl: new URL("../lib/high-density-solver-worker.ts", import.meta.url)
+      .href,
+    useGrowShrinkHighDensityIntraNodeSolver: false,
+    captureSearchDebug: false,
+  })
+
+  await solver.solveAsync()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(solver.routes).toHaveLength(1)
+  expect(solver.routes[0]?.connectionName).toBe("worker_net")
+  expect(solver.pendingEffects).toEqual([])
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,4 +5,7 @@ import tsconfigPaths from "vite-tsconfig-paths"
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react(), tsconfigPaths()],
+  worker: {
+    plugins: () => [tsconfigPaths()],
+  },
 })


### PR DESCRIPTION
## Summary

- add opt-in highDensitySolverParallelism to Pipeline7 and run independent high-density nodes through a bounded executor session
- keep intra-node routing algorithms synchronous and isolated from the transport-neutral parallel coordinator
- add shared async stepping for pending solver effects, deterministic result ordering, structured-clone-safe task DTOs, failure metadata, and worker cleanup
- ship a module Web Worker entry for browser and Bun hosts, with custom worker URL and executor hooks for outer workers and Node worker_threads adapters

## Validation

- bunx tsc --noEmit
- bun run build
- npm pack --dry-run
- 12 focused async, worker, failure, ordering, and existing Pipeline7 tests pass
- Biome format check is clean across all recognized changed files
- Vite production build emits a self-contained high-density worker asset
- built serial and two-worker solvers produce equal routes in stable historical order
- SRJ18 sample001 at 0.1 effort completes with parallelism 2: 595 high-density nodes, 1287 routes, no failure

## Usage

Set highDensitySolverParallelism to a positive integer greater than 1 and drive the pipeline with solveAsync or stepAsync. Browser and Bun hosts use the bundled module worker by default. Node.js hosts without a global Web Worker API provide a highDensitySolverExecutor backed by worker_threads.