### PR TITLE
Eliminate Pipeline7 circuit018's false DRC failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "dataset-srj11-45-degree": "git+https://github.com/tscircuit/dataset-srj11-45-degree.git#c49dd43c38f85fa2777c7d67393df413ca8d5a75",
     "dataset-srj18": "git+https://github.com/tscircuit/dataset-srj18.git#c0aad90256a95256fcac814f9f7da81a82a2fdea",
     "flatbush": "^4.4.0",
-    "format-si-unit": "0.0.10",
+    "format-si-unit": "0.0.12",
     "graphics-debug": "0.0.99",
     "high-density-dataset-z04": "git+https://github.com/tscircuit/high-density-dataset-z04.git#b9128ed52f5a50102b6526319be1d4ec33dca2c2",
     "kicad-to-circuit-json": "0.0.77",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@tsci/0hmX.multi-component-dataset-srj01": "git+https://github.com/tscircuit/multi-component-dataset-srj01.git#abf9d17c966d466b56ac21b735c6bb6f4518919d",
     "@tsci/tscircuit.dataset-srj12-bus-routing": "git+https://github.com/tscircuit/dataset-srj12-bus-routing.git#ba82f86a7d1288566b7144eb8661ad2549c5f328",
     "@tscircuit/autorouting-dataset-01": "git+https://github.com/tscircuit/autorouting-dataset-01.git#b97f5052a2359ab2da3f186765c6a5e839535efb",
-    "@tscircuit/checks": "^0.0.145",
+    "@tscircuit/checks": "^0.0.163",
     "@tscircuit/circuit-json-util": "^0.0.94",
     "@tscircuit/core": "0.0.337",
     "@tscircuit/curvy-trace-solver": "^0.0.10",


### PR DESCRIPTION
## Impact

This is the first split autorouter PR. It eliminates Pipeline7's false dataset01 circuit018 DRC failure without changing routing geometry or solver behavior.

Expected dataset01 effect for this PR alone:

- circuit018 / sample14: **1 false DRC error → 0**
- relaxed DRC pass rate: **83/85 → 84/85**
- circuit143 remains intentionally out of scope for the later repair PR

## Before / after

These paired snapshots come from the merged root geometry fix in [checks #215](https://github.com/tscircuit/checks/pull/215). They are included **only in this PR body**; this autorouter PR changes no snapshot or test asset.

| Before: false disconnect | After: valid boundary contact |
| --- | --- |
| ![circuit018 before](https://raw.githubusercontent.com/tscircuit/checks/719e8451111f6eeb011c80952964b48d14a9d375/tests/lib/__snapshots__/circuit018-pad-boundary-before.snap.svg) | ![circuit018 after](https://raw.githubusercontent.com/tscircuit/checks/719e8451111f6eeb011c80952964b48d14a9d375/tests/lib/__snapshots__/circuit018-pad-boundary-after.snap.svg) |

The copper geometry is unchanged; checks accepts only sub-nanometer floating-point residue at the mathematical pad boundary.

## Dependency updates

- `@tscircuit/checks`: `^0.0.145` → `^0.0.163`
- `format-si-unit`: `0.0.10` → `0.0.12`

Checks `0.0.163` imports the shared `formatMm` helper introduced after the older checks version. Updating autorouter's existing formatter dependency supplies that export during bundling.

## Scope

- one changed file: `package.json`
- no autorouter solver changes
- no repair03 dependency change
- no circuit143 change
- no Pipeline9 change
- no endpoint snapping, geometry normalization, fallback, or circuit-specific production logic

## Validation

- `bun run build` — JavaScript and declarations pass
- focused Pipeline7 dataset01 sample14 benchmark — **100% completed, 100% relaxed DRC, 0 failures**
- circuit018 route retains 16 vias
