### PR TITLE
Show DRC issue counts in benchmark comments

### DIFF
--- a/scripts/benchmark/benchmark-comment-comparison.js
+++ b/scripts/benchmark/benchmark-comment-comparison.js
@@ -64,6 +64,22 @@ const getTimeoutCount = (report, solverName) => {
   ).length
 }
 
+const getDrcIssueCount = (report, solverName) => {
+  if (!Array.isArray(report?.tests)) return null
+  const solvedTests = report.tests.filter(
+    (test) => test.solverName === solverName && test.didSolve,
+  )
+  if (solvedTests.length === 0) return null
+  let drcIssueCount = 0
+  for (const test of solvedTests) {
+    if (!Number.isInteger(test.drcErrorCount) || test.drcErrorCount < 0) {
+      return null
+    }
+    drcIssueCount += test.drcErrorCount
+  }
+  return drcIssueCount
+}
+
 const getTimePercentile = (report, solverName, percentile) => {
   if (!Array.isArray(report?.tests)) return null
   const elapsedTimes = report.tests
@@ -122,9 +138,12 @@ export const renderBenchmarkComparison = ({
     )
     const mainTimeouts = getTimeoutCount(mainReport, prSummary.solverName)
     const prTimeouts = getTimeoutCount(prReport, prSummary.solverName)
+    const mainDrcIssues = getDrcIssueCount(mainReport, prSummary.solverName)
+    const prDrcIssues = getDrcIssueCount(prReport, prSummary.solverName)
     rows.push(
       `| ${solver} | Completion | ${mainSummary?.completedRateLabel ?? "n/a"} | ${prSummary.completedRateLabel} | ${formatPercentPointDelta(mainSummary?.completedRateLabel, prSummary.completedRateLabel)} |`,
       `| ${solver} | Relaxed DRC pass | ${mainSummary?.relaxedDrcRateLabel ?? "n/a"} | ${prSummary.relaxedDrcRateLabel} | ${formatPercentPointDelta(mainSummary?.relaxedDrcRateLabel, prSummary.relaxedDrcRateLabel)} |`,
+      `| ${solver} | DRC issues | ${mainDrcIssues ?? "n/a"} | ${prDrcIssues ?? "n/a"} | ${formatCountDelta(mainDrcIssues, prDrcIssues)} |`,
       `| ${solver} | Timeouts | ${mainTimeouts ?? "n/a"} | ${prTimeouts ?? "n/a"} | ${formatCountDelta(mainTimeouts, prTimeouts)} |`,
     )
     for (const percentile of [50, 60, 70, 80, 90, 95]) {
@@ -154,6 +173,6 @@ export const renderBenchmarkComparison = ({
     "| --- | --- | ---: | ---: | ---: |",
     ...rows,
     "",
-    "_Timing percentiles include solved and timed-out samples. Negative timing changes are faster._",
+    "_DRC issues are totaled across solved samples. Timing percentiles include solved and timed-out samples; negative timing changes are faster._",
   ]
 }

--- a/scripts/benchmark/same-machine-results.ts
+++ b/scripts/benchmark/same-machine-results.ts
@@ -53,6 +53,37 @@ const formatRelativeDelta = (
   return formatSigned(((prValue - mainValue) / mainValue) * 100, "%")
 }
 
+const formatCountDelta = (
+  mainValue: number | null,
+  prValue: number | null,
+): string => {
+  if (mainValue === null || prValue === null) return "n/a"
+  const delta = prValue - mainValue
+  return `${delta > 0 ? "+" : ""}${delta}`
+}
+
+const getDrcIssueCount = (
+  report: BenchmarkReport,
+  solverName: string,
+): number | null => {
+  const solvedTests = report.tests.filter(
+    (test) => test.solverName === solverName && test.didSolve,
+  )
+  if (solvedTests.length === 0) return null
+  let drcIssueCount = 0
+  for (const test of solvedTests) {
+    if (
+      typeof test.drcErrorCount !== "number" ||
+      !Number.isInteger(test.drcErrorCount) ||
+      test.drcErrorCount < 0
+    ) {
+      return null
+    }
+    drcIssueCount += test.drcErrorCount
+  }
+  return drcIssueCount
+}
+
 const getTimePercentile = (
   report: BenchmarkReport,
   solverName: string,
@@ -165,6 +196,8 @@ export const renderSameMachineBenchmarkResults = ({
     const prTimeouts = prReport.tests.filter(
       (test) => test.solverName === prSummary.solverName && test.didTimeout,
     ).length
+    const mainDrcIssues = getDrcIssueCount(mainReport, prSummary.solverName)
+    const prDrcIssues = getDrcIssueCount(prReport, prSummary.solverName)
     const timePercentiles = [50, 60, 70, 80, 90, 95].map((percentile) => {
       const mainTime = getTimePercentile(
         mainReport,
@@ -182,6 +215,7 @@ export const renderSameMachineBenchmarkResults = ({
     lines.push(
       `| ${solver} | Completion | ${mainSummary.completedRateLabel} | ${prSummary.completedRateLabel} | ${formatPercentPointDelta(mainSummary.completedRateLabel, prSummary.completedRateLabel)} |`,
       `| ${solver} | Relaxed DRC pass | ${mainSummary.relaxedDrcRateLabel} | ${prSummary.relaxedDrcRateLabel} | ${formatPercentPointDelta(mainSummary.relaxedDrcRateLabel, prSummary.relaxedDrcRateLabel)} |`,
+      `| ${solver} | DRC issues | ${mainDrcIssues ?? "n/a"} | ${prDrcIssues ?? "n/a"} | ${formatCountDelta(mainDrcIssues, prDrcIssues)} |`,
       `| ${solver} | Timeouts | ${mainTimeouts} | ${prTimeouts} | ${prTimeouts - mainTimeouts > 0 ? "+" : ""}${prTimeouts - mainTimeouts} |`,
       ...timePercentiles,
       `| ${solver} | Average vias | ${formatAverage(mainSummary.avgVia)} | ${formatAverage(prSummary.avgVia)} | ${formatRelativeDelta(mainSummary.avgVia, prSummary.avgVia)} |`,
@@ -194,7 +228,7 @@ export const renderSameMachineBenchmarkResults = ({
   const regressionCount = changedOutcomes.length - improvementCount
   lines.push(
     "",
-    `Outcome changes: **${improvementCount} improved**, **${regressionCount} regressed**. Timing percentiles include solved and timed-out samples; negative timing deltas are faster.`,
+    `Outcome changes: **${improvementCount} improved**, **${regressionCount} regressed**. DRC issues are totaled across solved samples. Timing percentiles include solved and timed-out samples; negative timing deltas are faster.`,
   )
 
   if (changedOutcomes.length > 0) {

--- a/tests/benchmark-comment-comparison.test.ts
+++ b/tests/benchmark-comment-comparison.test.ts
@@ -41,7 +41,7 @@ test("PR benchmark comments render one main-versus-PR comparison table", () => {
       {
         solverName,
         completedRateLabel: "50.0% (🕒50.0%)",
-        relaxedDrcRateLabel: "50.0% (🕒50.0%)",
+        relaxedDrcRateLabel: "0.0% (🕒50.0%)",
         timedOutLabel: "1/2",
         p50TimeMs: 1_000,
         p95TimeMs: 1_000,
@@ -49,7 +49,10 @@ test("PR benchmark comments render one main-versus-PR comparison table", () => {
       },
     ],
     [
-      makeTest(1, 1_000),
+      makeTest(1, 1_000, {
+        relaxedDrcPassed: false,
+        drcErrorCount: 3,
+      }),
       makeTest(2, 2_000, {
         didSolve: false,
         didTimeout: true,
@@ -62,14 +65,20 @@ test("PR benchmark comments render one main-versus-PR comparison table", () => {
       {
         solverName,
         completedRateLabel: "100.0%",
-        relaxedDrcRateLabel: "100.0%",
+        relaxedDrcRateLabel: "50.0%",
         timedOutLabel: "0/2",
         p50TimeMs: 1_350,
         p95TimeMs: 1_755,
         avgVia: 2.2,
       },
     ],
-    [makeTest(1, 900), makeTest(2, 1_800)],
+    [
+      makeTest(1, 900, { drcErrorCount: 0 }),
+      makeTest(2, 1_800, {
+        relaxedDrcPassed: false,
+        drcErrorCount: 1,
+      }),
+    ],
   )
 
   expect(
@@ -79,7 +88,8 @@ test("PR benchmark comments render one main-versus-PR comparison table", () => {
 | Solver | Metric | Main | PR | Change |
 | --- | --- | ---: | ---: | ---: |
 | Pipeline7 | Completion | 50.0% (🕒50.0%) | 100.0% | +50.0 pp |
-| Pipeline7 | Relaxed DRC pass | 50.0% (🕒50.0%) | 100.0% | +50.0 pp |
+| Pipeline7 | Relaxed DRC pass | 0.0% (🕒50.0%) | 50.0% | +50.0 pp |
+| Pipeline7 | DRC issues | 3 | 1 | -2 |
 | Pipeline7 | Timeouts | 1 | 0 | -1 |
 | Pipeline7 | P50 time | 1.5s | 1.4s | -10.0% |
 | Pipeline7 | P60 time | 1.6s | 1.4s | -10.0% |
@@ -89,5 +99,5 @@ test("PR benchmark comments render one main-versus-PR comparison table", () => {
 | Pipeline7 | P95 time | 1.9s | 1.8s | -10.0% |
 | Pipeline7 | Average vias | 2.00 | 2.20 | +10.0% |
 
-_Timing percentiles include solved and timed-out samples. Negative timing changes are faster._`)
+_DRC issues are totaled across solved samples. Timing percentiles include solved and timed-out samples; negative timing changes are faster._`)
 })

--- a/tests/same-machine-benchmark-results.test.ts
+++ b/tests/same-machine-benchmark-results.test.ts
@@ -40,7 +40,7 @@ test("same-machine benchmark comments compare matching reports", () => {
       {
         solverName,
         completedRateLabel: "50.0% (🕒50.0%)",
-        relaxedDrcRateLabel: "50.0% (🕒50.0%)",
+        relaxedDrcRateLabel: "0.0% (🕒50.0%)",
         timedOutLabel: "1/2",
         p50TimeMs: 1_000,
         p95TimeMs: 2_000,
@@ -54,7 +54,10 @@ test("same-machine benchmark comments compare matching reports", () => {
         relaxedDrcPassed: false,
         elapsedTimeMs: 2_000,
       }),
-      makeTest(2, {}),
+      makeTest(2, {
+        relaxedDrcPassed: false,
+        drcErrorCount: 3,
+      }),
     ],
   })
   const prReport = makeReport({
@@ -62,14 +65,20 @@ test("same-machine benchmark comments compare matching reports", () => {
       {
         solverName,
         completedRateLabel: "100.0% (🕒0.0%)",
-        relaxedDrcRateLabel: "100.0% (🕒0.0%)",
+        relaxedDrcRateLabel: "50.0% (🕒0.0%)",
         timedOutLabel: "0/2",
         p50TimeMs: 900,
         p95TimeMs: 1_800,
         avgVia: 2.2,
       },
     ],
-    tests: [makeTest(1, { elapsedTimeMs: 1_800 }), makeTest(2, {})],
+    tests: [
+      makeTest(1, { elapsedTimeMs: 1_800, drcErrorCount: 0 }),
+      makeTest(2, {
+        relaxedDrcPassed: false,
+        drcErrorCount: 1,
+      }),
+    ],
   })
 
   const markdown = renderSameMachineBenchmarkResults({
@@ -88,6 +97,7 @@ test("same-machine benchmark comments compare matching reports", () => {
   expect(markdown).toContain(
     "| Pipeline7 | Completion | 50.0% (🕒50.0%) | 100.0% (🕒0.0%) | +50.0 pp |",
   )
+  expect(markdown).toContain("| Pipeline7 | DRC issues | 3 | 1 | -2 |")
   expect(markdown).toContain("| Pipeline7 | Timeouts | 1 | 0 | -1 |")
   expect(markdown).toContain("| Pipeline7 | P50 time | 1.5s | 1.4s | -6.7% |")
   expect(markdown).toContain("| Pipeline7 | P60 time |")


### PR DESCRIPTION
## Summary

- add total DRC issue counts to regular PR benchmark comparison comments
- add the same DRC issue stat to same-machine benchmark comments
- show `n/a` when solved samples do not contain complete DRC count data

## Testing

- `bun test tests/*benchmark*.test.ts tests/same-machine-benchmark-results.test.ts --timeout 9999999`
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`
