### PR TITLE
Validate max via counts per source connection

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -875,9 +875,14 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
       const traces = this.powerTraceExpansionSolver
         ? this.powerTraceExpansionSolver.getOutput()
         : this.getPrePowerTraceOutputSimplifiedPcbTraces()
+      if (!this.srjWithPointPairs) {
+        throw new Error(
+          "Pipeline7 cannot evaluate maxViaCount before point-pair routing",
+        )
+      }
       const viaCountViolation = getMaxViaCountViolation({
         connections: this.originalSrj.connections,
-        routedConnections: this.srjWithPointPairs?.connections,
+        routedConnections: this.srjWithPointPairs.connections,
         traces,
       })
       if (viaCountViolation) {

--- a/lib/solvers/NetToPointPairsSolver/NetToPointPairsSolver.ts
+++ b/lib/solvers/NetToPointPairsSolver/NetToPointPairsSolver.ts
@@ -84,6 +84,8 @@ export class NetToPointPairsSolver extends BaseSolver {
         ],
         __netConnectionName: connection.__netConnectionName,
         maxViaCount: connection.maxViaCount,
+        maxViaCountByRootConnectionName:
+          connection.maxViaCountByRootConnectionName,
       })
     }
   }

--- a/lib/solvers/NetToPointPairsSolver/mergeConnections.ts
+++ b/lib/solvers/NetToPointPairsSolver/mergeConnections.ts
@@ -89,7 +89,7 @@ export function mergeConnections(
     const mergedExternallyConnectedPointIds: PointId[][] = []
     const mergedNetConnectionNames: Set<string> = new Set()
     let nominalTraceWidth: number | undefined = undefined
-    let maxViaCount: number | undefined = undefined
+    const maxViaCountByRootConnectionName: Record<string, number> = {}
 
     simpleRouteConnectionGroup.forEach((simpleRouteConnection) => {
       // Collect unique points
@@ -101,12 +101,11 @@ export function mergeConnections(
       )
 
       const rootConnectionNames = simpleRouteConnection.__rootConnectionNames
-      if (rootConnectionNames && rootConnectionNames.length > 0) {
-        for (const rootConnectionName of rootConnectionNames) {
-          mergedRootConnectionNames.add(rootConnectionName)
-        }
-      } else {
-        mergedRootConnectionNames.add(simpleRouteConnection.name)
+        ?.length
+        ? simpleRouteConnection.__rootConnectionNames
+        : [simpleRouteConnection.name]
+      for (const rootConnectionName of rootConnectionNames) {
+        mergedRootConnectionNames.add(rootConnectionName)
       }
 
       // Merge isOffBoard property
@@ -135,13 +134,28 @@ export function mergeConnections(
         nominalTraceWidth = simpleRouteConnection.nominalTraceWidth
       }
 
-      if (simpleRouteConnection.maxViaCount !== undefined) {
-        maxViaCount = Math.min(
-          maxViaCount ?? Number.POSITIVE_INFINITY,
-          simpleRouteConnection.maxViaCount,
+      for (const [rootConnectionName, maxViaCount] of Object.entries(
+        simpleRouteConnection.maxViaCountByRootConnectionName ?? {},
+      )) {
+        maxViaCountByRootConnectionName[rootConnectionName] = Math.min(
+          maxViaCountByRootConnectionName[rootConnectionName] ??
+            Number.POSITIVE_INFINITY,
+          maxViaCount,
         )
       }
+
+      if (simpleRouteConnection.maxViaCount !== undefined) {
+        for (const rootConnectionName of rootConnectionNames) {
+          maxViaCountByRootConnectionName[rootConnectionName] = Math.min(
+            maxViaCountByRootConnectionName[rootConnectionName] ??
+              Number.POSITIVE_INFINITY,
+            simpleRouteConnection.maxViaCount,
+          )
+        }
+      }
     })
+
+    const [onlyRootConnectionName] = mergedRootConnectionNames
 
     // Create the new merged SimpleRouteConnection
     const newSimpleRouteConnection: SimpleRouteConnection = {
@@ -161,7 +175,14 @@ export function mergeConnections(
           : undefined,
       __rootConnectionNames: Array.from(mergedRootConnectionNames),
       nominalTraceWidth: nominalTraceWidth, // Keep the first found nominalTraceWidth
-      maxViaCount,
+      maxViaCount:
+        mergedRootConnectionNames.size === 1 && onlyRootConnectionName
+          ? maxViaCountByRootConnectionName[onlyRootConnectionName]
+          : undefined,
+      maxViaCountByRootConnectionName:
+        Object.keys(maxViaCountByRootConnectionName).length > 0
+          ? maxViaCountByRootConnectionName
+          : undefined,
     }
 
     mergedSimpleRouteConnections.push(newSimpleRouteConnection)

--- a/lib/solvers/NetToPointPairsSolver2_OffBoardConnection/NetToPointPairsSolver2_OffBoardConnection.ts
+++ b/lib/solvers/NetToPointPairsSolver2_OffBoardConnection/NetToPointPairsSolver2_OffBoardConnection.ts
@@ -177,6 +177,8 @@ export class NetToPointPairsSolver2_OffBoardConnection extends NetToPointPairsSo
         ],
         __netConnectionName: currentConnection.__netConnectionName,
         maxViaCount: currentConnection.maxViaCount,
+        maxViaCountByRootConnectionName:
+          currentConnection.maxViaCountByRootConnectionName,
       })
     }
   }

--- a/lib/types/srj-types.ts
+++ b/lib/types/srj-types.ts
@@ -140,8 +140,10 @@ export interface SimpleRouteConnection {
   netConnectionName?: string
   __netConnectionName?: string
   nominalTraceWidth?: number
-  /** Maximum number of vias permitted across this routed connection. */
+  /** Maximum vias permitted on the routed path connecting this connection's points. */
   maxViaCount?: number
+  /** @internal Original-connection via limits retained after connections merge. */
+  maxViaCountByRootConnectionName?: Record<string, number>
   pointsToConnect: Array<ConnectionPoint>
 
   /** @deprecated DO NOT USE **/

--- a/lib/utils/get-max-via-count-violation.ts
+++ b/lib/utils/get-max-via-count-violation.ts
@@ -1,4 +1,9 @@
-import type { SimpleRouteConnection, SimplifiedPcbTraces } from "lib/types"
+import type {
+  PointKey,
+  SimpleRouteConnection,
+  SimplifiedPcbTraces,
+} from "lib/types"
+import { getPointKey } from "lib/utils/getPointKey"
 
 export interface MaxViaCountViolation {
   connectionName: string
@@ -6,41 +11,221 @@ export interface MaxViaCountViolation {
   maxViaCount: number
 }
 
-/** Return the first routed connection that exceeds its declared via limit. */
+interface RouteGraphEdge {
+  edgeId: string
+  from: PointKey
+  to: PointKey
+  viaCount: number
+  rootConnectionNames: readonly string[]
+}
+
+interface RouteGraphNeighbor {
+  edgeId: string
+  point: PointKey
+  viaCount: number
+}
+
+const buildRouteGraphEdges = ({
+  constrainedConnectionNames,
+  routedConnections,
+  traces,
+}: {
+  constrainedConnectionNames: ReadonlySet<string>
+  routedConnections: readonly SimpleRouteConnection[]
+  traces: SimplifiedPcbTraces
+}): RouteGraphEdge[] => {
+  const viaCountByRoutedConnectionName = new Map<string, number>()
+
+  for (const trace of traces) {
+    const routedConnection = routedConnections
+      .filter((candidate) =>
+        trace.pcb_trace_id.startsWith(`${candidate.name}_`),
+      )
+      .sort((a, b) => b.name.length - a.name.length)[0]
+    if (!routedConnection) continue
+
+    const traceViaCount = trace.route.filter(
+      (routePoint) => routePoint.route_type === "via",
+    ).length
+    viaCountByRoutedConnectionName.set(
+      routedConnection.name,
+      (viaCountByRoutedConnectionName.get(routedConnection.name) ?? 0) +
+        traceViaCount,
+    )
+  }
+
+  const edges: RouteGraphEdge[] = []
+  for (const routedConnection of routedConnections) {
+    const rootConnectionNames = routedConnection.__rootConnectionNames ?? [
+      routedConnection.name,
+    ]
+    if (
+      !rootConnectionNames.some((connectionName) =>
+        constrainedConnectionNames.has(connectionName),
+      )
+    )
+      continue
+    if (routedConnection.pointsToConnect.length !== 2) {
+      throw new Error(
+        `Cannot evaluate maxViaCount: routed connection "${routedConnection.name}" has ${routedConnection.pointsToConnect.length} points`,
+      )
+    }
+    if (!viaCountByRoutedConnectionName.has(routedConnection.name)) {
+      throw new Error(
+        `Cannot evaluate maxViaCount: routed connection "${routedConnection.name}" has no output trace`,
+      )
+    }
+
+    const [from, to] = routedConnection.pointsToConnect
+    edges.push({
+      edgeId: routedConnection.name,
+      from: getPointKey(from),
+      to: getPointKey(to),
+      viaCount: viaCountByRoutedConnectionName.get(routedConnection.name) ?? 0,
+      rootConnectionNames,
+    })
+  }
+
+  return edges
+}
+
+const getShortestPathEdgeIds = ({
+  adjacency,
+  connectionName,
+  from,
+  to,
+}: {
+  adjacency: ReadonlyMap<PointKey, readonly RouteGraphNeighbor[]>
+  connectionName: string
+  from: PointKey
+  to: PointKey
+}): string[] => {
+  const distances = new Map<PointKey, number>([[from, 0]])
+  const previous = new Map<PointKey, { edgeId: string; point: PointKey }>()
+  const unvisited = new Set(adjacency.keys())
+
+  while (unvisited.size > 0) {
+    let currentPointKey: PointKey | undefined
+    let currentDistance = Number.POSITIVE_INFINITY
+    for (const pointKey of unvisited) {
+      const distance = distances.get(pointKey) ?? Number.POSITIVE_INFINITY
+      if (distance >= currentDistance) continue
+      currentPointKey = pointKey
+      currentDistance = distance
+    }
+    if (currentPointKey === undefined || currentPointKey === to) break
+
+    unvisited.delete(currentPointKey)
+    for (const neighbor of adjacency.get(currentPointKey) ?? []) {
+      if (!unvisited.has(neighbor.point)) continue
+      const nextDistance = currentDistance + neighbor.viaCount
+      if (
+        nextDistance >=
+        (distances.get(neighbor.point) ?? Number.POSITIVE_INFINITY)
+      )
+        continue
+      distances.set(neighbor.point, nextDistance)
+      previous.set(neighbor.point, {
+        edgeId: neighbor.edgeId,
+        point: currentPointKey,
+      })
+    }
+  }
+
+  if (!distances.has(to)) {
+    throw new Error(
+      `Cannot evaluate maxViaCount for connection "${connectionName}": routed output does not connect all original points`,
+    )
+  }
+
+  const edgeIds: string[] = []
+  let currentPointKey = to
+  while (currentPointKey !== from) {
+    const precedingStep = previous.get(currentPointKey)
+    if (!precedingStep) {
+      throw new Error(
+        `Cannot evaluate maxViaCount for connection "${connectionName}": routed path metadata is incomplete`,
+      )
+    }
+    edgeIds.push(precedingStep.edgeId)
+    currentPointKey = precedingStep.point
+  }
+
+  return edgeIds
+}
+
+const getViaCountForOriginalConnection = ({
+  connection,
+  routeGraphEdges,
+}: {
+  connection: SimpleRouteConnection
+  routeGraphEdges: readonly RouteGraphEdge[]
+}): number => {
+  const terminalPointKeys = Array.from(
+    new Set(connection.pointsToConnect.map((point) => getPointKey(point))),
+  )
+  if (terminalPointKeys.length <= 1) return 0
+
+  const adjacency = new Map<PointKey, RouteGraphNeighbor[]>()
+  const connectionEdges = routeGraphEdges.filter((edge) =>
+    edge.rootConnectionNames.includes(connection.name),
+  )
+  for (const edge of connectionEdges) {
+    adjacency.set(edge.from, [
+      ...(adjacency.get(edge.from) ?? []),
+      { edgeId: edge.edgeId, point: edge.to, viaCount: edge.viaCount },
+    ])
+    adjacency.set(edge.to, [
+      ...(adjacency.get(edge.to) ?? []),
+      { edgeId: edge.edgeId, point: edge.from, viaCount: edge.viaCount },
+    ])
+  }
+
+  const usedEdgeIds = new Set<string>()
+  const firstTerminalPointKey = terminalPointKeys[0]!
+  for (const targetPointKey of terminalPointKeys.slice(1)) {
+    for (const edgeId of getShortestPathEdgeIds({
+      adjacency,
+      connectionName: connection.name,
+      from: firstTerminalPointKey,
+      to: targetPointKey,
+    })) {
+      usedEdgeIds.add(edgeId)
+    }
+  }
+
+  return connectionEdges
+    .filter((edge) => usedEdgeIds.has(edge.edgeId))
+    .reduce((total, edge) => total + edge.viaCount, 0)
+}
+
+/** Return the first original connection whose routed path exceeds its via limit. */
 export const getMaxViaCountViolation = ({
   connections,
   routedConnections,
   traces,
 }: {
   connections: readonly SimpleRouteConnection[]
-  routedConnections?: readonly SimpleRouteConnection[]
+  routedConnections: readonly SimpleRouteConnection[]
   traces: SimplifiedPcbTraces
 }): MaxViaCountViolation | null => {
-  const viaCountByConnectionName = new Map<string, number>()
-  for (const trace of traces) {
-    const traceViaCount = trace.route.filter(
-      (routePoint) => routePoint.route_type === "via",
-    ).length
-    const routedConnection = routedConnections
-      ?.filter((connection) =>
-        trace.pcb_trace_id.startsWith(`${connection.name}_`),
-      )
-      .sort((a, b) => b.name.length - a.name.length)[0]
-    const rootConnectionNames = routedConnection?.__rootConnectionNames ?? [
-      trace.connection_name,
-    ]
-
-    for (const connectionName of rootConnectionNames) {
-      viaCountByConnectionName.set(
-        connectionName,
-        (viaCountByConnectionName.get(connectionName) ?? 0) + traceViaCount,
-      )
-    }
-  }
+  const constrainedConnectionNames = new Set(
+    connections
+      .filter((connection) => connection.maxViaCount !== undefined)
+      .map((connection) => connection.name),
+  )
+  const routeGraphEdges = buildRouteGraphEdges({
+    constrainedConnectionNames,
+    routedConnections,
+    traces,
+  })
 
   for (const connection of connections) {
     if (connection.maxViaCount === undefined) continue
-    const actualViaCount = viaCountByConnectionName.get(connection.name) ?? 0
+    const actualViaCount = getViaCountForOriginalConnection({
+      connection,
+      routeGraphEdges,
+    })
     if (actualViaCount <= connection.maxViaCount) continue
 
     return {

--- a/tests/get-max-via-count-per-trace.test.ts
+++ b/tests/get-max-via-count-per-trace.test.ts
@@ -2,10 +2,10 @@ import { expect, test } from "bun:test"
 import type { SimpleRouteConnection, SimplifiedPcbTraces } from "lib/types"
 import { getMaxViaCountViolation } from "lib/utils/get-max-via-count-violation"
 
-test("detects a via violation on a merged root connection", () => {
+test("a via on an adjacent merged branch does not count against the original trace", () => {
   const connections: SimpleRouteConnection[] = [
     {
-      name: "XTAL_OUT",
+      name: "NO_VIAS",
       maxViaCount: 0,
       pointsToConnect: [
         { x: 0, y: 0, layer: "top", pointId: "A" },
@@ -13,68 +13,61 @@ test("detects a via violation on a merged root connection", () => {
       ],
     },
     {
-      name: "XTAL_LOAD_OUT",
-      maxViaCount: 0,
+      name: "ONE_VIA_ALLOWED",
+      maxViaCount: 1,
       pointsToConnect: [
         { x: 1, y: 0, layer: "top", pointId: "J" },
-        { x: 2, y: 0, layer: "top", pointId: "B" },
+        { x: 2, y: 0, layer: "bottom", pointId: "B" },
       ],
     },
   ]
   const routedConnections: SimpleRouteConnection[] = [
     {
-      name: "XTAL_OUT__XTAL_LOAD_OUT_mst0",
-      __rootConnectionNames: ["XTAL_OUT", "XTAL_LOAD_OUT"],
+      name: "NO_VIAS__ONE_VIA_ALLOWED_mst0",
+      __rootConnectionNames: ["NO_VIAS", "ONE_VIA_ALLOWED"],
       pointsToConnect: [
         { x: 0, y: 0, layer: "top", pointId: "A" },
         { x: 1, y: 0, layer: "top", pointId: "J" },
       ],
     },
     {
-      name: "XTAL_OUT__XTAL_LOAD_OUT_mst1",
-      __rootConnectionNames: ["XTAL_OUT", "XTAL_LOAD_OUT"],
+      name: "NO_VIAS__ONE_VIA_ALLOWED_mst1",
+      __rootConnectionNames: ["NO_VIAS", "ONE_VIA_ALLOWED"],
       pointsToConnect: [
         { x: 1, y: 0, layer: "top", pointId: "J" },
-        { x: 2, y: 0, layer: "top", pointId: "B" },
+        { x: 2, y: 0, layer: "bottom", pointId: "B" },
       ],
     },
   ]
   const traces: SimplifiedPcbTraces = [
     {
       type: "pcb_trace",
-      pcb_trace_id: "XTAL_OUT__XTAL_LOAD_OUT_mst0_0",
-      connection_name: "XTAL_OUT",
+      pcb_trace_id: "NO_VIAS__ONE_VIA_ALLOWED_mst0_0",
+      connection_name: "NO_VIAS",
       route: [
         { route_type: "wire", x: 0, y: 0, width: 0.1, layer: "top" },
-        {
-          route_type: "via",
-          x: 1,
-          y: 0,
-          from_layer: "top",
-          to_layer: "bottom",
-        },
+        { route_type: "wire", x: 1, y: 0, width: 0.1, layer: "top" },
       ],
     },
     {
       type: "pcb_trace",
-      pcb_trace_id: "XTAL_OUT__XTAL_LOAD_OUT_mst1_0",
-      connection_name: "XTAL_OUT",
+      pcb_trace_id: "NO_VIAS__ONE_VIA_ALLOWED_mst1_0",
+      connection_name: "NO_VIAS",
       route: [
         { route_type: "wire", x: 1, y: 0, width: 0.1, layer: "top" },
-        { route_type: "wire", x: 2, y: 0, width: 0.1, layer: "top" },
+        {
+          route_type: "via",
+          x: 1.5,
+          y: 0,
+          from_layer: "top",
+          to_layer: "bottom",
+        },
+        { route_type: "wire", x: 2, y: 0, width: 0.1, layer: "bottom" },
       ],
     },
   ]
 
   expect(
-    getMaxViaCountViolation({
-      connections,
-      routedConnections,
-      traces,
-    }),
-  ).toEqual({
-    connectionName: "XTAL_OUT",
-    actualViaCount: 1,
-    maxViaCount: 0,
-  })
+    getMaxViaCountViolation({ connections, routedConnections, traces }),
+  ).toBeNull()
 })

--- a/tests/merge-connections-max-via-count.test.ts
+++ b/tests/merge-connections-max-via-count.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test"
 import { mergeConnections } from "lib/solvers/NetToPointPairsSolver/mergeConnections"
 
-test("merged connections keep the strictest via limit", () => {
+test("merged connections retain each original via limit", () => {
   const [mergedConnection] = mergeConnections([
     {
       name: "XTAL_OUT",
@@ -21,5 +21,9 @@ test("merged connections keep the strictest via limit", () => {
     },
   ])
 
-  expect(mergedConnection?.maxViaCount).toBe(0)
+  expect(mergedConnection?.maxViaCount).toBeUndefined()
+  expect(mergedConnection?.maxViaCountByRootConnectionName).toEqual({
+    XTAL_OUT: 2,
+    XTAL_LOAD_OUT: 0,
+  })
 })

--- a/tests/pipeline7-max-via-count.test.ts
+++ b/tests/pipeline7-max-via-count.test.ts
@@ -19,10 +19,11 @@ test("Pipeline7 fails when a routed connection exceeds maxViaCount", () => {
     ],
   })
   solver.pipelineDef = []
+  solver.srjWithPointPairs = structuredClone(solver.srj)
   solver.getPrePowerTraceOutputSimplifiedPcbTraces = () => [
     {
       type: "pcb_trace",
-      pcb_trace_id: "pcb_trace_xtal_in",
+      pcb_trace_id: "XTAL_IN_0",
       connection_name: "XTAL_IN",
       route: [
         { route_type: "wire", x: 1, y: 1, width: 0.15, layer: "top" },


### PR DESCRIPTION
## Summary
- preserve maximum-via constraints by original root when point-sharing connections merge
- reconstruct the routed point-pair graph and count vias only on the path connecting each original connection endpoints
- keep the existing single-root reroute behavior while allowing adjacent merged branches to use their own via budgets

## Why this is stacked
This PR builds on #2175, which introduces maxViaCount propagation and final Pipeline 7 validation. Keeping this follow-up separate makes the change from conservative net-wide enforcement to per-source-connection semantics reviewable on its own.

## Validation
- 8 affected tests pass
- bunx tsc --noEmit
- bun run build
- bun run format:check
- git diff --check

## Scope
This makes final validation path-aware. It does not yet bias the routing search toward a compliant alternative; Pipeline 7 still fails clearly when its completed route exceeds a connection budget.