### PR TITLE
ci: publish to npm with OIDC

### DIFF
--- a/.github/workflows/bun-pver-release.yml
+++ b/.github/workflows/bun-pver-release.yml
@@ -7,6 +7,11 @@ on:
       - '!version-bumps/**'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: write
+
 env:
   UPSTREAM_REPOS: "" # comma-separated list, e.g. "eval,tscircuit,docs"
   UPSTREAM_PACKAGES_TO_UPDATE: "" # comma-separated list, e.g. "@tscircuit/core,@tscircuit/protos"
@@ -20,16 +25,16 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org/
+          package-manager-cache: false
       - run: npm install -g pver
       - run: bun install --frozen-lockfile
       - run: bun run build
       - run: pver release --no-push-main
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.TSCIRCUIT_BOT_GITHUB_TOKEN }}
 
       - name: Get package version

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "main": "./dist/index.js",
   "version": "0.0.822",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tscircuit/tscircuit-autorouter"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## Summary

- grant the release workflow GitHub OIDC token permission
- move the publish job to Node 24 and setup-node v6 so npm supports trusted publishing
- remove the long-lived NPM_TOKEN from the publish step
- add repository metadata required by npm trusted publishing

## npm configuration required

Configure the trusted publisher for @tscircuit/capacity-autorouter with:

- Provider: GitHub Actions
- Repository: tscircuit/tscircuit-autorouter
- Workflow: bun-pver-release.yml
- Allowed action: npm publish

## Validation

- workflow YAML parse
- bun run build
- npm pack --dry-run --json
- git diff --check

This matches the working OIDC release setup in tscircuit/core and tscircuit/footprinter.