### PR TITLE
Fix Pipeline9 redundant vias in rerouted preloads

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph.ts
@@ -81,6 +81,7 @@ import { Pipeline9HighDensitySolver } from "./pipeline9-high-density-solver"
 import { Pipeline9JointDrcRepairSolver } from "./pipeline9-joint-drc-repair-solver"
 import { PreloadedTraceGraphSolver } from "./preloaded-trace-graph-solver"
 import { PreprocessSimpleRouteJsonWithoutTraceObstaclesSolver } from "./preprocess-simple-route-json-without-trace-obstacles-solver"
+import { removeUselessViasFromMutatedPreloadedTraces } from "./remove-useless-vias-from-mutated-preloaded-traces"
 import { MergedComponentTopologyView } from "../AutoroutingPipeline7_MultiGraph/MergedComponentTopologyView"
 import { PowerTraceExpansionSolver } from "../AutoroutingPipeline7_MultiGraph/PowerTraceExpansionSolver"
 import { convertPipeline7HdRoutesToSimplifiedPcbTraces } from "../AutoroutingPipeline7_MultiGraph/convertPipeline7HdRoutesToSimplifiedPcbTraces"
@@ -284,6 +285,9 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
   /** Available segment points after non-component cramped points are filtered. */
   sharedEdgeSegmentsWithNecessaryCrampedPortPoints?: SharedEdgeSegment[]
   highDensityNodePortPoints?: NodeWithPortPoints[]
+  private preloadedTraceUpdatesAfterHighDensity?: ReturnType<
+    typeof applyFixedRouteReplacementsToPreloadedTraces
+  >
 
   cacheProvider: CacheProvider | null = null
   pipelineDef = [
@@ -1281,6 +1285,10 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
   private getPreloadedTraceUpdatesAfterHighDensity(): ReturnType<
     typeof applyFixedRouteReplacementsToPreloadedTraces
   > {
+    const canCacheUpdates = this.highDensityStitchSolver?.solved === true
+    if (canCacheUpdates && this.preloadedTraceUpdatesAfterHighDensity) {
+      return this.preloadedTraceUpdatesAfterHighDensity
+    }
     const originalFixedRoutes = this.getOriginalFixedHdRoutes()
     const changedSections = this.getChangedPreloadedTraceSections()
     const fixedRoutesWithoutChangedSections =
@@ -1320,7 +1328,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
       ...materializedOriginalRouteNames,
     ])
 
-    return applyFixedRouteReplacementsToPreloadedTraces({
+    const rawUpdates = applyFixedRouteReplacementsToPreloadedTraces({
       originalTraces: this.originalSrj.traces ?? [],
       originalFixedRoutes,
       updatedFixedRoutes,
@@ -1330,6 +1338,28 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
       obstacles: this.originalSrj.obstacles,
       connMap: this.connMap,
     })
+    const cleanedUpdates = removeUselessViasFromMutatedPreloadedTraces({
+      updates: rawUpdates,
+      originalTraces: this.originalSrj.traces ?? [],
+      otherHdRoutes: this.highDensityStitchSolver?.mergedHdRoutes ?? [],
+      collisionObstacles: this.srj.obstacles,
+      routeConversionObstacles: this.originalSrj.obstacles,
+      colorMap: this.colorMap,
+      connMap: this.connMap,
+      outline: this.originalSrj.outline,
+      layerCount: this.originalSrj.layerCount,
+      defaultViaDiameter: this.viaDiameter,
+      defaultViaHoleDiameter: this.viaHoleDiameter,
+      traceClearance: 0.1,
+      obstacleClearance:
+        this.originalSrj.minTraceToPadEdgeClearance ??
+        this.originalSrj.defaultObstacleMargin ??
+        0.15,
+    })
+    if (canCacheUpdates) {
+      this.preloadedTraceUpdatesAfterHighDensity = cleanedUpdates
+    }
+    return cleanedUpdates
   }
 
   private getSrjWithMaterializedPreloadedTraces(): SimpleRouteJson {

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/remove-useless-vias-from-mutated-preloaded-traces.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/remove-useless-vias-from-mutated-preloaded-traces.ts
@@ -238,6 +238,8 @@ export const removeUselessViasFromMutatedPreloadedTraces = ({
     outline: outline ? [...outline] : undefined,
     layerMoveTraceMargin: traceClearance,
     layerMoveObstacleMargin: obstacleClearance,
+    includeCopperRadiusInBroadPhase: true,
+    protectMarkedTransitions: true,
     enableGeometryShortcuts: false,
     enableObstacleDetourShortcuts: false,
   })

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/remove-useless-vias-from-mutated-preloaded-traces.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/remove-useless-vias-from-mutated-preloaded-traces.ts
@@ -1,0 +1,295 @@
+import type { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { UselessViaRemovalSolver } from "lib/solvers/UselessViaRemovalSolver/UselessViaRemovalSolver"
+import type { Obstacle, SimplifiedPcbTrace } from "lib/types"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+import { convertHdRouteToSimplifiedRoute } from "lib/utils/convertHdRouteToSimplifiedRoute"
+import { mapLayerNameToZ } from "lib/utils/mapLayerNameToZ"
+import { convertPreloadedTraceToHdRoutes } from "./convert-preloaded-traces-to-hd-routes"
+
+type PreloadedTraceUpdates = {
+  updatedPreloadedTraces: SimplifiedPcbTrace[]
+  mutatedPreloadedTraces: SimplifiedPcbTrace[]
+}
+
+type MutableTraceRoute = {
+  trace: SimplifiedPcbTrace
+  hdRoute: HighDensityRoute
+}
+
+const POINT_EPSILON = 1e-9
+
+const pointsAreEqual = (
+  left: HighDensityRoute["route"][number],
+  right: HighDensityRoute["route"][number],
+) =>
+  Math.abs(left.x - right.x) <= POINT_EPSILON &&
+  Math.abs(left.y - right.y) <= POINT_EPSILON &&
+  left.z === right.z
+
+const pointsHaveSamePosition = (
+  left: HighDensityRoute["route"][number],
+  right: HighDensityRoute["route"][number],
+) =>
+  Math.abs(left.x - right.x) <= POINT_EPSILON &&
+  Math.abs(left.y - right.y) <= POINT_EPSILON
+
+const appendConnectedRoute = (
+  combinedPoints: HighDensityRoute["route"],
+  route: HighDensityRoute,
+) => {
+  if (combinedPoints.length === 0) {
+    combinedPoints.push(...route.route)
+    return
+  }
+
+  const previousEnd = combinedPoints.at(-1)!
+  if (route.route[0] && pointsAreEqual(previousEnd, route.route[0])) {
+    combinedPoints.push(...route.route.slice(1))
+    return
+  }
+  if (route.route.at(-1) && pointsAreEqual(previousEnd, route.route.at(-1)!)) {
+    combinedPoints.push(...route.route.slice(0, -1).reverse())
+    return
+  }
+
+  throw new Error(
+    `Pipeline9 could not reconnect mutated preloaded trace "${route.connectionName}" for via cleanup`,
+  )
+}
+
+const combinePreloadedTrace = ({
+  trace,
+  traceIndex,
+  layerCount,
+  defaultViaDiameter,
+  connMap,
+  originalTrace,
+}: {
+  trace: SimplifiedPcbTrace
+  traceIndex: number
+  layerCount: number
+  defaultViaDiameter: number
+  connMap: ConnectivityMap
+  originalTrace?: SimplifiedPcbTrace
+}): HighDensityRoute | null => {
+  const fixedRoutes = convertPreloadedTraceToHdRoutes(
+    trace,
+    traceIndex,
+    layerCount,
+    defaultViaDiameter,
+    connMap,
+  )
+  if (fixedRoutes.length === 0) return null
+
+  const route: HighDensityRoute["route"] = []
+  for (const fixedRoute of fixedRoutes) {
+    appendConnectedRoute(route, fixedRoute)
+  }
+
+  const startPcbPortId = trace.connectsTo?.[0]
+  const endPcbPortId = trace.connectsTo?.at(-1)
+  if (startPcbPortId && route[0]) {
+    route[0] = { ...route[0], pcb_port_id: startPcbPortId }
+  }
+  if (endPcbPortId && route.at(-1)) {
+    route[route.length - 1] = {
+      ...route.at(-1)!,
+      pcb_port_id: endPcbPortId,
+    }
+  }
+
+  const originalViaKeys = new Set(
+    (originalTrace?.route ?? []).flatMap((routePoint) =>
+      routePoint.route_type === "via"
+        ? [
+            `${routePoint.x}:${routePoint.y}:${Math.min(
+              mapLayerNameToZ(routePoint.from_layer, layerCount),
+              mapLayerNameToZ(routePoint.to_layer, layerCount),
+            )}:${Math.max(
+              mapLayerNameToZ(routePoint.from_layer, layerCount),
+              mapLayerNameToZ(routePoint.to_layer, layerCount),
+            )}`,
+          ]
+        : [],
+    ),
+  )
+  for (let pointIndex = 0; pointIndex < route.length - 1; pointIndex++) {
+    const point = route[pointIndex]!
+    const nextPoint = route[pointIndex + 1]!
+    if (point.z === nextPoint.z || !pointsHaveSamePosition(point, nextPoint)) {
+      continue
+    }
+    const viaKey = `${point.x}:${point.y}:${Math.min(point.z, nextPoint.z)}:${Math.max(point.z, nextPoint.z)}`
+    if (originalViaKeys.has(viaKey)) {
+      route[pointIndex] = {
+        ...point,
+        toNextSegmentType: "through_obstacle",
+      }
+    }
+  }
+
+  return {
+    connectionName: `pipeline9_mutated_preload_${traceIndex}`,
+    rootConnectionName:
+      fixedRoutes[0]!.rootConnectionName ??
+      connMap.getNetConnectedToId(trace.connection_name) ??
+      trace.connection_name,
+    traceThickness: Math.max(
+      ...fixedRoutes.map((fixedRoute) => fixedRoute.traceThickness),
+    ),
+    viaDiameter: Math.max(
+      ...fixedRoutes.map((fixedRoute) => fixedRoute.viaDiameter),
+    ),
+    route,
+    vias: route.slice(0, -1).flatMap((point, pointIndex) => {
+      const nextPoint = route[pointIndex + 1]!
+      return point.z !== nextPoint.z && pointsHaveSamePosition(point, nextPoint)
+        ? [{ x: nextPoint.x, y: nextPoint.y }]
+        : []
+    }),
+  }
+}
+
+/**
+ * Removes collision-free layer round trips introduced while Pipeline9 reroutes
+ * preloaded copper. Traces containing immutable through-obstacle or jumper
+ * primitives stay fixed.
+ */
+export const removeUselessViasFromMutatedPreloadedTraces = ({
+  updates,
+  originalTraces,
+  otherHdRoutes,
+  collisionObstacles,
+  routeConversionObstacles,
+  colorMap,
+  connMap,
+  outline,
+  layerCount,
+  defaultViaDiameter,
+  defaultViaHoleDiameter,
+  traceClearance,
+  obstacleClearance,
+}: {
+  updates: PreloadedTraceUpdates
+  originalTraces: ReadonlyArray<SimplifiedPcbTrace>
+  otherHdRoutes: ReadonlyArray<HighDensityRoute>
+  collisionObstacles: ReadonlyArray<Obstacle>
+  routeConversionObstacles: ReadonlyArray<Obstacle>
+  colorMap: Record<string, string>
+  connMap: ConnectivityMap
+  outline?: ReadonlyArray<{ x: number; y: number }>
+  layerCount: number
+  defaultViaDiameter: number
+  defaultViaHoleDiameter: number
+  traceClearance: number
+  obstacleClearance: number
+}): PreloadedTraceUpdates => {
+  const mutatedTraceIds = new Set(
+    updates.mutatedPreloadedTraces.map((trace) => trace.pcb_trace_id),
+  )
+  const originalTraceById = new Map(
+    originalTraces.map((trace) => [trace.pcb_trace_id, trace]),
+  )
+  const mutableTraceRoutes: MutableTraceRoute[] = []
+  const fixedPreloadedRoutes: HighDensityRoute[] = []
+
+  for (const [traceIndex, trace] of updates.updatedPreloadedTraces.entries()) {
+    const isMutable =
+      mutatedTraceIds.has(trace.pcb_trace_id) &&
+      trace.route.every(
+        (routePoint) =>
+          routePoint.route_type === "wire" || routePoint.route_type === "via",
+      )
+    if (isMutable) {
+      const hdRoute = combinePreloadedTrace({
+        trace,
+        traceIndex,
+        layerCount,
+        defaultViaDiameter,
+        connMap,
+        originalTrace: originalTraceById.get(
+          trace.__replaces_pcb_trace_id ?? trace.pcb_trace_id,
+        ),
+      })
+      if (hdRoute) mutableTraceRoutes.push({ trace, hdRoute })
+      continue
+    }
+
+    fixedPreloadedRoutes.push(
+      ...convertPreloadedTraceToHdRoutes(
+        trace,
+        traceIndex,
+        layerCount,
+        defaultViaDiameter,
+        connMap,
+      ),
+    )
+  }
+
+  if (mutableTraceRoutes.length === 0) return updates
+
+  const solver = new UselessViaRemovalSolver({
+    unsimplifiedHdRoutes: mutableTraceRoutes.map(({ hdRoute }) => hdRoute),
+    otherHdRoutes: [...otherHdRoutes, ...fixedPreloadedRoutes],
+    obstacles: [...collisionObstacles],
+    colorMap,
+    layerCount,
+    connMap,
+    outline: outline ? [...outline] : undefined,
+    layerMoveTraceMargin: traceClearance,
+    layerMoveObstacleMargin: obstacleClearance,
+    enableGeometryShortcuts: false,
+    enableObstacleDetourShortcuts: false,
+  })
+  solver.solve()
+  if (solver.failed) {
+    throw new Error(
+      `Pipeline9 failed to remove useless vias from mutated preloaded traces: ${solver.error ?? "unknown error"}`,
+    )
+  }
+
+  const optimizedRoutes = solver.getOptimizedHdRoutes()
+  if (
+    !optimizedRoutes ||
+    optimizedRoutes.length !== mutableTraceRoutes.length
+  ) {
+    throw new Error(
+      `Pipeline9 via cleanup returned ${optimizedRoutes?.length ?? 0} routes for ${mutableTraceRoutes.length} mutated preloaded traces`,
+    )
+  }
+
+  const cleanedTraceById = new Map<string, SimplifiedPcbTrace>()
+  for (const [routeIndex, mutableTraceRoute] of mutableTraceRoutes.entries()) {
+    const optimizedRoute = optimizedRoutes[routeIndex]!
+    const routeWithoutProtectionMarkers: HighDensityRoute = {
+      ...optimizedRoute,
+      route: optimizedRoute.route.map((point) => {
+        const cleanedPoint = { ...point }
+        delete cleanedPoint.toNextSegmentType
+        delete cleanedPoint.toNextSegmentCircuitJsonMetadata
+        return cleanedPoint
+      }),
+    }
+    cleanedTraceById.set(mutableTraceRoute.trace.pcb_trace_id, {
+      ...mutableTraceRoute.trace,
+      route: convertHdRouteToSimplifiedRoute(
+        routeWithoutProtectionMarkers,
+        layerCount,
+        {
+          defaultViaHoleDiameter,
+          obstacles: [...routeConversionObstacles],
+          connMap,
+        },
+      ),
+    })
+  }
+
+  return {
+    updatedPreloadedTraces: updates.updatedPreloadedTraces.map(
+      (trace) => cleanedTraceById.get(trace.pcb_trace_id) ?? trace,
+    ),
+    mutatedPreloadedTraces: updates.mutatedPreloadedTraces.map(
+      (trace) => cleanedTraceById.get(trace.pcb_trace_id) ?? trace,
+    ),
+  }
+}

--- a/lib/data-structures/HighDensityRouteSpatialIndex.ts
+++ b/lib/data-structures/HighDensityRouteSpatialIndex.ts
@@ -101,6 +101,7 @@ export class HighDensityRouteSpatialIndex {
   private segmentBuckets: Map<BucketCoordinate, StoredSegment[]>
   private viaBuckets: Map<BucketCoordinate, StoredVia[]> // New: Store vias
   private CELL_SIZE: number
+  private maximumCopperRadius = 0
 
   constructor(routes: HighDensityRoute[], cellSize: number = 1.0) {
     // console.time("HighDensityRouteSpatialIndex Constructor");
@@ -114,6 +115,11 @@ export class HighDensityRouteSpatialIndex {
         console.warn("Skipping route with missing data:", route)
         continue
       }
+      this.maximumCopperRadius = Math.max(
+        this.maximumCopperRadius,
+        route.traceThickness / 2,
+        route.viaDiameter / 2,
+      )
 
       // --- Index Segments ---
       if (route.route && route.route.length >= 2) {
@@ -201,12 +207,14 @@ export class HighDensityRouteSpatialIndex {
 
     // --- Define search area including margin for both segments and vias ---
     // Need to consider the maximum possible radius (trace/2 or via/2) + margin
-    // For simplicity, just use the provided margin for bucket search.
-    // Precise checks will use item-specific sizes.
-    const searchMinX = bounds.minX - margin
-    const searchMinY = bounds.minY - margin
-    const searchMaxX = bounds.maxX + margin
-    const searchMaxY = bounds.maxY + margin
+    // Stored centerlines can sit in a neighboring bucket while their copper
+    // still reaches the query margin. Expand by the largest indexed radius;
+    // item-specific checks below retain the exact separation test.
+    const broadPhaseMargin = margin + this.maximumCopperRadius
+    const searchMinX = bounds.minX - broadPhaseMargin
+    const searchMinY = bounds.minY - broadPhaseMargin
+    const searchMaxX = bounds.maxX + broadPhaseMargin
+    const searchMaxY = bounds.maxY + broadPhaseMargin
     const epsilon = 1e-9
 
     const minIndexX = Math.floor(searchMinX / this.CELL_SIZE)
@@ -363,6 +371,11 @@ export class HighDensityRouteSpatialIndex {
       console.warn("Skipping route with missing data:", route)
       return
     }
+    this.maximumCopperRadius = Math.max(
+      this.maximumCopperRadius,
+      route.traceThickness / 2,
+      route.viaDiameter / 2,
+    )
 
     const epsilon = 1e-9
 
@@ -443,10 +456,11 @@ export class HighDensityRouteSpatialIndex {
     margin: number, // Minimum required clearance
   ): Array<{ conflictingRoute: HighDensityRoute; distance: number }> {
     // --- Define search area ---
-    const searchMinX = point.x - margin
-    const searchMinY = point.y - margin
-    const searchMaxX = point.x + margin
-    const searchMaxY = point.y + margin
+    const broadPhaseMargin = margin + this.maximumCopperRadius
+    const searchMinX = point.x - broadPhaseMargin
+    const searchMinY = point.y - broadPhaseMargin
+    const searchMaxX = point.x + broadPhaseMargin
+    const searchMaxY = point.y + broadPhaseMargin
     const epsilon = 1e-9
 
     const minIndexX = Math.floor(searchMinX / this.CELL_SIZE)

--- a/lib/data-structures/HighDensityRouteSpatialIndex.ts
+++ b/lib/data-structures/HighDensityRouteSpatialIndex.ts
@@ -102,12 +102,19 @@ export class HighDensityRouteSpatialIndex {
   private viaBuckets: Map<BucketCoordinate, StoredVia[]> // New: Store vias
   private CELL_SIZE: number
   private maximumCopperRadius = 0
+  private includeCopperRadiusInBroadPhase: boolean
 
-  constructor(routes: HighDensityRoute[], cellSize: number = 1.0) {
+  constructor(
+    routes: HighDensityRoute[],
+    cellSize: number = 1.0,
+    options: { includeCopperRadiusInBroadPhase?: boolean } = {},
+  ) {
     // console.time("HighDensityRouteSpatialIndex Constructor");
     this.segmentBuckets = new Map()
     this.viaBuckets = new Map() // Initialize via buckets
     this.CELL_SIZE = cellSize
+    this.includeCopperRadiusInBroadPhase =
+      options.includeCopperRadiusInBroadPhase ?? false
     const epsilon = 1e-9 // For segment boundary checks
 
     for (const route of routes) {
@@ -207,10 +214,13 @@ export class HighDensityRouteSpatialIndex {
 
     // --- Define search area including margin for both segments and vias ---
     // Need to consider the maximum possible radius (trace/2 or via/2) + margin
-    // Stored centerlines can sit in a neighboring bucket while their copper
-    // still reaches the query margin. Expand by the largest indexed radius;
-    // item-specific checks below retain the exact separation test.
-    const broadPhaseMargin = margin + this.maximumCopperRadius
+    // In clearance-sensitive callers, stored centerlines can sit in a
+    // neighboring bucket while their copper still reaches the query margin.
+    // The optional expansion finds those candidates; item-specific checks
+    // below retain the exact separation test.
+    const broadPhaseMargin =
+      margin +
+      (this.includeCopperRadiusInBroadPhase ? this.maximumCopperRadius : 0)
     const searchMinX = bounds.minX - broadPhaseMargin
     const searchMinY = bounds.minY - broadPhaseMargin
     const searchMaxX = bounds.maxX + broadPhaseMargin
@@ -456,7 +466,9 @@ export class HighDensityRouteSpatialIndex {
     margin: number, // Minimum required clearance
   ): Array<{ conflictingRoute: HighDensityRoute; distance: number }> {
     // --- Define search area ---
-    const broadPhaseMargin = margin + this.maximumCopperRadius
+    const broadPhaseMargin =
+      margin +
+      (this.includeCopperRadiusInBroadPhase ? this.maximumCopperRadius : 0)
     const searchMinX = point.x - broadPhaseMargin
     const searchMinY = point.y - broadPhaseMargin
     const searchMaxX = point.x + broadPhaseMargin

--- a/lib/solvers/UselessViaRemovalSolver/SingleRouteUselessViaRemovalSolver.ts
+++ b/lib/solvers/UselessViaRemovalSolver/SingleRouteUselessViaRemovalSolver.ts
@@ -53,6 +53,7 @@ export class SingleRouteUselessViaRemovalSolver extends BaseSolver {
   TRACE_THICKNESS = 0.15
   OBSTACLE_MARGIN = 0.1
   LAYER_MOVE_TRACE_MARGIN = 0
+  PROTECT_MARKED_TRANSITIONS = false
   GEOMETRY_SHORTCUT_TRACE_MARGIN = 0.1
   GEOMETRY_SHORTCUT_OBSTACLE_MARGIN = 0.15
   MAX_GEOMETRY_SHORTCUT_ADDED_LENGTH = 4
@@ -71,6 +72,7 @@ export class SingleRouteUselessViaRemovalSolver extends BaseSolver {
     outline?: Array<{ x: number; y: number }>
     layerMoveTraceMargin?: number
     layerMoveObstacleMargin?: number
+    protectMarkedTransitions?: boolean
     geometryShortcutTraceMargin?: number
     geometryShortcutObstacleMargin?: number
     enableGeometryShortcuts?: boolean
@@ -87,6 +89,8 @@ export class SingleRouteUselessViaRemovalSolver extends BaseSolver {
       params.layerMoveTraceMargin ?? this.LAYER_MOVE_TRACE_MARGIN
     this.OBSTACLE_MARGIN =
       params.layerMoveObstacleMargin ?? this.OBSTACLE_MARGIN
+    this.PROTECT_MARKED_TRANSITIONS =
+      params.protectMarkedTransitions ?? this.PROTECT_MARKED_TRANSITIONS
     this.GEOMETRY_SHORTCUT_TRACE_MARGIN =
       params.geometryShortcutTraceMargin ?? this.GEOMETRY_SHORTCUT_TRACE_MARGIN
     this.GEOMETRY_SHORTCUT_OBSTACLE_MARGIN =
@@ -569,6 +573,7 @@ export class SingleRouteUselessViaRemovalSolver extends BaseSolver {
       const firstSection = this.routeSections[0]
       const secondSection = this.routeSections[1]
       const firstTransitionIsProtected =
+        this.PROTECT_MARKED_TRANSITIONS &&
         firstSection.points.at(-1)?.toNextSegmentType !== undefined
 
       if (firstSection.z !== secondSection.z && !firstTransitionIsProtected) {
@@ -619,6 +624,7 @@ export class SingleRouteUselessViaRemovalSolver extends BaseSolver {
         const secondLastSection =
           this.routeSections[this.routeSections.length - 2]
         const lastTransitionIsProtected =
+          this.PROTECT_MARKED_TRANSITIONS &&
           secondLastSection.points.at(-1)?.toNextSegmentType !== undefined
 
         if (
@@ -668,8 +674,9 @@ export class SingleRouteUselessViaRemovalSolver extends BaseSolver {
     const currentSection = this.routeSections[this.currentSectionIndex]
     const nextSection = this.routeSections[this.currentSectionIndex + 1]
     const adjacentTransitionIsProtected =
-      prevSection.points.at(-1)?.toNextSegmentType !== undefined ||
-      currentSection.points.at(-1)?.toNextSegmentType !== undefined
+      this.PROTECT_MARKED_TRANSITIONS &&
+      (prevSection.points.at(-1)?.toNextSegmentType !== undefined ||
+        currentSection.points.at(-1)?.toNextSegmentType !== undefined)
     if (adjacentTransitionIsProtected) {
       this.currentSectionIndex++
       return
@@ -737,6 +744,7 @@ export class SingleRouteUselessViaRemovalSolver extends BaseSolver {
       outline: this.outline,
       layerMoveTraceMargin: this.LAYER_MOVE_TRACE_MARGIN,
       layerMoveObstacleMargin: this.OBSTACLE_MARGIN,
+      protectMarkedTransitions: this.PROTECT_MARKED_TRANSITIONS,
       geometryShortcutTraceMargin: this.GEOMETRY_SHORTCUT_TRACE_MARGIN,
       geometryShortcutObstacleMargin: this.GEOMETRY_SHORTCUT_OBSTACLE_MARGIN,
       enableGeometryShortcuts: this.ENABLE_GEOMETRY_SHORTCUTS,

--- a/lib/solvers/UselessViaRemovalSolver/SingleRouteUselessViaRemovalSolver.ts
+++ b/lib/solvers/UselessViaRemovalSolver/SingleRouteUselessViaRemovalSolver.ts
@@ -52,6 +52,7 @@ export class SingleRouteUselessViaRemovalSolver extends BaseSolver {
 
   TRACE_THICKNESS = 0.15
   OBSTACLE_MARGIN = 0.1
+  LAYER_MOVE_TRACE_MARGIN = 0
   GEOMETRY_SHORTCUT_TRACE_MARGIN = 0.1
   GEOMETRY_SHORTCUT_OBSTACLE_MARGIN = 0.15
   MAX_GEOMETRY_SHORTCUT_ADDED_LENGTH = 4
@@ -68,6 +69,8 @@ export class SingleRouteUselessViaRemovalSolver extends BaseSolver {
     unsimplifiedRoute: HighDensityRoute
     connMap: ConnectivityMap
     outline?: Array<{ x: number; y: number }>
+    layerMoveTraceMargin?: number
+    layerMoveObstacleMargin?: number
     geometryShortcutTraceMargin?: number
     geometryShortcutObstacleMargin?: number
     enableGeometryShortcuts?: boolean
@@ -80,6 +83,10 @@ export class SingleRouteUselessViaRemovalSolver extends BaseSolver {
     this.unsimplifiedRoute = params.unsimplifiedRoute
     this.connMap = params.connMap
     this.outline = params.outline
+    this.LAYER_MOVE_TRACE_MARGIN =
+      params.layerMoveTraceMargin ?? this.LAYER_MOVE_TRACE_MARGIN
+    this.OBSTACLE_MARGIN =
+      params.layerMoveObstacleMargin ?? this.OBSTACLE_MARGIN
     this.GEOMETRY_SHORTCUT_TRACE_MARGIN =
       params.geometryShortcutTraceMargin ?? this.GEOMETRY_SHORTCUT_TRACE_MARGIN
     this.GEOMETRY_SHORTCUT_OBSTACLE_MARGIN =
@@ -561,8 +568,10 @@ export class SingleRouteUselessViaRemovalSolver extends BaseSolver {
     if (this.currentSectionIndex === 0 && this.routeSections.length > 1) {
       const firstSection = this.routeSections[0]
       const secondSection = this.routeSections[1]
+      const firstTransitionIsProtected =
+        firstSection.points.at(-1)?.toNextSegmentType !== undefined
 
-      if (firstSection.z !== secondSection.z) {
+      if (firstSection.z !== secondSection.z && !firstTransitionIsProtected) {
         // Try moving first section to match second section (for MLCP endpoints)
         const targetZ = secondSection.z
         // Check that the endpoint obstacle supports the target layer
@@ -586,6 +595,7 @@ export class SingleRouteUselessViaRemovalSolver extends BaseSolver {
             connMap: this.connMap,
             defaultTraceThickness: this.TRACE_THICKNESS,
             obstacleMargin: this.OBSTACLE_MARGIN,
+            traceMargin: this.LAYER_MOVE_TRACE_MARGIN,
           })
         ) {
           firstSection.z = targetZ
@@ -608,8 +618,13 @@ export class SingleRouteUselessViaRemovalSolver extends BaseSolver {
         const lastSection = this.routeSections[this.routeSections.length - 1]
         const secondLastSection =
           this.routeSections[this.routeSections.length - 2]
+        const lastTransitionIsProtected =
+          secondLastSection.points.at(-1)?.toNextSegmentType !== undefined
 
-        if (lastSection.z !== secondLastSection.z) {
+        if (
+          lastSection.z !== secondLastSection.z &&
+          !lastTransitionIsProtected
+        ) {
           // Try moving last section to match second-last section (for MLCP endpoints)
           const targetZ = secondLastSection.z
           // Check that the endpoint obstacle supports the target layer
@@ -633,6 +648,7 @@ export class SingleRouteUselessViaRemovalSolver extends BaseSolver {
               connMap: this.connMap,
               defaultTraceThickness: this.TRACE_THICKNESS,
               obstacleMargin: this.OBSTACLE_MARGIN,
+              traceMargin: this.LAYER_MOVE_TRACE_MARGIN,
             })
           ) {
             lastSection.z = targetZ
@@ -651,6 +667,13 @@ export class SingleRouteUselessViaRemovalSolver extends BaseSolver {
     const prevSection = this.routeSections[this.currentSectionIndex - 1]
     const currentSection = this.routeSections[this.currentSectionIndex]
     const nextSection = this.routeSections[this.currentSectionIndex + 1]
+    const adjacentTransitionIsProtected =
+      prevSection.points.at(-1)?.toNextSegmentType !== undefined ||
+      currentSection.points.at(-1)?.toNextSegmentType !== undefined
+    if (adjacentTransitionIsProtected) {
+      this.currentSectionIndex++
+      return
+    }
 
     if (prevSection.z !== nextSection.z) {
       const multilayerCollapse = this.findMultilayerSectionCollapse(
@@ -679,6 +702,7 @@ export class SingleRouteUselessViaRemovalSolver extends BaseSolver {
         connMap: this.connMap,
         defaultTraceThickness: this.TRACE_THICKNESS,
         obstacleMargin: this.OBSTACLE_MARGIN,
+        traceMargin: this.LAYER_MOVE_TRACE_MARGIN,
       })
     ) {
       currentSection.z = targetZ
@@ -711,6 +735,8 @@ export class SingleRouteUselessViaRemovalSolver extends BaseSolver {
       unsimplifiedRoute: this.unsimplifiedRoute,
       connMap: this.connMap,
       outline: this.outline,
+      layerMoveTraceMargin: this.LAYER_MOVE_TRACE_MARGIN,
+      layerMoveObstacleMargin: this.OBSTACLE_MARGIN,
       geometryShortcutTraceMargin: this.GEOMETRY_SHORTCUT_TRACE_MARGIN,
       geometryShortcutObstacleMargin: this.GEOMETRY_SHORTCUT_OBSTACLE_MARGIN,
       enableGeometryShortcuts: this.ENABLE_GEOMETRY_SHORTCUTS,

--- a/lib/solvers/UselessViaRemovalSolver/UselessViaRemovalSolver.ts
+++ b/lib/solvers/UselessViaRemovalSolver/UselessViaRemovalSolver.ts
@@ -20,6 +20,8 @@ export interface UselessViaRemovalSolverInput {
   layerCount: number
   connMap: ConnectivityMap
   outline?: Array<{ x: number; y: number }>
+  layerMoveTraceMargin?: number
+  layerMoveObstacleMargin?: number
   geometryShortcutTraceMargin?: number
   geometryShortcutObstacleMargin?: number
   enableGeometryShortcuts?: boolean
@@ -89,6 +91,8 @@ export class UselessViaRemovalSolver extends BaseSolver {
       unsimplifiedRoute: unprocessedRoute,
       connMap: this.input.connMap,
       outline: this.input.outline,
+      layerMoveTraceMargin: this.input.layerMoveTraceMargin,
+      layerMoveObstacleMargin: this.input.layerMoveObstacleMargin,
       geometryShortcutTraceMargin: this.input.geometryShortcutTraceMargin,
       geometryShortcutObstacleMargin: this.input.geometryShortcutObstacleMargin,
       enableGeometryShortcuts: this.input.enableGeometryShortcuts,

--- a/lib/solvers/UselessViaRemovalSolver/UselessViaRemovalSolver.ts
+++ b/lib/solvers/UselessViaRemovalSolver/UselessViaRemovalSolver.ts
@@ -22,6 +22,8 @@ export interface UselessViaRemovalSolverInput {
   outline?: Array<{ x: number; y: number }>
   layerMoveTraceMargin?: number
   layerMoveObstacleMargin?: number
+  includeCopperRadiusInBroadPhase?: boolean
+  protectMarkedTransitions?: boolean
   geometryShortcutTraceMargin?: number
   geometryShortcutObstacleMargin?: number
   enableGeometryShortcuts?: boolean
@@ -57,10 +59,13 @@ export class UselessViaRemovalSolver extends BaseSolver {
       "flatbush",
       this.input.obstacles,
     )
-    this.hdRouteSHI = new HighDensityRouteSpatialIndex([
-      ...this.unsimplifiedHdRoutes,
-      ...(input.otherHdRoutes ?? []),
-    ])
+    this.hdRouteSHI = new HighDensityRouteSpatialIndex(
+      [...this.unsimplifiedHdRoutes, ...(input.otherHdRoutes ?? [])],
+      1,
+      {
+        includeCopperRadiusInBroadPhase: input.includeCopperRadiusInBroadPhase,
+      },
+    )
   }
 
   _step() {
@@ -93,6 +98,7 @@ export class UselessViaRemovalSolver extends BaseSolver {
       outline: this.input.outline,
       layerMoveTraceMargin: this.input.layerMoveTraceMargin,
       layerMoveObstacleMargin: this.input.layerMoveObstacleMargin,
+      protectMarkedTransitions: this.input.protectMarkedTransitions,
       geometryShortcutTraceMargin: this.input.geometryShortcutTraceMargin,
       geometryShortcutObstacleMargin: this.input.geometryShortcutObstacleMargin,
       enableGeometryShortcuts: this.input.enableGeometryShortcuts,

--- a/tests/data-structures/high-density-route-spatial-index-copper-radius-broadphase.test.ts
+++ b/tests/data-structures/high-density-route-spatial-index-copper-radius-broadphase.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test"
+import { HighDensityRouteSpatialIndex } from "lib/data-structures/HighDensityRouteSpatialIndex"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+
+test("route spatial index includes neighboring-bucket copper within clearance", () => {
+  const neighboringRoute: HighDensityRoute = {
+    connectionName: "neighboring_route",
+    traceThickness: 0.15,
+    viaDiameter: 0.5,
+    route: [
+      { x: 1.04, y: 0, z: 0 },
+      { x: 1.04, y: 1, z: 0 },
+    ],
+    vias: [],
+  }
+  const spatialIndex = new HighDensityRouteSpatialIndex([neighboringRoute])
+
+  const conflicts = spatialIndex.getConflictingRoutesForSegment(
+    { x: 0.8, y: 0, z: 0 },
+    { x: 0.8, y: 1, z: 0 },
+    0.075 + 0.1,
+  )
+
+  expect(conflicts).toHaveLength(1)
+  expect(conflicts[0]!.conflictingRoute).toBe(neighboringRoute)
+  expect(conflicts[0]!.distance).toBeCloseTo(0.24, 10)
+
+  const pointConflicts = spatialIndex.getConflictingRoutesNearPoint(
+    { x: 0.8, y: 0.5, z: 0 },
+    0.075 + 0.1,
+  )
+  expect(pointConflicts).toHaveLength(1)
+  expect(pointConflicts[0]!.conflictingRoute).toBe(neighboringRoute)
+  expect(pointConflicts[0]!.distance).toBeCloseTo(0.24, 10)
+})

--- a/tests/data-structures/high-density-route-spatial-index-copper-radius-broadphase.test.ts
+++ b/tests/data-structures/high-density-route-spatial-index-copper-radius-broadphase.test.ts
@@ -13,7 +13,9 @@ test("route spatial index includes neighboring-bucket copper within clearance", 
     ],
     vias: [],
   }
-  const spatialIndex = new HighDensityRouteSpatialIndex([neighboringRoute])
+  const spatialIndex = new HighDensityRouteSpatialIndex([neighboringRoute], 1, {
+    includeCopperRadiusInBroadPhase: true,
+  })
 
   const conflicts = spatialIndex.getConflictingRoutesForSegment(
     { x: 0.8, y: 0, z: 0 },

--- a/tests/features/pipeline9-mutated-preloaded-via-cleanup.test.ts
+++ b/tests/features/pipeline9-mutated-preloaded-via-cleanup.test.ts
@@ -1,0 +1,169 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { removeUselessViasFromMutatedPreloadedTraces } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/remove-useless-vias-from-mutated-preloaded-traces"
+import type { SimplifiedPcbTrace } from "lib/types"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+
+const firstVia = { x: 8.443, y: -4.145 }
+const secondVia = { x: 8.847, y: -4.447 }
+
+const createMutatedTrace = (): SimplifiedPcbTrace => ({
+  type: "pcb_trace",
+  pcb_trace_id: "source_trace_10_0",
+  connection_name: "source_trace_10",
+  __replaces_pcb_trace_id: "source_trace_10_0",
+  route: [
+    {
+      route_type: "wire",
+      x: 8.379,
+      y: -4.038,
+      width: 0.15,
+      layer: "top",
+    },
+    {
+      route_type: "wire",
+      ...firstVia,
+      width: 0.15,
+      layer: "top",
+    },
+    {
+      route_type: "via",
+      ...firstVia,
+      from_layer: "top",
+      to_layer: "bottom",
+      via_diameter: 0.5,
+      via_hole_diameter: 0.2,
+    },
+    {
+      route_type: "wire",
+      ...firstVia,
+      width: 0.15,
+      layer: "bottom",
+    },
+    {
+      route_type: "wire",
+      x: 8.716,
+      y: -3.798,
+      width: 0.15,
+      layer: "bottom",
+    },
+    {
+      route_type: "wire",
+      x: 8.731,
+      y: -3.994,
+      width: 0.15,
+      layer: "bottom",
+    },
+    {
+      route_type: "wire",
+      x: 8.76,
+      y: -4.186,
+      width: 0.15,
+      layer: "bottom",
+    },
+    {
+      route_type: "wire",
+      x: 8.816,
+      y: -4.376,
+      width: 0.15,
+      layer: "bottom",
+    },
+    {
+      route_type: "wire",
+      ...secondVia,
+      width: 0.15,
+      layer: "bottom",
+    },
+    {
+      route_type: "via",
+      ...secondVia,
+      from_layer: "bottom",
+      to_layer: "top",
+      via_diameter: 0.5,
+      via_hole_diameter: 0.2,
+    },
+    {
+      route_type: "wire",
+      ...secondVia,
+      width: 0.15,
+      layer: "top",
+    },
+    {
+      route_type: "wire",
+      x: 8.92,
+      y: -4.572,
+      width: 0.15,
+      layer: "top",
+    },
+  ],
+})
+
+const runCleanup = (
+  trace: SimplifiedPcbTrace,
+  otherHdRoutes = [] as HighDensityRoute[],
+  originalTrace: SimplifiedPcbTrace = {
+    ...trace,
+    __replaces_pcb_trace_id: undefined,
+    route: [trace.route[0]!, trace.route.at(-1)!],
+  },
+) =>
+  removeUselessViasFromMutatedPreloadedTraces({
+    updates: {
+      updatedPreloadedTraces: [trace],
+      mutatedPreloadedTraces: [trace],
+    },
+    originalTraces: [originalTrace],
+    otherHdRoutes,
+    collisionObstacles: [],
+    routeConversionObstacles: [],
+    colorMap: {},
+    connMap: new ConnectivityMap({}),
+    layerCount: 2,
+    defaultViaDiameter: 0.5,
+    defaultViaHoleDiameter: 0.2,
+    traceClearance: 0.1,
+    obstacleClearance: 0.15,
+  }).updatedPreloadedTraces[0]!
+
+test("Pipeline9 removes only collision-free via pairs from mutated preloaded traces", () => {
+  const cleanedTrace = runCleanup(createMutatedTrace())
+
+  expect(
+    cleanedTrace.route.filter((point) => point.route_type === "via"),
+  ).toEqual([])
+  expect(
+    cleanedTrace.route.every(
+      (point) => point.route_type !== "wire" || point.layer === "top",
+    ),
+  ).toBeTrue()
+
+  const blockingTopRoute: HighDensityRoute = {
+    connectionName: "blocking_trace",
+    rootConnectionName: "blocking_net",
+    traceThickness: 0.15,
+    viaDiameter: 0.5,
+    route: [
+      { x: 8.706, y: -3.798, z: 0 },
+      { x: 8.726, y: -3.798, z: 0 },
+    ],
+    vias: [],
+  }
+  const blockedTrace = runCleanup(createMutatedTrace(), [blockingTopRoute])
+
+  expect(
+    blockedTrace.route
+      .filter((point) => point.route_type === "via")
+      .map((point) => ({ x: point.x, y: point.y })),
+  ).toEqual([firstVia, secondVia])
+
+  const protectedOriginalVias = runCleanup(
+    createMutatedTrace(),
+    [],
+    createMutatedTrace(),
+  )
+  expect(
+    protectedOriginalVias.route
+      .filter((point) => point.route_type === "via")
+      .map((point) => ({ x: point.x, y: point.y })),
+  ).toEqual([firstVia, secondVia])
+})


### PR DESCRIPTION
## Summary

- simplify collision-free layer round trips after Pipeline9 reassembles mutated preloaded traces
- preserve vias already present in the input trace and conservatively skip jumper or through-obstacle traces
- make the new cleanup collision-safe across spatial-index bucket boundaries without changing routing behavior in older pipelines

## Root cause

Pipeline9 regional fallback created the highlighted pair across two separate fixed-route replacements. Each replacement looked valid alone; the redundant top-to-bottom-to-top round trip became visible only after the replacements were spliced back into the full preloaded trace. The normal trace simplifier only edits newly routed traces and treats mutated preloads as immutable collision context, so the pair survived every later phase.

This runs the existing useless-via removal logic on the fully reconstructed mutated traces, with geometry shortcuts disabled. A section only moves to the neighboring layer when the existing geometry is clear against preprocessed board obstacles and all other copper. The stricter broad-phase search and input-via protection are opt-in for this Pipeline9 cleanup, preserving existing Pipeline4/Pipeline7 output.

## Verification

- exact highlighted QSPI_SD3 subroute regression removes both vias when clear
- the same regression retains both vias when a top-layer peer blocks the move
- vias present in the original preloaded trace remain protected
- neighboring-bucket segment and point clearance regressions pass
- existing Pipeline4 and multisection visual snapshots remain unchanged
- core dense RP2040 Pipeline9 parity completes all 18 phases with zero autorouting errors and 54 vias, down from 66
- focused Pipeline9, useless-via, spatial-index, and immutable-route tests pass
- TypeScript typecheck and production build pass