### PR TITLE
feat: constrain autorouting to selected layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The input to the autorouter is a `SimpleRouteJson` object with the following str
 ```typescript
 interface SimpleRouteJson {
   layerCount: number
+  routingLayers?: string[]
   minTraceWidth: number
   obstacles: Obstacle[]
   connections: Array<SimpleRouteConnection>
@@ -104,6 +105,20 @@ apply the constraint without losing the original membership or ordering.
 `traceWidth`, `traceGap`, and `allowedLayers` are resolved routing geometry;
 stackup-aware impedance targets should be converted to these dimensions before
 creating SimpleRouteJson.
+
+`routingLayers` limits newly generated wire segments and logical routing
+transitions to the listed board layers, for example `["top", "bottom"]` on a
+four-layer board whose inner layers are reserved for planes. Physical plated
+via spans are controlled independently and may cross reserved layers. Omit
+`routingLayers` to make every board layer available. A single-layer terminal
+or terminal-via destination on an excluded layer is rejected; a multi-layer
+terminal or bus allowlist is intersected with `routingLayers` and is rejected
+if that intersection is empty. Existing `traces` are preserved, including
+preloaded copper on excluded layers.
+
+Layer-changing DRC repairs currently run only when all board layers are
+routable because their upstream API does not yet accept an allowed-layer set.
+All other repair phases remain enabled.
 
 Via-in-pad repair is disabled by default because it generally requires filled
 and capped vias. Set `allowViaInPad: true` only when the fabrication process

--- a/lib/autorouter-pipelines/AssignableAutoroutingPipeline1/AssignableAutoroutingPipeline1Solver.ts
+++ b/lib/autorouter-pipelines/AssignableAutoroutingPipeline1/AssignableAutoroutingPipeline1Solver.ts
@@ -47,6 +47,10 @@ import { HyperAssignableViaCapacityPathingSolver } from "./HyperAssignableViaCap
 import { AssignableViaCapacityPathingSolver_DirectiveSubOptimal } from "./AssignableViaCapacityPathing/AssignableViaCapacityPathingSolver_DirectiveSubOptimal"
 import { OffboardCapacityNodeSolver } from "./OffboardCapacityNodeSolver"
 import { OffboardPathFragmentSolver } from "./OffboardPathFragmentSolver"
+import {
+  normalizeSrjRoutingLayers,
+  restrictCapacityNodesToRoutingLayers,
+} from "lib/utils/routing-layer-constraints"
 
 interface CapacityMeshSolverOptions {
   capacityDepth?: number
@@ -156,17 +160,23 @@ export class AssignableAutoroutingPipeline1Solver extends BaseSolver {
       ],
       {
         onSolved: (cms) => {
-          cms.capacityNodes = cms.nodeSolver?.finishedNodes!
+          cms.capacityNodes = restrictCapacityNodesToRoutingLayers(
+            cms.nodeSolver?.finishedNodes ?? [],
+            cms.srj,
+          )
         },
       },
     ),
     definePipelineStep(
       "mergeAssignableViaNodes",
       AssignableViaNodeMergerSolver,
-      (cms) => [cms.nodeSolver?.finishedNodes!],
+      (cms) => [cms.capacityNodes!],
       {
         onSolved: (cms) => {
-          cms.capacityNodes = cms.mergeAssignableViaNodes?.newNodes!
+          cms.capacityNodes = restrictCapacityNodesToRoutingLayers(
+            cms.mergeAssignableViaNodes?.newNodes ?? [],
+            cms.srj,
+          )
         },
       },
     ),
@@ -443,7 +453,7 @@ export class AssignableAutoroutingPipeline1Solver extends BaseSolver {
     public readonly opts: CapacityMeshSolverOptions = {},
   ) {
     super()
-    this.srj = srj
+    this.srj = normalizeSrjRoutingLayers(srj)
     this.opts = { ...opts }
     this.MAX_ITERATIONS = 100e6
     const mutableOpts = this.opts

--- a/lib/autorouter-pipelines/AssignableAutoroutingPipeline2/AssignableAutoroutingPipeline2.ts
+++ b/lib/autorouter-pipelines/AssignableAutoroutingPipeline2/AssignableAutoroutingPipeline2.ts
@@ -61,6 +61,10 @@ import { PortPointOffboardPathFragmentSolver } from "./PortPointOffboardPathFrag
 import { RelateNodesToOffBoardConnectionsSolver } from "./RelateNodesToOffBoardConnectionsSolver"
 import { SimpleHighDensitySolver } from "./SimpleHighDensitySolver"
 import { updateConnMapWithOffboardObstacleConnections } from "./updateConnMapWithOffboardObstacleConnections"
+import {
+  normalizeSrjRoutingLayers,
+  restrictCapacityNodesToRoutingLayers,
+} from "lib/utils/routing-layer-constraints"
 
 interface CapacityMeshSolverOptions {
   capacityDepth?: number
@@ -173,7 +177,10 @@ export class AssignableAutoroutingPipeline2 extends BaseSolver {
       ],
       {
         onSolved: (cms) => {
-          cms.capacityNodes = cms.nodeSolver?.getOutput().meshNodes ?? []
+          cms.capacityNodes = restrictCapacityNodesToRoutingLayers(
+            cms.nodeSolver?.getOutput().meshNodes ?? [],
+            cms.srj,
+          )
         },
       },
     ),
@@ -411,7 +418,7 @@ export class AssignableAutoroutingPipeline2 extends BaseSolver {
     public readonly opts: CapacityMeshSolverOptions = {},
   ) {
     super()
-    this.srj = srj
+    this.srj = normalizeSrjRoutingLayers(srj)
     this.opts = { ...opts }
     this.viaDiameter = getViaDimensions(srj).padDiameter
     this.minTraceWidth = srj.minTraceWidth

--- a/lib/autorouter-pipelines/AssignableAutoroutingPipeline3/AssignableAutoroutingPipeline3.ts
+++ b/lib/autorouter-pipelines/AssignableAutoroutingPipeline3/AssignableAutoroutingPipeline3.ts
@@ -64,6 +64,10 @@ import { Jumper as HdJumper } from "../../types/high-density-types"
 import { combineVisualizations } from "../../utils/combineVisualizations"
 import { calculateOptimalCapacityDepth } from "../../utils/getTunedTotalCapacity1"
 import { JUMPER_DIMENSIONS } from "../../utils/jumperSizes"
+import {
+  normalizeSrjRoutingLayers,
+  restrictCapacityNodesToRoutingLayers,
+} from "lib/utils/routing-layer-constraints"
 import { JumperHighDensitySolver } from "../AssignableAutoroutingPipeline2/JumperHighDensitySolver"
 import { PortPointOffboardPathFragmentSolver } from "../AssignableAutoroutingPipeline2/PortPointOffboardPathFragmentSolver"
 import { RelateNodesToOffBoardConnectionsSolver } from "../AssignableAutoroutingPipeline2/RelateNodesToOffBoardConnectionsSolver"
@@ -181,7 +185,10 @@ export class AssignableAutoroutingPipeline3 extends BaseSolver {
       ],
       {
         onSolved: (cms) => {
-          cms.capacityNodes = cms.nodeSolver?.getOutput().meshNodes ?? []
+          cms.capacityNodes = restrictCapacityNodesToRoutingLayers(
+            cms.nodeSolver?.getOutput().meshNodes ?? [],
+            cms.srj,
+          )
         },
       },
     ),
@@ -460,7 +467,7 @@ export class AssignableAutoroutingPipeline3 extends BaseSolver {
     public readonly opts: CapacityMeshSolverOptions = {},
   ) {
     super()
-    this.srj = srj
+    this.srj = normalizeSrjRoutingLayers(srj)
     this.opts = { ...opts }
     this.viaDiameter = getViaDimensions(srj).padDiameter
     this.minTraceWidth = srj.minTraceWidth

--- a/lib/autorouter-pipelines/AssignableAutoroutingPipeline3/AssignableAutoroutingPipeline3.ts
+++ b/lib/autorouter-pipelines/AssignableAutoroutingPipeline3/AssignableAutoroutingPipeline3.ts
@@ -21,6 +21,7 @@ import {
 } from "lib/utils/getGraphicsObjectLayer"
 import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
 import { getInitiallyConnectedMapFromSimpleRouteJson } from "lib/utils/get-initially-connected-map-from-simple-route-json"
+import { getIntraNodeCrossingsUsingCircle } from "lib/utils/getIntraNodeCrossingsUsingCircle"
 import { getViaDimensions } from "lib/utils/getViaDimensions"
 import { AvailableSegmentPointSolver } from "../../solvers/AvailableSegmentPointSolver/AvailableSegmentPointSolver"
 import { BaseSolver } from "../../solvers/BaseSolver"
@@ -65,6 +66,7 @@ import { combineVisualizations } from "../../utils/combineVisualizations"
 import { calculateOptimalCapacityDepth } from "../../utils/getTunedTotalCapacity1"
 import { JUMPER_DIMENSIONS } from "../../utils/jumperSizes"
 import {
+  getRoutingZLayers,
   normalizeSrjRoutingLayers,
   restrictCapacityNodesToRoutingLayers,
 } from "lib/utils/routing-layer-constraints"
@@ -376,22 +378,36 @@ export class AssignableAutoroutingPipeline3 extends BaseSolver {
     //     connMap: cms.connMap,
     //   },
     // ]),
-    definePipelineStep("highDensitySolver", JumperHighDensitySolver, (cms) => [
-      {
-        nodePortPoints:
-          cms.multiSectionPortPointOptimizer?.getNodesWithPortPoints() ??
-          cms.portPointPathingSolver?.getNodesWithPortPoints() ??
-          [],
-        colorMap: cms.colorMap,
-        viaDiameter: cms.viaDiameter,
-        traceWidth: cms.minTraceWidth,
-        obstacleMargin: cms.srj.defaultObstacleMargin ?? 0.15,
-        connMap: cms.connMap,
-        capacityMeshNodes: cms.capacityNodes ?? [],
-        capacityMeshEdges: cms.capacityEdges ?? [],
-        availableJumperTypes: cms.srj.availableJumperTypes,
-      },
-    ]),
+    definePipelineStep("highDensitySolver", JumperHighDensitySolver, (cms) => {
+      const nodePortPoints =
+        cms.multiSectionPortPointOptimizer?.getNodesWithPortPoints() ??
+        cms.portPointPathingSolver?.getNodesWithPortPoints() ??
+        []
+      if (
+        !getRoutingZLayers(cms.srj).includes(0) &&
+        nodePortPoints.some(
+          (node) =>
+            getIntraNodeCrossingsUsingCircle(node).numSameLayerCrossings > 0,
+        )
+      ) {
+        throw new Error(
+          'AssignablePipeline3 cannot place top-layer jumpers because routingLayers excludes "top"',
+        )
+      }
+      return [
+        {
+          nodePortPoints,
+          colorMap: cms.colorMap,
+          viaDiameter: cms.viaDiameter,
+          traceWidth: cms.minTraceWidth,
+          obstacleMargin: cms.srj.defaultObstacleMargin ?? 0.15,
+          connMap: cms.connMap,
+          capacityMeshNodes: cms.capacityNodes ?? [],
+          capacityMeshEdges: cms.capacityEdges ?? [],
+          availableJumperTypes: cms.srj.availableJumperTypes,
+        },
+      ]
+    }),
     definePipelineStep(
       "highDensityStitchSolver",
       MultipleHighDensityRouteStitchSolver2,

--- a/lib/autorouter-pipelines/AutoroutingPipeline10_BgaFanout/AutoroutingPipelineSolver10_BgaFanout.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline10_BgaFanout/AutoroutingPipelineSolver10_BgaFanout.ts
@@ -26,6 +26,7 @@ import {
 } from "lib/solvers/ComponentDetectionSolver/ComponentDetectionSolver"
 import type { SimpleRouteJson, SimplifiedPcbTraces } from "lib/types"
 import { convertSrjToGraphicsObject } from "lib/utils/convertSrjToGraphicsObject"
+import { normalizeSrjRoutingLayers } from "lib/utils/routing-layer-constraints"
 
 const MAX_FANOUT_BOUNDARY_MARGIN_MM = 4.5
 const MIN_FANOUT_BOUNDARY_MARGIN_MM = 2
@@ -306,6 +307,7 @@ function getFanoutOptions({
   return {
     buses: getPhysicalFanoutBuses({ inputSrj, source, target }),
     sourceComponentId: source.componentId,
+    escapeLayers: inputSrj.routingLayers,
     availableCornersAndSides,
     componentBounds: { [source.componentId]: getPlainBounds(source) },
     sharedBoundary: getExpandedBounds(source, fanoutBoundaryMargin),
@@ -501,7 +503,7 @@ export class AutoroutingPipelineSolver10_BgaFanout extends BasePipelineSolver<Au
     inputSrj: SimpleRouteJson,
     options: AutoroutingPipelineSolverOptions = {},
   ) {
-    super({ inputSrj, options })
+    super({ inputSrj: normalizeSrjRoutingLayers(inputSrj), options })
     this.MAX_ITERATIONS = 100e6 * (options.effort ?? 1) + 1_024
   }
 

--- a/lib/autorouter-pipelines/AutoroutingPipeline1_OriginalUnravel/AutoroutingPipeline1_OriginalUnravel.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline1_OriginalUnravel/AutoroutingPipeline1_OriginalUnravel.ts
@@ -61,6 +61,10 @@ import { getViaDimensions } from "lib/utils/getViaDimensions"
 import { calculateOptimalCapacityDepth } from "lib/utils/getTunedTotalCapacity1"
 import { mapLayerNameToZ } from "lib/utils/mapLayerNameToZ"
 import { mergeRouteSegments } from "lib/utils/mergeRouteSegments"
+import {
+  normalizeSrjRoutingLayers,
+  restrictCapacityNodesToRoutingLayers,
+} from "lib/utils/routing-layer-constraints"
 
 interface CapacityMeshSolverOptions {
   capacityDepth?: number
@@ -165,7 +169,10 @@ export class AutoroutingPipeline1_OriginalUnravel extends BaseSolver {
       ],
       {
         onSolved: (cms) => {
-          cms.capacityNodes = cms.nodeSolver?.finishedNodes!
+          cms.capacityNodes = restrictCapacityNodesToRoutingLayers(
+            cms.nodeSolver?.finishedNodes ?? [],
+            cms.srj,
+          )
         },
       },
     ),
@@ -364,7 +371,7 @@ export class AutoroutingPipeline1_OriginalUnravel extends BaseSolver {
     public readonly opts: CapacityMeshSolverOptions = {},
   ) {
     super()
-    this.srj = srj
+    this.srj = normalizeSrjRoutingLayers(srj)
     this.opts = { ...opts }
     this.MAX_ITERATIONS = 100e6
     this.viaDiameter = getViaDimensions(srj).padDiameter

--- a/lib/autorouter-pipelines/AutoroutingPipeline2_PortPointPathing/AutoroutingPipelineSolver2_PortPointPathing.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline2_PortPointPathing/AutoroutingPipelineSolver2_PortPointPathing.ts
@@ -20,6 +20,10 @@ import {
 import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
 import { getInitiallyConnectedMapFromSimpleRouteJson } from "lib/utils/get-initially-connected-map-from-simple-route-json"
 import { getViaDimensions } from "lib/utils/getViaDimensions"
+import {
+  normalizeSrjRoutingLayers,
+  restrictCapacityNodesToRoutingLayers,
+} from "lib/utils/routing-layer-constraints"
 import { AvailableSegmentPointSolver } from "../../solvers/AvailableSegmentPointSolver/AvailableSegmentPointSolver"
 import { BaseSolver } from "../../solvers/BaseSolver"
 import { CapacityMeshEdgeSolver } from "../../solvers/CapacityMeshSolver/CapacityMeshEdgeSolver"
@@ -165,7 +169,10 @@ export class AutoroutingPipelineSolver2_PortPointPathing extends BaseSolver {
       ],
       {
         onSolved: (cms) => {
-          cms.capacityNodes = cms.nodeSolver?.getOutput().meshNodes ?? []
+          cms.capacityNodes = restrictCapacityNodesToRoutingLayers(
+            cms.nodeSolver?.getOutput().meshNodes ?? [],
+            cms.srj,
+          )
         },
       },
     ),
@@ -411,7 +418,7 @@ export class AutoroutingPipelineSolver2_PortPointPathing extends BaseSolver {
     public readonly opts: CapacityMeshSolverOptions = {},
   ) {
     super()
-    this.srj = srj
+    this.srj = normalizeSrjRoutingLayers(srj)
     this.opts = { ...opts }
     this.viaDiameter = getViaDimensions(srj).padDiameter
     this.minTraceWidth = srj.minTraceWidth

--- a/lib/autorouter-pipelines/AutoroutingPipeline3_HgPortPointPathing/AutoroutingPipelineSolver3_HgPortPointPathing.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline3_HgPortPointPathing/AutoroutingPipelineSolver3_HgPortPointPathing.ts
@@ -32,6 +32,10 @@ import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivity
 import { getInitiallyConnectedMapFromSimpleRouteJson } from "lib/utils/get-initially-connected-map-from-simple-route-json"
 import { getViaDimensions } from "lib/utils/getViaDimensions"
 import { calculateOptimalCapacityDepth } from "lib/utils/getTunedTotalCapacity1"
+import {
+  normalizeSrjRoutingLayers,
+  restrictCapacityNodesToRoutingLayers,
+} from "lib/utils/routing-layer-constraints"
 import { AvailableSegmentPointSolver } from "../../solvers/AvailableSegmentPointSolver/AvailableSegmentPointSolver"
 import { BaseSolver } from "../../solvers/BaseSolver"
 import { CapacityMeshEdgeSolver } from "../../solvers/CapacityMeshSolver/CapacityMeshEdgeSolver"
@@ -150,7 +154,10 @@ export class AutoroutingPipelineSolver3_HgPortPointPathing extends BaseSolver {
       ],
       {
         onSolved: (cms) => {
-          cms.capacityNodes = cms.nodeSolver?.getOutput().meshNodes ?? []
+          cms.capacityNodes = restrictCapacityNodesToRoutingLayers(
+            cms.nodeSolver?.getOutput().meshNodes ?? [],
+            cms.srj,
+          )
         },
       },
     ),
@@ -375,7 +382,7 @@ export class AutoroutingPipelineSolver3_HgPortPointPathing extends BaseSolver {
     public readonly opts: CapacityMeshSolverOptions = {},
   ) {
     super()
-    this.srj = srj
+    this.srj = normalizeSrjRoutingLayers(srj)
     this.opts = { ...opts }
     this.viaDiameter = getViaDimensions(srj).padDiameter
     this.minTraceWidth = srj.minTraceWidth

--- a/lib/autorouter-pipelines/AutoroutingPipeline4_TinyHypergraph/AutoroutingPipelineSolver4_TinyHypergraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline4_TinyHypergraph/AutoroutingPipelineSolver4_TinyHypergraph.ts
@@ -37,6 +37,7 @@ import { getPresuppliedTraceVisualization } from "lib/utils/getPresuppliedTraceV
 import { calculateOptimalCapacityDepth } from "lib/utils/getTunedTotalCapacity1"
 import { getViaDimensions } from "lib/utils/getViaDimensions"
 import {
+  getRoutingZLayers,
   normalizeSrjRoutingLayers,
   restrictCapacityNodesToRoutingLayers,
 } from "lib/utils/routing-layer-constraints"
@@ -345,10 +346,7 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
         hasImpossibleSameLayerCrossingGeometry(node)
           ? {
               ...node,
-              availableZ: Array.from(
-                { length: cms.srj.layerCount },
-                (_, z) => z,
-              ),
+              availableZ: getRoutingZLayers(cms.srj),
             }
           : node,
       )

--- a/lib/autorouter-pipelines/AutoroutingPipeline4_TinyHypergraph/AutoroutingPipelineSolver4_TinyHypergraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline4_TinyHypergraph/AutoroutingPipelineSolver4_TinyHypergraph.ts
@@ -36,6 +36,10 @@ import {
 import { getPresuppliedTraceVisualization } from "lib/utils/getPresuppliedTraceVisualization"
 import { calculateOptimalCapacityDepth } from "lib/utils/getTunedTotalCapacity1"
 import { getViaDimensions } from "lib/utils/getViaDimensions"
+import {
+  normalizeSrjRoutingLayers,
+  restrictCapacityNodesToRoutingLayers,
+} from "lib/utils/routing-layer-constraints"
 import { AvailableSegmentPointSolver } from "../../solvers/AvailableSegmentPointSolver/AvailableSegmentPointSolver"
 import { BaseSolver } from "../../solvers/BaseSolver"
 import { CapacityMeshEdgeSolver } from "../../solvers/CapacityMeshSolver/CapacityMeshEdgeSolver"
@@ -206,7 +210,10 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
       ],
       {
         onSolved: (cms) => {
-          cms.capacityNodes = cms.nodeSolver?.getOutput().meshNodes ?? []
+          cms.capacityNodes = restrictCapacityNodesToRoutingLayers(
+            cms.nodeSolver?.getOutput().meshNodes ?? [],
+            cms.srj,
+          )
         },
       },
     ),
@@ -462,7 +469,8 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
     public readonly opts: CapacityMeshSolverOptions = {},
   ) {
     super()
-    this.originalSrj = srj
+    const normalizedSrj = normalizeSrjRoutingLayers(srj)
+    this.originalSrj = normalizedSrj
     this.opts = { ...opts }
     const mutableOpts = this.opts
     this.effort = mutableOpts.effort ?? 1
@@ -471,7 +479,7 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
     this.maxNodeDimension = mutableOpts.maxNodeDimension ?? 16
     this.maxNodeRatio = mutableOpts.maxNodeRatio ?? 6
     this.minNodeArea = mutableOpts.minNodeArea ?? 0.1 ** 2
-    this.setSimpleRouteJson(srj)
+    this.setSimpleRouteJson(normalizedSrj)
 
     if (mutableOpts.capacityDepth === undefined) {
       const boundsWidth = this.srj.bounds.maxX - this.srj.bounds.minX

--- a/lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/AutoroutingPipelineSolver6_PolyHypergraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/AutoroutingPipelineSolver6_PolyHypergraph.ts
@@ -30,6 +30,7 @@ import {
 import { getPresuppliedTraceVisualization } from "lib/utils/getPresuppliedTraceVisualization"
 import { calculateOptimalCapacityDepth } from "lib/utils/getTunedTotalCapacity1"
 import { getViaDimensions } from "lib/utils/getViaDimensions"
+import { normalizeSrjRoutingLayers } from "lib/utils/routing-layer-constraints"
 import { AttachProjectedRectsSolver } from "./AttachProjectedRectsSolver"
 import { PolyHighDensitySolver } from "./PolyHighDensitySolver"
 import { PolyHypergraphPortPointPathingSolver } from "./PolyHypergraphPortPointPathingSolver"
@@ -309,7 +310,8 @@ export class AutoroutingPipelineSolver6_PolyHypergraph extends BaseSolver {
     public readonly opts: CapacityMeshSolverOptions = {},
   ) {
     super()
-    this.originalSrj = srj
+    const normalizedSrj = normalizeSrjRoutingLayers(srj)
+    this.originalSrj = normalizedSrj
     this.opts = { ...opts }
     const mutableOpts = this.opts
     this.effort = mutableOpts.effort ?? 1
@@ -318,7 +320,7 @@ export class AutoroutingPipelineSolver6_PolyHypergraph extends BaseSolver {
     this.maxNodeDimension = mutableOpts.maxNodeDimension ?? 16
     this.maxNodeRatio = mutableOpts.maxNodeRatio ?? 6
     this.minNodeArea = mutableOpts.minNodeArea ?? 0.1 ** 2
-    this.setSimpleRouteJson(srj)
+    this.setSimpleRouteJson(normalizedSrj)
     this.equivalentAreaExpansionFactor =
       mutableOpts.equivalentAreaExpansionFactor ?? 2
     this.minProjectedRectDimension =

--- a/lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/PolyHypergraphPortPointPathingSolver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/PolyHypergraphPortPointPathingSolver.ts
@@ -8,6 +8,7 @@ import { calculateNodeProbabilityOfFailure } from "lib/solvers/UnravelSolver/cal
 import type { CapacityMeshNodeId, SimpleRouteJson } from "lib/types"
 import type { PortPoint } from "lib/types/high-density-types"
 import { getIntraNodeCrossingsUsingCircle } from "lib/utils/getIntraNodeCrossingsUsingCircle"
+import { restrictZLayersToRoutingLayers } from "lib/utils/routing-layer-constraints"
 import {
   type ConvexRegionsComputeResult,
   type LayerMergeMode,
@@ -177,7 +178,9 @@ export class PolyHypergraphPortPointPathingSolver extends BaseSolver {
     }
     this.serializedGraph = buildPolyHyperGraphFromRegions({
       regions: this.convexRegions.regions,
-      availableZ: this.convexRegions.availableZ,
+      availableZ: this.convexRegions.availableZ?.map((zLayers) =>
+        restrictZLayersToRoutingLayers(zLayers, params.srj),
+      ),
       layerCount: params.srj.layerCount,
       connections: getPolyGraphConnectionsFromSrj(params.srj),
       obstacleRegions: getConnectedObstacleRegionsFromSrj(

--- a/lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/srjToPolyHyperGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/srjToPolyHyperGraph.ts
@@ -13,6 +13,7 @@ import type {
   SimpleRouteConnection,
   SimpleRouteJson,
 } from "lib/types"
+import { restrictZLayersToRoutingLayers } from "lib/utils/routing-layer-constraints"
 
 type AnyObstacle = Omit<Obstacle, "type"> & {
   type: string
@@ -110,9 +111,12 @@ export const getConnectedObstacleRegionsFromSrj = (
       return []
     }
 
-    const availableZ = getAvailableZFromMask(
-      getObstacleLayerMask(obstacle as any, srj.layerCount),
-      srj.layerCount,
+    const availableZ = restrictZLayersToRoutingLayers(
+      getAvailableZFromMask(
+        getObstacleLayerMask(obstacle as any, srj.layerCount),
+        srj.layerCount,
+      ),
+      srj,
     )
     if (availableZ.length === 0) return []
 

--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -718,6 +718,11 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
       "lengthMatchingPostProcessingSolver",
       DifferentialPairPostProcessingSolver,
       (cms) => {
+        if (!canUseUnrestrictedLayerMoves(cms.originalSrj)) {
+          throw new Error(
+            "Differential-pair post-processing cannot run when routingLayers excludes board layers",
+          )
+        }
         const netToPointPairsSolver = cms.netToPointPairsSolver
         if (!netToPointPairsSolver)
           throw new Error(
@@ -902,6 +907,18 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
         this.failed = true
         this.activeSubSolver = null
       }
+      return
+    }
+
+    if (
+      pipelineStepDef.solverName === "lengthMatchingPostProcessingSolver" &&
+      !canUseUnrestrictedLayerMoves(this.originalSrj)
+    ) {
+      this.stats = {
+        ...this.stats,
+        lengthMatchingPostProcessingSkippedForRoutingLayers: true,
+      }
+      this.currentPipelineStepIndex++
       return
     }
 

--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -718,7 +718,10 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
       "lengthMatchingPostProcessingSolver",
       DifferentialPairPostProcessingSolver,
       (cms) => {
-        if (!canUseUnrestrictedLayerMoves(cms.originalSrj)) {
+        if (
+          !canUseUnrestrictedLayerMoves(cms.originalSrj) &&
+          (cms.originalSrj.differentialPairs?.length ?? 0) > 0
+        ) {
           throw new Error(
             "Differential-pair post-processing cannot run when routingLayers excludes board layers",
           )
@@ -912,7 +915,8 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
 
     if (
       pipelineStepDef.solverName === "lengthMatchingPostProcessingSolver" &&
-      !canUseUnrestrictedLayerMoves(this.originalSrj)
+      !canUseUnrestrictedLayerMoves(this.originalSrj) &&
+      (this.originalSrj.differentialPairs?.length ?? 0) === 0
     ) {
       this.stats = {
         ...this.stats,

--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -45,6 +45,11 @@ import { getPresuppliedTraceVisualization } from "lib/utils/getPresuppliedTraceV
 import { calculateOptimalCapacityDepth } from "lib/utils/getTunedTotalCapacity1"
 import { getViaDimensions } from "lib/utils/getViaDimensions"
 import {
+  canUseUnrestrictedLayerMoves,
+  normalizeSrjRoutingLayers,
+  restrictCapacityNodesToRoutingLayers,
+} from "lib/utils/routing-layer-constraints"
+import {
   AvailableSegmentPointSolver,
   type SharedEdgeSegment,
 } from "../../solvers/AvailableSegmentPointSolver/AvailableSegmentPointSolver"
@@ -373,7 +378,10 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
       },
       {
         onSolved: (cms) => {
-          cms.capacityNodes = cms.topologyMergingSolver!.getOutput()
+          cms.capacityNodes = restrictCapacityNodesToRoutingLayers(
+            cms.topologyMergingSolver!.getOutput(),
+            cms.srj,
+          )
         },
       },
     ),
@@ -693,8 +701,12 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
             enableBroadFallback: false,
             enableTargetedErrorSweep: true,
             enablePostSolveClearanceRelaxation: false,
-            enableSafeTraceLayerMoves: true,
-            enableViaInPadLayerMoves: cms.originalSrj.allowViaInPad ?? false,
+            enableSafeTraceLayerMoves: canUseUnrestrictedLayerMoves(
+              cms.originalSrj,
+            ),
+            enableViaInPadLayerMoves:
+              canUseUnrestrictedLayerMoves(cms.originalSrj) &&
+              (cms.originalSrj.allowViaInPad ?? false),
             viaInPadMaxIterations: 32,
             broadMaxIterations: 12,
             broadPassMultiplier: 3,
@@ -817,7 +829,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
   ) {
     super()
     const srjWithBoardValidObstacleLayers =
-      createSrjWithBoardValidObstacleLayers(srj)
+      createSrjWithBoardValidObstacleLayers(normalizeSrjRoutingLayers(srj))
     this.originalSrj = srjWithBoardValidObstacleLayers
     this.opts = { ...opts }
     const mutableOpts = this.opts

--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/PowerTraceExpansionSolver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/PowerTraceExpansionSolver.ts
@@ -6,6 +6,7 @@ import {
 import type { GraphicsObject } from "graphics-debug"
 import type { SimpleRouteJson, SimplifiedPcbTraces } from "lib/types"
 import { convertSrjToGraphicsObject } from "lib/utils/convertSrjToGraphicsObject"
+import { canUseUnrestrictedLayerMoves } from "lib/utils/routing-layer-constraints"
 import { BaseSolver } from "../../solvers/BaseSolver"
 
 export class PowerTraceExpansionSolver extends BaseSolver {
@@ -16,6 +17,14 @@ export class PowerTraceExpansionSolver extends BaseSolver {
     public readonly options: PowerTraceExpanderOptions = {},
   ) {
     super()
+    if (
+      options.allowNewVias !== false &&
+      !canUseUnrestrictedLayerMoves(inputSrj)
+    ) {
+      throw new Error(
+        "Power trace expansion cannot add vias when routingLayers excludes board layers",
+      )
+    }
     this.powerTraceExpanderSolver = new PowerTraceExpanderSolver(
       inputSrj as unknown as PowerTraceExpanderInput,
       options,

--- a/lib/autorouter-pipelines/AutoroutingPipeline8/AutoroutingPipelineSolver8.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline8/AutoroutingPipelineSolver8.ts
@@ -38,6 +38,10 @@ import {
 import { getPresuppliedTraceVisualization } from "lib/utils/getPresuppliedTraceVisualization"
 import { calculateOptimalCapacityDepth } from "lib/utils/getTunedTotalCapacity1"
 import { getViaDimensions } from "lib/utils/getViaDimensions"
+import {
+  normalizeSrjRoutingLayers,
+  restrictCapacityNodesToRoutingLayers,
+} from "lib/utils/routing-layer-constraints"
 import { getAssignableViaPointKeys } from "./assignableViaUtils"
 import { getXyPointKey } from "./getXyPointKey"
 import { AvailableSegmentPointSolver } from "../../solvers/AvailableSegmentPointSolver/AvailableSegmentPointSolver"
@@ -212,7 +216,10 @@ export class AutoroutingPipelineSolver8 extends BaseSolver {
       ],
       {
         onSolved: (cms) => {
-          cms.capacityNodes = cms.nodeSolver?.getOutput().meshNodes ?? []
+          cms.capacityNodes = restrictCapacityNodesToRoutingLayers(
+            cms.nodeSolver?.getOutput().meshNodes ?? [],
+            cms.srj,
+          )
         },
       },
     ),
@@ -506,7 +513,8 @@ export class AutoroutingPipelineSolver8 extends BaseSolver {
     public readonly opts: CapacityMeshSolverOptions = {},
   ) {
     super()
-    this.originalSrj = srj
+    const normalizedSrj = normalizeSrjRoutingLayers(srj)
+    this.originalSrj = normalizedSrj
     this.opts = { ...opts }
     const mutableOpts = this.opts
     this.effort = mutableOpts.effort ?? 1
@@ -515,7 +523,7 @@ export class AutoroutingPipelineSolver8 extends BaseSolver {
     this.maxNodeDimension = mutableOpts.maxNodeDimension ?? 16
     this.maxNodeRatio = mutableOpts.maxNodeRatio ?? 6
     this.minNodeArea = mutableOpts.minNodeArea ?? 0.1 ** 2
-    this.setSimpleRouteJson(srj)
+    this.setSimpleRouteJson(normalizedSrj)
 
     if (mutableOpts.capacityDepth === undefined) {
       const boundsWidth = this.srj.bounds.maxX - this.srj.bounds.minX

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/apply-pipeline9-regional-b01-repairs.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/apply-pipeline9-regional-b01-repairs.ts
@@ -5,6 +5,7 @@ import {
 } from "high-density-repair03/lib"
 import type { SimpleRouteConnection, SimpleRouteJson } from "lib/types"
 import type { HighDensityRoute } from "lib/types/high-density-types"
+import { canUseUnrestrictedLayerMoves } from "lib/utils/routing-layer-constraints"
 import type { PreloadedHighDensityRoute } from "./convert-preloaded-traces-to-hd-routes"
 import {
   arePipeline9RoutesOnSameNet,
@@ -692,7 +693,11 @@ export const applyPipeline9RegionalB01Repairs = ({
   )
   const safeTraceLayerRepairSkippedForBudget =
     hasSafeLayerRepairableError && candidateSearchBudgetExhausted
-  if (hasSafeLayerRepairableError && !candidateSearchBudgetExhausted) {
+  if (
+    hasSafeLayerRepairableError &&
+    !candidateSearchBudgetExhausted &&
+    canUseUnrestrictedLayerMoves(srj)
+  ) {
     const safeTraceLayerSolver = new GlobalDrcForceImproveSolver({
       srj: { ...srj, traces: undefined },
       hdRoutes: currentRoutes,

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/apply-pipeline9-regional-b01-repairs.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/apply-pipeline9-regional-b01-repairs.ts
@@ -5,7 +5,10 @@ import {
 } from "high-density-repair03/lib"
 import type { SimpleRouteConnection, SimpleRouteJson } from "lib/types"
 import type { HighDensityRoute } from "lib/types/high-density-types"
-import { canUseUnrestrictedLayerMoves } from "lib/utils/routing-layer-constraints"
+import {
+  canUseUnrestrictedLayerMoves,
+  getRoutingZLayers,
+} from "lib/utils/routing-layer-constraints"
 import type { PreloadedHighDensityRoute } from "./convert-preloaded-traces-to-hd-routes"
 import {
   arePipeline9RoutesOnSameNet,
@@ -339,7 +342,7 @@ const getRegionalCandidate = ({
     center,
     width: regionSize,
     height: regionSize,
-    availableZ: Array.from({ length: srj.layerCount }, (_, z) => z),
+    availableZ: getRoutingZLayers(srj),
     portPoints: [],
     portPointsInPairs: [],
   }
@@ -359,6 +362,7 @@ const getRegionalCandidate = ({
     colorMap,
     obstacles: srj.obstacles,
     layerCount: srj.layerCount,
+    allowedZ: getRoutingZLayers(srj),
     viaDiameter,
     traceWidth,
     obstacleMargin,
@@ -416,7 +420,7 @@ const getRegularRegionalCandidate = ({
     center,
     width: regionSize,
     height: regionSize,
-    availableZ: Array.from({ length: srj.layerCount }, (_, z) => z),
+    availableZ: getRoutingZLayers(srj),
     portPoints: [],
     portPointsInPairs: [],
   }

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph.ts
@@ -850,7 +850,10 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
       "lengthMatchingPostProcessingSolver",
       DifferentialPairPostProcessingSolver,
       (cms) => {
-        if (!canUseUnrestrictedLayerMoves(cms.originalSrj)) {
+        if (
+          !canUseUnrestrictedLayerMoves(cms.originalSrj) &&
+          (cms.originalSrj.differentialPairs?.length ?? 0) > 0
+        ) {
           throw new Error(
             "Differential-pair post-processing cannot run when routingLayers excludes board layers",
           )
@@ -1046,7 +1049,8 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
 
     if (
       pipelineStepDef.solverName === "lengthMatchingPostProcessingSolver" &&
-      !canUseUnrestrictedLayerMoves(this.originalSrj)
+      !canUseUnrestrictedLayerMoves(this.originalSrj) &&
+      (this.originalSrj.differentialPairs?.length ?? 0) === 0
     ) {
       this.stats = {
         ...this.stats,

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph.ts
@@ -48,6 +48,10 @@ import { getPresuppliedTraceVisualization } from "lib/utils/getPresuppliedTraceV
 import { calculateOptimalCapacityDepth } from "lib/utils/getTunedTotalCapacity1"
 import { getViaDimensions } from "lib/utils/getViaDimensions"
 import {
+  normalizeSrjRoutingLayers,
+  restrictCapacityNodesToRoutingLayers,
+} from "lib/utils/routing-layer-constraints"
+import {
   AvailableSegmentPointSolver,
   type SharedEdgeSegment,
 } from "../../solvers/AvailableSegmentPointSolver/AvailableSegmentPointSolver"
@@ -408,7 +412,10 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
       },
       {
         onSolved: (cms) => {
-          cms.capacityNodes = cms.topologyMergingSolver!.getOutput()
+          cms.capacityNodes = restrictCapacityNodesToRoutingLayers(
+            cms.topologyMergingSolver!.getOutput(),
+            cms.srj,
+          )
         },
       },
     ),
@@ -953,7 +960,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
   ) {
     super()
     const srjWithBoardValidObstacleLayers =
-      createSrjWithBoardValidObstacleLayers(srj)
+      createSrjWithBoardValidObstacleLayers(normalizeSrjRoutingLayers(srj))
     this.originalSrj = srjWithBoardValidObstacleLayers
     this.opts = { ...opts }
     const mutableOpts = this.opts

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph.ts
@@ -48,6 +48,8 @@ import { getPresuppliedTraceVisualization } from "lib/utils/getPresuppliedTraceV
 import { calculateOptimalCapacityDepth } from "lib/utils/getTunedTotalCapacity1"
 import { getViaDimensions } from "lib/utils/getViaDimensions"
 import {
+  canUseUnrestrictedLayerMoves,
+  getRoutingZLayers,
   normalizeSrjRoutingLayers,
   restrictCapacityNodesToRoutingLayers,
 } from "lib/utils/routing-layer-constraints"
@@ -621,6 +623,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
             colorMap: cms.colorMap,
             obstacles: cms.srj.obstacles,
             layerCount: cms.srj.layerCount,
+            allowedZ: getRoutingZLayers(cms.srj),
             viaDiameter: cms.viaDiameter,
             traceWidth: cms.minTraceWidth,
             obstacleMargin: cms.srj.defaultObstacleMargin ?? 0.15,
@@ -847,6 +850,11 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
       "lengthMatchingPostProcessingSolver",
       DifferentialPairPostProcessingSolver,
       (cms) => {
+        if (!canUseUnrestrictedLayerMoves(cms.originalSrj)) {
+          throw new Error(
+            "Differential-pair post-processing cannot run when routingLayers excludes board layers",
+          )
+        }
         const netToPointPairsSolver = cms.netToPointPairsSolver
         if (!netToPointPairsSolver)
           throw new Error(
@@ -1033,6 +1041,18 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
         this.failed = true
         this.activeSubSolver = null
       }
+      return
+    }
+
+    if (
+      pipelineStepDef.solverName === "lengthMatchingPostProcessingSolver" &&
+      !canUseUnrestrictedLayerMoves(this.originalSrj)
+    ) {
+      this.stats = {
+        ...this.stats,
+        lengthMatchingPostProcessingSkippedForRoutingLayers: true,
+      }
+      this.currentPipelineStepIndex++
       return
     }
 

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-high-density-solver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-high-density-solver.ts
@@ -38,6 +38,8 @@ type Pipeline9HighDensitySolverParams = {
   colorMap?: Record<string, string>
   obstacles: Obstacle[]
   layerCount: number
+  /** Logical copper layers that newly generated routes may use. */
+  allowedZ?: number[]
   viaDiameter: number
   traceWidth: number
   obstacleMargin: number
@@ -325,6 +327,7 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
   readonly colorMap: Record<string, string>
   readonly obstacles: Obstacle[]
   readonly layerCount: number
+  readonly allowedZ: number[]
   readonly viaDiameter: number
   readonly traceWidth: number
   readonly obstacleMargin: number
@@ -357,6 +360,22 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
     this.colorMap = params.colorMap ?? {}
     this.obstacles = params.obstacles
     this.layerCount = params.layerCount
+    this.allowedZ = [
+      ...new Set(
+        params.allowedZ ??
+          Array.from({ length: params.layerCount }, (_, z) => z),
+      ),
+    ].sort((a, b) => a - b)
+    if (
+      this.allowedZ.length === 0 ||
+      this.allowedZ.some(
+        (z) => !Number.isInteger(z) || z < 0 || z >= params.layerCount,
+      )
+    ) {
+      throw new Error(
+        `Pipeline9 allowedZ must contain valid layers for a ${params.layerCount}-layer board`,
+      )
+    }
     this.viaDiameter = params.viaDiameter
     this.traceWidth = params.traceWidth
     this.obstacleMargin = params.obstacleMargin
@@ -460,7 +479,7 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
       // Once B01 has proved that assignment unroutable, the regional repair
       // must be able to add a legal layer transition; board obstacles still
       // constrain which of these layers it can actually use.
-      availableZ: Array.from({ length: this.layerCount }, (_, z) => z),
+      availableZ: this.allowedZ,
     }
     const fallbackProblem = createRegionalFallbackProblem(
       regionalNode,
@@ -730,7 +749,7 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
         ...normalizeNodeRootConnectionNames(this.activeNode, this.connMap),
         portPoints: [],
         portPointsInPairs: [],
-        availableZ: Array.from({ length: this.layerCount }, (_, z) => z),
+        availableZ: this.allowedZ,
       },
       this.getUpdatedFixedHdRoutes(),
     )

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-joint-drc-repair-solver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-joint-drc-repair-solver.ts
@@ -20,6 +20,7 @@ import type {
   SimplifiedPcbTrace,
 } from "lib/types"
 import type { HighDensityRoute } from "lib/types/high-density-types"
+import { canUseUnrestrictedLayerMoves } from "lib/utils/routing-layer-constraints"
 import { convertHdRouteToSimplifiedRoute } from "lib/utils/convertHdRouteToSimplifiedRoute"
 import { mapZToLayerName } from "lib/utils/mapZToLayerName"
 import { Pipeline7AdaptiveDrcBranchPortfolioSolver } from "../AutoroutingPipeline7_MultiGraph/Pipeline7AdaptiveDrcBranchPortfolioSolver"
@@ -1308,8 +1309,12 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
       enableTargetedErrorSweep: true,
       enableTraceViaOwnerTargeting: true,
       enablePostSolveClearanceRelaxation: false,
-      enableSafeTraceLayerMoves: true,
-      enableViaInPadLayerMoves: params.originalSrj.allowViaInPad ?? false,
+      enableSafeTraceLayerMoves: canUseUnrestrictedLayerMoves(
+        params.originalSrj,
+      ),
+      enableViaInPadLayerMoves:
+        canUseUnrestrictedLayerMoves(params.originalSrj) &&
+        (params.originalSrj.allowViaInPad ?? false),
       viaInPadMaxIterations: EXACT_REPAIR_MAX_ITERATIONS,
       broadMaxIterations: EXACT_REPAIR_BROAD_MAX_ITERATIONS,
       broadPassMultiplier: 3,

--- a/lib/solvers/CapacityMeshSolver/CapacityMeshNodeSolver1.ts
+++ b/lib/solvers/CapacityMeshSolver/CapacityMeshNodeSolver1.ts
@@ -24,6 +24,7 @@ import { getTunedTotalCapacity1 } from "lib/utils/getTunedTotalCapacity1"
 import { ObstacleSpatialHashIndex } from "lib/data-structures/ObstacleTree"
 import { TargetTree } from "lib/data-structures/TargetTree"
 import { createObjectsWithZLayers } from "lib/utils/createObjectsWithZLayers"
+import { getRoutingZLayers } from "lib/utils/routing-layer-constraints"
 
 interface CapacityMeshNodeSolverOptions {
   capacityDepth?: number
@@ -90,7 +91,7 @@ export class CapacityMeshNodeSolver extends BaseSolver {
         width: maxWidthHeight,
         height: maxWidthHeight,
         layer: "top",
-        availableZ: Array.from({ length: this.layerCount }, (_, i) => i),
+        availableZ: getRoutingZLayers(srj),
         _depth: 0,
         _containsTarget: true,
         _containsObstacle: true,

--- a/lib/solvers/EscapeViaLocationSolver/EscapeViaLocationSolver.ts
+++ b/lib/solvers/EscapeViaLocationSolver/EscapeViaLocationSolver.ts
@@ -18,6 +18,7 @@ import { mapLayerNameToZ } from "lib/utils/mapLayerNameToZ"
 import { mapZToLayerName } from "lib/utils/mapZToLayerName"
 import { getPointKey } from "lib/utils/getPointKey"
 import { getViaDimensions } from "lib/utils/getViaDimensions"
+import { getRoutingZLayers } from "lib/utils/routing-layer-constraints"
 import {
   doesSegmentCrossPolygonBoundary,
   isPointInOrOnPolygon,
@@ -102,6 +103,7 @@ export class EscapeViaLocationSolver extends BaseSolver {
   outputSrj: SimpleRouteJson
   escapeViaMetadataByPointId: Map<string, EscapeViaMetadata>
   createdEscapeVias: EscapeViaMetadata[]
+  routingZLayers: ReadonlySet<number>
   nextEscapeViaIndex = 0
 
   constructor(
@@ -127,6 +129,7 @@ export class EscapeViaLocationSolver extends BaseSolver {
     this.outputSrj = ogSrj
     this.escapeViaMetadataByPointId = new Map()
     this.createdEscapeVias = []
+    this.routingZLayers = new Set(getRoutingZLayers(ogSrj))
   }
 
   private getConnectionNetIds(connection: SimpleRouteConnection): Set<string> {
@@ -722,6 +725,7 @@ export class EscapeViaLocationSolver extends BaseSolver {
       if (!targetLayer || targetLayer === sourceLayer) continue
 
       const targetZ = mapLayerNameToZ(targetLayer, this.ogSrj.layerCount)
+      if (!this.routingZLayers.has(targetZ)) continue
       const targetPourKey = getObstacleKey(copperPour)
 
       for (const candidate of candidates) {

--- a/lib/types/srj-types.ts
+++ b/lib/types/srj-types.ts
@@ -53,6 +53,11 @@ export type JumperType = "1206x4" | "0603"
 
 export interface SimpleRouteJson {
   layerCount: number
+  /**
+   * Copper layers available for newly generated wire segments and logical
+   * routing transitions. Physical via spans are controlled independently.
+   */
+  routingLayers?: string[]
   minTraceWidth: number
   nominalTraceWidth?: number
   /** @deprecated Use `min_via_pad_diameter` / `minViaPadDiameter` instead. */

--- a/lib/utils/routing-layer-constraints.ts
+++ b/lib/utils/routing-layer-constraints.ts
@@ -1,0 +1,125 @@
+import type { CapacityMeshNode, SimpleRouteJson } from "lib/types"
+import { isMultiLayerConnectionPoint } from "lib/types/srj-types"
+
+function resolveRoutingLayer(layer: string, layerCount: number): number {
+  if (layer === "top") return 0
+  if (layer === "bottom") return layerCount - 1
+
+  const innerLayerMatch = /^inner([1-9][0-9]*)$/.exec(layer)
+  const z = innerLayerMatch ? Number(innerLayerMatch[1]) : Number.NaN
+  if (!Number.isInteger(z) || z <= 0 || z >= layerCount - 1) {
+    throw new Error(
+      `Invalid routing layer "${layer}" for a ${layerCount}-layer board`,
+    )
+  }
+  return z
+}
+
+export function getRoutingZLayers(srj: SimpleRouteJson): number[] {
+  if (srj.routingLayers === undefined) {
+    return Array.from({ length: srj.layerCount }, (_, z) => z)
+  }
+  if (srj.routingLayers.length === 0) {
+    throw new Error("routingLayers must contain at least one board layer")
+  }
+
+  const routingZLayers = srj.routingLayers.map((layer) =>
+    resolveRoutingLayer(layer, srj.layerCount),
+  )
+  if (new Set(routingZLayers).size !== routingZLayers.length) {
+    throw new Error("routingLayers must not contain duplicate board layers")
+  }
+  return [...routingZLayers].sort((a, b) => a - b)
+}
+
+export function normalizeSrjRoutingLayers(
+  srj: SimpleRouteJson,
+): SimpleRouteJson {
+  if (srj.routingLayers === undefined) return srj
+
+  const routingZLayers = new Set(getRoutingZLayers(srj))
+  const connections = srj.connections.map((connection) => ({
+    ...connection,
+    pointsToConnect: connection.pointsToConnect.map((point, pointIndex) => {
+      if (isMultiLayerConnectionPoint(point)) {
+        const layers = point.layers.filter((layer) =>
+          routingZLayers.has(resolveRoutingLayer(layer, srj.layerCount)),
+        )
+        if (layers.length === 0) {
+          throw new Error(
+            `Connection "${connection.name}" point ${pointIndex} has no layer allowed by routingLayers`,
+          )
+        }
+        return { ...point, layers }
+      }
+
+      const z = resolveRoutingLayer(point.layer, srj.layerCount)
+      if (!routingZLayers.has(z)) {
+        throw new Error(
+          `Connection "${connection.name}" point ${pointIndex} is on excluded routing layer "${point.layer}"`,
+        )
+      }
+      if (point.terminalVia) {
+        const terminalViaZ = resolveRoutingLayer(
+          point.terminalVia.toLayer,
+          srj.layerCount,
+        )
+        if (!routingZLayers.has(terminalViaZ)) {
+          throw new Error(
+            `Connection "${connection.name}" point ${pointIndex} terminal via ends on excluded routing layer "${point.terminalVia.toLayer}"`,
+          )
+        }
+      }
+      return point
+    }),
+  }))
+
+  const buses = srj.buses?.map((bus) => {
+    if (bus.allowedLayers === undefined) return bus
+    const allowedLayers = bus.allowedLayers.filter((layer) =>
+      routingZLayers.has(resolveRoutingLayer(layer, srj.layerCount)),
+    )
+    if (allowedLayers.length === 0) {
+      throw new Error(
+        `Bus "${bus.busId}" has no layer allowed by routingLayers`,
+      )
+    }
+    return { ...bus, allowedLayers }
+  })
+
+  return { ...srj, connections, buses }
+}
+
+export function restrictCapacityNodesToRoutingLayers(
+  capacityNodes: CapacityMeshNode[],
+  srj: SimpleRouteJson,
+): CapacityMeshNode[] {
+  if (srj.routingLayers === undefined) return capacityNodes
+
+  const routingZLayers = new Set(getRoutingZLayers(srj))
+  return capacityNodes
+    .map((node) => ({
+      ...node,
+      availableZ: node.availableZ.filter((z) => routingZLayers.has(z)),
+    }))
+    .filter((node) => node.availableZ.length > 0)
+}
+
+export function restrictZLayersToRoutingLayers(
+  zLayers: readonly number[],
+  srj: SimpleRouteJson,
+): number[] {
+  if (srj.routingLayers === undefined) return [...zLayers]
+  const routingZLayers = new Set(getRoutingZLayers(srj))
+  return zLayers.filter((z) => routingZLayers.has(z))
+}
+
+/**
+ * The current high-density-repair03 layer-move APIs enumerate every z from
+ * zero through layerCount - 1 and do not accept an allowlist. Keep those
+ * optional moves off for a proper subset until that API can enforce allowed
+ * targets itself. Other repair phases remain enabled.
+ */
+export function canUseUnrestrictedLayerMoves(srj: SimpleRouteJson): boolean {
+  return getRoutingZLayers(srj).length === srj.layerCount
+}

--- a/lib/utils/routing-layer-constraints.ts
+++ b/lib/utils/routing-layer-constraints.ts
@@ -3,7 +3,7 @@ import { isMultiLayerConnectionPoint } from "lib/types/srj-types"
 
 function resolveRoutingLayer(layer: string, layerCount: number): number {
   if (layer === "top") return 0
-  if (layer === "bottom") return layerCount - 1
+  if (layer === "bottom" && layerCount > 1) return layerCount - 1
 
   const innerLayerMatch = /^inner([1-9][0-9]*)$/.exec(layer)
   const z = innerLayerMatch ? Number(innerLayerMatch[1]) : Number.NaN

--- a/tests/features/pipeline9-high-density-no-invalid-fallback.test.ts
+++ b/tests/features/pipeline9-high-density-no-invalid-fallback.test.ts
@@ -71,6 +71,7 @@ test("Pipeline9 rejects invalid geometry and retries across legal layers", () =>
     nodePortPoints: [nodeWithPortPoints],
     fixedHdRoutes: [],
     layerCount: 2,
+    allowedZ: [0, 1],
   })
   twoLayerSolver.solve()
   expect(twoLayerSolver.solved).toBeTrue()
@@ -81,4 +82,16 @@ test("Pipeline9 rejects invalid geometry and retries across legal layers", () =>
       route.route.some((point) => point.z === 1),
     ),
   ).toBeTrue()
+
+  const topOnlySolver = new Pipeline9HighDensitySolver({
+    ...sharedParams,
+    nodePortPoints: [nodeWithPortPoints],
+    fixedHdRoutes: [],
+    layerCount: 2,
+    allowedZ: [0],
+  })
+  topOnlySolver.solve()
+  expect(topOnlySolver.solved).toBeFalse()
+  expect(topOnlySolver.failed).toBeTrue()
+  expect(topOnlySolver.routes).toEqual([])
 })

--- a/tests/features/routing-layers-assignable3-jumpers.test.ts
+++ b/tests/features/routing-layers-assignable3-jumpers.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test"
+import { AssignableAutoroutingPipeline3 } from "lib/autorouter-pipelines/AssignableAutoroutingPipeline3/AssignableAutoroutingPipeline3"
+import type { SimpleRouteJson } from "lib/types"
+
+test("AssignablePipeline3 fails clearly before placing a jumper on an excluded top layer", () => {
+  const input = {
+    layerCount: 2,
+    routingLayers: ["bottom"],
+    minTraceWidth: 0.1,
+    minViaPadDiameter: 0.3,
+    bounds: { minX: -1.05, maxX: 1.05, minY: -1.05, maxY: 1.05 },
+    obstacles: [],
+    connections: [
+      {
+        name: "horizontal",
+        pointsToConnect: [
+          { x: -1, y: 0, layer: "bottom" },
+          { x: 1, y: 0, layer: "bottom" },
+        ],
+      },
+      {
+        name: "vertical",
+        pointsToConnect: [
+          { x: 0, y: -1, layer: "bottom" },
+          { x: 0, y: 1, layer: "bottom" },
+        ],
+      },
+    ],
+  } satisfies SimpleRouteJson
+  const solver = new AssignableAutoroutingPipeline3(input, {
+    cacheProvider: null,
+    effort: 0.1,
+  })
+
+  expect(() => solver.solve()).toThrow(
+    'AssignablePipeline3 cannot place top-layer jumpers because routingLayers excludes "top"',
+  )
+})

--- a/tests/features/routing-layers-capacity-candidates.test.ts
+++ b/tests/features/routing-layers-capacity-candidates.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "bun:test"
+import type { CapacityMeshNode, SimpleRouteJson } from "lib/types"
+import { restrictCapacityNodesToRoutingLayers } from "lib/utils/routing-layer-constraints"
+
+test("capacity candidates are limited to the allowed routing layers", () => {
+  const srj = {
+    layerCount: 4,
+    routingLayers: ["top", "bottom"],
+    minTraceWidth: 0.15,
+    obstacles: [],
+    connections: [],
+    bounds: { minX: -5, maxX: 5, minY: -5, maxY: 5 },
+  } satisfies SimpleRouteJson
+  const nodes = [
+    {
+      capacityMeshNodeId: "all-layers",
+      center: { x: 0, y: 0 },
+      width: 2,
+      height: 2,
+      layer: "top",
+      availableZ: [0, 1, 2, 3],
+      _containsObstacle: false,
+      _containsTarget: false,
+    },
+    {
+      capacityMeshNodeId: "reserved-layer-only",
+      center: { x: 3, y: 0 },
+      width: 2,
+      height: 2,
+      layer: "inner1",
+      availableZ: [1, 2],
+      _containsObstacle: false,
+      _containsTarget: false,
+    },
+  ] satisfies CapacityMeshNode[]
+
+  expect(restrictCapacityNodesToRoutingLayers(nodes, srj)).toEqual([
+    expect.objectContaining({
+      capacityMeshNodeId: "all-layers",
+      availableZ: [0, 3],
+    }),
+  ])
+})

--- a/tests/features/routing-layers-crossing-fallbacks.test.ts
+++ b/tests/features/routing-layers-crossing-fallbacks.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver4_TinyHypergraph } from "lib/autorouter-pipelines/AutoroutingPipeline4_TinyHypergraph/AutoroutingPipelineSolver4_TinyHypergraph"
+import type { SimpleRouteJson } from "lib/types"
+
+const createTopOnlyCrossingInput = (): SimpleRouteJson => ({
+  layerCount: 2,
+  routingLayers: ["top"],
+  minTraceWidth: 0.1,
+  minViaPadDiameter: 0.3,
+  bounds: { minX: -1.05, maxX: 1.05, minY: -1.05, maxY: 1.05 },
+  obstacles: [],
+  connections: [
+    {
+      name: "horizontal",
+      pointsToConnect: [
+        { x: -1, y: 0, layer: "top" },
+        { x: 1, y: 0, layer: "top" },
+      ],
+    },
+    {
+      name: "vertical",
+      pointsToConnect: [
+        { x: 0, y: -1, layer: "top" },
+        { x: 0, y: 1, layer: "top" },
+      ],
+    },
+  ],
+})
+
+test("Pipeline4 fails closed when an impossible crossing has one allowed layer", () => {
+  const solver = new AutoroutingPipelineSolver4_TinyHypergraph(
+    createTopOnlyCrossingInput(),
+    { cacheProvider: null, effort: 0.1, maxNodeDimension: 10 },
+  )
+  solver.solve()
+
+  expect(solver.solved).toBeFalse()
+  expect(solver.failed).toBeTrue()
+  expect(
+    solver.highDensityNodePortPoints?.every((node) =>
+      node.availableZ?.every((z) => z === 0),
+    ),
+  ).toBeTrue()
+})

--- a/tests/features/routing-layers-default.test.ts
+++ b/tests/features/routing-layers-default.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "bun:test"
+import type { SimpleRouteJson } from "lib/types"
+import {
+  getRoutingZLayers,
+  normalizeSrjRoutingLayers,
+} from "lib/utils/routing-layer-constraints"
+
+test("omitting routingLayers preserves every board layer", () => {
+  const srj = {
+    layerCount: 4,
+    minTraceWidth: 0.15,
+    obstacles: [],
+    connections: [],
+    bounds: { minX: -5, maxX: 5, minY: -5, maxY: 5 },
+  } satisfies SimpleRouteJson
+
+  expect(getRoutingZLayers(srj)).toEqual([0, 1, 2, 3])
+  expect(normalizeSrjRoutingLayers(srj)).toBe(srj)
+})

--- a/tests/features/routing-layers-differential-pair-postprocessing.test.ts
+++ b/tests/features/routing-layers-differential-pair-postprocessing.test.ts
@@ -3,7 +3,7 @@ import { AutoroutingPipelineSolver7_MultiGraph } from "lib/autorouter-pipelines/
 import { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph"
 import type { SimpleRouteJson } from "lib/types"
 
-test("Pipelines 7 and 9 preserve routed pairs when layer-changing postprocessing cannot honor routingLayers", () => {
+test("Pipelines 7 and 9 only skip layer-changing postprocessing when no differential pairs were requested", () => {
   const input = {
     layerCount: 2,
     routingLayers: ["top"],
@@ -25,11 +25,6 @@ test("Pipelines 7 and 9 preserve routed pairs when layer-changing postprocessing
     const stepIndex = solver.pipelineDef.findIndex(
       (step) => step.solverName === "lengthMatchingPostProcessingSolver",
     )
-    const step = solver.pipelineDef[stepIndex]!
-    expect(() => step.getConstructorParams(solver as never)).toThrow(
-      "Differential-pair post-processing cannot run when routingLayers excludes board layers",
-    )
-
     solver.currentPipelineStepIndex = stepIndex
     solver.step()
     expect(solver.currentPipelineStepIndex).toBe(stepIndex + 1)
@@ -37,5 +32,47 @@ test("Pipelines 7 and 9 preserve routed pairs when layer-changing postprocessing
     expect(
       solver.stats.lengthMatchingPostProcessingSkippedForRoutingLayers,
     ).toBe(true)
+  }
+
+  const requestedPairInput = {
+    ...input,
+    differentialPairs: [
+      {
+        connectionNames: ["positive", "negative"],
+        lengthTolerance: 0.1,
+      },
+    ],
+  } satisfies SimpleRouteJson
+  const solversWithRequestedPairs = [
+    new AutoroutingPipelineSolver7_MultiGraph(
+      structuredClone(requestedPairInput),
+      { cacheProvider: null },
+    ),
+    new AutoroutingPipelineSolver9_PreloadedTraceGraph(
+      structuredClone(requestedPairInput),
+      { cacheProvider: null },
+    ),
+  ]
+
+  for (const solver of solversWithRequestedPairs) {
+    const stepIndex = solver.pipelineDef.findIndex(
+      (step) => step.solverName === "lengthMatchingPostProcessingSolver",
+    )
+    const step = solver.pipelineDef[stepIndex]!
+    expect(() => step.getConstructorParams(solver as never)).toThrow(
+      "Differential-pair post-processing cannot run when routingLayers excludes board layers",
+    )
+
+    solver.currentPipelineStepIndex = stepIndex
+    expect(() => solver.step()).toThrow(
+      "Differential-pair post-processing cannot run when routingLayers excludes board layers",
+    )
+    expect(solver.solved).toBeFalse()
+    expect(solver.failed).toBeTrue()
+    expect(solver.currentPipelineStepIndex).toBe(stepIndex)
+    expect(solver.lengthMatchingPostProcessingSolver).toBeUndefined()
+    expect(
+      solver.stats.lengthMatchingPostProcessingSkippedForRoutingLayers,
+    ).toBeUndefined()
   }
 })

--- a/tests/features/routing-layers-differential-pair-postprocessing.test.ts
+++ b/tests/features/routing-layers-differential-pair-postprocessing.test.ts
@@ -34,8 +34,8 @@ test("Pipelines 7 and 9 preserve routed pairs when layer-changing postprocessing
     solver.step()
     expect(solver.currentPipelineStepIndex).toBe(stepIndex + 1)
     expect(solver.lengthMatchingPostProcessingSolver).toBeUndefined()
-    expect(solver.stats.lengthMatchingPostProcessingSkippedForRoutingLayers).toBe(
-      true,
-    )
+    expect(
+      solver.stats.lengthMatchingPostProcessingSkippedForRoutingLayers,
+    ).toBe(true)
   }
 })

--- a/tests/features/routing-layers-differential-pair-postprocessing.test.ts
+++ b/tests/features/routing-layers-differential-pair-postprocessing.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver7_MultiGraph } from "lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph"
+import { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph"
+import type { SimpleRouteJson } from "lib/types"
+
+test("Pipelines 7 and 9 preserve routed pairs when layer-changing postprocessing cannot honor routingLayers", () => {
+  const input = {
+    layerCount: 2,
+    routingLayers: ["top"],
+    minTraceWidth: 0.1,
+    bounds: { minX: -1, maxX: 1, minY: -1, maxY: 1 },
+    obstacles: [],
+    connections: [],
+  } satisfies SimpleRouteJson
+  const solvers = [
+    new AutoroutingPipelineSolver7_MultiGraph(structuredClone(input), {
+      cacheProvider: null,
+    }),
+    new AutoroutingPipelineSolver9_PreloadedTraceGraph(structuredClone(input), {
+      cacheProvider: null,
+    }),
+  ]
+
+  for (const solver of solvers) {
+    const stepIndex = solver.pipelineDef.findIndex(
+      (step) => step.solverName === "lengthMatchingPostProcessingSolver",
+    )
+    const step = solver.pipelineDef[stepIndex]!
+    expect(() => step.getConstructorParams(solver as never)).toThrow(
+      "Differential-pair post-processing cannot run when routingLayers excludes board layers",
+    )
+
+    solver.currentPipelineStepIndex = stepIndex
+    solver.step()
+    expect(solver.currentPipelineStepIndex).toBe(stepIndex + 1)
+    expect(solver.lengthMatchingPostProcessingSolver).toBeUndefined()
+    expect(solver.stats.lengthMatchingPostProcessingSkippedForRoutingLayers).toBe(
+      true,
+    )
+  }
+})

--- a/tests/features/routing-layers-invalid-input.test.ts
+++ b/tests/features/routing-layers-invalid-input.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test"
+import type { SimpleRouteJson } from "lib/types"
+import { getRoutingZLayers } from "lib/utils/routing-layer-constraints"
+
+test("invalid routing layer allow-lists fail clearly", () => {
+  const baseSrj = {
+    layerCount: 4,
+    minTraceWidth: 0.15,
+    obstacles: [],
+    connections: [],
+    bounds: { minX: -5, maxX: 5, minY: -5, maxY: 5 },
+  } satisfies SimpleRouteJson
+
+  expect(() => getRoutingZLayers({ ...baseSrj, routingLayers: [] })).toThrow(
+    "routingLayers must contain at least one board layer",
+  )
+  expect(() =>
+    getRoutingZLayers({ ...baseSrj, routingLayers: ["top", "signal2"] }),
+  ).toThrow('Invalid routing layer "signal2" for a 4-layer board')
+  expect(() =>
+    getRoutingZLayers({ ...baseSrj, routingLayers: ["top", "top"] }),
+  ).toThrow("routingLayers must not contain duplicate board layers")
+})

--- a/tests/features/routing-layers-invalid-input.test.ts
+++ b/tests/features/routing-layers-invalid-input.test.ts
@@ -20,4 +20,18 @@ test("invalid routing layer allow-lists fail clearly", () => {
   expect(() =>
     getRoutingZLayers({ ...baseSrj, routingLayers: ["top", "top"] }),
   ).toThrow("routingLayers must not contain duplicate board layers")
+  expect(() =>
+    getRoutingZLayers({
+      ...baseSrj,
+      layerCount: 1,
+      routingLayers: ["bottom"],
+    }),
+  ).toThrow('Invalid routing layer "bottom" for a 1-layer board')
+  expect(() =>
+    getRoutingZLayers({
+      ...baseSrj,
+      layerCount: 1,
+      routingLayers: ["top", "bottom"],
+    }),
+  ).toThrow('Invalid routing layer "bottom" for a 1-layer board')
 })

--- a/tests/features/routing-layers-outer-output.test.ts
+++ b/tests/features/routing-layers-outer-output.test.ts
@@ -30,17 +30,15 @@ test("a top-to-bottom four-layer route uses only allowed routing layers", () => 
 
   expect(solver.failed).toBe(false)
   expect(route.length).toBeGreaterThan(0)
-  expect(
-    routeUsesOnlyRoutingLayers(output.traces![0]!, allowedLayers),
-  ).toBe(true)
+  expect(routeUsesOnlyRoutingLayers(output.traces![0]!, allowedLayers)).toBe(
+    true,
+  )
   expect(route.some((segment) => segment.route_type === "via")).toBe(true)
   expect(
-    solver.exactGeometryDrcForceImproveSolver?.params
-      .enableSafeTraceLayerMoves,
+    solver.exactGeometryDrcForceImproveSolver?.params.enableSafeTraceLayerMoves,
   ).toBe(false)
   expect(
-    solver.exactGeometryDrcForceImproveSolver?.params
-      .enableViaInPadLayerMoves,
+    solver.exactGeometryDrcForceImproveSolver?.params.enableViaInPadLayerMoves,
   ).toBe(false)
   const traceSimplificationStep = solver.pipelineDef.find(
     (step) => step.solverName === "traceSimplificationSolver",

--- a/tests/features/routing-layers-outer-output.test.ts
+++ b/tests/features/routing-layers-outer-output.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver7_MultiGraph } from "lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph"
+import type { SimpleRouteJson } from "lib/types"
+import { routeUsesOnlyRoutingLayers } from "../helpers/route-uses-only-routing-layers"
+
+test("a top-to-bottom four-layer route uses only allowed routing layers", () => {
+  const input = {
+    layerCount: 4,
+    routingLayers: ["top", "bottom"],
+    minTraceWidth: 0.15,
+    minViaPadDiameter: 0.3,
+    bounds: { minX: -5, maxX: 5, minY: -5, maxY: 5 },
+    obstacles: [],
+    connections: [
+      {
+        name: "outer-layers",
+        pointsToConnect: [
+          { x: -3, y: 0, layer: "top" },
+          { x: 3, y: 0, layer: "bottom" },
+        ],
+      },
+    ],
+  } satisfies SimpleRouteJson
+
+  const solver = new AutoroutingPipelineSolver7_MultiGraph(input)
+  solver.solve()
+  const output = solver.getOutputSimpleRouteJson()
+  const route = output.traces?.[0]?.route ?? []
+  const allowedLayers = new Set(["top", "bottom"])
+
+  expect(solver.failed).toBe(false)
+  expect(route.length).toBeGreaterThan(0)
+  expect(
+    routeUsesOnlyRoutingLayers(output.traces![0]!, allowedLayers),
+  ).toBe(true)
+  expect(route.some((segment) => segment.route_type === "via")).toBe(true)
+  expect(
+    solver.exactGeometryDrcForceImproveSolver?.params
+      .enableSafeTraceLayerMoves,
+  ).toBe(false)
+  expect(
+    solver.exactGeometryDrcForceImproveSolver?.params
+      .enableViaInPadLayerMoves,
+  ).toBe(false)
+  const traceSimplificationStep = solver.pipelineDef.find(
+    (step) => step.solverName === "traceSimplificationSolver",
+  )
+  const [traceSimplificationParams] =
+    traceSimplificationStep!.getConstructorParams(solver)
+  expect(traceSimplificationParams).toMatchObject({
+    enableCrossingViaReduction: true,
+  })
+})

--- a/tests/features/routing-layers-pipeline-coverage.test.ts
+++ b/tests/features/routing-layers-pipeline-coverage.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "bun:test"
+import { AssignableAutoroutingPipeline1Solver } from "lib/autorouter-pipelines/AssignableAutoroutingPipeline1/AssignableAutoroutingPipeline1Solver"
+import { AssignableAutoroutingPipeline2 } from "lib/autorouter-pipelines/AssignableAutoroutingPipeline2/AssignableAutoroutingPipeline2"
+import { AssignableAutoroutingPipeline3 } from "lib/autorouter-pipelines/AssignableAutoroutingPipeline3/AssignableAutoroutingPipeline3"
+import { AutoroutingPipeline1_OriginalUnravel } from "lib/autorouter-pipelines/AutoroutingPipeline1_OriginalUnravel/AutoroutingPipeline1_OriginalUnravel"
+import { AutoroutingPipelineSolver2_PortPointPathing } from "lib/autorouter-pipelines/AutoroutingPipeline2_PortPointPathing/AutoroutingPipelineSolver2_PortPointPathing"
+import { AutoroutingPipelineSolver3_HgPortPointPathing } from "lib/autorouter-pipelines/AutoroutingPipeline3_HgPortPointPathing/AutoroutingPipelineSolver3_HgPortPointPathing"
+import { AutoroutingPipelineSolver4_TinyHypergraph } from "lib/autorouter-pipelines/AutoroutingPipeline4_TinyHypergraph/AutoroutingPipelineSolver4_TinyHypergraph"
+import { AutoroutingPipelineSolver6_PolyHypergraph } from "lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/AutoroutingPipelineSolver6_PolyHypergraph"
+import { AutoroutingPipelineSolver7_MultiGraph } from "lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph"
+import { AutoroutingPipelineSolver8 } from "lib/autorouter-pipelines/AutoroutingPipeline8/AutoroutingPipelineSolver8"
+import type { SimpleRouteJson } from "lib/types"
+import { routeUsesOnlyRoutingLayers } from "../helpers/route-uses-only-routing-layers"
+
+test("routing pipelines constrain generated candidates to the allowed z layers", () => {
+  const input = {
+    layerCount: 4,
+    routingLayers: ["top", "bottom"],
+    minTraceWidth: 0.15,
+    minViaPadDiameter: 0.3,
+    bounds: { minX: -5, maxX: 5, minY: -5, maxY: 5 },
+    obstacles: [],
+    connections: [
+      {
+        name: "outer_layers",
+        pointsToConnect: [
+          { x: -3, y: 0, layer: "top" },
+          { x: 3, y: 0, layer: "bottom" },
+        ],
+      },
+    ],
+  } satisfies SimpleRouteJson
+  const allowedLayers = new Set(input.routingLayers)
+  const outputSolvers = [
+    new AutoroutingPipeline1_OriginalUnravel(structuredClone(input)),
+    new AutoroutingPipelineSolver2_PortPointPathing(structuredClone(input)),
+    new AutoroutingPipelineSolver4_TinyHypergraph(structuredClone(input)),
+    new AutoroutingPipelineSolver6_PolyHypergraph(structuredClone(input)),
+    new AutoroutingPipelineSolver7_MultiGraph(structuredClone(input)),
+    new AssignableAutoroutingPipeline2(structuredClone(input)),
+    new AssignableAutoroutingPipeline3(structuredClone(input)),
+  ]
+
+  for (const solver of outputSolvers) {
+    solver.solve()
+    const traces = solver.getOutputSimpleRouteJson().traces ?? []
+    expect(solver.failed).toBe(false)
+    expect(traces.length).toBeGreaterThan(0)
+    expect(
+      traces.every((trace) =>
+        routeUsesOnlyRoutingLayers(trace, allowedLayers),
+      ),
+    ).toBe(true)
+  }
+
+  const candidateSolvers = [
+    new AutoroutingPipelineSolver3_HgPortPointPathing(structuredClone(input)),
+    new AutoroutingPipelineSolver8(structuredClone(input)),
+  ]
+  for (const solver of candidateSolvers) {
+    solver.solveUntilPhase("edgeSolver")
+    expect(solver.failed).toBe(false)
+    expect(
+      solver.capacityNodes?.every((node) =>
+        node.availableZ.every((z) => z === 0 || z === 3),
+      ),
+    ).toBe(true)
+  }
+
+  const assignableCandidateSolver = new AssignableAutoroutingPipeline1Solver(
+    structuredClone(input),
+  )
+  assignableCandidateSolver.solveUntilPhase("singleLayerNodeMerger")
+  expect(assignableCandidateSolver.failed).toBe(false)
+  expect(
+    assignableCandidateSolver.capacityNodes?.every((node) =>
+      node.availableZ.every((z) => z === 0 || z === 3),
+    ),
+  ).toBe(true)
+})

--- a/tests/features/routing-layers-pipeline-coverage.test.ts
+++ b/tests/features/routing-layers-pipeline-coverage.test.ts
@@ -47,9 +47,7 @@ test("routing pipelines constrain generated candidates to the allowed z layers",
     expect(solver.failed).toBe(false)
     expect(traces.length).toBeGreaterThan(0)
     expect(
-      traces.every((trace) =>
-        routeUsesOnlyRoutingLayers(trace, allowedLayers),
-      ),
+      traces.every((trace) => routeUsesOnlyRoutingLayers(trace, allowedLayers)),
     ).toBe(true)
   }
 

--- a/tests/features/routing-layers-pipeline10-output.test.ts
+++ b/tests/features/routing-layers-pipeline10-output.test.ts
@@ -21,8 +21,6 @@ test("Pipeline 10 constrains both BGA fanout and autorouted copper", () => {
   expect(solver.failed).toBe(false)
   expect(traces.length).toBeGreaterThan(1)
   expect(
-    traces.every((trace) =>
-      routeUsesOnlyRoutingLayers(trace, allowedLayers),
-    ),
+    traces.every((trace) => routeUsesOnlyRoutingLayers(trace, allowedLayers)),
   ).toBe(true)
 })

--- a/tests/features/routing-layers-pipeline10-output.test.ts
+++ b/tests/features/routing-layers-pipeline10-output.test.ts
@@ -1,0 +1,28 @@
+import { sample001 } from "@tscircuit/dataset-srj29-ddr3-bga-pairs"
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver10_BgaFanout } from "lib/autorouter-pipelines/AutoroutingPipeline10_BgaFanout/AutoroutingPipelineSolver10_BgaFanout"
+import type { SimpleRouteJson } from "lib/types"
+import { routeUsesOnlyRoutingLayers } from "../helpers/route-uses-only-routing-layers"
+
+test("Pipeline 10 constrains both BGA fanout and autorouted copper", () => {
+  const input = structuredClone(sample001) as SimpleRouteJson
+  input.routingLayers = ["top", "bottom"]
+  input.connections = input.connections.slice(0, 1)
+  input.buses = []
+  input.differentialPairs = []
+
+  const solver = new AutoroutingPipelineSolver10_BgaFanout(input, {
+    cacheProvider: null,
+  })
+  solver.solve()
+  const traces = solver.getOutputSimpleRouteJson().traces ?? []
+  const allowedLayers = new Set(input.routingLayers)
+
+  expect(solver.failed).toBe(false)
+  expect(traces.length).toBeGreaterThan(1)
+  expect(
+    traces.every((trace) =>
+      routeUsesOnlyRoutingLayers(trace, allowedLayers),
+    ),
+  ).toBe(true)
+})

--- a/tests/features/routing-layers-pipeline9-fallback.test.ts
+++ b/tests/features/routing-layers-pipeline9-fallback.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph"
+import type { SimpleRouteJson } from "lib/types"
+
+test("Pipeline9 regional fallback cannot add an excluded layer", () => {
+  const input = {
+    layerCount: 2,
+    routingLayers: ["top"],
+    minTraceWidth: 0.1,
+    minViaPadDiameter: 0.3,
+    bounds: { minX: -1.05, maxX: 1.05, minY: -1.05, maxY: 1.05 },
+    obstacles: [],
+    connections: [
+      {
+        name: "horizontal",
+        pointsToConnect: [
+          { x: -1, y: 0, layer: "top" },
+          { x: 1, y: 0, layer: "top" },
+        ],
+      },
+      {
+        name: "vertical",
+        pointsToConnect: [
+          { x: 0, y: -1, layer: "top" },
+          { x: 0, y: 1, layer: "top" },
+        ],
+      },
+    ],
+  } satisfies SimpleRouteJson
+  const solver = new AutoroutingPipelineSolver9_PreloadedTraceGraph(input, {
+    cacheProvider: null,
+    effort: 0.1,
+    maxNodeDimension: 10,
+  })
+  solver.solve()
+
+  expect(solver.solved).toBeFalse()
+  expect(solver.failed).toBeTrue()
+  expect(solver.highDensityRouteSolver?.allowedZ).toEqual([0])
+  expect(
+    solver.highDensityRouteSolver?.routes.every((route) =>
+      route.route.every((point) => point.z === 0),
+    ),
+  ).toBeTrue()
+})

--- a/tests/features/routing-layers-pour-escape.test.ts
+++ b/tests/features/routing-layers-pour-escape.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test"
+import { EscapeViaLocationSolver } from "lib/solvers/EscapeViaLocationSolver/EscapeViaLocationSolver"
+import type { SimpleRouteJson } from "lib/types"
+
+test("pour escape does not generate a routing transition to an excluded layer", () => {
+  const input = {
+    layerCount: 4,
+    routingLayers: ["top", "bottom"],
+    minTraceWidth: 0.15,
+    minViaPadDiameter: 0.3,
+    defaultObstacleMargin: 0.15,
+    bounds: { minX: -3, maxX: 3, minY: -3, maxY: 3 },
+    obstacles: [
+      {
+        obstacleId: "source-pad",
+        type: "rect",
+        layers: ["top"],
+        center: { x: 0, y: 0 },
+        width: 0.65,
+        height: 0.15,
+        connectedTo: ["net.GND", "source-pad"],
+      },
+      {
+        obstacleId: "gnd-pour",
+        type: "rect",
+        layers: ["inner1"],
+        center: { x: 0, y: 0 },
+        width: 5,
+        height: 5,
+        connectedTo: ["net.GND"],
+        isCopperPour: true,
+      },
+    ],
+    connections: [
+      {
+        name: "net.GND",
+        pointsToConnect: [
+          { x: 0, y: 0, layer: "top", pointId: "source-pad" },
+        ],
+      },
+    ],
+  } satisfies SimpleRouteJson
+
+  const solver = new EscapeViaLocationSolver(input)
+  solver.solve()
+  const output = solver.getOutputSimpleRouteJson()
+
+  expect(solver.createdEscapeVias).toHaveLength(0)
+  expect(output.connections[0]?.pointsToConnect).toEqual(
+    input.connections[0]?.pointsToConnect,
+  )
+})

--- a/tests/features/routing-layers-pour-escape.test.ts
+++ b/tests/features/routing-layers-pour-escape.test.ts
@@ -34,9 +34,7 @@ test("pour escape does not generate a routing transition to an excluded layer", 
     connections: [
       {
         name: "net.GND",
-        pointsToConnect: [
-          { x: 0, y: 0, layer: "top", pointId: "source-pad" },
-        ],
+        pointsToConnect: [{ x: 0, y: 0, layer: "top", pointId: "source-pad" }],
       },
     ],
   } satisfies SimpleRouteJson

--- a/tests/features/routing-layers-power-expansion.test.ts
+++ b/tests/features/routing-layers-power-expansion.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test"
+import { PowerTraceExpansionSolver } from "lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/PowerTraceExpansionSolver"
+import type { SimpleRouteJson } from "lib/types"
+
+const input = {
+  layerCount: 2,
+  routingLayers: ["top"],
+  minTraceWidth: 0.15,
+  bounds: { minX: -1, maxX: 1, minY: -1, maxY: 1 },
+  obstacles: [],
+  connections: [],
+  traces: [],
+} satisfies SimpleRouteJson
+
+test("power expansion fails clearly before adding vias on excluded layers", () => {
+  expect(() => new PowerTraceExpansionSolver(input)).toThrow(
+    "Power trace expansion cannot add vias when routingLayers excludes board layers",
+  )
+  expect(
+    () => new PowerTraceExpansionSolver(input, { allowNewVias: true }),
+  ).toThrow(
+    "Power trace expansion cannot add vias when routingLayers excludes board layers",
+  )
+})

--- a/tests/features/routing-layers-preloaded-trace-preservation.test.ts
+++ b/tests/features/routing-layers-preloaded-trace-preservation.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph"
+import type { SimpleRouteJson, SimplifiedPcbTrace } from "lib/types"
+import { routeUsesOnlyRoutingLayers } from "../helpers/route-uses-only-routing-layers"
+
+test("preloaded copper on an excluded layer is preserved while new copper is constrained", () => {
+  const preloadedTrace = {
+    type: "pcb_trace",
+    pcb_trace_id: "preloaded_inner1",
+    connection_name: "preloaded_inner1",
+    route: [
+      {
+        route_type: "wire",
+        x: -4,
+        y: 3,
+        width: 0.15,
+        layer: "inner1",
+      },
+      {
+        route_type: "wire",
+        x: 4,
+        y: 3,
+        width: 0.15,
+        layer: "inner1",
+      },
+    ],
+  } satisfies SimplifiedPcbTrace
+  const input = {
+    layerCount: 4,
+    routingLayers: ["top", "bottom"],
+    minTraceWidth: 0.15,
+    minViaPadDiameter: 0.3,
+    bounds: { minX: -5, maxX: 5, minY: -5, maxY: 5 },
+    obstacles: [],
+    connections: [
+      {
+        name: "new_outer_route",
+        pointsToConnect: [
+          { x: -3, y: 0, layer: "top" },
+          { x: 3, y: 0, layer: "bottom" },
+        ],
+      },
+    ],
+    traces: [preloadedTrace],
+  } satisfies SimpleRouteJson
+
+  const solver = new AutoroutingPipelineSolver9_PreloadedTraceGraph(input, {
+    cacheProvider: null,
+  })
+  solver.solve()
+  const output = solver.getOutputSimpleRouteJson()
+  const preservedTrace = output.traces?.find(
+    (trace) => trace.pcb_trace_id === preloadedTrace.pcb_trace_id,
+  )
+  const newTraces = output.traces?.filter(
+    (trace) => trace.pcb_trace_id !== preloadedTrace.pcb_trace_id,
+  )
+  const allowedLayers = new Set(["top", "bottom"])
+
+  expect(solver.failed).toBe(false)
+  expect(preservedTrace).toEqual(preloadedTrace)
+  expect(newTraces?.length).toBeGreaterThan(0)
+  expect(
+    newTraces?.every((trace) =>
+      routeUsesOnlyRoutingLayers(trace, allowedLayers),
+    ),
+  ).toBe(true)
+})

--- a/tests/features/routing-layers-repair-policy.test.ts
+++ b/tests/features/routing-layers-repair-policy.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test"
+import type { SimpleRouteJson } from "lib/types"
+import { canUseUnrestrictedLayerMoves } from "lib/utils/routing-layer-constraints"
+
+test("layer-changing repairs run only when every board layer is routable", () => {
+  const input = {
+    layerCount: 4,
+    minTraceWidth: 0.15,
+    bounds: { minX: -5, maxX: 5, minY: -5, maxY: 5 },
+    obstacles: [],
+    connections: [],
+  } satisfies SimpleRouteJson
+
+  expect(canUseUnrestrictedLayerMoves(input)).toBe(true)
+  expect(
+    canUseUnrestrictedLayerMoves({
+      ...input,
+      routingLayers: ["top", "inner1", "inner2", "bottom"],
+    }),
+  ).toBe(true)
+  expect(
+    canUseUnrestrictedLayerMoves({
+      ...input,
+      routingLayers: ["top", "bottom"],
+    }),
+  ).toBe(false)
+})

--- a/tests/features/routing-layers-terminal-behavior.test.ts
+++ b/tests/features/routing-layers-terminal-behavior.test.ts
@@ -51,9 +51,7 @@ test("connection points must expose at least one allowed routing layer", () => {
     connections: [
       {
         name: "multilayer-terminal",
-        pointsToConnect: [
-          { x: 0, y: 0, layers: ["inner1", "bottom"] },
-        ],
+        pointsToConnect: [{ x: 0, y: 0, layers: ["inner1", "bottom"] }],
       },
     ],
   })

--- a/tests/features/routing-layers-terminal-behavior.test.ts
+++ b/tests/features/routing-layers-terminal-behavior.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test"
+import type { SimpleRouteJson } from "lib/types"
+import { normalizeSrjRoutingLayers } from "lib/utils/routing-layer-constraints"
+
+test("connection points must expose at least one allowed routing layer", () => {
+  const baseSrj = {
+    layerCount: 4,
+    routingLayers: ["top", "bottom"],
+    minTraceWidth: 0.15,
+    obstacles: [],
+    bounds: { minX: -5, maxX: 5, minY: -5, maxY: 5 },
+  } satisfies Omit<SimpleRouteJson, "connections">
+
+  expect(() =>
+    normalizeSrjRoutingLayers({
+      ...baseSrj,
+      connections: [
+        {
+          name: "excluded-terminal",
+          pointsToConnect: [{ x: 0, y: 0, layer: "inner1" }],
+        },
+      ],
+    }),
+  ).toThrow(
+    'Connection "excluded-terminal" point 0 is on excluded routing layer "inner1"',
+  )
+
+  expect(() =>
+    normalizeSrjRoutingLayers({
+      ...baseSrj,
+      connections: [
+        {
+          name: "excluded-terminal-via",
+          pointsToConnect: [
+            {
+              x: 0,
+              y: 0,
+              layer: "top",
+              terminalVia: { toLayer: "inner1" },
+            },
+          ],
+        },
+      ],
+    }),
+  ).toThrow(
+    'Connection "excluded-terminal-via" point 0 terminal via ends on excluded routing layer "inner1"',
+  )
+
+  const normalized = normalizeSrjRoutingLayers({
+    ...baseSrj,
+    connections: [
+      {
+        name: "multilayer-terminal",
+        pointsToConnect: [
+          { x: 0, y: 0, layers: ["inner1", "bottom"] },
+        ],
+      },
+    ],
+  })
+  expect(normalized.connections[0]?.pointsToConnect[0]).toMatchObject({
+    layers: ["bottom"],
+  })
+})

--- a/tests/features/routing-layers-top-only-output.test.ts
+++ b/tests/features/routing-layers-top-only-output.test.ts
@@ -28,6 +28,10 @@ test("a top-only four-layer route generates copper only on top", () => {
 
   expect(solver.failed).toBe(false)
   expect(route.length).toBeGreaterThan(0)
-  expect(route.every((segment) => segment.route_type !== "wire" || segment.layer === "top")).toBe(true)
+  expect(
+    route.every(
+      (segment) => segment.route_type !== "wire" || segment.layer === "top",
+    ),
+  ).toBe(true)
   expect(route.some((segment) => segment.route_type === "via")).toBe(false)
 })

--- a/tests/features/routing-layers-top-only-output.test.ts
+++ b/tests/features/routing-layers-top-only-output.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver7_MultiGraph } from "lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph"
+import type { SimpleRouteJson } from "lib/types"
+
+test("a top-only four-layer route generates copper only on top", () => {
+  const input = {
+    layerCount: 4,
+    routingLayers: ["top"],
+    minTraceWidth: 0.15,
+    minViaPadDiameter: 0.3,
+    bounds: { minX: -5, maxX: 5, minY: -5, maxY: 5 },
+    obstacles: [],
+    connections: [
+      {
+        name: "top-only",
+        pointsToConnect: [
+          { x: -3, y: 0, layer: "top" },
+          { x: 3, y: 0, layer: "top" },
+        ],
+      },
+    ],
+  } satisfies SimpleRouteJson
+
+  const solver = new AutoroutingPipelineSolver7_MultiGraph(input)
+  solver.solve()
+  const output = solver.getOutputSimpleRouteJson()
+  const route = output.traces?.[0]?.route ?? []
+
+  expect(solver.failed).toBe(false)
+  expect(route.length).toBeGreaterThan(0)
+  expect(route.every((segment) => segment.route_type !== "wire" || segment.layer === "top")).toBe(true)
+  expect(route.some((segment) => segment.route_type === "via")).toBe(false)
+})

--- a/tests/helpers/route-uses-only-routing-layers.ts
+++ b/tests/helpers/route-uses-only-routing-layers.ts
@@ -1,0 +1,31 @@
+import type { SimplifiedPcbTrace } from "lib/types"
+
+export function routeUsesOnlyRoutingLayers(
+  trace: SimplifiedPcbTrace,
+  allowedLayers: ReadonlySet<string>,
+): boolean {
+  for (const [segmentIndex, segment] of trace.route.entries()) {
+    if (segment.route_type === "wire") {
+      if (!allowedLayers.has(segment.layer)) return false
+      continue
+    }
+    if (segment.route_type !== "via") continue
+
+    const previousWire = trace.route
+      .slice(0, segmentIndex)
+      .reverse()
+      .find((candidate) => candidate.route_type === "wire")
+    const nextWire = trace.route
+      .slice(segmentIndex + 1)
+      .find((candidate) => candidate.route_type === "wire")
+    if (
+      (previousWire?.route_type === "wire" &&
+        !allowedLayers.has(previousWire.layer)) ||
+      (nextWire?.route_type === "wire" && !allowedLayers.has(nextWire.layer))
+    ) {
+      return false
+    }
+  }
+
+  return true
+}


### PR DESCRIPTION
## Summary

- add `routingLayers?: string[]` to Simple Route JSON
- constrain newly generated wire segments and logical layer transitions across Pipelines 1–10 and the assignable pipelines
- intersect multilayer terminals, buses, capacity nodes, polygraph regions, fanout escapes, copper-pour escapes, and repair candidates with the allowlist
- preserve existing/preloaded traces, including caller-authored copper on excluded layers
- reject empty, duplicate, unknown, single-layer-incompatible, or terminal-incompatible selections with actionable errors
- keep fallback, jumper, power-expansion, and differential-pair stages from silently reopening excluded layers

## Why

Multilayer boards often reserve inner copper for power/ground planes. The autorouter currently treats every board layer as a signal-routing candidate, so a board can silently fragment those planes with unrelated traces.

This is the router enforcement for the board API in tscircuit/props#808 and the transport fields in tscircuit/circuit-json#719. Omitting `routingLayers` preserves the current all-layer behavior.

`routingLayers` controls wire layers and logical routing transitions. The physical plated span of a via is intentionally independent and is controlled by `viaSpanPolicy`; for example, an ordinary through-via can cross a reserved plane without routing a wire on that plane.

## Unsupported external moves

Some optional postprocessors currently enumerate every board layer and do not accept an allowlist. When a proper subset is selected:

- unrestricted high-density repair phases are disabled while safe repair/simplification phases remain enabled
- differential-pair length-matching is a no-op only when no pairs were requested; requested pair work fails closed until the external solver accepts an allowlist
- power expansion fails closed if it is allowed to add vias
- the top-only jumper stage fails closed when a crossing would require a top-layer jumper but `top` is excluded

This prevents a late fallback or optimization stage from escaping onto a reserved layer.

## Validation

- 17 focused routing-layer files pass with 106 assertions
- coverage includes every routing pipeline family, Pipeline 10 fanout, P4/P9 crossing fallbacks, power-expansion defaults, Assignable Pipeline 3 jumpers, differential-pair postprocessing, top-only and top/bottom four-layer output, one-layer validation, terminals/buses, pour escapes, preloaded traces, and repair policy
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`
- broad suite run completed the functional/routing coverage; the only observed SVG snapshot mismatch (`bugreport51-7db9f8`) reproduces unchanged on current `main` in the same environment
