### PR TITLE
fix: update length matching solver

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@tscircuit/hypergraph": "^0.0.71",
     "@tscircuit/jumper-topology-generator": "^0.0.4",
     "@tscircuit/krt-wasm": "^0.1.0",
-    "@tscircuit/length-matching-solver": "git+https://github.com/tscircuit/length-matching-solver.git#32449d5903d7bee1e237569ac4ecb6a3c4e07efe",
+    "@tscircuit/length-matching-solver": "git+https://github.com/tscircuit/length-matching-solver.git#c4098fb4526609ffbb5dd4d68efdf768e104aadc",
     "@tscircuit/math-utils": "^0.0.36",
     "@tscircuit/power-trace-expander": "git+https://github.com/tscircuit/power-trace-expander.git#6fa2ac79cf13129c47432db3a23e61c17067e912",
     "@tscircuit/rectdiff": "git+https://github.com/tscircuit/rectdiff.git#262f1b7e2c70021785f0ccdbe8e2562f827c7dbf",


### PR DESCRIPTION
## Summary

- update `@tscircuit/length-matching-solver` to the merge commit from tscircuit/length-matching-solver#54
- restore length matching when coupled rerouting fails but the original differential-pair copper is complete and outside tolerance
- unblock the `@tscircuit/capacity-autorouter` update in tscircuit/core#3376

## Verification

- `bun test tests/pipeline7-differential-pair-routing-phase.test.ts tests/pipeline7-post-processing-ambiguous-differential-pair.test.ts tests/pipeline7-post-processing-before-power-expansion.test.ts tests/features/simple-route-json-bus-types.test.ts --timeout 9999999`
- `bun run build`
- tscircuit/core `tests/components/primitive-components/differential-pair/routing-phase.test.tsx` passes with this local autorouter build; it fails with published `0.0.833`

No Core assertion or snapshot was changed.
