### PR TITLE
fix: preserve Pipeline9 vias during force improvement

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph.ts
@@ -73,6 +73,7 @@ import {
   getMaterializedPreloadedSectionHdRoutes,
   removeChangedSectionsFromFixedHdRoutes,
 } from "./materialize-hypergraph-preloaded-trace-sections"
+import { materializePipeline9HdRouteVias } from "./materialize-pipeline9-hd-route-vias"
 import {
   type PreparedPipeline9MutationSections,
   applyPipeline9MutatedPreloadedSections,
@@ -636,7 +637,9 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
       (cms) => [
         {
           nodeWithPortPoints: cms.highDensityNodePortPoints ?? [],
-          hdRoutes: cms.highDensityRouteSolver!.routes,
+          hdRoutes: materializePipeline9HdRouteVias(
+            cms.highDensityRouteSolver!.routes,
+          ),
           colorMap: cms.colorMap,
           totalStepsPerNode: Math.max(12, Math.round(20 * cms.effort)),
           nodeAssignmentMargin: cms.srj.defaultObstacleMargin ?? 0.2,

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/materialize-pipeline9-hd-route-vias.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/materialize-pipeline9-hd-route-vias.ts
@@ -1,0 +1,77 @@
+import type { HighDensityRoute } from "lib/types/high-density-types"
+
+const POSITION_EPSILON = 1e-6
+
+/**
+ * Canonicalizes Pipeline9 layer transitions before force improvement.
+ *
+ * Route x/y coordinates are board-world millimeters and z is the zero-based
+ * copper-layer index. Some Pipeline9 high-density solvers encode a transition
+ * as a diagonal segment whose explicit via is located at either endpoint. The
+ * force improver only preserves vias represented by co-located route points,
+ * so this materializes that endpoint without changing the routed copper.
+ */
+export const materializePipeline9HdRouteVias = (
+  hdRoutes: readonly HighDensityRoute[],
+): HighDensityRoute[] => {
+  return hdRoutes.map((hdRoute) => {
+    const route: HighDensityRoute["route"] = []
+
+    for (const routePoint of hdRoute.route) {
+      const previousRoutePoint = route.at(-1)
+      if (
+        !previousRoutePoint ||
+        previousRoutePoint.z === routePoint.z ||
+        previousRoutePoint.toNextSegmentType === "through_obstacle"
+      ) {
+        route.push(routePoint)
+        continue
+      }
+
+      const transitionIsColocated =
+        Math.abs(previousRoutePoint.x - routePoint.x) <= POSITION_EPSILON &&
+        Math.abs(previousRoutePoint.y - routePoint.y) <= POSITION_EPSILON
+      const hasViaAtPreviousPoint = hdRoute.vias.some(
+        (via) =>
+          Math.abs(via.x - previousRoutePoint.x) <= POSITION_EPSILON &&
+          Math.abs(via.y - previousRoutePoint.y) <= POSITION_EPSILON,
+      )
+      const hasViaAtRoutePoint = hdRoute.vias.some(
+        (via) =>
+          Math.abs(via.x - routePoint.x) <= POSITION_EPSILON &&
+          Math.abs(via.y - routePoint.y) <= POSITION_EPSILON,
+      )
+
+      if (transitionIsColocated) {
+        route.push(routePoint)
+        continue
+      }
+      if (!hasViaAtPreviousPoint && !hasViaAtRoutePoint) {
+        throw new Error(
+          `Pipeline9 route "${hdRoute.connectionName}" changes layers from z=${previousRoutePoint.z} to z=${routePoint.z} without an explicit via`,
+        )
+      }
+      if (hasViaAtPreviousPoint === hasViaAtRoutePoint) {
+        throw new Error(
+          `Pipeline9 route "${hdRoute.connectionName}" has an ambiguous layer transition between (${previousRoutePoint.x}, ${previousRoutePoint.y}) and (${routePoint.x}, ${routePoint.y})`,
+        )
+      }
+      if (hasViaAtPreviousPoint) {
+        route.push({
+          x: previousRoutePoint.x,
+          y: previousRoutePoint.y,
+          z: routePoint.z,
+        })
+      } else {
+        route.push({
+          x: routePoint.x,
+          y: routePoint.y,
+          z: previousRoutePoint.z,
+        })
+      }
+      route.push(routePoint)
+    }
+
+    return { ...hdRoute, route }
+  })
+}

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-regional-fallback-solver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-regional-fallback-solver.ts
@@ -10,6 +10,7 @@ import type {
 import type { Obstacle } from "lib/types/srj-types"
 import type { ConnectivityMap } from "circuit-json-to-connectivity-map"
 import type { CapacityMeshNodeId } from "lib/types/capacity-mesh-types"
+import { materializePipeline9HdRouteVias } from "./materialize-pipeline9-hd-route-vias"
 
 type Pipeline9RegionalFallbackSolverParams = {
   nodeWithPortPoints: NodeWithPortPoints
@@ -73,7 +74,9 @@ export class Pipeline9RegionalFallbackSolver extends BaseSolver {
       if (!this.highDensitySolver.solved) return
       this.forceImproveSolver = new HighDensityForceImproveSolver({
         nodeWithPortPoints: [this.params.nodeWithPortPoints],
-        hdRoutes: this.highDensitySolver.routes,
+        hdRoutes: materializePipeline9HdRouteVias(
+          this.highDensitySolver.routes,
+        ),
         colorMap: this.params.colorMap,
         totalStepsPerNode: Math.max(12, Math.round(20 * this.params.effort)),
         nodeAssignmentMargin: this.params.obstacleMargin,

--- a/tests/features/pipeline9-preserves-vias-through-force-improvement.test.ts
+++ b/tests/features/pipeline9-preserves-vias-through-force-improvement.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "bun:test"
+import { HighDensityForceImproveSolver } from "high-density-repair01/lib/HighDensityForceImproveSolver"
+import { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph"
+import type { Pipeline9HighDensitySolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-high-density-solver"
+import type { SimpleRouteJson } from "lib/types"
+import type {
+  HighDensityRoute,
+  NodeWithPortPoints,
+} from "lib/types/high-density-types"
+
+test("Pipeline9 preserves vias through force improvement", (): void => {
+  const srj: SimpleRouteJson = {
+    layerCount: 2,
+    minTraceWidth: 0.15,
+    minViaPadDiameter: 0.3,
+    bounds: { minX: -1, minY: -1, maxX: 1, maxY: 1 },
+    obstacles: [],
+    connections: [
+      {
+        name: "route",
+        pointsToConnect: [
+          { x: -0.5, y: 0, layer: "bottom" },
+          { x: 0.5, y: 0, layer: "top" },
+        ],
+      },
+    ],
+  }
+  const nodeWithPortPoints: NodeWithPortPoints = {
+    capacityMeshNodeId: "node",
+    center: { x: 0, y: 0 },
+    width: 2,
+    height: 2,
+    availableZ: [0, 1],
+    portPoints: [
+      { connectionName: "route", x: -0.5, y: 0, z: 1 },
+      { connectionName: "route", x: 0.5, y: 0, z: 0 },
+    ],
+  }
+  const rawRoute: HighDensityRoute = {
+    connectionName: "route",
+    traceThickness: 0.15,
+    viaDiameter: 0.3,
+    route: [
+      { x: -0.5, y: 0, z: 1 },
+      { x: 0, y: 0.2, z: 0 },
+      { x: 0.5, y: 0, z: 0 },
+    ],
+    vias: [{ x: 0, y: 0.2 }],
+  }
+  const pipeline9 = new AutoroutingPipelineSolver9_PreloadedTraceGraph(srj, {
+    effort: 0.1,
+  })
+  pipeline9.colorMap = { route: "#ff0000" }
+  pipeline9.highDensityNodePortPoints = [nodeWithPortPoints]
+  pipeline9.highDensityRouteSolver = {
+    routes: [rawRoute],
+  } as Pipeline9HighDensitySolver
+
+  const forceImproveStep = pipeline9.pipelineDef.find(
+    (step) => step.solverName === "highDensityForceImproveSolver",
+  )!
+  const [forceImproveParams] = forceImproveStep.getConstructorParams(
+    pipeline9,
+  ) as ConstructorParameters<typeof HighDensityForceImproveSolver>
+
+  expect(forceImproveParams.hdRoutes[0]?.route).toEqual([
+    { x: -0.5, y: 0, z: 1 },
+    { x: 0, y: 0.2, z: 1 },
+    { x: 0, y: 0.2, z: 0 },
+    { x: 0.5, y: 0, z: 0 },
+  ])
+  const forceImproveSolver = new HighDensityForceImproveSolver(
+    forceImproveParams,
+  )
+  forceImproveSolver.solve()
+
+  expect(forceImproveSolver.failed).toBeFalse()
+  expect(forceImproveSolver.solved).toBeTrue()
+  expect(forceImproveSolver.getOutput()[0]?.vias).toEqual([{ x: 0, y: 0.2 }])
+})


### PR DESCRIPTION
## Summary

- materialize endpoint-encoded Pipeline9 vias as co-located layer transitions before force improvement
- apply the same normalization in the regional fallback cleanup path
- add a regression test proving force improvement preserves the via

This fixes the layer switch without a via exposed by tscircuit/core's `unrelated-winding-breakout-scopes` fixture.

## Downstream

- tscircuit/core#3378 consumes the expected `@tscircuit/capacity-autorouter@0.0.836` release and removes its temporary compensation.

## Validation

- `bun run build`
- `bunx tsc --noEmit`
- all 48 non-visual Pipeline9 feature tests
- focused Pipeline9 force-improvement regression test
