### PR TITLE
Update A03 to preserve terminal layer transitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "high-density-repair01": "git+https://github.com/tscircuit/high-density-repair01.git#8eaa775e7c7a2c32c12a82da4edef22477549027",
     "high-density-repair02": "https://codeload.github.com/tscircuit/high-density-repair02/tar.gz/2afc0cbba3bf2f7eb6b9cd33615d21e9ad9352d4",
     "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#8bbc82edb2474f0a5ad00609316ef7034f482050",
-    "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d",
+    "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#64161e1",
     "@tscircuit/high-density-b01": "git+https://github.com/tscircuit/high-density-b01.git#e651cab6c314e7aab6df31fd6067277436f67148"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- update the pinned high-density A03 solver to the terminal-layer fix from tscircuit/high-density-a01#89
- keep Pipeline9's explicit-via invariant intact instead of restoring a Core-side workaround
- fix the tscircuit/core#3378 Arduino center-region regression where a route ended on another layer without a via

## Dependency

This is stacked on tscircuit/high-density-a01#89. After that PR is squash-merged, this pin should be updated to its merged commit before this PR is merged.

## Verification

- captured Core Pipeline9 input: solved 17 connections, 184679 iterations, no missing-via error
- clean Core center-region test with rebuilt linked packages: 1 pass, 124 assertions
- bun run build
- bunx tsc --noEmit
- bun run format:check
- git diff --check
- full autorouter suite: 567 pass, 59 skip; 7 visual snapshot mismatches also reproduce unchanged on the baseline high-density commit and are unrelated to this dependency bump