### PR TITLE
fix: forward differential pair terminal escape length

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -752,7 +752,11 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
                 `Pipeline7: differential pair ${pair.connectionNames.join("/")} resolves both members to "${connectionNames[0]}"`,
               )
             if (pair.traceGap === undefined)
-              return { connectionNames, lengthTolerance: pair.lengthTolerance }
+              return {
+                connectionNames,
+                lengthTolerance: pair.lengthTolerance,
+                maxUncoupledLength: pair.maxUncoupledLength,
+              }
             const pairRoutes = connectionNames.map((connectionName) => {
               const matchingRoutes = hdRoutes.filter(
                 (route) => route.connectionName === connectionName,
@@ -773,6 +777,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
             return {
               connectionNames,
               lengthTolerance: pair.lengthTolerance,
+              maxUncoupledLength: pair.maxUncoupledLength,
               minimumCenterlineDistance: centerlineDistance,
               maximumCenterlineDistance: centerlineDistance,
             }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@tscircuit/hypergraph": "^0.0.71",
     "@tscircuit/jumper-topology-generator": "^0.0.4",
     "@tscircuit/krt-wasm": "^0.1.0",
-    "@tscircuit/length-matching-solver": "git+https://github.com/tscircuit/length-matching-solver.git#c4098fb4526609ffbb5dd4d68efdf768e104aadc",
+    "@tscircuit/length-matching-solver": "git+https://github.com/tscircuit/length-matching-solver.git#53b330f1edc4e5382730319989c912a1e5bac242",
     "@tscircuit/math-utils": "^0.0.36",
     "@tscircuit/power-trace-expander": "git+https://github.com/tscircuit/power-trace-expander.git#8dd76ba8421e92c2286e8196bcc57e3d3b5871f1",
     "@tscircuit/rectdiff": "git+https://github.com/tscircuit/rectdiff.git#262f1b7e2c70021785f0ccdbe8e2562f827c7dbf",

--- a/tests/pipeline7-differential-pair-routing-phase.test.ts
+++ b/tests/pipeline7-differential-pair-routing-phase.test.ts
@@ -155,6 +155,7 @@ test("Pipeline7 completes post-processing for a routed differential pair", () =>
         connectionNames: ["source_trace_0", "source_trace_1"],
         lengthTolerance: 0.05,
         traceGap: 0.75,
+        maxUncoupledLength: 3,
       },
     ],
     layerCount: 2,
@@ -169,5 +170,9 @@ test("Pipeline7 completes post-processing for a routed differential pair", () =>
   expect(solver.failed).toBe(false)
   expect(solver.solved).toBe(true)
   expect(solver.lengthMatchingPostProcessingSolver).toBeDefined()
+  expect(
+    solver.lengthMatchingPostProcessingSolver?.getConstructorParams()[0]
+      .differentialPairs[0]?.maxUncoupledLength,
+  ).toBe(3)
   expect(solver.getOutputSimpleRouteJson().traces).toHaveLength(2)
 })


### PR DESCRIPTION
## Summary

- pin @tscircuit/length-matching-solver to merged commit 53b330f1edc4e5382730319989c912a1e5bac242
- forward maxUncoupledLength into Pipeline 7 post-processing with and without an explicit trace gap
- assert the terminal escape constraint reaches the post-processing solver

## Context

Consumes the terminal escape fix from https://github.com/tscircuit/length-matching-solver/pull/56.

## Testing

- bun test tests/pipeline7-differential-pair-routing-phase.test.ts --timeout 9999999
- bun run build