### PR TITLE
Keep Pipeline9 interior ports out of A-series fallback

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/apply-pipeline9-regional-b01-repairs.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/apply-pipeline9-regional-b01-repairs.ts
@@ -17,6 +17,7 @@ import {
   type Pipeline9RouteWireSegment,
 } from "./pipeline9-fixed-route-copper"
 import {
+  areAllPortPointsOnNodeBoundary,
   createRegionalFallbackProblem,
   spliceFixedRouteSection,
 } from "./pipeline9-regional-fallback"
@@ -421,6 +422,12 @@ const getRegularRegionalCandidate = ({
   }
   const problem = createRegionalFallbackProblem(node, regionalRoutes)
   if (problem.fixedRouteSectionsByConnectionName.size === 0) return undefined
+  // A-series solvers require perimeter terminals. A fixed route contained by
+  // this DRC window creates interior splice anchors, so leave that candidate
+  // to the later repair stages instead of passing an invalid node to A01/A03.
+  if (!areAllPortPointsOnNodeBoundary(problem.nodeWithPortPoints)) {
+    return undefined
+  }
   const regionalSourceRoutes = [
     ...problem.fixedRouteSectionsByConnectionName.values(),
   ].flatMap((section) => section.sourceRoutes)

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-regional-fallback.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-regional-fallback.ts
@@ -3,6 +3,7 @@ import type {
   NodeWithPortPoints,
   PortPoint,
 } from "lib/types/high-density-types"
+import { classifyPointInBounds } from "lib/utils/classifyPointInBounds"
 import type { PreloadedHighDensityRoute } from "./convert-preloaded-traces-to-hd-routes"
 
 type RoutePoint = HighDensityRoute["route"][number]
@@ -45,6 +46,16 @@ const getNodeBounds = (node: NodeWithPortPoints): NodeBounds => ({
   minY: node.center.y - node.height / 2,
   maxY: node.center.y + node.height / 2,
 })
+
+export const areAllPortPointsOnNodeBoundary = (
+  node: NodeWithPortPoints,
+): boolean => {
+  const bounds = getNodeBounds(node)
+  return node.portPoints.every(
+    (portPoint) =>
+      classifyPointInBounds({ point: portPoint, bounds }) === "on-boundary",
+  )
+}
 
 const isPointInsideBounds = (point: RoutePoint, bounds: NodeBounds) =>
   point.x >= bounds.minX - POINT_EPSILON &&

--- a/tests/features/pipeline9-regional-a-series-boundary-input.test.ts
+++ b/tests/features/pipeline9-regional-a-series-boundary-input.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test"
+import type { PreloadedHighDensityRoute } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/convert-preloaded-traces-to-hd-routes"
+import {
+  areAllPortPointsOnNodeBoundary,
+  createRegionalFallbackProblem,
+} from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-regional-fallback"
+
+test("Pipeline9 rejects interior fixed-route endpoints from its A-series regional fallback", () => {
+  const fullyContainedRoute: PreloadedHighDensityRoute = {
+    connectionName: "pipeline9_preloaded_drc_8",
+    rootConnectionName: "connectivity_net5",
+    preloadedTraceIndex: 0,
+    preloadedRouteIndex: 0,
+    traceThickness: 0.15,
+    viaDiameter: 0.3,
+    route: [
+      { x: -0.5, y: 0, z: 0 },
+      { x: 0.5, y: 0, z: 0 },
+    ],
+    vias: [],
+  }
+  const problem = createRegionalFallbackProblem(
+    {
+      capacityMeshNodeId: "pipeline9_joint_drc_regular_fallback",
+      center: { x: 0, y: 0 },
+      width: 3,
+      height: 3,
+      availableZ: [0, 1],
+      portPoints: [],
+      portPointsInPairs: [],
+    },
+    [fullyContainedRoute],
+  )
+
+  expect(problem.nodeWithPortPoints.portPoints).toHaveLength(2)
+  expect(areAllPortPointsOnNodeBoundary(problem.nodeWithPortPoints)).toBeFalse()
+})


### PR DESCRIPTION
## Summary

- detect when clipped fixed-route sections create port points away from the regional node boundary
- skip Pipeline9's joint-DRC A01/A03 batch candidate for that invalid input and continue with the existing later repair stages
- add a regression test for a fully contained fixed route whose two splice anchors are interior

## Root cause

Pipeline9's 3 mm joint-DRC window can fully contain a preloaded route section. Clipping that section leaves its endpoints inside the window, but the A-series high-density solvers expect terminals on the routing-node perimeter. Passing that node to A03 allowed a terminal layer transition to be emitted without a via.

## Verification

- bun test tests/features/pipeline9-regional-a-series-boundary-input.test.ts tests/features/pipeline9-srj23-sample46-regional-trace-set.test.ts --timeout 9999999
- bun test tests/autorouting-dataset18-sample10-exact-drc-residue-visual.test.ts --timeout 9999999
- bunx tsc --noEmit
- bun run build
- git diff --check
- full suite: 569 pass, 60 skip; the same 7 unrelated local SVG snapshot mismatches seen on baseline, with all functional assertions green

## Same-machine Blacksmith benchmarks

Pipeline9 ran sequentially on current main and this PR on the same 4-vCPU runner.

### dataset01 (85 scenarios)

- completion: 100.0% -> 100.0%
- relaxed DRC pass: 100.0% -> 100.0%
- timeouts: 0 -> 0
- outcome changes: 0 improved, 0 regressed
- average vias: 37.47 -> 37.47

### srj18 (16 scenarios)

- completion: 68.8% -> 68.8%
- relaxed DRC pass: 43.8% -> 43.8%
- DRC issues: 78 -> 78
- timeouts: 3 -> 3, on the same samples and phases
- solver failures: the same samples 14 and 15
- outcome changes: 0 improved, 0 regressed
- average vias: 172.18 -> 172.18