### PR TITLE
Update autorouter to cross-layer-safe length-matching solver

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@tscircuit/hypergraph": "^0.0.71",
     "@tscircuit/jumper-topology-generator": "^0.0.4",
     "@tscircuit/krt-wasm": "^0.1.0",
-    "@tscircuit/length-matching-solver": "git+https://github.com/tscircuit/length-matching-solver.git#53b330f1edc4e5382730319989c912a1e5bac242",
+    "@tscircuit/length-matching-solver": "git+https://github.com/tscircuit/length-matching-solver.git#0c7f84810aceb70f9517c274116071f2af1ace6b",
     "@tscircuit/math-utils": "^0.0.36",
     "@tscircuit/power-trace-expander": "git+https://github.com/tscircuit/power-trace-expander.git#8dd76ba8421e92c2286e8196bcc57e3d3b5871f1",
     "@tscircuit/rectdiff": "git+https://github.com/tscircuit/rectdiff.git#262f1b7e2c70021785f0ccdbe8e2562f827c7dbf",


### PR DESCRIPTION
## Summary\n\n- update @tscircuit/length-matching-solver from 53b330f to merged commit 0c7f848 from tscircuit/length-matching-solver#58\n- pick up the cross-layer-safe fallback that skips unmeasurable meander candidates instead of throwing\n- keep the autorouter change dependency-only with no source API or snapshot changes\n\n## Validation\n\n- four focused Pipeline 7/9 tests: 4 pass, 0 fail, 137 assertions\n- bunx tsc --noEmit\n- bun run build\n- ohmx-box Linux targeted bugreport51 and bugreport58 tests: 3 pass, 0 fail\n- old and new solver Linux baselines match, so no snapshots were updated