### PR TITLE
Fix cross-layer stitch endpoint selection

### DIFF
--- a/lib/solvers/RouteStitchingSolver/MultipleHighDensityRouteStitchSolver3.ts
+++ b/lib/solvers/RouteStitchingSolver/MultipleHighDensityRouteStitchSolver3.ts
@@ -19,6 +19,7 @@ import {
 } from "./routeStitchingEndpointHelpers"
 import {
   compareRoutes,
+  DISTANCE_TIE_TOLERANCE,
   MAX_TERMINAL_STITCH_GAP_DISTANCE_3,
 } from "./routeStitchingShared"
 
@@ -264,9 +265,20 @@ export class MultipleHighDensityRouteStitchSolver3 extends BaseSolver {
           globalEnd,
         }))
 
+        const directTerminalDistance =
+          distance(start, globalStart) + distance(end, globalEnd)
+        const swappedTerminalDistance =
+          distance(start, globalEnd) + distance(end, globalStart)
+        const directLayerMatchCount =
+          Number(start.z === globalStart.z) + Number(end.z === globalEnd.z)
+        const swappedLayerMatchCount =
+          Number(start.z === globalEnd.z) + Number(end.z === globalStart.z)
         if (
-          distance(start, connection.pointsToConnect[1]) <
-          distance(end, connection.pointsToConnect[0])
+          swappedTerminalDistance <
+            directTerminalDistance - DISTANCE_TIE_TOLERANCE ||
+          (Math.abs(swappedTerminalDistance - directTerminalDistance) <=
+            DISTANCE_TIE_TOLERANCE &&
+            swappedLayerMatchCount > directLayerMatchCount)
         ) {
           ;[start, end] = [end, start]
         }

--- a/lib/solvers/RouteStitchingSolver/SingleHighDensityRouteStitchSolver3.ts
+++ b/lib/solvers/RouteStitchingSolver/SingleHighDensityRouteStitchSolver3.ts
@@ -181,6 +181,7 @@ export class SingleHighDensityRouteStitchSolver3 extends BaseSolver {
     }
 
     let bestDist = Infinity
+    let bestHasLayerMatch = false
     let firstRoute = canonicalHdRoutes[0]
     let orientation: "start-to-end" | "end-to-start" = "start-to-end"
 
@@ -199,23 +200,48 @@ export class SingleHighDensityRouteStitchSolver3 extends BaseSolver {
         distEndToFirst,
         distEndToLast,
       )
+      const hasLayerMatch =
+        (opts.start.z === firstPoint.z &&
+          Math.abs(distStartToFirst - minDist) <= DISTANCE_TIE_TOLERANCE) ||
+        (opts.start.z === lastPoint.z &&
+          Math.abs(distStartToLast - minDist) <= DISTANCE_TIE_TOLERANCE) ||
+        (opts.end.z === firstPoint.z &&
+          Math.abs(distEndToFirst - minDist) <= DISTANCE_TIE_TOLERANCE) ||
+        (opts.end.z === lastPoint.z &&
+          Math.abs(distEndToLast - minDist) <= DISTANCE_TIE_TOLERANCE)
 
       if (
         minDist < bestDist - DISTANCE_TIE_TOLERANCE ||
         (Math.abs(minDist - bestDist) <= DISTANCE_TIE_TOLERANCE &&
-          compareRoutes(route, firstRoute!) < 0)
+          ((hasLayerMatch && !bestHasLayerMatch) ||
+            (hasLayerMatch === bestHasLayerMatch &&
+              compareRoutes(route, firstRoute!) < 0)))
       ) {
         bestDist = minDist
+        bestHasLayerMatch = hasLayerMatch
         firstRoute = route
+        const minStartDistance = Math.min(distStartToFirst, distStartToLast)
+        const minEndDistance = Math.min(distEndToFirst, distEndToLast)
+        const startHasLayerMatch =
+          (opts.start.z === firstPoint.z &&
+            Math.abs(distStartToFirst - minStartDistance) <=
+              DISTANCE_TIE_TOLERANCE) ||
+          (opts.start.z === lastPoint.z &&
+            Math.abs(distStartToLast - minStartDistance) <=
+              DISTANCE_TIE_TOLERANCE)
+        const endHasLayerMatch =
+          (opts.end.z === firstPoint.z &&
+            Math.abs(distEndToFirst - minEndDistance) <=
+              DISTANCE_TIE_TOLERANCE) ||
+          (opts.end.z === lastPoint.z &&
+            Math.abs(distEndToLast - minEndDistance) <= DISTANCE_TIE_TOLERANCE)
         if (
-          Math.min(distEndToFirst, distEndToLast) <
-            Math.min(distStartToFirst, distStartToLast) -
-              DISTANCE_TIE_TOLERANCE ||
-          (Math.abs(
-            Math.min(distEndToFirst, distEndToLast) -
-              Math.min(distStartToFirst, distStartToLast),
-          ) <= DISTANCE_TIE_TOLERANCE &&
-            comparePoints(opts.end, opts.start) < 0)
+          minEndDistance < minStartDistance - DISTANCE_TIE_TOLERANCE ||
+          (Math.abs(minEndDistance - minStartDistance) <=
+            DISTANCE_TIE_TOLERANCE &&
+            ((endHasLayerMatch && !startHasLayerMatch) ||
+              (endHasLayerMatch === startHasLayerMatch &&
+                comparePoints(opts.end, opts.start) < 0)))
         ) {
           orientation = "end-to-start"
         } else {
@@ -236,10 +262,14 @@ export class SingleHighDensityRouteStitchSolver3 extends BaseSolver {
     const firstRouteLastPoint = firstRoute.route[firstRoute.route.length - 1]
     const distToFirst = distance(this.start, firstRouteFirstPoint)
     const distToLast = distance(this.start, firstRouteLastPoint)
+    const firstPointMatchesLayer = this.start.z === firstRouteFirstPoint.z
+    const lastPointMatchesLayer = this.start.z === firstRouteLastPoint.z
     const closestFirstRoutePoint =
       distToFirst < distToLast - DISTANCE_TIE_TOLERANCE ||
       (Math.abs(distToFirst - distToLast) <= DISTANCE_TIE_TOLERANCE &&
-        comparePoints(firstRouteFirstPoint, firstRouteLastPoint) <= 0)
+        ((firstPointMatchesLayer && !lastPointMatchesLayer) ||
+          (firstPointMatchesLayer === lastPointMatchesLayer &&
+            comparePoints(firstRouteFirstPoint, firstRouteLastPoint) <= 0)))
         ? firstRouteFirstPoint
         : firstRouteLastPoint
     const closestFirstRoutePcbPortId =

--- a/lib/solvers/RouteStitchingSolver/routeStitchingEndpointHelpers.ts
+++ b/lib/solvers/RouteStitchingSolver/routeStitchingEndpointHelpers.ts
@@ -13,6 +13,33 @@ import {
  */
 export const ENDPOINT_MATCH_TOLERANCE = 0.1
 
+const isBetterEndpointForTerminal = ({
+  candidate,
+  current,
+  terminal,
+}: {
+  candidate: Point3
+  current: Point3
+  terminal: Point3
+}): boolean => {
+  const candidateDistance = distance(candidate, terminal)
+  const currentDistance = distance(current, terminal)
+  if (candidateDistance < currentDistance - DISTANCE_TIE_TOLERANCE) {
+    return true
+  }
+  if (Math.abs(candidateDistance - currentDistance) > DISTANCE_TIE_TOLERANCE) {
+    return false
+  }
+
+  const candidateMatchesLayer = candidate.z === terminal.z
+  const currentMatchesLayer = current.z === terminal.z
+  if (candidateMatchesLayer !== currentMatchesLayer) {
+    return candidateMatchesLayer
+  }
+
+  return comparePoints(candidate, current) < 0
+}
+
 type EndpointEdge = {
   nextHash: string
   routeIndex: number | null
@@ -98,14 +125,18 @@ export class EndpointClusterIndex {
     for (const endpoint of candidateEndpoints) {
       const dist = distance(point, endpoint)
       const endpointHash = this.getEndpointKey(connectionName, endpoint)
+      const endpointMatchesLayer = endpoint.z === point.z
+      const bestEndpointMatchesLayer = bestEndpoint?.z === point.z
       if (
         dist < bestDist - DISTANCE_TIE_TOLERANCE ||
         (Math.abs(dist - bestDist) <= DISTANCE_TIE_TOLERANCE &&
-          (bestHash === null ||
-            endpointHash.localeCompare(bestHash) < 0 ||
-            (endpointHash === bestHash &&
-              bestEndpoint !== null &&
-              comparePoints(endpoint, bestEndpoint) < 0)))
+          ((endpointMatchesLayer && !bestEndpointMatchesLayer) ||
+            (endpointMatchesLayer === bestEndpointMatchesLayer &&
+              (bestHash === null ||
+                endpointHash.localeCompare(bestHash) < 0 ||
+                (endpointHash === bestHash &&
+                  bestEndpoint !== null &&
+                  comparePoints(endpoint, bestEndpoint) < 0)))))
       ) {
         bestDist = dist
         bestHash = endpointHash
@@ -146,15 +177,15 @@ export const selectIslandEndpoints = (params: {
   globalEnd: Point3
 }) => {
   const sortedEndpoints = [...params.possibleEndpoints].sort(comparePoints)
-  const start = sortedEndpoints.reduce((bestPoint, point) => {
-    const pointDistance = distance(point, params.globalStart)
-    const bestDistance = distance(bestPoint, params.globalStart)
-    return pointDistance < bestDistance - DISTANCE_TIE_TOLERANCE ||
-      (Math.abs(pointDistance - bestDistance) <= DISTANCE_TIE_TOLERANCE &&
-        comparePoints(point, bestPoint) < 0)
+  const start = sortedEndpoints.reduce((bestPoint, point) =>
+    isBetterEndpointForTerminal({
+      candidate: point,
+      current: bestPoint,
+      terminal: params.globalStart,
+    })
       ? point
-      : bestPoint
-  })
+      : bestPoint,
+  )
 
   const remainingEndpoints = sortedEndpoints.filter((point) => point !== start)
 
@@ -163,15 +194,15 @@ export const selectIslandEndpoints = (params: {
       ? remainingEndpoints
       : params.possibleEndpoints
 
-  const end = endCandidates.reduce((bestPoint, point) => {
-    const pointDistance = distance(point, params.globalEnd)
-    const bestDistance = distance(bestPoint, params.globalEnd)
-    return pointDistance < bestDistance - DISTANCE_TIE_TOLERANCE ||
-      (Math.abs(pointDistance - bestDistance) <= DISTANCE_TIE_TOLERANCE &&
-        comparePoints(point, bestPoint) < 0)
+  const end = endCandidates.reduce((bestPoint, point) =>
+    isBetterEndpointForTerminal({
+      candidate: point,
+      current: bestPoint,
+      terminal: params.globalEnd,
+    })
       ? point
-      : bestPoint
-  })
+      : bestPoint,
+  )
 
   return { start, end }
 }
@@ -185,22 +216,24 @@ export const snapIslandEndpointToNearestTerminal = (params: {
   terminals: Point3[]
 }) => {
   const sortedTerminals = [...params.terminals].sort(comparePoints)
+  if (sortedTerminals.length === 0) return params.islandEndpoint
   let closestTerminal = sortedTerminals[0]
-  let closestDistance = distance(params.islandEndpoint, closestTerminal)
 
   for (const terminal of sortedTerminals.slice(1)) {
-    const terminalDistance = distance(params.islandEndpoint, terminal)
     if (
-      terminalDistance < closestDistance - DISTANCE_TIE_TOLERANCE ||
-      (Math.abs(terminalDistance - closestDistance) <= DISTANCE_TIE_TOLERANCE &&
-        comparePoints(terminal, closestTerminal) < 0)
+      isBetterEndpointForTerminal({
+        candidate: terminal,
+        current: closestTerminal,
+        terminal: params.islandEndpoint,
+      })
     ) {
       closestTerminal = terminal
-      closestDistance = terminalDistance
     }
   }
 
-  return closestDistance <= MAX_TERMINAL_STITCH_GAP_DISTANCE_3
+  return closestTerminal.z === params.islandEndpoint.z &&
+    distance(params.islandEndpoint, closestTerminal) <=
+      MAX_TERMINAL_STITCH_GAP_DISTANCE_3
     ? closestTerminal
     : params.islandEndpoint
 }

--- a/tests/stitch-solver/cross-layer-terminal-path-selection.test.ts
+++ b/tests/stitch-solver/cross-layer-terminal-path-selection.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "bun:test"
+import { MultipleHighDensityRouteStitchSolver3 } from "lib/solvers/RouteStitchingSolver/MultipleHighDensityRouteStitchSolver3"
+import type { HighDensityIntraNodeRoute } from "lib/types/high-density-types"
+
+test("stitch path retains the via to a colocated cross-layer terminal", () => {
+  const connectionName = "changed-preloaded-section"
+  const routes: HighDensityIntraNodeRoute[] = [
+    {
+      connectionName,
+      rootConnectionName: "shared-net",
+      traceThickness: 0.1,
+      viaDiameter: 0.3,
+      route: [
+        { x: 0, y: 1, z: 0 },
+        { x: 6, y: 0, z: 0 },
+      ],
+      vias: [],
+    },
+    {
+      connectionName,
+      rootConnectionName: "shared-net",
+      traceThickness: 0.1,
+      viaDiameter: 0.3,
+      route: [
+        { x: 6, y: 0, z: 0 },
+        { x: 6, y: 0, z: 10 },
+      ],
+      vias: [{ x: 6, y: 0 }],
+    },
+    {
+      connectionName,
+      rootConnectionName: "shared-net",
+      traceThickness: 0.1,
+      viaDiameter: 0.3,
+      route: [{ x: 2, y: 2, z: 0 }],
+      vias: [],
+    },
+  ]
+  const solver = new MultipleHighDensityRouteStitchSolver3({
+    connections: [
+      {
+        name: connectionName,
+        pointsToConnect: [
+          { x: 0, y: 0, layer: "top" },
+          { x: 6.2, y: 0, layer: "inner10" },
+        ],
+      },
+    ],
+    hdRoutes: routes,
+    layerCount: 12,
+    defaultViaDiameter: 0.3,
+  })
+
+  solver.solve()
+
+  expect(solver.failed).toBeFalse()
+  expect(solver.mergedHdRoutes).toHaveLength(1)
+  expect([
+    solver.mergedHdRoutes[0]!.route[0],
+    solver.mergedHdRoutes[0]!.route.at(-1),
+  ]).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ x: 0, y: 0, z: 0 }),
+      expect.objectContaining({ x: 6.2, y: 0, z: 10 }),
+    ]),
+  )
+  expect(solver.mergedHdRoutes[0]!.vias).toEqual([{ x: 6, y: 0 }])
+})


### PR DESCRIPTION
## Stack

- Base: #2215 — reproduces the MangoPi Pipeline 9 pre-power connectivity loss
- This PR — fixes cross-layer endpoint selection during route stitching

## Root cause

Route stitching broke equal-distance endpoint ties with coordinate ordering alone. When route islands met at the same XY position on different copper layers, stitching could select the wrong-layer endpoint, omit the island containing the required via, and leave original terminals physically disconnected even though Pipeline 9 later reported solved.

## Fix

- Prefer terminal-layer agreement when endpoint distances tie.
- Preserve layer-aware orientation when assigning stitch start and end terminals.
- Do not snap an island endpoint across layers without retaining its transition.
- Add a focused regression proving that a colocated cross-layer terminal keeps its via-bearing route island.

This revives and adapts the approach from the stale, automatically closed #2134 to the current Pipeline 9 stitch safeguards.

## Validation

- `bun run format`
- `bun test tests/stitch-solver --timeout 9999999` — 9 passed
- `bun test tests/bugs/bugreport99-mangopi-r3c-pipeline9-connectivity.test.ts --timeout 9999999` — 1 passed
- `bun run build`