### PR TITLE
Fix pipeline9 browser crash without preloaded traces

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-high-density-solver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-high-density-solver.ts
@@ -334,7 +334,7 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
   readonly includeBoardObstacles: boolean
   readonly enableRegionalFallback: boolean
   readonly maxB01Rips?: number
-  readonly routes: HighDensityIntraNodeRoute[] = []
+  readonly routes: HighDensityIntraNodeRoute[]
   readonly failedSolvers: HighDensitySolverB01[] = []
   readonly unsolvedNodePortPoints: NodeWithPortPoints[]
   readonly fixedRouteReplacements = new Map<string, PreloadedHighDensityRoute>()
@@ -349,6 +349,7 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
   activeFallbackPromotedFixedRouteConnectionNames = new Set<string>()
   activeFallbackReason: string | null = null
   activeNode: NodeWithPortPoints | null = null
+  readonly standardSolver: HighDensitySolver | null
 
   constructor(params: Pipeline9HighDensitySolverParams) {
     super()
@@ -370,8 +371,29 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
     this.enableRegionalFallback = params.enableRegionalFallback ?? true
     this.maxB01Rips = params.maxB01Rips
     this.unsolvedNodePortPoints = [...params.nodePortPoints]
+    this.standardSolver =
+      params.fixedHdRoutes.length === 0
+        ? new HighDensitySolver({
+            nodePortPoints: this.unsolvedNodePortPoints,
+            nodePfById: params.nodePfById,
+            colorMap: this.colorMap,
+            connMap: this.connMap,
+            viaDiameter: this.viaDiameter,
+            traceWidth: this.traceWidth,
+            obstacleMargin: this.obstacleMargin,
+            effort: this.effort,
+            obstacles: this.obstacles,
+            layerCount: this.layerCount,
+            useGrowShrinkHighDensityIntraNodeSolver: true,
+            preserveTerminalPcbPortIds: this.preserveTerminalPcbPortIds,
+            growShrinkFallbackToInvalidGeometryOnFailure: true,
+            captureSearchDebug: false,
+          })
+        : null
+    this.routes = this.standardSolver?.routes ?? []
     this.MAX_ITERATIONS = 100e6 * this.effort
     this.stats = {
+      routingMode: this.standardSolver ? "standard" : "preloaded-b01",
       nodeCount: params.nodePortPoints.length,
       solvedNodeCount: 0,
       fixedObstacleCount: params.fixedHdRoutes.length,
@@ -813,6 +835,19 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
   }
 
   override _step(): void {
+    if (this.standardSolver) {
+      this.standardSolver.step()
+      if (this.standardSolver.failed) {
+        this.error = this.standardSolver.error
+        this.failed = true
+        return
+      }
+      if (this.standardSolver.solved) {
+        this.solved = true
+      }
+      return
+    }
+
     if (this.activeFallbackSolver) {
       this.activeFallbackSolver.step()
       if (this.activeFallbackSolver.failed) {
@@ -941,6 +976,10 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
   }
 
   override visualize(): GraphicsObject {
+    if (this.standardSolver) {
+      return this.standardSolver.visualize()
+    }
+
     return (
       this.activeFallbackSolver?.visualize() ??
       this.activeRegularSolver?.visualize() ??

--- a/lib/testing/AutoroutingPipelineDebugger.tsx
+++ b/lib/testing/AutoroutingPipelineDebugger.tsx
@@ -182,12 +182,14 @@ const waitForNextPaint = () =>
       typeof window !== "undefined" &&
       typeof window.requestAnimationFrame === "function"
     ) {
-      window.requestAnimationFrame(() => resolve())
+      window.requestAnimationFrame(() => setTimeout(resolve, 0))
       return
     }
 
     setTimeout(resolve, 0)
   })
+
+const SOLVER_UI_YIELD_INTERVAL_MS = 250
 
 const downloadJsonFile = (filename: string, data: unknown) => {
   const blob = new Blob([JSON.stringify(data)], {
@@ -494,6 +496,23 @@ export const AutoroutingPipelineDebugger = ({
     solverToStep.step()
   }
 
+  const stepSolverWhile = async (
+    shouldContinue: () => boolean,
+    onProgress?: () => Promise<void> | void,
+  ) => {
+    let lastYieldTime = performance.now()
+    while (shouldContinue()) {
+      await stepSolver(solver as AsyncPipelineDebuggerSolver)
+      if (
+        performance.now() - lastYieldTime >=
+        SOLVER_UI_YIELD_INTERVAL_MS
+      ) {
+        await (onProgress?.() ?? waitForNextPaint())
+        lastYieldTime = performance.now()
+      }
+    }
+  }
+
   const solveSolver = async (
     solverToSolve: AsyncPipelineDebuggerSolver,
     opts: {
@@ -528,6 +547,22 @@ export const AutoroutingPipelineDebugger = ({
 
         await opts.onProgress()
       }
+      return
+    }
+
+    if (opts.onProgress) {
+      let lastProgressTime = performance.now()
+      while (!solverToSolve.solved && !solverToSolve.failed) {
+        solverToSolve.step()
+        if (
+          performance.now() - lastProgressTime >=
+          SOLVER_UI_YIELD_INTERVAL_MS
+        ) {
+          await opts.onProgress()
+          lastProgressTime = performance.now()
+        }
+      }
+      await opts.onProgress()
       return
     }
 
@@ -671,24 +706,22 @@ export const AutoroutingPipelineDebugger = ({
 
       // Step until we get a new subsolver (null -> something)
       if (initialSubSolver === null) {
-        while (
-          !solver.solved &&
-          !solver.failed &&
-          solver.activeSubSolver === null
-        ) {
-          await stepSolver(solver as AsyncPipelineDebuggerSolver)
-        }
+        await stepSolverWhile(
+          () =>
+            !solver.solved &&
+            !solver.failed &&
+            solver.activeSubSolver === null,
+        )
       }
 
       // Now step until the subsolver completes (something -> null)
       if (solver.activeSubSolver !== null) {
-        while (
-          !solver.solved &&
-          !solver.failed &&
-          solver.activeSubSolver !== null
-        ) {
-          await stepSolver(solver as AsyncPipelineDebuggerSolver)
-        }
+        await stepSolverWhile(
+          () =>
+            !solver.solved &&
+            !solver.failed &&
+            solver.activeSubSolver !== null,
+        )
       }
 
       setForceUpdate((prev) => prev + 1)
@@ -710,26 +743,16 @@ export const AutoroutingPipelineDebugger = ({
       const initialSubSolver = currentPhase.activeSubSolver
 
       // Step until the sub-solver changes or becomes solved
-      while (!solver.solved && !solver.failed) {
+      await stepSolverWhile(() => {
         const currentSubSolver = solver.activeSubSolver?.activeSubSolver
-
-        // Stop if sub-solver changed
-        if (currentSubSolver !== initialSubSolver) {
-          break
-        }
-
-        // Stop if sub-solver is now solved
-        if (currentSubSolver?.solved) {
-          break
-        }
-
-        // Stop if the phase itself changed
-        if (solver.activeSubSolver !== currentPhase) {
-          break
-        }
-
-        await stepSolver(solver as AsyncPipelineDebuggerSolver)
-      }
+        return (
+          !solver.solved &&
+          !solver.failed &&
+          currentSubSolver === initialSubSolver &&
+          !currentSubSolver?.solved &&
+          solver.activeSubSolver === currentPhase
+        )
+      })
 
       setForceUpdate((prev) => prev + 1)
     }

--- a/tests/features/pipeline9-no-preloaded-traces-standard-router.test.ts
+++ b/tests/features/pipeline9-no-preloaded-traces-standard-router.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { Pipeline9HighDensitySolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-high-density-solver"
+import { HighDensitySolver } from "lib/solvers/HighDensitySolver/HighDensitySolver"
+import type { NodeWithPortPoints } from "lib/types/high-density-types"
+
+test("Pipeline9 uses the standard high-density router without preloaded traces", () => {
+  const start = {
+    connectionName: "source_net_0_mst0",
+    rootConnectionName: "connectivity_net0",
+    portPointId: "start",
+    pcb_port_id: "pcb_port_start",
+    x: 0,
+    y: 0,
+    z: 0,
+  }
+  const end = {
+    connectionName: "source_net_0_mst0",
+    rootConnectionName: "connectivity_net0",
+    portPointId: "end",
+    pcb_port_id: "pcb_port_end",
+    x: 2,
+    y: 0,
+    z: 0,
+  }
+  const node: NodeWithPortPoints = {
+    capacityMeshNodeId: "no-preloaded-traces-node",
+    center: { x: 1, y: 0 },
+    width: 2,
+    height: 1,
+    availableZ: [0, 1],
+    portPoints: [start, end],
+    portPointsInPairs: [[start, end]],
+  }
+  const solver = new Pipeline9HighDensitySolver({
+    nodePortPoints: [node],
+    fixedHdRoutes: [],
+    connMap: new ConnectivityMap({
+      connectivity_net0: ["source_net_0_mst0"],
+    }),
+    obstacles: [],
+    layerCount: 2,
+    viaDiameter: 0.3,
+    traceWidth: 0.1,
+    obstacleMargin: 0.15,
+    effort: 1,
+    preserveTerminalPcbPortIds: true,
+  })
+
+  expect(solver.standardSolver).toBeInstanceOf(HighDensitySolver)
+  expect(solver.stats.routingMode).toBe("standard")
+
+  solver.solve()
+
+  expect(solver.solved).toBeTrue()
+  expect(solver.failed).toBeFalse()
+  expect(solver.routes).toHaveLength(1)
+  expect([
+    solver.routes[0]?.startPcbPortId,
+    solver.routes[0]?.endPcbPortId,
+  ].sort()).toEqual(["pcb_port_end", "pcb_port_start"])
+  expect(solver.getUpdatedFixedHdRoutes()).toEqual([])
+})


### PR DESCRIPTION
## Summary

- delegate pipeline9 to the standard high-density router when there are no preloaded traces
- retain the preload-aware B01 and regional routing path when fixed copper exists
- yield long debugger solve loops to Chrome every 250 ms
- add regression coverage for the zero-preload routing mode

## Why

Bugreport88 has no preloaded traces, but pipeline9 still drove the preload-aware high-density wrapper node by node. Combined with the debugger's synchronous solve loops, this produced millions of iterations while monopolizing the Chrome renderer. Pipeline7 avoids that expensive path.

## Testing

- bun test tests/features/pipeline9-no-preloaded-traces-standard-router.test.ts tests/features/pipeline9-high-density-regional-fallback.test.ts tests/features/pipeline9-minimal-preloaded-trace-graph.test.ts
- ./node_modules/.bin/tsc --noEmit
- bun run build