### PR TITLE
Improve Pipeline 9 final DRC repair with guarded branch rerouting

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph.ts
@@ -84,6 +84,7 @@ import {
   type PreloadedHighDensityRoute,
 } from "./convert-preloaded-traces-to-hd-routes"
 import { Pipeline9HighDensitySolver } from "./pipeline9-high-density-solver"
+import { Pipeline9BranchRipDrcFallbackSolver } from "./pipeline9-branch-rip-drc-fallback-solver"
 import { Pipeline9JointDrcRepairSolver } from "./pipeline9-joint-drc-repair-solver"
 import { PreloadedTraceGraphSolver } from "./preloaded-trace-graph-solver"
 import { PreprocessSimpleRouteJsonWithoutTraceObstaclesSolver } from "./preprocess-simple-route-json-without-trace-obstacles-solver"
@@ -107,6 +108,8 @@ interface CapacityMeshSolverOptions {
   minNodeArea?: number
   visualizationTraceColorMode?: TraceColorMode
   powerTraceExpansion?: PowerTraceExpanderOptions
+  /** Internal recursion guard for the post-route branch-rip DRC fallback. */
+  disableBranchRipDrcFallback?: boolean
 }
 export type AutoroutingPipelineSolverOptions = CapacityMeshSolverOptions
 
@@ -260,6 +263,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
   highDensityStitchSolver?: MultipleHighDensityRouteStitchSolver3
   globalDrcForceImproveSolver?: GlobalDrcForceImproveSolver
   pipeline9JointDrcRepairSolver?: Pipeline9JointDrcRepairSolver
+  pipeline9BranchRipDrcFallbackSolver?: Pipeline9BranchRipDrcFallbackSolver
   singleLayerNodeMerger?: SingleLayerNodeMergerSolver
   strawSolver?: StrawSolver
   deadEndSolver?: DeadEndSolver
@@ -948,6 +952,38 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
         ]
       },
     ),
+    definePipelineStep(
+      "pipeline9BranchRipDrcFallbackSolver",
+      Pipeline9BranchRipDrcFallbackSolver,
+      (cms) => {
+        const newlyRoutedTraces = cms.powerTraceExpansionSolver!.getOutput()
+        return [
+          {
+            originalSrj: cms.originalSrj,
+            currentTraces: [
+              ...cms.getPowerTraceExpansionFixedTraces(),
+              ...newlyRoutedTraces,
+            ] as SimplifiedPcbTraces,
+            eligibleTraceIds: new Set(
+              cms.opts.disableBranchRipDrcFallback
+                ? []
+                : newlyRoutedTraces.map((trace) => trace.pcb_trace_id),
+            ),
+            createNestedSolver: (input: SimpleRouteJson) =>
+              new AutoroutingPipelineSolver9_PreloadedTraceGraph(input, {
+                cacheProvider: null,
+                effort: cms.effort,
+                maxNodeDimension: cms.opts.maxNodeDimension,
+                maxNodeRatio: cms.opts.maxNodeRatio,
+                minNodeArea: cms.opts.minNodeArea,
+                visualizationTraceColorMode: cms.visualizationTraceColorMode,
+                powerTraceExpansion: cms.opts.powerTraceExpansion,
+                disableBranchRipDrcFallback: true,
+              }),
+          },
+        ]
+      },
+    ),
   ]
 
   constructor(
@@ -1484,6 +1520,17 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
         "Pipeline9 invariant violated: solved pipeline is missing the unconditional power-trace expansion solver",
       )
     }
+    const finalTraces = this.pipeline9BranchRipDrcFallbackSolver?.getOutput()
+    if (finalTraces) {
+      const originalPreloadedTraceIds = new Set(
+        (this.originalSrj.traces ?? []).map((trace) => trace.pcb_trace_id),
+      )
+      return finalTraces.filter(
+        (trace) =>
+          trace.__replaces_pcb_trace_id !== undefined ||
+          !originalPreloadedTraceIds.has(trace.pcb_trace_id),
+      )
+    }
     return [
       ...this.getPowerTraceExpansionFixedTraces().filter(
         (trace) => trace.__replaces_pcb_trace_id !== undefined,
@@ -1501,7 +1548,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
         "Pipeline9 invariant violated: solved pipeline is missing the unconditional power-trace expansion solver",
       )
     }
-    const traces = [
+    const traces = this.pipeline9BranchRipDrcFallbackSolver?.getOutput() ?? [
       ...this.getPowerTraceExpansionFixedTraces(),
       ...this.powerTraceExpansionSolver.getOutput(),
     ]

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-branch-rip-drc-fallback-solver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-branch-rip-drc-fallback-solver.ts
@@ -1,0 +1,423 @@
+import { BaseSolver } from "lib/solvers/BaseSolver"
+import type {
+  SimpleRouteJson,
+  SimplifiedPcbTrace,
+  SimplifiedPcbTraces,
+} from "lib/types"
+import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
+import { getPipeline9DrcErrorTraceIds } from "./pipeline9-joint-drc-repair-utils"
+
+type NestedPipeline9Solver = BaseSolver & {
+  getOutputSimpleRouteJson: () => SimpleRouteJson
+}
+
+type Pipeline9BranchRipDrcFallbackSolverParams = {
+  originalSrj: SimpleRouteJson
+  currentTraces: SimplifiedPcbTraces
+  eligibleTraceIds: ReadonlySet<string>
+  createNestedSolver: (input: SimpleRouteJson) => NestedPipeline9Solver
+}
+
+type WireRoutePoint = Extract<
+  SimplifiedPcbTrace["route"][number],
+  { route_type: "wire" }
+>
+
+type BranchCandidate = {
+  trace: SimplifiedPcbTrace
+  syntheticConnectionName: string
+  traceWidth: number
+  start: ReturnType<typeof getTraceEndpoint>
+  end: ReturnType<typeof getTraceEndpoint>
+}
+
+const COORDINATE_EPSILON = 1e-9
+
+const getWirePoints = (trace: SimplifiedPcbTrace): WireRoutePoint[] =>
+  trace.route.filter(
+    (point): point is WireRoutePoint => point.route_type === "wire",
+  )
+
+const getTraceEndpoint = (trace: SimplifiedPcbTrace, side: "start" | "end") => {
+  const wirePoints = getWirePoints(trace)
+  const point = side === "start" ? wirePoints[0] : wirePoints.at(-1)
+  if (!point) return undefined
+  return {
+    x: point.x,
+    y: point.y,
+    layer: point.layer,
+    pcb_port_id:
+      side === "start"
+        ? (point.start_pcb_port_id ?? trace.connectsTo?.[0])
+        : (point.end_pcb_port_id ?? trace.connectsTo?.[1]),
+  }
+}
+
+const getTraceLength = (trace: SimplifiedPcbTrace) => {
+  let length = 0
+  let previous: WireRoutePoint | undefined
+  for (const point of trace.route) {
+    if (point.route_type !== "wire") {
+      previous = undefined
+      continue
+    }
+    if (previous && previous.layer === point.layer) {
+      length += Math.hypot(point.x - previous.x, point.y - previous.y)
+    }
+    previous = point
+  }
+  return length
+}
+
+const endpointsMatch = (
+  left: NonNullable<ReturnType<typeof getTraceEndpoint>>,
+  right: NonNullable<ReturnType<typeof getTraceEndpoint>>,
+) =>
+  left.layer === right.layer &&
+  Math.abs(left.x - right.x) <= COORDINATE_EPSILON &&
+  Math.abs(left.y - right.y) <= COORDINATE_EPSILON
+
+const endpointIdentityMatches = (
+  expected: NonNullable<ReturnType<typeof getTraceEndpoint>>,
+  actual: NonNullable<ReturnType<typeof getTraceEndpoint>>,
+) => expected.pcb_port_id === actual.pcb_port_id
+
+const stringSetsMatch = (
+  left: readonly string[] | undefined,
+  right: readonly string[] | undefined,
+) =>
+  JSON.stringify([...(left ?? [])].sort()) ===
+  JSON.stringify([...(right ?? [])].sort())
+
+const getWireWidths = (trace: SimplifiedPcbTrace) =>
+  [...new Set(getWirePoints(trace).map((point) => point.width))].sort(
+    (left, right) => left - right,
+  )
+
+const getViaDimensions = (trace: SimplifiedPcbTrace) =>
+  [
+    ...new Set(
+      trace.route
+        .filter((point) => point.route_type === "via")
+        .map(
+          (point) =>
+            `${point.via_diameter ?? "default"}:${point.via_hole_diameter ?? "default"}`,
+        ),
+    ),
+  ].sort()
+
+const tracePreservesElectricalInvariants = (
+  expectedTrace: SimplifiedPcbTrace,
+  actualTrace: SimplifiedPcbTrace,
+) => {
+  if (actualTrace.connection_name !== expectedTrace.connection_name)
+    return false
+  const expectedStart = getTraceEndpoint(expectedTrace, "start")
+  const expectedEnd = getTraceEndpoint(expectedTrace, "end")
+  const actualStart = getTraceEndpoint(actualTrace, "start")
+  const actualEnd = getTraceEndpoint(actualTrace, "end")
+  if (!expectedStart || !expectedEnd || !actualStart || !actualEnd) return false
+  const endpointsPreserved =
+    (endpointsMatch(expectedStart, actualStart) &&
+      endpointIdentityMatches(expectedStart, actualStart) &&
+      endpointsMatch(expectedEnd, actualEnd) &&
+      endpointIdentityMatches(expectedEnd, actualEnd)) ||
+    (endpointsMatch(expectedStart, actualEnd) &&
+      endpointIdentityMatches(expectedStart, actualEnd) &&
+      endpointsMatch(expectedEnd, actualStart) &&
+      endpointIdentityMatches(expectedEnd, actualStart))
+  return (
+    endpointsPreserved &&
+    stringSetsMatch(actualTrace.connectsTo, expectedTrace.connectsTo) &&
+    JSON.stringify(getWireWidths(actualTrace)) ===
+      JSON.stringify(getWireWidths(expectedTrace)) &&
+    JSON.stringify(getViaDimensions(actualTrace)) ===
+      JSON.stringify(getViaDimensions(expectedTrace))
+  )
+}
+
+const candidatePreservesElectricalInvariants = ({
+  candidate,
+  reroutedTraces,
+}: {
+  candidate: BranchCandidate
+  reroutedTraces: SimplifiedPcbTraces
+}) => {
+  if (!candidate.start || !candidate.end || reroutedTraces.length !== 1) {
+    return false
+  }
+  const reroutedTrace = reroutedTraces[0]!
+  const reroutedStart = getTraceEndpoint(reroutedTrace, "start")
+  const reroutedEnd = getTraceEndpoint(reroutedTrace, "end")
+  if (!reroutedStart || !reroutedEnd) return false
+  const endpointsPreserved =
+    (endpointsMatch(candidate.start, reroutedStart) &&
+      endpointsMatch(candidate.end, reroutedEnd)) ||
+    (endpointsMatch(candidate.start, reroutedEnd) &&
+      endpointsMatch(candidate.end, reroutedStart))
+  if (!endpointsPreserved) return false
+
+  return (
+    JSON.stringify(getWireWidths(reroutedTrace)) ===
+      JSON.stringify(getWireWidths(candidate.trace)) &&
+    JSON.stringify(getViaDimensions(reroutedTrace)) ===
+      JSON.stringify(getViaDimensions(candidate.trace))
+  )
+}
+
+const reconnectReroutedTrace = (
+  trace: SimplifiedPcbTrace,
+  candidate: BranchCandidate,
+): SimplifiedPcbTrace => {
+  if (!candidate.start || !candidate.end) return trace
+  const actualStart = getTraceEndpoint(trace, "start")
+  const actualEnd = getTraceEndpoint(trace, "end")
+  if (!actualStart || !actualEnd) return trace
+  const forward =
+    endpointsMatch(candidate.start, actualStart) &&
+    endpointsMatch(candidate.end, actualEnd)
+  const startPcbPortId = forward
+    ? candidate.start.pcb_port_id
+    : candidate.end.pcb_port_id
+  const endPcbPortId = forward
+    ? candidate.end.pcb_port_id
+    : candidate.start.pcb_port_id
+  const route = trace.route.map((point) => ({ ...point }))
+  const firstWireIndex = route.findIndex((point) => point.route_type === "wire")
+  const lastWireIndex = route.findLastIndex(
+    (point) => point.route_type === "wire",
+  )
+  const firstWire = route[firstWireIndex]
+  const lastWire = route[lastWireIndex]
+  if (firstWire?.route_type === "wire" && startPcbPortId) {
+    firstWire.start_pcb_port_id = startPcbPortId
+  }
+  if (lastWire?.route_type === "wire" && endPcbPortId) {
+    lastWire.end_pcb_port_id = endPcbPortId
+  }
+  return {
+    ...trace,
+    connection_name: candidate.trace.connection_name,
+    connectsTo: candidate.trace.connectsTo
+      ? [...candidate.trace.connectsTo]
+      : undefined,
+    route,
+  }
+}
+
+/**
+ * Last-resort Pipeline 9 repair for one remaining trace-pair DRC. Only a
+ * newly-routed participant may be removed; every other trace is supplied to a
+ * nested Pipeline 9 run as pre-routed copper while it reconnects the same two
+ * endpoints. Pipeline 9 may adjust that copper, but a candidate is accepted
+ * only when all electrical invariants survive and full-board DRC improves.
+ */
+export class Pipeline9BranchRipDrcFallbackSolver extends BaseSolver {
+  readonly params: Pipeline9BranchRipDrcFallbackSolverParams
+  private initialized = false
+  private candidates: BranchCandidate[] = []
+  private candidateCursor = 0
+  private activeCandidate?: BranchCandidate
+  private activeNestedSolver?: NestedPipeline9Solver
+  private initialDrcCount = 0
+  private outputTraces: SimplifiedPcbTraces
+
+  constructor(params: Pipeline9BranchRipDrcFallbackSolverParams) {
+    super()
+    this.params = params
+    this.outputTraces = structuredClone(params.currentTraces)
+    this.MAX_ITERATIONS = 100e6
+  }
+
+  private initialize() {
+    this.initialized = true
+    const result = evaluateRelaxedDrc({
+      inputSrj: { ...this.params.originalSrj, traces: [] },
+      srjWithPointPairs: this.params.originalSrj,
+      routedTraces: this.params.currentTraces,
+    })
+    this.initialDrcCount = result.errors.length
+    this.stats.initialDrcCount = this.initialDrcCount
+    if (
+      result.errors.length !== 1 ||
+      result.errors[0]?.type !== "pcb_trace_error"
+    ) {
+      this.stats.skipped = true
+      this.solved = true
+      return
+    }
+
+    const traceById = new Map(
+      this.params.currentTraces.map((trace) => [trace.pcb_trace_id, trace]),
+    )
+    this.candidates = getPipeline9DrcErrorTraceIds(
+      result.errors[0] as unknown as Record<string, unknown>,
+    )
+      .filter((traceId) => this.params.eligibleTraceIds.has(traceId))
+      .map((traceId) => traceById.get(traceId))
+      .filter((trace): trace is SimplifiedPcbTrace => Boolean(trace))
+      .map((trace, index) => {
+        const wirePoints = getWirePoints(trace)
+        return {
+          trace,
+          syntheticConnectionName: `${trace.connection_name}_branch_reroute_${index}`,
+          traceWidth:
+            wirePoints[0]?.width ?? this.params.originalSrj.minTraceWidth,
+          start: getTraceEndpoint(trace, "start"),
+          end: getTraceEndpoint(trace, "end"),
+        }
+      })
+      .filter((candidate): candidate is BranchCandidate =>
+        Boolean(candidate.start && candidate.end),
+      )
+      .sort(
+        (left, right) =>
+          getTraceLength(left.trace) - getTraceLength(right.trace),
+      )
+    this.stats.candidateCount = this.candidates.length
+    if (this.candidates.length === 0) this.solved = true
+  }
+
+  private startNextCandidate() {
+    const candidate = this.candidates[this.candidateCursor++]
+    if (!candidate || !candidate.start || !candidate.end) {
+      this.solved = true
+      return
+    }
+    const rerouteInput: SimpleRouteJson = {
+      ...structuredClone(this.params.originalSrj),
+      connections: [
+        {
+          name: candidate.syntheticConnectionName,
+          __rootConnectionNames: [candidate.trace.connection_name],
+          nominalTraceWidth: candidate.traceWidth,
+          pointsToConnect: [candidate.start, candidate.end],
+        },
+      ],
+      differentialPairs: undefined,
+      buses: undefined,
+      traces: this.params.currentTraces.filter(
+        (trace) => trace.pcb_trace_id !== candidate.trace.pcb_trace_id,
+      ),
+    }
+    this.activeCandidate = candidate
+    this.activeNestedSolver = this.params.createNestedSolver(rerouteInput)
+    this.activeSubSolver = this.activeNestedSolver
+    this.stats.candidatesAttempted =
+      Number(this.stats.candidatesAttempted ?? 0) + 1
+  }
+
+  private evaluateActiveCandidate() {
+    const candidate = this.activeCandidate
+    const nestedSolver = this.activeNestedSolver
+    this.activeCandidate = undefined
+    this.activeNestedSolver = undefined
+    this.activeSubSolver = undefined
+    if (!candidate || !nestedSolver?.solved) return
+    this.stats.lastNestedSolverIterations = nestedSolver.iterations
+
+    const nestedOutput = nestedSolver.getOutputSimpleRouteJson().traces ?? []
+    const preservedTraceById = new Map(
+      this.params.currentTraces
+        .filter((trace) => trace.pcb_trace_id !== candidate.trace.pcb_trace_id)
+        .map((trace) => [trace.pcb_trace_id, trace]),
+    )
+    let preservedTraceMutationCount = 0
+    const preservedTracesMaintainInvariants = [...preservedTraceById].every(
+      ([traceId, expectedTrace]) => {
+        const actualTrace = nestedOutput.find(
+          (trace) => trace.pcb_trace_id === traceId,
+        )
+        if (
+          actualTrace &&
+          JSON.stringify(actualTrace.route) !==
+            JSON.stringify(expectedTrace.route)
+        ) {
+          preservedTraceMutationCount += 1
+        }
+        return (
+          actualTrace !== undefined &&
+          tracePreservesElectricalInvariants(expectedTrace, actualTrace)
+        )
+      },
+    )
+    const reroutedTraces = nestedOutput.filter(
+      (trace) => !preservedTraceById.has(trace.pcb_trace_id),
+    )
+    if (
+      !candidatePreservesElectricalInvariants({ candidate, reroutedTraces })
+    ) {
+      this.stats.candidatesRejectedForInvariant =
+        Number(this.stats.candidatesRejectedForInvariant ?? 0) + 1
+      return
+    }
+    if (!preservedTracesMaintainInvariants) {
+      this.stats.candidatesRejectedForElectricalInvariant =
+        Number(this.stats.candidatesRejectedForElectricalInvariant ?? 0) + 1
+      return
+    }
+    const reroutedTraceIds = new Set(
+      reroutedTraces.map((trace) => trace.pcb_trace_id),
+    )
+    const reconnectedTraces = nestedOutput.map((trace) =>
+      reroutedTraceIds.has(trace.pcb_trace_id)
+        ? reconnectReroutedTrace(trace, candidate)
+        : trace,
+    )
+    const originalPreloadedTraceById = new Map(
+      (this.params.originalSrj.traces ?? []).map((trace) => [
+        trace.pcb_trace_id,
+        trace,
+      ]),
+    )
+    const outputTraces = reconnectedTraces.map((trace) => {
+      const originalPreloadedTrace = originalPreloadedTraceById.get(
+        trace.pcb_trace_id,
+      )
+      if (
+        !originalPreloadedTrace ||
+        trace.__replaces_pcb_trace_id !== undefined ||
+        JSON.stringify(trace.route) ===
+          JSON.stringify(originalPreloadedTrace.route)
+      ) {
+        return trace
+      }
+      return {
+        ...trace,
+        __replaces_pcb_trace_id: originalPreloadedTrace.pcb_trace_id,
+      }
+    })
+    const result = evaluateRelaxedDrc({
+      inputSrj: { ...this.params.originalSrj, traces: [] },
+      srjWithPointPairs: this.params.originalSrj,
+      routedTraces: outputTraces,
+    })
+    if (result.errors.length >= this.initialDrcCount) return
+
+    this.outputTraces = outputTraces
+    this.stats.finalDrcCount = result.errors.length
+    this.stats.acceptedTraceId = candidate.trace.pcb_trace_id
+    this.stats.preservedTraceMutationCount = preservedTraceMutationCount
+    this.solved = true
+  }
+
+  override _step() {
+    if (!this.initialized) {
+      this.initialize()
+      return
+    }
+    if (this.activeNestedSolver) {
+      this.activeNestedSolver.step()
+      if (this.activeNestedSolver.solved || this.activeNestedSolver.failed) {
+        this.evaluateActiveCandidate()
+      }
+      return
+    }
+    if (this.solved) return
+    this.startNextCandidate()
+  }
+
+  getOutput(): SimplifiedPcbTraces {
+    return structuredClone(this.outputTraces)
+  }
+}

--- a/tests/features/pipeline9-branch-rip-drc-fallback.test.ts
+++ b/tests/features/pipeline9-branch-rip-drc-fallback.test.ts
@@ -1,0 +1,226 @@
+import { expect, test } from "bun:test"
+import { Pipeline9BranchRipDrcFallbackSolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-branch-rip-drc-fallback-solver"
+import { BaseSolver } from "lib/solvers/BaseSolver"
+import type {
+  SimpleRouteJson,
+  SimplifiedPcbTrace,
+  SimplifiedPcbTraces,
+} from "lib/types"
+
+const fixedTrace: SimplifiedPcbTrace = {
+  type: "pcb_trace",
+  pcb_trace_id: "fixed_trace",
+  connection_name: "FIXED",
+  connectsTo: ["fixed_start", "fixed_end"],
+  route: [
+    {
+      route_type: "wire",
+      x: -2,
+      y: 0,
+      width: 0.15,
+      layer: "top",
+      start_pcb_port_id: "fixed_start",
+    },
+    {
+      route_type: "wire",
+      x: 2,
+      y: 0,
+      width: 0.15,
+      layer: "top",
+      end_pcb_port_id: "fixed_end",
+    },
+  ],
+}
+
+const movableTrace: SimplifiedPcbTrace = {
+  type: "pcb_trace",
+  pcb_trace_id: "movable_trace",
+  connection_name: "MOVABLE",
+  connectsTo: ["movable_start", "movable_end"],
+  route: [
+    {
+      route_type: "wire",
+      x: 0,
+      y: -2,
+      width: 0.15,
+      layer: "top",
+      start_pcb_port_id: "movable_start",
+    },
+    {
+      route_type: "wire",
+      x: 0,
+      y: 2,
+      width: 0.15,
+      layer: "top",
+      end_pcb_port_id: "movable_end",
+    },
+  ],
+}
+
+const srj: SimpleRouteJson = {
+  layerCount: 2,
+  minTraceWidth: 0.15,
+  bounds: { minX: -4, minY: -3, maxX: 4, maxY: 3 },
+  obstacles: [],
+  connections: [
+    {
+      name: "FIXED",
+      pointsToConnect: [
+        { x: -2, y: 0, layer: "top", pcb_port_id: "fixed_start" },
+        { x: 2, y: 0, layer: "top", pcb_port_id: "fixed_end" },
+      ],
+    },
+    {
+      name: "MOVABLE",
+      pointsToConnect: [
+        { x: 0, y: -2, layer: "top", pcb_port_id: "movable_start" },
+        { x: 0, y: 2, layer: "top", pcb_port_id: "movable_end" },
+      ],
+    },
+  ],
+}
+
+class StubNestedPipeline9Solver extends BaseSolver {
+  constructor(
+    private readonly input: SimpleRouteJson,
+    private readonly outputTraces: SimplifiedPcbTraces,
+  ) {
+    super()
+  }
+
+  override _step() {
+    this.solved = true
+  }
+
+  getOutputSimpleRouteJson(): SimpleRouteJson {
+    return { ...this.input, traces: structuredClone(this.outputTraces) }
+  }
+}
+
+test("Pipeline9 branch-rip fallback reconnects one DRC branch without changing electrical constraints", () => {
+  const detouredTrace: SimplifiedPcbTrace = {
+    type: "pcb_trace",
+    pcb_trace_id: "nested_reroute",
+    connection_name: "temporary_name",
+    route: [
+      { route_type: "wire", x: 0, y: 2, width: 0.15, layer: "top" },
+      { route_type: "wire", x: 3, y: 2, width: 0.15, layer: "top" },
+      { route_type: "wire", x: 3, y: -2, width: 0.15, layer: "top" },
+      { route_type: "wire", x: 0, y: -2, width: 0.15, layer: "top" },
+    ],
+  }
+  const solver = new Pipeline9BranchRipDrcFallbackSolver({
+    originalSrj: srj,
+    currentTraces: [fixedTrace, movableTrace],
+    eligibleTraceIds: new Set([movableTrace.pcb_trace_id]),
+    createNestedSolver: (input) =>
+      new StubNestedPipeline9Solver(input, [fixedTrace, detouredTrace]),
+  })
+
+  solver.solve()
+
+  expect(solver.stats).toMatchObject({
+    initialDrcCount: 1,
+    finalDrcCount: 0,
+    acceptedTraceId: movableTrace.pcb_trace_id,
+  })
+  const expectedReroutedTrace: SimplifiedPcbTrace = {
+    ...detouredTrace,
+    connection_name: movableTrace.connection_name,
+    connectsTo: ["movable_start", "movable_end"],
+    route: [
+      {
+        route_type: "wire",
+        x: 0,
+        y: 2,
+        width: 0.15,
+        layer: "top",
+        start_pcb_port_id: "movable_end",
+      },
+      { route_type: "wire", x: 3, y: 2, width: 0.15, layer: "top" },
+      { route_type: "wire", x: 3, y: -2, width: 0.15, layer: "top" },
+      {
+        route_type: "wire",
+        x: 0,
+        y: -2,
+        width: 0.15,
+        layer: "top",
+        end_pcb_port_id: "movable_start",
+      },
+    ],
+  }
+  expect(solver.getOutput()).toEqual([fixedTrace, expectedReroutedTrace])
+})
+
+test("Pipeline9 branch-rip fallback rejects a reroute with a changed trace width", () => {
+  const wrongWidthTrace: SimplifiedPcbTrace = {
+    type: "pcb_trace",
+    pcb_trace_id: "nested_reroute",
+    connection_name: "temporary_name",
+    route: [
+      { route_type: "wire", x: 0, y: 2, width: 0.2, layer: "top" },
+      { route_type: "wire", x: 3, y: 2, width: 0.2, layer: "top" },
+      { route_type: "wire", x: 3, y: -2, width: 0.2, layer: "top" },
+      { route_type: "wire", x: 0, y: -2, width: 0.2, layer: "top" },
+    ],
+  }
+  const solver = new Pipeline9BranchRipDrcFallbackSolver({
+    originalSrj: srj,
+    currentTraces: [fixedTrace, movableTrace],
+    eligibleTraceIds: new Set([movableTrace.pcb_trace_id]),
+    createNestedSolver: (input) =>
+      new StubNestedPipeline9Solver(input, [fixedTrace, wrongWidthTrace]),
+  })
+
+  solver.solve()
+
+  expect(solver.stats).toMatchObject({
+    initialDrcCount: 1,
+    candidatesAttempted: 1,
+    candidatesRejectedForInvariant: 1,
+  })
+  expect(solver.getOutput()).toEqual([fixedTrace, movableTrace])
+})
+
+test("Pipeline9 branch-rip fallback marks adjusted preloaded copper as a replacement", () => {
+  const adjustedFixedTrace: SimplifiedPcbTrace = {
+    ...fixedTrace,
+    route: [
+      fixedTrace.route[0]!,
+      { route_type: "wire", x: -2, y: 0.5, width: 0.15, layer: "top" },
+      { route_type: "wire", x: 2, y: 0.5, width: 0.15, layer: "top" },
+      fixedTrace.route[1]!,
+    ],
+  }
+  const detouredTrace: SimplifiedPcbTrace = {
+    type: "pcb_trace",
+    pcb_trace_id: "nested_reroute",
+    connection_name: "temporary_name",
+    route: [
+      { route_type: "wire", x: 0, y: 2, width: 0.15, layer: "top" },
+      { route_type: "wire", x: 3, y: 2, width: 0.15, layer: "top" },
+      { route_type: "wire", x: 3, y: -2, width: 0.15, layer: "top" },
+      { route_type: "wire", x: 0, y: -2, width: 0.15, layer: "top" },
+    ],
+  }
+  const solver = new Pipeline9BranchRipDrcFallbackSolver({
+    originalSrj: { ...srj, traces: [fixedTrace] },
+    currentTraces: [fixedTrace, movableTrace],
+    eligibleTraceIds: new Set([movableTrace.pcb_trace_id]),
+    createNestedSolver: (input) =>
+      new StubNestedPipeline9Solver(input, [adjustedFixedTrace, detouredTrace]),
+  })
+
+  solver.solve()
+
+  expect(solver.stats).toMatchObject({
+    initialDrcCount: 1,
+    finalDrcCount: 0,
+    preservedTraceMutationCount: 1,
+  })
+  expect(solver.getOutput()[0]).toMatchObject({
+    pcb_trace_id: fixedTrace.pcb_trace_id,
+    __replaces_pcb_trace_id: fixedTrace.pcb_trace_id,
+    route: adjustedFixedTrace.route,
+  })
+})

--- a/tests/features/pipeline9-minimal-preloaded-trace-graph.test.ts
+++ b/tests/features/pipeline9-minimal-preloaded-trace-graph.test.ts
@@ -105,7 +105,7 @@ test("Pipeline9 owns copied stages with minimal preloaded-trace changes", () => 
   const pipeline7SharedStageCount = pipeline7.pipelineDef.filter(
     (step) => step.solverName !== "exactGeometryDrcForceImproveSolver",
   ).length
-  expect(solver.pipelineDef).toHaveLength(pipeline7SharedStageCount + 3)
+  expect(solver.pipelineDef).toHaveLength(pipeline7SharedStageCount + 4)
   for (const stageName of [
     "highDensityForceImproveSolver",
     "highDensityRepairSolver",

--- a/tests/features/pipeline9-power-trace-expansion-preload-alias.test.ts
+++ b/tests/features/pipeline9-power-trace-expansion-preload-alias.test.ts
@@ -12,7 +12,9 @@ test("Pipeline9 expands a preloaded power trace named by a connected alias", () 
   const powerConnection = srj.connections[0]!
   powerConnection.nominalTraceWidth = 0.6
   const solver = new AutoroutingPipelineSolver9_PreloadedTraceGraph(srj)
-  const powerStep = solver.pipelineDef.at(-1)!
+  const powerStep = solver.pipelineDef.find(
+    (step) => step.solverName === "powerTraceExpansionSolver",
+  )!
 
   expect(powerStep.solverName).toBe("powerTraceExpansionSolver")
   const originalGetNewTracesBeforePowerExpansion =

--- a/tests/features/pipeline9-power-trace-expansion-preloads.test.ts
+++ b/tests/features/pipeline9-power-trace-expansion-preloads.test.ts
@@ -62,7 +62,9 @@ test("Pipeline9 power expansion uses current preloads without disabling its stag
   const newlyRoutedTraces: SimplifiedPcbTraces = [
     createTrace("new-route", "NEW", 3),
   ]
-  const powerStep = solver.pipelineDef.at(-1)!
+  const powerStep = solver.pipelineDef.find(
+    (step) => step.solverName === "powerTraceExpansionSolver",
+  )!
 
   expect(() => solver.getOutputSimplifiedPcbTraces()).toThrow(
     "Cannot get output before solving is complete",
@@ -71,7 +73,13 @@ test("Pipeline9 power expansion uses current preloads without disabling its stag
     "Cannot get output before solving is complete",
   )
   expect(powerStep.solverName).toBe("powerTraceExpansionSolver")
+  expect(solver.pipelineDef.at(-1)?.solverName).toBe(
+    "pipeline9BranchRipDrcFallbackSolver",
+  )
   expect(solver.pipelineDef.at(-2)?.solverName).toBe(
+    "powerTraceExpansionSolver",
+  )
+  expect(solver.pipelineDef.at(-3)?.solverName).toBe(
     "lengthMatchingPostProcessingSolver",
   )
   solver.getNewTracesBeforePowerExpansion = () => newlyRoutedTraces


### PR DESCRIPTION
## Summary

- add a final Pipeline 9 fallback for exactly one remaining trace-pair DRC
- rip only an eligible newly routed branch, shortest first, while supplying all other copper as pre-routed traces
- accept a reroute only when full-board DRC strictly improves and electrical invariants remain unchanged
- emit replacement metadata when the nested reroute adjusts pre-routed copper

## Safety invariants

- preserve terminal coordinates, layers, PCB port identities, and complete `connectsTo` metadata
- preserve the exact wire-width set and via diameter/hole-diameter set
- reject missing or electrically changed preserved traces
- disable nested fallback recursion

## Results

- RP2350 MCU board: 79 traces, 1 physical DRC -> 0, no autorouting failures
- SRJ23 sample 21: 1 DRC -> 0
- full Game Boy no-breakout fixture: routed successfully in 177 seconds
- a broad regional rip experiment was rejected because it produced 92 DRCs

## Full Game Boy routed snapshot

![Full Game Boy Advance routed with Pipeline 9](https://raw.githubusercontent.com/Abse2001/tscircuit-autorouter/7d51246246385781b0371e08ba14bde46217e1c9/tests/bugs/__snapshots__/bugreport96-full-gameboy-no-breakout-routed.snap.svg)

The routed snapshot was regenerated on this branch and remained byte-for-byte stable.

## Verification

- `bunx tsc --noEmit`
- `bun run format:check`
- 7 targeted tests pass with 96 assertions
- `bugreport96-full-gameboy-no-breakout`: 1 pass, 0 failures, 10 assertions
- exact RP2350 SimpleRouteJson integration run passes with 0 physical DRCs

## Draft note

The nested Pipeline 9 reroute has a measurable runtime cost on affected boards. This is a draft until benchmark-all evaluates routing outcomes and performance.