### PR TITLE
Avoid redundant Pipeline9 reference DRC scans

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/filter-pipeline9-physically-connected-endpoint-errors.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/filter-pipeline9-physically-connected-endpoint-errors.ts
@@ -1,0 +1,84 @@
+import type { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import type { SimplifiedPcbTrace } from "lib/types"
+
+type DrcError = Record<string, unknown>
+
+// Simplified route output is rounded to 0.001 mm while retained preload
+// endpoints preserve imported precision.
+const ENDPOINT_LOCATION_EPSILON = 1e-3
+const COPPER_CONTACT_NUMERIC_EPSILON = 1e-9
+
+/** Removes disconnected-endpoint findings disproved by same-net copper contact. */
+export const filterPipeline9PhysicallyConnectedEndpointErrors = <
+  TError extends DrcError,
+>({
+  errors,
+  evaluatedTraces,
+  connMap,
+}: {
+  errors: TError[]
+  evaluatedTraces: readonly SimplifiedPcbTrace[]
+  connMap: ConnectivityMap
+}): TError[] => {
+  const traceById = new Map(
+    evaluatedTraces.map((trace) => [trace.pcb_trace_id, trace]),
+  )
+
+  return errors.filter((error) => {
+    const traceId =
+      typeof error.pcb_trace_id === "string" ? error.pcb_trace_id : undefined
+    const errorId =
+      typeof error.pcb_trace_error_id === "string"
+        ? error.pcb_trace_error_id
+        : undefined
+    const center =
+      error.center && typeof error.center === "object"
+        ? (error.center as Record<string, unknown>)
+        : undefined
+    if (
+      !traceId ||
+      !errorId?.startsWith(`disconnected_endpoint_${traceId}_`) ||
+      typeof center?.x !== "number" ||
+      typeof center.y !== "number"
+    ) {
+      return true
+    }
+    const centerX = center.x
+    const centerY = center.y
+
+    const disconnectedTrace = traceById.get(traceId)
+    if (!disconnectedTrace) return true
+    const endpoint = [
+      disconnectedTrace.route[0],
+      disconnectedTrace.route.at(-1),
+    ].find(
+      (routePoint) =>
+        routePoint?.route_type === "wire" &&
+        Math.hypot(routePoint.x - centerX, routePoint.y - centerY) <=
+          ENDPOINT_LOCATION_EPSILON,
+    )
+    if (!endpoint || endpoint.route_type !== "wire") return true
+
+    for (const otherTrace of evaluatedTraces) {
+      if (otherTrace.pcb_trace_id === disconnectedTrace.pcb_trace_id) continue
+      const sameNet =
+        otherTrace.connection_name === disconnectedTrace.connection_name ||
+        connMap.areIdsConnected(
+          otherTrace.connection_name,
+          disconnectedTrace.connection_name,
+        )
+      if (!sameNet) continue
+      const hasCopperContact = otherTrace.route.some(
+        (routePoint) =>
+          routePoint.route_type === "wire" &&
+          routePoint.layer === endpoint.layer &&
+          Math.hypot(routePoint.x - endpoint.x, routePoint.y - endpoint.y) <=
+            (routePoint.width + endpoint.width) / 2 +
+              COPPER_CONTACT_NUMERIC_EPSILON,
+      )
+      if (hasCopperContact) return false
+    }
+
+    return true
+  })
+}

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-joint-drc-repair-solver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-joint-drc-repair-solver.ts
@@ -32,6 +32,7 @@ import {
   convertPreloadedTraceToHdRoutes,
 } from "./convert-preloaded-traces-to-hd-routes"
 import { filterPipeline9DrcErrorsAgainstBaseline } from "./filter-pipeline9-drc-errors-against-baseline"
+import { filterPipeline9PhysicallyConnectedEndpointErrors } from "./filter-pipeline9-physically-connected-endpoint-errors"
 import { getPipeline9PreloadedTraceIdsInInitialDrcRegions } from "./get-pipeline9-preloaded-trace-ids-in-initial-drc-regions"
 import { getPipeline9PreloadedViaPairTraceGroups } from "./get-pipeline9-preloaded-via-pair-trace-groups"
 import { mergePipeline9MovablePreloadedVias } from "./merge-pipeline9-movable-preloaded-vias"
@@ -709,26 +710,36 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
       routedTraces: preparedCurrentOutput.routedTraces,
       drcOptions: { traceClearance },
     })
-    const currentEvaluatedTraceIds = new Set(
-      combinePreloadedAndRoutedTraces(
-        params.originalSrj.traces ?? [],
-        preparedCurrentOutput.routedTraces,
-      ).map((trace) => trace.pcb_trace_id),
+    const currentEvaluatedTraces = combinePreloadedAndRoutedTraces(
+      params.originalSrj.traces ?? [],
+      preparedCurrentOutput.routedTraces,
     )
-    const currentErrors = addAutoroutingViaTraceIds({
-      errors: currentDrcResult.errors as unknown as Array<
-        Record<string, unknown>
-      >,
-      circuitJson: currentDrcResult.circuitJson,
-      evaluatedTraceIds: currentEvaluatedTraceIds,
+    const currentEvaluatedTraceIds = new Set(
+      currentEvaluatedTraces.map((trace) => trace.pcb_trace_id),
+    )
+    const currentErrors = filterPipeline9PhysicallyConnectedEndpointErrors({
+      errors: addAutoroutingViaTraceIds({
+        errors: currentDrcResult.errors as unknown as Array<
+          Record<string, unknown>
+        >,
+        circuitJson: currentDrcResult.circuitJson,
+        evaluatedTraceIds: currentEvaluatedTraceIds,
+      }),
+      evaluatedTraces: currentEvaluatedTraces,
+      connMap: params.connMap,
     })
-    const currentErrorsWithCenters = addAutoroutingViaTraceIds({
-      errors: currentDrcResult.errorsWithCenters as unknown as Array<
-        Record<string, unknown>
-      >,
-      circuitJson: currentDrcResult.circuitJson,
-      evaluatedTraceIds: currentEvaluatedTraceIds,
-    })
+    const currentErrorsWithCenters =
+      filterPipeline9PhysicallyConnectedEndpointErrors({
+        errors: addAutoroutingViaTraceIds({
+          errors: currentDrcResult.errorsWithCenters as unknown as Array<
+            Record<string, unknown>
+          >,
+          circuitJson: currentDrcResult.circuitJson,
+          evaluatedTraceIds: currentEvaluatedTraceIds,
+        }),
+        evaluatedTraces: currentEvaluatedTraces,
+        connMap: params.connMap,
+      })
     const currentDrc = {
       ...currentDrcResult,
       errors: filterPipeline9DrcErrorsAgainstBaseline({
@@ -933,6 +944,8 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
     }
 
     if (currentDrc.errors.length === 0) {
+      this.stats.referenceDrcValidationCount = 0
+      this.stats.referenceDrcFalseNegativeCount = 0
       this.solved = true
       return
     }
@@ -1160,20 +1173,30 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
       const evaluatedTraceIds = new Set(
         candidateDrcInput.evaluatedTraces.map((trace) => trace.pcb_trace_id),
       )
-      const evaluatedErrors = addAutoroutingViaTraceIds({
-        errors: evaluatedDrc.errors as unknown as Array<
-          Record<string, unknown>
-        >,
-        circuitJson: evaluatedDrc.circuitJson,
-        evaluatedTraceIds,
-      })
-      const evaluatedErrorsWithCenters = addAutoroutingViaTraceIds({
-        errors: evaluatedDrc.errorsWithCenters as unknown as Array<
-          Record<string, unknown>
-        >,
-        circuitJson: evaluatedDrc.circuitJson,
-        evaluatedTraceIds,
-      })
+      const evaluatedErrors =
+        filterPipeline9PhysicallyConnectedEndpointErrors({
+          errors: addAutoroutingViaTraceIds({
+            errors: evaluatedDrc.errors as unknown as Array<
+              Record<string, unknown>
+            >,
+            circuitJson: evaluatedDrc.circuitJson,
+            evaluatedTraceIds,
+          }),
+          evaluatedTraces: candidateDrcInput.evaluatedTraces,
+          connMap: params.connMap,
+        })
+      const evaluatedErrorsWithCenters =
+        filterPipeline9PhysicallyConnectedEndpointErrors({
+          errors: addAutoroutingViaTraceIds({
+            errors: evaluatedDrc.errorsWithCenters as unknown as Array<
+              Record<string, unknown>
+            >,
+            circuitJson: evaluatedDrc.circuitJson,
+            evaluatedTraceIds,
+          }),
+          evaluatedTraces: candidateDrcInput.evaluatedTraces,
+          connMap: params.connMap,
+        })
       const evaluatedNewErrors = filterPipeline9DrcErrorsAgainstBaseline({
         errors: evaluatedErrors,
         baselineErrors,

--- a/tests/features/pipeline9-physically-connected-endpoint-errors.test.ts
+++ b/tests/features/pipeline9-physically-connected-endpoint-errors.test.ts
@@ -1,0 +1,153 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { filterPipeline9PhysicallyConnectedEndpointErrors } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/filter-pipeline9-physically-connected-endpoint-errors"
+import type { SimplifiedPcbTrace } from "lib/types"
+
+test("Pipeline9 only removes disconnected endpoints with exact same-net layer contact", () => {
+  const connMap = new ConnectivityMap({})
+  connMap.addConnections([
+    ["rerouted", "fixed", "net_a"],
+    ["wrong_layer", "wrong_layer_fixed", "net_b"],
+    ["wrong_net", "net_c"],
+    ["wrong_net_fixed", "net_d"],
+    ["thin_rerouted", "thin_fixed", "net_e"],
+  ])
+  const evaluatedTraces: SimplifiedPcbTrace[] = [
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "rerouted_trace",
+      connection_name: "rerouted",
+      route: [
+        { route_type: "wire", x: 0, y: 0, width: 0.15, layer: "top" },
+        { route_type: "wire", x: 1, y: 0, width: 0.15, layer: "top" },
+      ],
+    },
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "fixed_trace",
+      connection_name: "fixed",
+      route: [
+        { route_type: "wire", x: -1, y: 0, width: 0.15, layer: "top" },
+        { route_type: "wire", x: 0, y: 0, width: 0.15, layer: "top" },
+      ],
+    },
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "wrong_layer_trace",
+      connection_name: "wrong_layer",
+      route: [
+        { route_type: "wire", x: 0, y: 2, width: 0.15, layer: "top" },
+        { route_type: "wire", x: 1, y: 2, width: 0.15, layer: "top" },
+      ],
+    },
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "wrong_layer_fixed_trace",
+      connection_name: "wrong_layer_fixed",
+      route: [
+        {
+          route_type: "wire",
+          x: -1,
+          y: 2,
+          width: 0.15,
+          layer: "bottom",
+        },
+        {
+          route_type: "wire",
+          x: 0,
+          y: 2,
+          width: 0.15,
+          layer: "bottom",
+        },
+      ],
+    },
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "wrong_net_trace",
+      connection_name: "wrong_net",
+      route: [
+        { route_type: "wire", x: 0, y: 4, width: 0.15, layer: "top" },
+        { route_type: "wire", x: 1, y: 4, width: 0.15, layer: "top" },
+      ],
+    },
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "wrong_net_fixed_trace",
+      connection_name: "wrong_net_fixed",
+      route: [
+        { route_type: "wire", x: -1, y: 4, width: 0.15, layer: "top" },
+        { route_type: "wire", x: 0, y: 4, width: 0.15, layer: "top" },
+      ],
+    },
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "thin_rerouted_trace",
+      connection_name: "thin_rerouted",
+      route: [
+        { route_type: "wire", x: 0, y: 6, width: 0.0001, layer: "top" },
+        { route_type: "wire", x: 1, y: 6, width: 0.0001, layer: "top" },
+      ],
+    },
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "thin_fixed_trace",
+      connection_name: "thin_fixed",
+      route: [
+        {
+          route_type: "wire",
+          x: -1,
+          y: 6,
+          width: 0.0001,
+          layer: "top",
+        },
+        {
+          route_type: "wire",
+          x: 0.0005,
+          y: 6,
+          width: 0.0001,
+          layer: "top",
+        },
+      ],
+    },
+  ]
+  const errors = [
+    {
+      pcb_trace_id: "rerouted_trace",
+      pcb_trace_error_id: "disconnected_endpoint_rerouted_trace_start",
+      center: { x: 0, y: 0 },
+    },
+    {
+      pcb_trace_id: "wrong_layer_trace",
+      pcb_trace_error_id: "disconnected_endpoint_wrong_layer_trace_start",
+      center: { x: 0, y: 2 },
+    },
+    {
+      pcb_trace_id: "wrong_net_trace",
+      pcb_trace_error_id: "disconnected_endpoint_wrong_net_trace_start",
+      center: { x: 0, y: 4 },
+    },
+    {
+      pcb_trace_id: "rerouted_trace",
+      pcb_trace_error_id: "overlap_rerouted_trace_fixed_trace",
+      center: { x: 0, y: 0 },
+    },
+    {
+      pcb_trace_id: "thin_rerouted_trace",
+      pcb_trace_error_id: "disconnected_endpoint_thin_rerouted_trace_start",
+      center: { x: 0, y: 6 },
+    },
+  ]
+
+  expect(
+    filterPipeline9PhysicallyConnectedEndpointErrors({
+      errors,
+      evaluatedTraces,
+      connMap,
+    }).map((error) => error.pcb_trace_error_id),
+  ).toEqual([
+    "disconnected_endpoint_wrong_layer_trace_start",
+    "disconnected_endpoint_wrong_net_trace_start",
+    "overlap_rerouted_trace_fixed_trace",
+    "disconnected_endpoint_thin_rerouted_trace_start",
+  ])
+})

--- a/tests/repro/pipeline9-arduino-region-reroute-performance.test.ts
+++ b/tests/repro/pipeline9-arduino-region-reroute-performance.test.ts
@@ -18,7 +18,7 @@ const VISUAL_BOUNDS = {
   maxY: 18.5,
 }
 
-test("Pipeline9 records repeated reference DRC work for an Arduino region reroute", async () => {
+test("Pipeline9 recognizes same-net Arduino region boundary contacts", async () => {
   const input = structuredClone(
     capturedArduinoRegionReroute,
   ) as unknown as SimpleRouteJson
@@ -40,20 +40,18 @@ test("Pipeline9 records repeated reference DRC work for an Arduino region rerout
     createHash("sha256").update(JSON.stringify(outputTraces)).digest("hex"),
   ).toBe(EXPECTED_OUTPUT_TRACES_SHA256)
 
-  // Captured from core's repro116 region (8..18 mm). On the original board,
-  // Pipeline9 took about 15 s versus Pipeline7's 4.2 s. The indexed DRC sees
-  // no issue, but reference DRC repeatedly reports the eight intentional
-  // boundary joins as disconnected while the exact-repair portfolio explores
-  // candidates. This deterministic count exposes the cost without a flaky
-  // wall-clock assertion.
+  // The reproduction branch recorded 61 full reference validations because
+  // the eight intentional same-net boundary joins were reported as
+  // disconnected. Proving their physical contact avoids entering exact repair.
   const jointDrcStats = solver.pipeline9JointDrcRepairSolver?.stats
   expect(jointDrcStats).toMatchObject({
-    initialJointDrcIssueCount: 8,
-    globalDrcForceImproveCandidateAttempts: 12,
-    regionalB01RepairCandidateCount: 0,
-    referenceDrcValidationCount: 61,
-    referenceDrcFalseNegativeCount: 61,
+    initialJointDrcIssueCount: 0,
+    referenceDrcValidationCount: 0,
+    referenceDrcFalseNegativeCount: 0,
   })
+  expect(
+    solver.pipeline9JointDrcRepairSolver?.exactRepairSolver,
+  ).toBeUndefined()
 
   const inputTraceIds = new Set(
     (input.traces ?? []).map((trace) => trace.pcb_trace_id),


### PR DESCRIPTION
## Stack

- reproduction: #2232
- this PR is based on `repro/arduino-region-reroute-performance`; merge or retarget it after the reproduction lands

## Root cause

The reference DRC checker reports eight regional boundary endpoints as disconnected even though each endpoint physically overlaps retained same-net copper on the same layer. Pipeline9 therefore enters the exact-repair portfolio and performs 61 full-board reference validations, none of which can improve the already-valid geometry.

## Fix

- filter only `disconnected_endpoint_<trace>_*` findings disproved by physical same-net, same-layer wire contact
- keep the 0.001 mm tolerance only for locating an endpoint after route serialization
- require actual copper overlap using the sum of wire radii, with only a `1e-9` numeric epsilon
- preserve wrong-net, wrong-layer, thin-trace near-miss, and unrelated DRC findings
- skip constructing exact repair when no real joint-DRC issues remain

## Results

- reference validations: 61 -> 0
- indexed/reference false negatives: 61 -> 0
- exact-repair construction: avoided
- 214-trace output: byte-identical SHA-256
- paired local median: 7.340 s -> 2.432 s (3.02x faster, 66.9% lower)
- routed-region visual snapshot: byte-identical to the reproduction (`1a682431…d332`), confirming the performance fix preserves the focused copper geometry

Wall time is reported for context; CI asserts deterministic solver work and output identity.

## Blacksmith benchmark

`/benchmark-all --pipeline 9 --same-machine` completed across dataset01 and SRJ18/19/20/21/23:

- 587 scenarios total
- 0 improved and 0 regressed routing outcomes on every dataset
- identical completion, relaxed-DRC, DRC-issue, timeout, and average-via totals
- timing deltas were mixed outside the targeted fixture; the exact Arduino reproduction remains the deterministic performance gate

## Validation

- exact Arduino reproduction plus focused contact test: 2/2 pass
- focused visual snapshot reverified at tolerance 0
- broader Pipeline9 joint-DRC suite: 17/17 files, 138 assertions
- `bunx tsc --noEmit --pretty false`
- `bun run build`
- `git diff --check`
