### PR TITLE
Add Pipeline9 differential-pair post-processing parity

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph.ts
@@ -1,5 +1,4 @@
 import { RectDiffPipeline } from "@tscircuit/rectdiff"
-import { PostProcessingSolver as DifferentialPairPostProcessingSolver } from "@tscircuit/length-matching-solver"
 import type { PowerTraceExpanderOptions } from "@tscircuit/power-trace-expander"
 import { ConnectivityMap } from "circuit-json-to-connectivity-map"
 import type { GraphicsObject, Line } from "graphics-debug"
@@ -84,6 +83,7 @@ import {
   type PreloadedHighDensityRoute,
 } from "./convert-preloaded-traces-to-hd-routes"
 import { Pipeline9HighDensitySolver } from "./pipeline9-high-density-solver"
+import { Pipeline9DifferentialPairPostProcessingSolver as DifferentialPairPostProcessingSolver } from "./pipeline9-differential-pair-post-processing-solver"
 import { Pipeline9JointDrcRepairSolver } from "./pipeline9-joint-drc-repair-solver"
 import { PreloadedTraceGraphSolver } from "./preloaded-trace-graph-solver"
 import { PreprocessSimpleRouteJsonWithoutTraceObstaclesSolver } from "./preprocess-simple-route-json-without-trace-obstacles-solver"
@@ -887,7 +887,11 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
                 `Pipeline9: differential pair ${pair.connectionNames.join("/")} resolves both members to "${connectionNames[0]}"`,
               )
             if (pair.traceGap === undefined)
-              return { connectionNames, lengthTolerance: pair.lengthTolerance }
+              return {
+                connectionNames,
+                lengthTolerance: pair.lengthTolerance,
+                maxUncoupledLength: pair.maxUncoupledLength,
+              }
             const pairRoutes = connectionNames.map((connectionName) => {
               const matchingRoutes = hdRoutes.filter(
                 (route) => route.connectionName === connectionName,
@@ -908,6 +912,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
             return {
               connectionNames,
               lengthTolerance: pair.lengthTolerance,
+              maxUncoupledLength: pair.maxUncoupledLength,
               minimumCenterlineDistance: centerlineDistance,
               maximumCenterlineDistance: centerlineDistance,
             }
@@ -920,6 +925,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
             obstacles: cms.srj.obstacles,
             bounds: cms.srj.bounds,
             layerCount: cms.srj.layerCount,
+            obstacleMargin: cms.srj.minTraceToPadEdgeClearance ?? 0.15,
           },
         ]
       },

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-differential-pair-post-processing-solver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-differential-pair-post-processing-solver.ts
@@ -1,0 +1,192 @@
+import {
+  LengthMatchingSolver,
+  LengthMatchingNoSolutionError,
+  PostProcessingSolver,
+  type PostProcessingSolverOutput,
+  type PostProcessingSolverParams,
+} from "@tscircuit/length-matching-solver"
+import type { GraphicsObject } from "graphics-debug"
+import { BaseSolver } from "../../solvers/BaseSolver"
+
+export type Pipeline9DifferentialPairPostProcessingSolverParams =
+  PostProcessingSolverParams & {
+    obstacleMargin: number
+  }
+
+/** Length-matches unconstrained pairs before applying coupled-pair rerouting. */
+export class Pipeline9DifferentialPairPostProcessingSolver extends BaseSolver {
+  readonly lengthMatchingSolver?: LengthMatchingSolver
+  postProcessingSolver?: PostProcessingSolver
+  private readonly lengthOnlyPairs: PostProcessingSolverParams["differentialPairs"]
+  private readonly coupledPairs: PostProcessingSolverParams["differentialPairs"]
+  private readonly validatedPostProcessingSolver: PostProcessingSolver
+  private phase: "length-matching" | "coupled-rerouting" | "complete"
+  private output?: PostProcessingSolverOutput
+
+  constructor(
+    public readonly inputProblem: Pipeline9DifferentialPairPostProcessingSolverParams,
+  ) {
+    super()
+    this.validatedPostProcessingSolver = new PostProcessingSolver(inputProblem)
+    const lengthOnlyPairs: PostProcessingSolverParams["differentialPairs"] = []
+    const coupledPairs: PostProcessingSolverParams["differentialPairs"] = []
+    for (const pair of inputProblem.differentialPairs) {
+      const usesOnlyLengthConstraint =
+        pair.minimumCenterlineDistance === undefined &&
+        pair.maximumCenterlineDistance === undefined &&
+        pair.maxUncoupledLength === undefined
+      const hasDirectLengthMatchingRoutes = pair.connectionNames.every(
+        (connectionName) => {
+          const matchingRoutes = inputProblem.hdRoutes.filter(
+            (route) => route.connectionName === connectionName,
+          )
+          return (
+            matchingRoutes.length === 1 && matchingRoutes[0]!.route.length > 0
+          )
+        },
+      )
+      if (usesOnlyLengthConstraint && hasDirectLengthMatchingRoutes)
+        lengthOnlyPairs.push(pair)
+      else coupledPairs.push(pair)
+    }
+    this.lengthOnlyPairs = lengthOnlyPairs
+    this.coupledPairs = coupledPairs
+    if (this.validatedPostProcessingSolver.solved) {
+      this.postProcessingSolver = this.validatedPostProcessingSolver
+      this.output = this.validatedPostProcessingSolver.getOutput()
+      this.phase = "complete"
+      this.solved = true
+      this.progress = 1
+      this.MAX_ITERATIONS = 1
+      return
+    }
+    if (this.lengthOnlyPairs.length > 0) {
+      const originalConnections = this.lengthOnlyPairs.flatMap((pair) =>
+        pair.connectionNames.map((connectionName) => {
+          const route = inputProblem.hdRoutes.find(
+            (route) => route.connectionName === connectionName,
+          )!
+          const start = route.route[0]!
+          const end = route.route.at(-1)!
+          return {
+            name: connectionName,
+            pointsToConnect: [
+              { x: start.x, y: start.y, layer: `z${start.z}` },
+              { x: end.x, y: end.y, layer: `z${end.z}` },
+            ],
+          }
+        }),
+      )
+      this.lengthMatchingSolver = new LengthMatchingSolver({
+        hdRoutes: inputProblem.hdRoutes,
+        originalConnections,
+        differentialPairs: this.lengthOnlyPairs,
+        obstacles: inputProblem.obstacles,
+        bounds: inputProblem.bounds,
+        layerCount: inputProblem.layerCount,
+        obstacleMargin: inputProblem.obstacleMargin,
+      })
+      this.phase = "length-matching"
+      this.MAX_ITERATIONS = this.lengthMatchingSolver.MAX_ITERATIONS + 2
+      return
+    }
+    this.postProcessingSolver = this.validatedPostProcessingSolver
+    this.phase = "coupled-rerouting"
+    this.MAX_ITERATIONS = this.postProcessingSolver.MAX_ITERATIONS + 1
+  }
+
+  override getSolverName(): string {
+    return "Pipeline9DifferentialPairPostProcessingSolver"
+  }
+
+  private startBestEffortPostProcessing(): void {
+    this.postProcessingSolver = this.validatedPostProcessingSolver
+    this.MAX_ITERATIONS += this.postProcessingSolver.MAX_ITERATIONS + 1
+    this.phase = "coupled-rerouting"
+    this.progress = 0
+    this.stats = { phase: "best-effort-post-processing" }
+  }
+
+  override _step(): void {
+    if (this.phase === "length-matching") {
+      try {
+        this.lengthMatchingSolver!.step()
+      } catch (error) {
+        if (!(error instanceof LengthMatchingNoSolutionError)) throw error
+        this.startBestEffortPostProcessing()
+        return
+      }
+      this.progress = this.lengthMatchingSolver!.progress
+      this.stats = {
+        phase: "length-matching",
+        ...this.lengthMatchingSolver!.stats,
+      }
+      if (this.lengthMatchingSolver!.failed) {
+        this.startBestEffortPostProcessing()
+        return
+      }
+      if (!this.lengthMatchingSolver!.solved) return
+      const matchedHdRoutes =
+        this.lengthMatchingSolver!.getOutput().matchedHdRoutes
+      if (this.coupledPairs.length === 0) {
+        this.output = { hdRoutes: matchedHdRoutes, postProcessingErrors: [] }
+        this.phase = "complete"
+        this.solved = true
+        this.progress = 1
+        return
+      }
+      this.postProcessingSolver = new PostProcessingSolver({
+        ...this.inputProblem,
+        hdRoutes: matchedHdRoutes,
+        differentialPairs: this.coupledPairs,
+      })
+      this.MAX_ITERATIONS += this.postProcessingSolver.MAX_ITERATIONS + 1
+      this.phase = "coupled-rerouting"
+      this.progress = 0
+      this.stats = { phase: "coupled-rerouting" }
+      return
+    }
+
+    if (this.phase === "coupled-rerouting") {
+      this.postProcessingSolver!.step()
+      this.progress = this.postProcessingSolver!.progress
+      this.stats = {
+        phase: "coupled-rerouting",
+        ...this.postProcessingSolver!.stats,
+      }
+      if (this.postProcessingSolver!.failed) {
+        this.failed = true
+        this.error = this.postProcessingSolver!.error
+        return
+      }
+      if (!this.postProcessingSolver!.solved) return
+      this.output = this.postProcessingSolver!.getOutput()
+      this.phase = "complete"
+      this.solved = true
+      this.progress = 1
+    }
+  }
+
+  override getConstructorParams(): [
+    Pipeline9DifferentialPairPostProcessingSolverParams,
+  ] {
+    return [this.inputProblem]
+  }
+
+  getOutput(): PostProcessingSolverOutput {
+    if (!this.solved || !this.output)
+      throw new Error(
+        "Pipeline9DifferentialPairPostProcessingSolver: getOutput() called before completion",
+      )
+    return structuredClone(this.output)
+  }
+
+  override visualize(): GraphicsObject {
+    if (this.phase === "length-matching")
+      return this.lengthMatchingSolver!.visualize()
+    return (
+      this.postProcessingSolver?.visualize() ??
+      this.lengthMatchingSolver?.visualize() ?? { lines: [] }
+    )
+  }
+}

--- a/tests/features/pipeline9-differential-pair-duplicate-membership-validation.test.ts
+++ b/tests/features/pipeline9-differential-pair-duplicate-membership-validation.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test"
+import { Pipeline9DifferentialPairPostProcessingSolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-differential-pair-post-processing-solver"
+
+test("Pipeline9 validates duplicate pair membership before partitioning", () => {
+  const createRoute = (connectionName: string, y: number) => ({
+    connectionName,
+    traceThickness: 0.15,
+    viaDiameter: 0.3,
+    route: [
+      { x: 0, y, z: 0 },
+      { x: 5, y, z: 0 },
+    ],
+    vias: [],
+  })
+
+  expect(
+    () =>
+      new Pipeline9DifferentialPairPostProcessingSolver({
+        hdRoutes: [
+          createRoute("P", 0),
+          createRoute("N", 1),
+          createRoute("OTHER", 2),
+        ],
+        differentialPairs: [
+          { connectionNames: ["P", "N"], lengthTolerance: 0.01 },
+          {
+            connectionNames: ["N", "OTHER"],
+            lengthTolerance: 0.01,
+            minimumCenterlineDistance: 0.3,
+            maximumCenterlineDistance: 0.5,
+          },
+        ],
+        obstacles: [],
+        bounds: { minX: -1, maxX: 6, minY: -1, maxY: 3 },
+        layerCount: 2,
+        obstacleMargin: 0.1,
+      }),
+  ).toThrow(/connection "N" belongs to multiple differential pairs/)
+})

--- a/tests/features/pipeline9-differential-pair-grid-capacity-best-effort.test.ts
+++ b/tests/features/pipeline9-differential-pair-grid-capacity-best-effort.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test"
+import { Pipeline9DifferentialPairPostProcessingSolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-differential-pair-post-processing-solver"
+
+test("Pipeline9 preserves upstream grid-capacity best-effort output", () => {
+  const hdRoutes = [
+    {
+      connectionName: "P",
+      traceThickness: 0.15,
+      viaDiameter: 0.3,
+      route: [
+        { x: 0, y: 0, z: 0 },
+        { x: 5, y: 0, z: 0 },
+      ],
+      vias: [],
+    },
+    {
+      connectionName: "N",
+      traceThickness: 0.15,
+      viaDiameter: 0.3,
+      route: [
+        { x: 0, y: 1, z: 0 },
+        { x: 5, y: 1, z: 0 },
+      ],
+      vias: [],
+    },
+  ]
+  const solver = new Pipeline9DifferentialPairPostProcessingSolver({
+    hdRoutes,
+    differentialPairs: [{ connectionNames: ["P", "N"], lengthTolerance: 0.01 }],
+    obstacles: [],
+    bounds: { minX: -500, maxX: 500, minY: -500, maxY: 500 },
+    layerCount: 2,
+    obstacleMargin: 0.1,
+  })
+
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(solver.lengthMatchingSolver).toBeUndefined()
+  expect(solver.postProcessingSolver).toBeDefined()
+  expect(solver.getOutput().hdRoutes).toEqual(hdRoutes)
+  expect(solver.getOutput().postProcessingErrors).toMatchObject([
+    {
+      reason: "grid-capacity-exhausted",
+      returnedRouteSource: "input-hd-routes",
+    },
+  ])
+})

--- a/tests/features/pipeline9-differential-pair-routing-phase.test.ts
+++ b/tests/features/pipeline9-differential-pair-routing-phase.test.ts
@@ -1,0 +1,151 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph"
+import type { SimpleRouteConnection, SimpleRouteJson } from "lib/types"
+
+type CoreRoutingPhaseConnection = SimpleRouteConnection & {
+  source_trace_id: string
+  width: number
+}
+
+type CoreRoutingPhaseSimpleRouteJson = SimpleRouteJson & {
+  minViaHoleEdgeToViaHoleEdgeClearance: number
+  minPlatedHoleDrillEdgeToDrillEdgeClearance: number
+  minPadEdgeToPadEdgeClearance: number
+}
+
+test("Pipeline9 length-matches the routing-phase differential pair", () => {
+  const padPositions = [-7.15, -2.85, 2.85, 7.15].flatMap((x) =>
+    [1.905, 0.635, -0.635, -1.905].map((y) => ({ x, y })),
+  )
+  const connectivityNetIds = [
+    0, 3, 38, 39, 40, 41, 42, 43, 0, 44, 45, 46, 47, 3, 48, 49,
+  ]
+  const obstacles = padPositions.map(({ x, y }, padIndex) => {
+    const connectedPair =
+      padIndex === 0 || padIndex === 8
+        ? { netId: 0, traceId: 0, portIds: [0, 8] }
+        : padIndex === 1 || padIndex === 13
+          ? { netId: 3, traceId: 1, portIds: [1, 13] }
+          : null
+    const connectedTo = connectedPair
+      ? [
+          `pcb_smtpad_${padIndex}`,
+          `connectivity_net${connectedPair.netId}`,
+          `source_trace_${connectedPair.traceId}`,
+          ...connectedPair.portIds.map((portId) => `source_port_${portId}`),
+          ...connectedPair.portIds.flatMap((portId) => [
+            `pcb_smtpad_${portId}`,
+            `pcb_port_${portId}`,
+          ]),
+        ]
+      : [
+          `pcb_smtpad_${padIndex}`,
+          `connectivity_net${connectivityNetIds[padIndex]}`,
+          `source_port_${padIndex}`,
+          `pcb_smtpad_${padIndex}`,
+          `pcb_port_${padIndex}`,
+        ]
+    return {
+      circuitJsonMetadata: {
+        pcb_smtpad_id: `pcb_smtpad_${padIndex}`,
+        pcb_port_id: `pcb_port_${padIndex}`,
+        source_port_name: `pin${(padIndex % 8) + 1}`,
+      },
+      componentId: `pcb_component_${Math.floor(padIndex / 8)}`,
+      type: "rect" as const,
+      layers: ["top"],
+      center: { x, y },
+      width: 1,
+      height: 0.6,
+      connectedTo,
+    }
+  })
+  const connections: CoreRoutingPhaseConnection[] = [
+    {
+      name: "source_trace_0",
+      source_trace_id: "source_trace_0",
+      nominalTraceWidth: 0.15,
+      width: 0.15,
+      pointsToConnect: [
+        {
+          x: -7.15,
+          y: 1.905,
+          layer: "top",
+          pointId: "pcb_port_0",
+          pcb_port_id: "pcb_port_0",
+        },
+        {
+          x: 2.85,
+          y: 1.905,
+          layer: "top",
+          pointId: "pcb_port_8",
+          pcb_port_id: "pcb_port_8",
+        },
+      ],
+    },
+    {
+      name: "source_trace_1",
+      source_trace_id: "source_trace_1",
+      nominalTraceWidth: 0.15,
+      width: 0.15,
+      pointsToConnect: [
+        {
+          x: -7.15,
+          y: 0.635,
+          layer: "top",
+          pointId: "pcb_port_1",
+          pcb_port_id: "pcb_port_1",
+        },
+        {
+          x: 7.15,
+          y: -0.635,
+          layer: "top",
+          pointId: "pcb_port_13",
+          pcb_port_id: "pcb_port_13",
+        },
+      ],
+    },
+  ]
+  const input: CoreRoutingPhaseSimpleRouteJson = {
+    bounds: { minX: -10, maxX: 10, minY: -10, maxY: 10 },
+    obstacles,
+    connections,
+    differentialPairs: [
+      {
+        connectionNames: ["source_trace_0", "source_trace_1"],
+        lengthTolerance: 0.05,
+      },
+    ],
+    layerCount: 2,
+    minTraceWidth: 0.15,
+    minViaDiameter: 0.3,
+    minViaHoleDiameter: 0.2,
+    minViaPadDiameter: 0.3,
+    minTraceToPadEdgeClearance: 0.1,
+    minViaHoleEdgeToViaHoleEdgeClearance: 0.1,
+    minPlatedHoleDrillEdgeToDrillEdgeClearance: 0.15,
+    minPadEdgeToPadEdgeClearance: 0.1,
+    minBoardEdgeClearance: 0.2,
+    nominalTraceWidth: 0.15,
+  }
+  const solver = new AutoroutingPipelineSolver9_PreloadedTraceGraph(input)
+
+  solver.solve()
+
+  const routedLengths = Object.fromEntries(
+    (solver.getOutputSimpleRouteJson().traces ?? []).map((trace) => {
+      const wires = trace.route.filter((point) => point.route_type === "wire")
+      const length = wires.slice(1).reduce((total, point, index) => {
+        const previous = wires[index]!
+        return total + Math.hypot(point.x - previous.x, point.y - previous.y)
+      }, 0)
+      return [trace.connection_name, length]
+    }),
+  )
+
+  expect(solver.failed).toBe(false)
+  expect(solver.solved).toBe(true)
+  expect(
+    Math.abs(routedLengths.source_trace_0! - routedLengths.source_trace_1!),
+  ).toBeLessThanOrEqual(0.05)
+})

--- a/tests/features/pipeline9-differential-pair-structural-validation.test.ts
+++ b/tests/features/pipeline9-differential-pair-structural-validation.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test"
+import { Pipeline9DifferentialPairPostProcessingSolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-differential-pair-post-processing-solver"
+
+test("Pipeline9 validates malformed structural input before partitioning", () => {
+  expect(
+    () =>
+      new Pipeline9DifferentialPairPostProcessingSolver({
+        hdRoutes: [
+          {
+            connectionName: "P",
+            traceThickness: 0.15,
+            viaDiameter: 0.3,
+            route: [
+              { x: 0, y: 0, z: 0 },
+              { x: 5, y: 0, z: 0 },
+            ],
+            vias: [],
+          },
+          {
+            connectionName: "N",
+            traceThickness: 0.15,
+            viaDiameter: 0.3,
+            route: [
+              { x: 0, y: 1, z: 0 },
+              { x: 5, y: 1, z: 0 },
+            ],
+            vias: [],
+          },
+        ],
+        differentialPairs: [
+          { connectionNames: ["P", "N"], lengthTolerance: 0.01 },
+        ],
+        obstacles: [
+          {
+            type: "rect",
+            center: { x: Number.NaN, y: 0 },
+            width: -1,
+            height: 1,
+            layers: ["top"],
+            connectedTo: [],
+          },
+        ],
+        bounds: { minX: -1, maxX: 6, minY: -1, maxY: 2 },
+        layerCount: 2,
+        obstacleMargin: 0.1,
+      }),
+  ).toThrow("PostProcessingSolver: obstacle declaration is invalid")
+})

--- a/tests/features/pipeline9-length-matching-no-solution-best-effort.test.ts
+++ b/tests/features/pipeline9-length-matching-no-solution-best-effort.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test"
+import { Pipeline9DifferentialPairPostProcessingSolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-differential-pair-post-processing-solver"
+
+test("Pipeline9 preserves best-effort output when length matching has no solution", () => {
+  const hdRoutes = [
+    {
+      connectionName: "P",
+      traceThickness: 0.15,
+      viaDiameter: 0.3,
+      route: [
+        { x: 0, y: 0, z: 0 },
+        { x: 1, y: 0, z: 0 },
+      ],
+      vias: [],
+    },
+    {
+      connectionName: "N",
+      traceThickness: 0.15,
+      viaDiameter: 0.3,
+      route: [
+        { x: 0, y: 2, z: 0 },
+        { x: 5, y: 2, z: 0 },
+      ],
+      vias: [],
+    },
+  ]
+  const solver = new Pipeline9DifferentialPairPostProcessingSolver({
+    hdRoutes,
+    differentialPairs: [{ connectionNames: ["P", "N"], lengthTolerance: 0.01 }],
+    obstacles: [],
+    bounds: { minX: 0, maxX: 5, minY: 0, maxY: 2 },
+    layerCount: 2,
+    obstacleMargin: 0.1,
+  })
+
+  solver.solve()
+
+  expect(solver.lengthMatchingSolver?.failed).toBe(true)
+  expect(solver.lengthMatchingSolver?.error).toContain(
+    "no same-layer straight segment",
+  )
+  expect(solver.failed).toBe(false)
+  expect(solver.solved).toBe(true)
+  expect(solver.getOutput().hdRoutes).toMatchObject(hdRoutes)
+  expect(solver.getOutput().postProcessingErrors.length).toBeGreaterThan(0)
+})

--- a/tests/features/pipeline9-max-uncoupled-length-uses-coupled-processing.test.ts
+++ b/tests/features/pipeline9-max-uncoupled-length-uses-coupled-processing.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test"
+import { Pipeline9DifferentialPairPostProcessingSolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-differential-pair-post-processing-solver"
+
+test("Pipeline9 keeps maxUncoupledLength pairs on coupled post-processing", () => {
+  const solver = new Pipeline9DifferentialPairPostProcessingSolver({
+    hdRoutes: [
+      {
+        connectionName: "P",
+        traceThickness: 0.15,
+        viaDiameter: 0.3,
+        route: [
+          { x: 0, y: 0, z: 0 },
+          { x: 5, y: 0, z: 0 },
+        ],
+        vias: [],
+      },
+      {
+        connectionName: "N",
+        traceThickness: 0.15,
+        viaDiameter: 0.3,
+        route: [
+          { x: 0, y: 1, z: 0 },
+          { x: 5, y: 1, z: 0 },
+        ],
+        vias: [],
+      },
+    ],
+    differentialPairs: [
+      {
+        connectionNames: ["P", "N"],
+        lengthTolerance: 0.05,
+        maxUncoupledLength: 3,
+      },
+    ],
+    obstacles: [],
+    bounds: { minX: -1, maxX: 6, minY: -1, maxY: 2 },
+    layerCount: 2,
+    obstacleMargin: 0.1,
+  })
+
+  expect(solver.lengthMatchingSolver).toBeUndefined()
+  expect(solver.postProcessingSolver).toBeDefined()
+  expect(
+    solver.postProcessingSolver?.getConstructorParams()[0].differentialPairs[0]
+      ?.maxUncoupledLength,
+  ).toBe(3)
+})

--- a/tests/features/pipeline9-mixed-differential-pair-post-processing.test.ts
+++ b/tests/features/pipeline9-mixed-differential-pair-post-processing.test.ts
@@ -1,0 +1,100 @@
+import { expect, test } from "bun:test"
+import { Pipeline9DifferentialPairPostProcessingSolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-differential-pair-post-processing-solver"
+
+test("Pipeline9 feeds length-matched routes into coupled-pair processing", () => {
+  const lengthOnlyPair = {
+    connectionNames: ["LP", "LN"] as [string, string],
+    lengthTolerance: 0.01,
+  }
+  const coupledPair = {
+    connectionNames: ["CP", "CN"] as [string, string],
+    lengthTolerance: 0.01,
+    minimumCenterlineDistance: 0.3,
+    maximumCenterlineDistance: 0.5,
+  }
+  const solver = new Pipeline9DifferentialPairPostProcessingSolver({
+    hdRoutes: [
+      {
+        connectionName: "LP",
+        traceThickness: 0.1,
+        viaDiameter: 0.3,
+        route: [
+          { x: 0, y: 0, z: 0 },
+          { x: 6, y: 0, z: 0 },
+        ],
+        vias: [],
+      },
+      {
+        connectionName: "LN",
+        traceThickness: 0.1,
+        viaDiameter: 0.3,
+        route: [
+          { x: 0, y: 3, z: 0 },
+          { x: 8, y: 3, z: 0 },
+        ],
+        vias: [],
+      },
+      {
+        connectionName: "CP",
+        traceThickness: 0.1,
+        viaDiameter: 0.3,
+        route: [
+          { x: 0, y: 10, z: 0 },
+          { x: 10, y: 10, z: 0 },
+        ],
+        vias: [],
+      },
+      {
+        connectionName: "CN",
+        traceThickness: 0.1,
+        viaDiameter: 0.3,
+        route: [
+          { x: 0, y: 10.4, z: 0 },
+          { x: 10, y: 10.4, z: 0 },
+        ],
+        vias: [],
+      },
+    ],
+    differentialPairs: [lengthOnlyPair, coupledPair],
+    obstacles: [],
+    bounds: { minX: -2, maxX: 12, minY: -4, maxY: 14 },
+    layerCount: 2,
+    obstacleMargin: 0.1,
+  })
+
+  while (!solver.postProcessingSolver && !solver.solved && !solver.failed)
+    solver.step()
+  expect(solver.solved).toBe(false)
+  expect(solver.progress).toBe(0)
+  solver.solve()
+
+  const coupledInput = solver.postProcessingSolver?.getConstructorParams()[0]
+  expect(coupledInput?.differentialPairs).toEqual([coupledPair])
+  const getLength = (
+    connectionName: string,
+    hdRoutes = solver.getOutput().hdRoutes,
+  ): number => {
+    const route = hdRoutes.find(
+      (candidate) => candidate.connectionName === connectionName,
+    )
+    if (!route) throw new Error(`Missing HD route for ${connectionName}`)
+    return route.route.slice(1).reduce((length, point, index) => {
+      const previous = route.route[index]!
+      return length + Math.hypot(point.x - previous.x, point.y - previous.y)
+    }, 0)
+  }
+  expect(
+    Math.abs(
+      getLength("LP", coupledInput?.hdRoutes) -
+        getLength("LN", coupledInput?.hdRoutes),
+    ),
+  ).toBeLessThanOrEqual(lengthOnlyPair.lengthTolerance)
+  expect(getLength("LP", coupledInput?.hdRoutes)).toBeGreaterThan(6)
+  expect(Math.abs(getLength("LP") - getLength("LN"))).toBeLessThanOrEqual(
+    lengthOnlyPair.lengthTolerance,
+  )
+  expect(Math.abs(getLength("CP") - getLength("CN"))).toBeLessThanOrEqual(
+    coupledPair.lengthTolerance,
+  )
+  expect(solver.getOutput().postProcessingErrors).toEqual([])
+})

--- a/tests/features/pipeline9-split-differential-pair-route-best-effort.test.ts
+++ b/tests/features/pipeline9-split-differential-pair-route-best-effort.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "bun:test"
+import { Pipeline9DifferentialPairPostProcessingSolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-differential-pair-post-processing-solver"
+
+test("Pipeline9 keeps split differential-pair routes on best-effort post-processing", () => {
+  const pair = {
+    connectionNames: ["P", "N"] as [string, string],
+    lengthTolerance: 0.01,
+  }
+  const solver = new Pipeline9DifferentialPairPostProcessingSolver({
+    hdRoutes: [
+      {
+        connectionName: "P",
+        traceThickness: 0.15,
+        viaDiameter: 0.3,
+        route: [
+          { x: 0, y: 0, z: 0 },
+          { x: 2, y: 0, z: 0 },
+        ],
+        vias: [],
+      },
+      {
+        connectionName: "P",
+        traceThickness: 0.15,
+        viaDiameter: 0.3,
+        route: [
+          { x: 2, y: 0, z: 0 },
+          { x: 5, y: 0, z: 0 },
+        ],
+        vias: [],
+      },
+      {
+        connectionName: "N",
+        traceThickness: 0.15,
+        viaDiameter: 0.3,
+        route: [
+          { x: 0, y: 1, z: 0 },
+          { x: 5, y: 1, z: 0 },
+        ],
+        vias: [],
+      },
+    ],
+    differentialPairs: [pair],
+    obstacles: [],
+    bounds: { minX: -1, maxX: 6, minY: -1, maxY: 2 },
+    layerCount: 2,
+    obstacleMargin: 0.1,
+  })
+
+  expect(solver.lengthMatchingSolver).toBeUndefined()
+  expect(
+    solver.postProcessingSolver?.getConstructorParams()[0].differentialPairs,
+  ).toEqual([pair])
+  solver.solve()
+  expect(solver.failed).toBe(false)
+  expect(solver.solved).toBe(true)
+  expect(solver.getOutput().hdRoutes).toHaveLength(3)
+})


### PR DESCRIPTION
## Summary
- route unconstrained, single-route differential pairs through length matching before coupled rerouting
- preserve upstream post-processing validation, failure, and best-effort semantics for constrained, split, invalid, and no-solution inputs
- carry maxUncoupledLength and the SRJ obstacle margin into Pipeline9 post-processing
- cover routing phase, coupled selection, no-solution, validation, grid-capacity, mixed, and split-route behavior in eight focused test files

## Validation
- 11 focused Pipeline7/Pipeline9 tests: 11 pass, 48 assertions
- bunx tsc --noEmit
- bun run build
- git diff --check

No snapshots changed.