### PR TITLE
Reproduce Pipeline9 multipoint bus trace-width loss

### DIFF
--- a/tests/repro/__snapshots__/pipeline9-multipoint-bus-trace-width.snap.svg
+++ b/tests/repro/__snapshots__/pipeline9-multipoint-bus-trace-width.snap.svg
@@ -1,0 +1,50 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="0,0 10,0" data-type="line" data-label="" points="40,398.5160768 600,398.5160768" fill="none" stroke="rgba(25,25,25,0.62)" stroke-linejoin="round" stroke-width="2.8000000000000003"/></g><g><polyline data-points="10,0 10,2.44" data-type="line" data-label="" points="600,398.5160768 600,261.8760768" fill="none" stroke="rgba(25,25,25,0.62)" stroke-linejoin="round" stroke-width="2.8000000000000003"/></g><g><polyline data-points="10,2.44 0,2.44" data-type="line" data-label="" points="600,261.8760768 40,261.8760768" fill="none" stroke="rgba(25,25,25,0.62)" stroke-linejoin="round" stroke-width="2.8000000000000003"/></g><g><polyline data-points="0,2.44 0,0" data-type="line" data-label="" points="40,261.8760768 40,398.5160768" fill="none" stroke="rgba(25,25,25,0.62)" stroke-linejoin="round" stroke-width="2.8000000000000003"/></g><g><polyline data-points="0,0 5,0" data-type="line" data-label="TMDS_P" points="40,398.5160768 320,398.5160768" fill="none" stroke="hsl(0, 100%, 50%)" stroke-linejoin="round" stroke-width="5.6000000000000005"/></g><g><polyline data-points="5,0 10,0" data-type="line" data-label="TMDS_P" points="320,398.5160768 600,398.5160768" fill="none" stroke="hsl(0, 100%, 50%)" stroke-linejoin="round" stroke-width="5.6000000000000005"/></g><g><rect data-type="rect" data-label="BUG • bus requests 0.40mm; Pipeline9 routes 0.10mm:end step:unknown layer:all" data-x="5" data-y="1.22" x="40" y="261.8760768" width="560" height="136.64" fill="rgba(255,255,255,0)" stroke="rgba(25,25,25,0.42)" stroke-width="0.017857142857142856"/></g><text data-type="text" data-label="BUS REQUEST: 0.40mm" data-x="0" data-y="2.25" x="40" y="272.5160768" fill="black" font-size="21.28" font-family="sans-serif" text-anchor="start" dominant-baseline="central">BUS REQUEST: 0.40mm</text><text data-type="text" data-label="PIPELINE9 OUTPUT: 0.10mm" data-x="0" data-y="1.65" x="40" y="306.11607680000003" fill="#b91c1c" font-size="21.28" font-family="sans-serif" text-anchor="start" dominant-baseline="central">PIPELINE9 OUTPUT: 0.10mm</text><text data-type="text" data-label="BUG • bus requests 0.40mm; Pipeline9 routes 0.10mm:end" data-x="1.6506607999999998" data-y="2.8041456" x="132.43700479999998" y="241.4839232" fill="rgb(18,18,18)" font-size="11.20448" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge">BUG • bus requests 0.40mm; Pipeline9 routes 0.10mm:end</text><text data-type="text" data-label="step:unknown" data-x="3.6354544" data-y="2.580056" x="243.5854464" y="254.0329408" fill="rgb(190,92,12)" font-size="11.20448" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge">step:unknown</text><text data-type="text" data-label=" layer:all" data-x="5.1240496" data-y="2.580056" x="326.9467776" y="254.0329408" fill="rgb(120,58,175)" font-size="11.20448" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge"> layer:all</text><g><circle data-type="point" data-label="TMDS_P
+TMDS_P
+top" data-x="0" data-y="0" cx="40" cy="398.5160768" r="3" fill="hsl(0, 100%, 50%)"/></g><g><circle data-type="point" data-label="TMDS_P
+TMDS_P
+top" data-x="5" data-y="0" cx="320" cy="398.5160768" r="3" fill="hsl(0, 100%, 50%)"/></g><g><circle data-type="point" data-label="TMDS_P
+TMDS_P
+top" data-x="10" data-y="0" cx="600" cy="398.5160768" r="3" fill="hsl(0, 100%, 50%)"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":56,"c":0,"e":40,"b":0,"d":-56,"f":398.5160768};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/repro/pipeline9-multipoint-bus-trace-width.test.ts
+++ b/tests/repro/pipeline9-multipoint-bus-trace-width.test.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "bun:test"
+import type { GraphicsObject } from "graphics-debug"
+import { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph"
+import type { SimpleRouteJson } from "lib/types"
+import { convertSrjToGraphicsObject } from "lib/utils/convertSrjToGraphicsObject"
+import { getGraphicsSvgFrames } from "../fixtures/solver-svg-frames"
+
+test("Pipeline9 ignores a multipoint bus trace width", async (): Promise<void> => {
+  const inputSrj: SimpleRouteJson = {
+    bounds: { minX: -7, maxX: 7, minY: -3, maxY: 3 },
+    layerCount: 2,
+    minTraceWidth: 0.1,
+    minTraceToPadEdgeClearance: 0.1,
+    obstacles: [],
+    connections: [
+      {
+        name: "TMDS_P",
+        pointsToConnect: [
+          { x: -5, y: 0, layer: "top", pointId: "source" },
+          { x: 0, y: 0, layer: "top", pointId: "protector" },
+          { x: 5, y: 0, layer: "top", pointId: "connector" },
+        ],
+      },
+    ],
+    buses: [
+      {
+        busId: "TMDS_PAIR",
+        connectionNames: ["TMDS_P"],
+        traceWidth: 0.4,
+      },
+    ],
+  }
+  const solver = new AutoroutingPipelineSolver9_PreloadedTraceGraph(inputSrj, {
+    cacheProvider: null,
+    visualizationTraceColorMode: "net",
+  })
+
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  const routedTraces = solver.getOutputSimplifiedPcbTraces()
+  const routedWireWidths = new Set(
+    routedTraces.flatMap((trace) =>
+      trace.route.flatMap((routePoint) =>
+        routePoint.route_type === "wire" ? [routePoint.width] : [],
+      ),
+    ),
+  )
+  expect(routedWireWidths).toEqual(new Set([0.1]))
+
+  const routedGraphics: GraphicsObject = convertSrjToGraphicsObject(
+    { ...inputSrj, traces: routedTraces },
+    { traceColorMode: "net" },
+  )
+  routedGraphics.texts = [
+    ...(routedGraphics.texts ?? []),
+    {
+      x: -5,
+      y: 2.25,
+      text: "BUS REQUEST: 0.40mm",
+      fontSize: 0.38,
+      color: "black",
+      anchorSide: "center_left",
+    },
+    {
+      x: -5,
+      y: 1.65,
+      text: "PIPELINE9 OUTPUT: 0.10mm",
+      fontSize: 0.38,
+      color: "#b91c1c",
+      anchorSide: "center_left",
+    },
+  ]
+
+  await expect(
+    getGraphicsSvgFrames({
+      frames: [
+        {
+          name: "BUG • bus requests 0.40mm; Pipeline9 routes 0.10mm",
+          pipeline: "end",
+          graphics: routedGraphics,
+        },
+      ],
+      columns: 1,
+      backgroundColor: "white",
+    }),
+  ).toMatchSvgSnapshot(import.meta.path)
+})


### PR DESCRIPTION
## Summary

- adds a minimal Pipeline9 multipoint-bus reproduction
- requests a 0.40 mm bus trace width
- snapshots the incorrect 0.10 mm routed output

This is the repro half of a two-PR stack; the fix is intentionally kept out so its SVG change is reviewable in the next PR.

## Validation

- focused Bun regression test passes
- SVG snapshot generated by graphics-debug