### PR TITLE
Reproduce preloaded via transition-coordinate drift

### DIFF
--- a/tests/repro/__snapshots__/preloaded-via-transition-layers.snap.svg
+++ b/tests/repro/__snapshots__/preloaded-via-transition-layers.snap.svg
@@ -1,0 +1,44 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="-0.5,0 0,0" data-type="line" data-label="route-a (z=0)" points="40,368.2204362801378 200.73478760045924,368.2204362801378" fill="none" stroke="rgba(255, 0, 0, 0.5)" stroke-linejoin="round" stroke-width="48.22043628013777"/></g><g><polyline data-points="0,0 0.5,0" data-type="line" data-label="route-a (z=1)" points="200.73478760045924,368.2204362801378 361.4695752009185,368.2204362801378" fill="none" stroke="rgba(0, 0, 255, 0.5)" stroke-linejoin="round" stroke-width="48.22043628013777"/></g><g><polyline data-points="-0.09960000000000002,0 0.4004,0" data-type="line" data-label="preloaded-route-b (z=0)" points="168.71641791044775,368.2204362801378 329.451205510907,368.2204362801378" fill="none" stroke="rgba(255, 0, 0, 0.5)" stroke-linejoin="round" stroke-width="48.22043628013777"/></g><g><polyline data-points="0.4004,0 0.9004,0" data-type="line" data-label="preloaded-route-b (z=1)" points="329.451205510907,368.2204362801378 490.18599311136626,368.2204362801378" fill="none" stroke="rgba(0, 0, 255, 0.5)" stroke-linejoin="round" stroke-width="48.22043628013777"/></g><circle data-type="circle" data-label="" data-x="0" data-y="0" cx="200.73478760045924" cy="368.2204362801378" r="48.22043628013777" fill="rgba(255, 0, 255, 0.5)" stroke="black" stroke-width="0.0031107142857142857"/><circle data-type="circle" data-label="" data-x="0.4" data-y="0" cx="329.3226176808266" cy="368.2204362801378" r="48.22043628013777" fill="rgba(255, 0, 255, 0.5)" stroke="black" stroke-width="0.0031107142857142857"/><text data-type="text" data-label="BUG • rounded lookup loses preloaded via layers" data-x="-0.45" data-y="0.42" x="56.07347876004593" y="233.20321469575202" fill="#111827" font-size="19.288174512055107" font-family="sans-serif" text-anchor="start" dominant-baseline="central">BUG • rounded lookup loses preloaded via layers</text><text data-type="text" data-label="via x=0.4000 • transition x=0.4004" data-x="-0.45" data-y="0.31" x="56.07347876004593" y="268.56486796785305" fill="#b91c1c" font-size="16.073478760045926" font-family="sans-serif" text-anchor="start" dominant-baseline="central">via x=0.4000 • transition x=0.4004</text><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":321.4695752009185,"c":0,"e":200.73478760045924,"b":0,"d":-321.4695752009185,"f":368.2204362801378};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/repro/preloaded-via-transition-layers.test.ts
+++ b/tests/repro/preloaded-via-transition-layers.test.ts
@@ -1,0 +1,81 @@
+import { expect, spyOn, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { SameNetViaMergerSolver } from "lib/solvers/SameNetViaMergerSolver/SameNetViaMergerSolver"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+
+const makeViaRoute = ({
+  connectionName,
+  viaX,
+  transitionX = viaX,
+}: {
+  connectionName: string
+  viaX: number
+  transitionX?: number
+}): HighDensityRoute => ({
+  connectionName,
+  traceThickness: 0.15,
+  viaDiameter: 0.3,
+  route: [
+    { x: transitionX - 0.5, y: 0, z: 0 },
+    { x: transitionX, y: 0, z: 0 },
+    { x: transitionX, y: 0, z: 1 },
+    { x: transitionX + 0.5, y: 0, z: 1 },
+  ],
+  vias: [{ x: viaX, y: 0 }],
+})
+
+test("repro: preloaded via rounding hides valid transition layers", () => {
+  const solver = new SameNetViaMergerSolver({
+    inputHdRoutes: [
+      makeViaRoute({ connectionName: "route-a", viaX: 0 }),
+      makeViaRoute({
+        connectionName: "preloaded-route-b",
+        viaX: 0.4,
+        transitionX: 0.4004,
+      }),
+    ],
+    obstacles: [],
+    colorMap: {
+      "route-a": "#ef4444",
+      "preloaded-route-b": "#3b82f6",
+    },
+    layerCount: 2,
+    connMap: new ConnectivityMap({
+      net0: ["route-a", "preloaded-route-b"],
+    }),
+  })
+
+  const consoleError = spyOn(console, "error").mockImplementation(() => {})
+  try {
+    expect(() => solver.solve()).toThrow(
+      "could not find transition layers for via at (0.4, 0)",
+    )
+  } finally {
+    consoleError.mockRestore()
+  }
+  expect(solver.failed).toBe(true)
+  expect(String(solver.error)).toContain(
+    "could not find transition layers for via at (0.4, 0)",
+  )
+  const graphics = solver.visualize()
+  graphics.texts = [
+    ...(graphics.texts ?? []),
+    {
+      x: -0.45,
+      y: 0.42,
+      text: "BUG • rounded lookup loses preloaded via layers",
+      fontSize: 0.06,
+      color: "#111827",
+      anchorSide: "center_left",
+    },
+    {
+      x: -0.45,
+      y: 0.31,
+      text: "via x=0.4000 • transition x=0.4004",
+      fontSize: 0.05,
+      color: "#b91c1c",
+      anchorSide: "center_left",
+    },
+  ]
+  expect(graphics).toMatchGraphicsSvg(import.meta.path)
+})


### PR DESCRIPTION
## Summary

- adds a minimal preloaded-via merge reproduction
- models a serialized layer transition displaced by 0.0004 mm from its via
- snapshots the exact-coordinate lookup failure before applying any tolerance fix

This is the repro half of a two-PR stack.

## Validation

- focused Bun regression test passes
- SVG snapshot generated by graphics-debug