### PR TITLE
use default effort for pipeline9 joint drc repair

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-joint-drc-repair-solver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-joint-drc-repair-solver.ts
@@ -1304,7 +1304,6 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
         ),
       ],
       connMap: params.connMap,
-      effort: params.effort,
       viaHoleDiameter: params.defaultViaHoleDiameter,
       drcEvaluator,
       viaInPadDrcEvaluator: drcEvaluator,

--- a/tests/repro/rv1106g2-pipeline9-joint-drc-timeout.test.ts
+++ b/tests/repro/rv1106g2-pipeline9-joint-drc-timeout.test.ts
@@ -5,9 +5,9 @@ import type { SimpleRouteJson } from "lib/types"
 import { convertSrjToGraphicsObject } from "lib/utils/convertSrjToGraphicsObject"
 import srj from "./assets/rv1106g2-pipeline9.srj.json" with { type: "json" }
 
-const AUTOROUTER_PHASE_TIMEOUT_MS = 180_000
+const JOINT_DRC_REPAIR_TIMEOUT_MS = 60_000
 
-test.skip("RV1106G2 Pipeline9 exceeds the 180 second phase timeout", () => {
+test.skip("RV1106G2 Pipeline9 completes joint DRC repair before timeout", () => {
   const simpleRouteJson = srj as SimpleRouteJson
   expect(simpleRouteJson.connections).toHaveLength(76)
   expect(simpleRouteJson.obstacles).toHaveLength(382)
@@ -16,18 +16,22 @@ test.skip("RV1106G2 Pipeline9 exceeds the 180 second phase timeout", () => {
     simpleRouteJson,
     { cacheProvider: null, effort: 5 },
   )
+  solver.solveUntilPhase("pipeline9JointDrcRepairSolver")
   const startedAtMs = performance.now()
 
   while (
-    !solver.solved &&
+    performance.now() - startedAtMs < JOINT_DRC_REPAIR_TIMEOUT_MS &&
     !solver.failed &&
-    performance.now() - startedAtMs < AUTOROUTER_PHASE_TIMEOUT_MS
+    solver.getCurrentPhase() === "pipeline9JointDrcRepairSolver"
   ) {
     solver.step()
   }
 
   expect(solver.failed).toBeFalse()
-  expect(solver.solved).toBeFalse()
+  expect(solver.getCurrentPhase()).toBe("lengthMatchingPostProcessingSolver")
+  expect(performance.now() - startedAtMs).toBeLessThan(
+    JOINT_DRC_REPAIR_TIMEOUT_MS,
+  )
   const svg = getSvgFromGraphicsObject(
     convertSrjToGraphicsObject(simpleRouteJson, { traceColorMode: "net" }),
     { backgroundColor: "white" },


### PR DESCRIPTION
### Motivation
- fix the joint DRC phase timeout reproduced in [#2260](https://github.com/tscircuit/tscircuit-autorouter/pull/2260) without adding another repair budget

### Before
- Pipeline9 forwarded board effort 5 into final joint repair, producing 243 candidate checks and about 88 seconds of repair work

### After
- omit the repair effort so the solver uses its default, reducing the repro to 69 candidate checks and about 23 seconds
- the measured reference DRC residue changes from 7 issues to 8 issues