### PR TITLE
feat: add Pipeline9 networked high-density cache

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/autorouter-version.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/autorouter-version.ts
@@ -1,0 +1,4 @@
+import packageJson from "../../../package.json" with { type: "json" }
+
+/** The exact published autorouter version used to isolate network cache keys. */
+export const AUTOROUTER_VERSION = String(packageJson.version)

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/autorouting-pipeline-solver9-networked.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/autorouting-pipeline-solver9-networked.ts
@@ -53,10 +53,7 @@ export class AutoroutingPipelineSolver9_Networked extends AutoroutingPipelineSol
     this.hdCacheTransportTimeoutMs =
       opts.hdCacheTransportTimeoutMs ??
       DEFAULT_PIPELINE9_NETWORKED_TRANSPORT_TIMEOUT_MS
-    if (
-      !Number.isFinite(this.hdCacheTimeoutMs) ||
-      this.hdCacheTimeoutMs <= 0
-    ) {
+    if (!Number.isFinite(this.hdCacheTimeoutMs) || this.hdCacheTimeoutMs <= 0) {
       throw new Error(
         `Pipeline9 network request timeout must be a positive number, received ${this.hdCacheTimeoutMs}`,
       )
@@ -85,9 +82,7 @@ export class AutoroutingPipelineSolver9_Networked extends AutoroutingPipelineSol
     this.pipelineDef[highDensityStepIndex] = {
       ...originalStep,
       solverClass: Pipeline9NetworkedHighDensitySolver as any,
-      getConstructorParams: (
-        solver: AutoroutingPipelineSolver9_Networked,
-      ) => {
+      getConstructorParams: (solver: AutoroutingPipelineSolver9_Networked) => {
         const [params] = getOriginalConstructorParams(solver)
         return [
           {

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/autorouting-pipeline-solver9-networked.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/autorouting-pipeline-solver9-networked.ts
@@ -1,0 +1,149 @@
+import type { SimpleRouteJson } from "../../types/srj-types"
+import { getPendingEffectsFromSolverTree } from "../../solvers/getPendingEffectsFromSolverTree"
+import {
+  AutoroutingPipelineSolver9_PreloadedTraceGraph,
+  type AutoroutingPipelineSolverOptions,
+} from "../AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph"
+import { AUTOROUTER_VERSION } from "./autorouter-version"
+import {
+  DEFAULT_PIPELINE9_NETWORKED_CACHE_URL,
+  DEFAULT_PIPELINE9_NETWORKED_TIMEOUT_MS,
+  DEFAULT_PIPELINE9_NETWORKED_TRANSPORT_TIMEOUT_MS,
+  Pipeline9NetworkedHighDensitySolver,
+} from "./pipeline9-networked-high-density-solver"
+
+export type AutoroutingPipelineSolver9NetworkedOptions = Omit<
+  AutoroutingPipelineSolverOptions,
+  "effort"
+> & {
+  effort?: 1
+  hdCacheBaseUrl?: string
+  hdCacheFetch?: typeof fetch
+  hdCacheTimeoutMs?: number
+  hdCacheTransportTimeoutMs?: number
+}
+
+/** Pipeline9 with exact, version-scoped remote ordinary-node solving. */
+export class AutoroutingPipelineSolver9_Networked extends AutoroutingPipelineSolver9_PreloadedTraceGraph {
+  readonly hdCacheBaseUrl: string
+  readonly hdCacheFetch?: typeof fetch
+  readonly hdCacheTimeoutMs: number
+  readonly hdCacheTransportTimeoutMs: number
+
+  override getSolverName(): string {
+    return "AutoroutingPipelineSolver9_Networked"
+  }
+
+  constructor(
+    srj: SimpleRouteJson,
+    opts: AutoroutingPipelineSolver9NetworkedOptions = {},
+  ) {
+    super(srj, opts)
+    if (this.effort !== 1) {
+      throw new Error(
+        `AutoroutingPipelineSolver9_Networked is only available at effort=1, received ${this.effort}`,
+      )
+    }
+
+    this.hdCacheBaseUrl =
+      opts.hdCacheBaseUrl ?? DEFAULT_PIPELINE9_NETWORKED_CACHE_URL
+    this.hdCacheFetch = opts.hdCacheFetch
+    this.hdCacheTimeoutMs =
+      opts.hdCacheTimeoutMs ?? DEFAULT_PIPELINE9_NETWORKED_TIMEOUT_MS
+    this.hdCacheTransportTimeoutMs =
+      opts.hdCacheTransportTimeoutMs ??
+      DEFAULT_PIPELINE9_NETWORKED_TRANSPORT_TIMEOUT_MS
+    if (
+      !Number.isFinite(this.hdCacheTimeoutMs) ||
+      this.hdCacheTimeoutMs <= 0
+    ) {
+      throw new Error(
+        `Pipeline9 network request timeout must be a positive number, received ${this.hdCacheTimeoutMs}`,
+      )
+    }
+    if (
+      !Number.isFinite(this.hdCacheTransportTimeoutMs) ||
+      this.hdCacheTransportTimeoutMs < this.hdCacheTimeoutMs
+    ) {
+      throw new Error(
+        `Pipeline9 network transport timeout must be at least the logical request timeout (${this.hdCacheTimeoutMs}ms), received ${this.hdCacheTransportTimeoutMs}`,
+      )
+    }
+    this.replaceHighDensityPipelineStep()
+  }
+
+  private replaceHighDensityPipelineStep(): void {
+    const highDensityStepIndex = this.pipelineDef.findIndex(
+      (step) => step.solverName === "highDensityRouteSolver",
+    )
+    const originalStep = this.pipelineDef[highDensityStepIndex]
+    if (!originalStep) {
+      throw new Error("Pipeline9 highDensityRouteSolver step is missing")
+    }
+    const getOriginalConstructorParams = originalStep.getConstructorParams
+
+    this.pipelineDef[highDensityStepIndex] = {
+      ...originalStep,
+      solverClass: Pipeline9NetworkedHighDensitySolver as any,
+      getConstructorParams: (
+        solver: AutoroutingPipelineSolver9_Networked,
+      ) => {
+        const [params] = getOriginalConstructorParams(solver)
+        return [
+          {
+            ...params,
+            autorouterVersion: AUTOROUTER_VERSION,
+            hdCacheBaseUrl: solver.hdCacheBaseUrl,
+            fetchImpl: solver.hdCacheFetch,
+            requestTimeoutMs: solver.hdCacheTimeoutMs,
+            transportTimeoutMs: solver.hdCacheTransportTimeoutMs,
+          },
+        ]
+      },
+    } as any
+  }
+
+  async stepAsync(): Promise<void> {
+    if (this.solved || this.failed) return
+    this.step()
+
+    const pendingEffects = getPendingEffectsFromSolverTree(this)
+    if (pendingEffects.length === 0) return
+    await Promise.race(
+      pendingEffects.map((effect) =>
+        effect.promise.then(
+          () => effect.name,
+          () => effect.name,
+        ),
+      ),
+    )
+
+    if (!this.solved && !this.failed) this.step()
+  }
+
+  async solveAsync(): Promise<void> {
+    const startTime = Date.now()
+    while (!this.solved && !this.failed) {
+      await this.stepAsync()
+    }
+    this.timeToSolve = Date.now() - startTime
+  }
+
+  async solveUntilPhaseAsync(phase: string): Promise<void> {
+    while (this.getCurrentPhase() !== phase && !this.solved && !this.failed) {
+      await this.stepAsync()
+    }
+  }
+
+  override solve(): void {
+    throw new Error(
+      "AutoroutingPipelineSolver9_Networked requires async execution. Use solveAsync() or stepAsync().",
+    )
+  }
+
+  override solveUntilPhase(_phase: string): void {
+    throw new Error(
+      "AutoroutingPipelineSolver9_Networked requires solveUntilPhaseAsync().",
+    )
+  }
+}

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-high-density-solver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-high-density-solver.ts
@@ -58,8 +58,7 @@ const isValidCircuitJsonMetadata = (value: unknown): boolean => {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false
   return Object.entries(value).every(
     ([key, metadataValue]) =>
-      CIRCUIT_JSON_METADATA_KEYS.has(key) &&
-      typeof metadataValue === "string",
+      CIRCUIT_JSON_METADATA_KEYS.has(key) && typeof metadataValue === "string",
   )
 }
 
@@ -170,9 +169,7 @@ const isValidRemoteRoutes = (
       }
       if (
         point.toNextSegmentCircuitJsonMetadata !== undefined &&
-        !isValidCircuitJsonMetadata(
-          point.toNextSegmentCircuitJsonMetadata,
-        )
+        !isValidCircuitJsonMetadata(point.toNextSegmentCircuitJsonMetadata)
       ) {
         return false
       }
@@ -275,10 +272,7 @@ export class Pipeline9NetworkedHighDensitySolver extends Pipeline9HighDensitySol
       requestTimeoutMs ?? DEFAULT_PIPELINE9_NETWORKED_TIMEOUT_MS
     this.transportTimeoutMs =
       transportTimeoutMs ?? DEFAULT_PIPELINE9_NETWORKED_TRANSPORT_TIMEOUT_MS
-    if (
-      !Number.isFinite(this.requestTimeoutMs) ||
-      this.requestTimeoutMs <= 0
-    ) {
+    if (!Number.isFinite(this.requestTimeoutMs) || this.requestTimeoutMs <= 0) {
       throw new Error(
         `Pipeline9 network request timeout must be a positive number, received ${this.requestTimeoutMs}`,
       )
@@ -505,10 +499,7 @@ export class Pipeline9NetworkedHighDensitySolver extends Pipeline9HighDensitySol
       const request = this.remoteRequestByNode.get(node)
       if (request) {
         this.waitingForRemoteNode = node
-        const waitPromise = this.waitForCurrentRemoteNode(
-          node,
-          request.promise,
-        )
+        const waitPromise = this.waitForCurrentRemoteNode(node, request.promise)
         waitPromise.then(() => {
           if (this.waitingForRemoteNode !== node) return
           this.pendingEffects = []

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-high-density-solver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-high-density-solver.ts
@@ -1,0 +1,574 @@
+import type {
+  HighDensityIntraNodeRoute,
+  NodeWithPortPoints,
+} from "../../types/high-density-types"
+import type { PendingEffect } from "../../solvers/BaseSolver"
+import {
+  Pipeline9HighDensitySolver,
+  type Pipeline9HighDensitySolverParams,
+} from "../AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-high-density-solver"
+import { projectPipeline9OrdinaryHighDensityInput } from "../AutoroutingPipeline9_PreloadedTraceGraph/project-pipeline9-ordinary-high-density-input"
+import type {
+  Pipeline9NetworkedHighDensityNodeInput,
+  Pipeline9NetworkedSolveRequest,
+  Pipeline9NetworkedSolveResponse,
+} from "./pipeline9-networked-types"
+
+export const DEFAULT_PIPELINE9_NETWORKED_CACHE_URL =
+  "https://hd-cache2.tscircuit.com"
+export const DEFAULT_PIPELINE9_NETWORKED_TIMEOUT_MS = 30_000
+export const DEFAULT_PIPELINE9_NETWORKED_TRANSPORT_TIMEOUT_MS = 310_000
+
+export type Pipeline9NetworkedHighDensitySolverParams =
+  Pipeline9HighDensitySolverParams & {
+    autorouterVersion: string
+    hdCacheBaseUrl?: string
+    fetchImpl?: typeof fetch
+    requestTimeoutMs?: number
+    transportTimeoutMs?: number
+  }
+
+type RemoteNodeResult =
+  | {
+      kind: "remote"
+      response: Extract<Pipeline9NetworkedSolveResponse, { ok: true }>
+    }
+  | {
+      kind: "local-fallback"
+      error: string
+    }
+
+type RemoteNodeRequest = {
+  promise: Promise<void>
+}
+
+const getErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error)
+
+const CIRCUIT_JSON_METADATA_KEYS = new Set([
+  "pcb_smtpad_id",
+  "pcb_plated_hole_id",
+  "pcb_port_id",
+  "pcb_via_id",
+  "source_component_name",
+  "source_port_name",
+])
+
+const isValidCircuitJsonMetadata = (value: unknown): boolean => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false
+  return Object.entries(value).every(
+    ([key, metadataValue]) =>
+      CIRCUIT_JSON_METADATA_KEYS.has(key) &&
+      typeof metadataValue === "string",
+  )
+}
+
+const nearlyEqual = (left: number, right: number): boolean =>
+  Math.abs(left - right) <= 1e-9 * Math.max(1, Math.abs(left), Math.abs(right))
+
+const isValidRemoteRoutes = (
+  value: unknown,
+  input: Pipeline9NetworkedHighDensityNodeInput,
+): value is HighDensityIntraNodeRoute[] => {
+  if (!Array.isArray(value)) return false
+  const portPointsByConnectionName = new Map<
+    string,
+    NodeWithPortPoints["portPoints"]
+  >()
+  for (const portPoint of input.nodeWithPortPoints.portPoints) {
+    const portPoints =
+      portPointsByConnectionName.get(portPoint.connectionName) ?? []
+    portPoints.push(portPoint)
+    portPointsByConnectionName.set(portPoint.connectionName, portPoints)
+  }
+  const isPortPointForConnection = (
+    point: Record<string, unknown>,
+    connectionName: string,
+  ): boolean =>
+    (portPointsByConnectionName.get(connectionName) ?? []).some(
+      (portPoint) =>
+        typeof point.x === "number" &&
+        nearlyEqual(point.x, portPoint.x) &&
+        typeof point.y === "number" &&
+        nearlyEqual(point.y, portPoint.y) &&
+        point.z === portPoint.z,
+    )
+
+  for (const routeValue of value) {
+    if (!routeValue || typeof routeValue !== "object") return false
+    const route = routeValue as Record<string, unknown>
+    if (
+      typeof route.connectionName !== "string" ||
+      route.connectionName.length === 0 ||
+      !portPointsByConnectionName.has(route.connectionName) ||
+      typeof route.traceThickness !== "number" ||
+      !Number.isFinite(route.traceThickness) ||
+      route.traceThickness <= 0 ||
+      (!nearlyEqual(route.traceThickness, input.traceWidth) &&
+        // The A03 portfolio candidate currently emits its fixed 0.1 mm width.
+        !nearlyEqual(route.traceThickness, 0.1)) ||
+      typeof route.viaDiameter !== "number" ||
+      !Number.isFinite(route.viaDiameter) ||
+      route.viaDiameter <= 0 ||
+      !nearlyEqual(route.viaDiameter, input.viaDiameter) ||
+      !Array.isArray(route.route) ||
+      route.route.length < 2 ||
+      !Array.isArray(route.vias)
+    ) {
+      return false
+    }
+    for (const optionalString of [
+      route.rootConnectionName,
+      route.startPcbPortId,
+      route.endPcbPortId,
+      route.regionId,
+    ]) {
+      if (optionalString !== undefined && typeof optionalString !== "string") {
+        return false
+      }
+    }
+    for (const pointValue of route.route) {
+      if (!pointValue || typeof pointValue !== "object") return false
+      const point = pointValue as Record<string, unknown>
+      if (
+        typeof point.x !== "number" ||
+        !Number.isFinite(point.x) ||
+        typeof point.y !== "number" ||
+        !Number.isFinite(point.y) ||
+        typeof point.z !== "number" ||
+        !Number.isInteger(point.z) ||
+        point.z < 0 ||
+        point.z >= input.layerCount
+      ) {
+        return false
+      }
+      if (
+        point.traceThickness !== undefined &&
+        (typeof point.traceThickness !== "number" ||
+          !Number.isFinite(point.traceThickness) ||
+          point.traceThickness <= 0)
+      ) {
+        return false
+      }
+      if (
+        point.pcb_port_id !== undefined &&
+        typeof point.pcb_port_id !== "string"
+      ) {
+        return false
+      }
+      if (
+        point.insideJumperPad !== undefined &&
+        typeof point.insideJumperPad !== "boolean"
+      ) {
+        return false
+      }
+      if (
+        point.toNextSegmentType !== undefined &&
+        point.toNextSegmentType !== "through_obstacle"
+      ) {
+        return false
+      }
+      if (
+        point.toNextSegmentCircuitJsonMetadata !== undefined &&
+        !isValidCircuitJsonMetadata(
+          point.toNextSegmentCircuitJsonMetadata,
+        )
+      ) {
+        return false
+      }
+    }
+    const routePoints = route.route as Record<string, unknown>[]
+    if (
+      !isPortPointForConnection(routePoints[0]!, route.connectionName) ||
+      !isPortPointForConnection(routePoints.at(-1)!, route.connectionName)
+    ) {
+      return false
+    }
+    for (const viaValue of route.vias) {
+      if (!viaValue || typeof viaValue !== "object") return false
+      const via = viaValue as Record<string, unknown>
+      if (
+        typeof via.x !== "number" ||
+        !Number.isFinite(via.x) ||
+        typeof via.y !== "number" ||
+        !Number.isFinite(via.y)
+      ) {
+        return false
+      }
+    }
+    if (route.jumpers !== undefined) {
+      if (!Array.isArray(route.jumpers)) return false
+      for (const jumperValue of route.jumpers) {
+        if (!jumperValue || typeof jumperValue !== "object") return false
+        const jumper = jumperValue as Record<string, unknown>
+        const start = jumper.start as Record<string, unknown> | undefined
+        const end = jumper.end as Record<string, unknown> | undefined
+        if (
+          jumper.route_type !== "jumper" ||
+          (jumper.footprint !== "0603" &&
+            jumper.footprint !== "1206" &&
+            jumper.footprint !== "1206x4_pair") ||
+          !start ||
+          typeof start.x !== "number" ||
+          !Number.isFinite(start.x) ||
+          typeof start.y !== "number" ||
+          !Number.isFinite(start.y) ||
+          !end ||
+          typeof end.x !== "number" ||
+          !Number.isFinite(end.x) ||
+          typeof end.y !== "number" ||
+          !Number.isFinite(end.y)
+        ) {
+          return false
+        }
+      }
+    }
+  }
+  return true
+}
+
+export const getPipeline9NetworkedSolveUrl = (baseUrl: string): string =>
+  /\/solve\/?$/.test(baseUrl)
+    ? baseUrl.replace(/\/+$/, "")
+    : `${baseUrl.replace(/\/+$/, "")}/solve`
+
+/**
+ * Starts every exact-cache request together, then lets Pipeline9 consume the
+ * results in its existing node order. Requests for fixed-copper nodes are
+ * intentionally speculative and ignored when that node reaches the B01 path.
+ */
+export class Pipeline9NetworkedHighDensitySolver extends Pipeline9HighDensitySolver {
+  readonly autorouterVersion: string
+  readonly hdCacheBaseUrl: string
+  readonly fetchImpl: typeof fetch
+  readonly requestTimeoutMs: number
+  readonly transportTimeoutMs: number
+
+  private launchedRemoteSolves = false
+  private waitingForRemoteNode: NodeWithPortPoints | null = null
+  private readonly remoteRequestByNode = new Map<
+    NodeWithPortPoints,
+    RemoteNodeRequest
+  >()
+  private readonly remoteResultByNode = new Map<
+    NodeWithPortPoints,
+    RemoteNodeResult
+  >()
+  private readonly logicallyTimedOutNodes = new Set<NodeWithPortPoints>()
+
+  constructor({
+    autorouterVersion,
+    hdCacheBaseUrl,
+    fetchImpl,
+    requestTimeoutMs,
+    transportTimeoutMs,
+    ...pipeline9Params
+  }: Pipeline9NetworkedHighDensitySolverParams) {
+    super(pipeline9Params)
+    if (pipeline9Params.effort !== 1) {
+      throw new Error(
+        `Pipeline9 networked high-density routing requires effort=1, received ${pipeline9Params.effort}`,
+      )
+    }
+
+    this.requestTimeoutMs =
+      requestTimeoutMs ?? DEFAULT_PIPELINE9_NETWORKED_TIMEOUT_MS
+    this.transportTimeoutMs =
+      transportTimeoutMs ?? DEFAULT_PIPELINE9_NETWORKED_TRANSPORT_TIMEOUT_MS
+    if (
+      !Number.isFinite(this.requestTimeoutMs) ||
+      this.requestTimeoutMs <= 0
+    ) {
+      throw new Error(
+        `Pipeline9 network request timeout must be a positive number, received ${this.requestTimeoutMs}`,
+      )
+    }
+    if (
+      !Number.isFinite(this.transportTimeoutMs) ||
+      this.transportTimeoutMs < this.requestTimeoutMs
+    ) {
+      throw new Error(
+        `Pipeline9 network transport timeout must be at least the logical request timeout (${this.requestTimeoutMs}ms), received ${this.transportTimeoutMs}`,
+      )
+    }
+
+    this.autorouterVersion = autorouterVersion
+    this.hdCacheBaseUrl =
+      hdCacheBaseUrl ?? DEFAULT_PIPELINE9_NETWORKED_CACHE_URL
+    this.fetchImpl = (fetchImpl ?? globalThis.fetch).bind(
+      globalThis,
+    ) as typeof fetch
+    this.pendingEffects = []
+    this.stats = {
+      ...this.stats,
+      remoteRequestsStarted: 0,
+      remoteRequestsCompleted: 0,
+      remoteCacheHits: 0,
+      remoteSolverResults: 0,
+      remoteSolvedResults: 0,
+      remoteFailedResults: 0,
+      remoteTransportFallbacks: 0,
+      remoteLogicalTimeoutFallbacks: 0,
+    }
+  }
+
+  override getSolverName(): string {
+    return "Pipeline9NetworkedHighDensitySolver"
+  }
+
+  private createNodeInput(
+    node: NodeWithPortPoints,
+  ): Pipeline9NetworkedHighDensityNodeInput {
+    const projectedInput = projectPipeline9OrdinaryHighDensityInput({
+      nodeWithPortPoints: node,
+      connMap: this.connMap,
+      colorMap: this.colorMap,
+      obstacles: this.obstacles,
+      obstacleMargin: this.obstacleMargin,
+      traceWidth: this.traceWidth,
+      viaDiameter: this.viaDiameter,
+    })
+    return {
+      nodeWithPortPoints: node,
+      connectivityNetMap: projectedInput.connectivityNetMap,
+      colorMap: projectedInput.colorMap,
+      viaDiameter: this.viaDiameter,
+      traceWidth: this.traceWidth,
+      obstacleMargin: this.obstacleMargin,
+      effort: 1,
+      obstacles: projectedInput.obstacles,
+      layerCount: this.layerCount,
+      nodePf: this.nodePfById.get(node.capacityMeshNodeId) ?? null,
+    }
+  }
+
+  private parseSuccessfulResponse(
+    value: unknown,
+    input: Pipeline9NetworkedHighDensityNodeInput,
+  ): Extract<Pipeline9NetworkedSolveResponse, { ok: true }> {
+    if (!value || typeof value !== "object") {
+      throw new Error("hd-cache2 returned a non-object response")
+    }
+
+    const response = value as Record<string, unknown>
+    if (response.ok !== true) {
+      throw new Error(
+        typeof response.message === "string"
+          ? response.message
+          : "hd-cache2 returned an unsuccessful response",
+      )
+    }
+    if (response.autorouterVersion !== this.autorouterVersion) {
+      throw new Error(
+        `hd-cache2 returned autorouter version ${String(response.autorouterVersion)}, expected ${this.autorouterVersion}`,
+      )
+    }
+    if (response.source !== "cache" && response.source !== "solver") {
+      throw new Error("hd-cache2 returned an invalid cache source")
+    }
+    if (
+      response.status === "solved" &&
+      isValidRemoteRoutes(response.routes, input)
+    ) {
+      return response as Extract<Pipeline9NetworkedSolveResponse, { ok: true }>
+    }
+    if (response.status === "failed" && typeof response.error === "string") {
+      return response as Extract<Pipeline9NetworkedSolveResponse, { ok: true }>
+    }
+
+    throw new Error("hd-cache2 returned an invalid solve result")
+  }
+
+  private async fetchNodeResult(
+    request: Pipeline9NetworkedSolveRequest,
+  ): Promise<Extract<Pipeline9NetworkedSolveResponse, { ok: true }>> {
+    const controller = new AbortController()
+    const requestPromise = (async () => {
+      const response = await this.fetchImpl(
+        getPipeline9NetworkedSolveUrl(this.hdCacheBaseUrl),
+        {
+          method: "POST",
+          headers: {
+            accept: "application/json",
+            "content-type": "application/json",
+          },
+          body: JSON.stringify(request),
+          signal: controller.signal,
+        },
+      )
+      const responseText = await response.text()
+      let responseBody: unknown
+      try {
+        responseBody = responseText ? JSON.parse(responseText) : null
+      } catch {
+        throw new Error(
+          `hd-cache2 returned invalid JSON with status ${response.status}`,
+        )
+      }
+      if (!response.ok) {
+        const message =
+          responseBody &&
+          typeof responseBody === "object" &&
+          "message" in responseBody &&
+          typeof responseBody.message === "string"
+            ? responseBody.message
+            : `hd-cache2 request failed with status ${response.status}`
+        throw new Error(message)
+      }
+      return this.parseSuccessfulResponse(responseBody, request.input)
+    })()
+    const transportTimeoutId = setTimeout(() => {
+      controller.abort(
+        new Error(
+          `hd-cache2 transport timed out after ${this.transportTimeoutMs}ms`,
+        ),
+      )
+    }, this.transportTimeoutMs)
+    const backgroundTimer = transportTimeoutId as ReturnType<
+      typeof setTimeout
+    > & { unref?: () => void }
+    backgroundTimer.unref?.()
+    const observedRequestPromise = requestPromise.then(
+      (response) => {
+        clearTimeout(transportTimeoutId)
+        return { kind: "response" as const, response }
+      },
+      (error: unknown) => {
+        clearTimeout(transportTimeoutId)
+        return { kind: "error" as const, error }
+      },
+    )
+    const result = await observedRequestPromise
+    if (result.kind === "error") throw result.error
+    return result.response
+  }
+
+  private async solveNodeRemotely(node: NodeWithPortPoints): Promise<void> {
+    try {
+      const response = await this.fetchNodeResult({
+        autorouterVersion: this.autorouterVersion,
+        input: this.createNodeInput(node),
+      })
+      if (!this.logicallyTimedOutNodes.has(node)) {
+        this.remoteResultByNode.set(node, { kind: "remote", response })
+      }
+      if (response.source === "cache") this.stats.remoteCacheHits += 1
+      if (response.source === "solver") this.stats.remoteSolverResults += 1
+      if (response.status === "solved") this.stats.remoteSolvedResults += 1
+      if (response.status === "failed") this.stats.remoteFailedResults += 1
+    } catch (error) {
+      if (!this.logicallyTimedOutNodes.has(node)) {
+        this.remoteResultByNode.set(node, {
+          kind: "local-fallback",
+          error: getErrorMessage(error),
+        })
+        this.stats.remoteTransportFallbacks += 1
+      }
+    } finally {
+      this.stats.remoteRequestsCompleted += 1
+    }
+  }
+
+  private launchRemoteSolves(): void {
+    for (const node of this.unsolvedNodePortPoints) {
+      const promise = this.solveNodeRemotely(node)
+      this.remoteRequestByNode.set(node, { promise })
+      this.stats.remoteRequestsStarted += 1
+    }
+  }
+
+  private async waitForCurrentRemoteNode(
+    node: NodeWithPortPoints,
+    requestPromise: Promise<void>,
+  ): Promise<void> {
+    let logicalTimeoutId: ReturnType<typeof setTimeout> | undefined
+    const result = await Promise.race([
+      requestPromise.then(() => "request-settled" as const),
+      new Promise<"logical-timeout">((resolve) => {
+        logicalTimeoutId = setTimeout(
+          () => resolve("logical-timeout"),
+          this.requestTimeoutMs,
+        )
+      }),
+    ])
+    if (logicalTimeoutId !== undefined) clearTimeout(logicalTimeoutId)
+    if (result !== "logical-timeout") return
+
+    this.logicallyTimedOutNodes.add(node)
+    this.stats.remoteLogicalTimeoutFallbacks += 1
+    this.stats.remoteTransportFallbacks += 1
+  }
+
+  protected override startRegularSolver(node: NodeWithPortPoints): void {
+    const result = this.remoteResultByNode.get(node)
+    if (!result) {
+      const request = this.remoteRequestByNode.get(node)
+      if (request) {
+        this.waitingForRemoteNode = node
+        const waitPromise = this.waitForCurrentRemoteNode(
+          node,
+          request.promise,
+        )
+        waitPromise.then(() => {
+          if (this.waitingForRemoteNode !== node) return
+          this.pendingEffects = []
+        })
+        const pendingEffect: PendingEffect = {
+          name: `hd-cache2:${node.capacityMeshNodeId}`,
+          promise: waitPromise,
+        }
+        this.pendingEffects = [pendingEffect]
+        return
+      }
+
+      super.startRegularSolver(node)
+      return
+    }
+
+    this.applyRemoteResultToRegularNode(node, result)
+  }
+
+  private applyRemoteResultToRegularNode(
+    node: NodeWithPortPoints,
+    result: RemoteNodeResult,
+  ): void {
+    if (result.kind === "local-fallback") {
+      super.startRegularSolver(node)
+      return
+    }
+
+    this.stats.regularNodeCount = Number(this.stats.regularNodeCount ?? 0) + 1
+    this.activeNode = node
+    if (result.response.status === "failed") {
+      this.finishRegularSolverFailure(result.response.error)
+      return
+    }
+
+    this.finishActiveNode(result.response.routes)
+  }
+
+  override _step(): void {
+    if (!this.launchedRemoteSolves) {
+      this.launchedRemoteSolves = true
+      this.launchRemoteSolves()
+    }
+
+    if (this.waitingForRemoteNode) {
+      const node = this.waitingForRemoteNode
+      if (this.logicallyTimedOutNodes.has(node)) {
+        this.waitingForRemoteNode = null
+        this.pendingEffects = []
+        super.startRegularSolver(node)
+        return
+      }
+      const result = this.remoteResultByNode.get(node)
+      if (!result) return
+      this.waitingForRemoteNode = null
+      this.pendingEffects = []
+      this.applyRemoteResultToRegularNode(node, result)
+      return
+    }
+
+    super._step()
+  }
+}

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-types.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-types.ts
@@ -1,0 +1,52 @@
+import type {
+  HighDensityIntraNodeRoute,
+  NodeWithPortPoints,
+} from "../../types/high-density-types"
+import type { Obstacle } from "../../types/srj-types"
+
+export type Pipeline9NetworkedCacheSource = "cache" | "solver"
+
+/**
+ * Every solution-affecting input for Pipeline9's ordinary single-node
+ * high-density solver. The shape is JSON-serializable so the exact same helper
+ * can run in the cache service.
+ */
+export type Pipeline9NetworkedHighDensityNodeInput = {
+  nodeWithPortPoints: NodeWithPortPoints
+  connectivityNetMap: Record<string, string[]>
+  colorMap: Record<string, string>
+  viaDiameter: number
+  traceWidth: number
+  obstacleMargin: number
+  effort: 1
+  obstacles: Obstacle[]
+  layerCount: number
+  nodePf: number | null
+}
+
+export type Pipeline9NetworkedHighDensityNodeOutput =
+  | {
+      status: "solved"
+      routes: HighDensityIntraNodeRoute[]
+    }
+  | {
+      status: "failed"
+      error: string
+    }
+
+export type Pipeline9NetworkedSolveRequest = {
+  autorouterVersion: string
+  input: Pipeline9NetworkedHighDensityNodeInput
+}
+
+export type Pipeline9NetworkedSolveResponse =
+  | ({
+      ok: true
+      autorouterVersion: string
+      source: Pipeline9NetworkedCacheSource
+    } & Pipeline9NetworkedHighDensityNodeOutput)
+  | {
+      ok: false
+      autorouterVersion?: string
+      message: string
+    }

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/solve-pipeline9-networked-high-density-node.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/solve-pipeline9-networked-high-density-node.ts
@@ -1,0 +1,57 @@
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { HighDensitySolver } from "../../solvers/HighDensitySolver/HighDensitySolver"
+import { normalizePipeline9NodeRootConnectionNames } from "../AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-high-density-solver"
+import type {
+  Pipeline9NetworkedHighDensityNodeInput,
+  Pipeline9NetworkedHighDensityNodeOutput,
+} from "./pipeline9-networked-types"
+
+/**
+ * Runs the exact ordinary-node solver used by Pipeline9. hd-cache2 calls this
+ * exported helper so a cache entry can only be produced by its installed
+ * autorouter implementation.
+ */
+export function solvePipeline9NetworkedHighDensityNode(
+  input: Pipeline9NetworkedHighDensityNodeInput,
+): Pipeline9NetworkedHighDensityNodeOutput {
+  if (input.effort !== 1) {
+    throw new Error(
+      `Pipeline9 networked high-density solving requires effort=1, received ${input.effort}`,
+    )
+  }
+
+  const connMap = new ConnectivityMap(input.connectivityNetMap)
+  const solver = new HighDensitySolver({
+    nodePortPoints: [
+      normalizePipeline9NodeRootConnectionNames(
+        input.nodeWithPortPoints,
+        connMap,
+      ),
+    ],
+    colorMap: input.colorMap,
+    connMap,
+    viaDiameter: input.viaDiameter,
+    traceWidth: input.traceWidth,
+    obstacleMargin: input.obstacleMargin,
+    effort: input.effort,
+    nodePfById: {
+      [input.nodeWithPortPoints.capacityMeshNodeId]: input.nodePf,
+    },
+    obstacles: input.obstacles,
+    layerCount: input.layerCount,
+    useGrowShrinkHighDensityIntraNodeSolver: true,
+    preserveTerminalPcbPortIds: false,
+    growShrinkFallbackToInvalidGeometryOnFailure: false,
+    captureSearchDebug: false,
+  })
+
+  solver.solve()
+  if (solver.solved) {
+    return { status: "solved", routes: solver.routes }
+  }
+
+  return {
+    status: "failed",
+    error: solver.error ?? "Pipeline9 ordinary high-density solver failed",
+  }
+}

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-high-density-solver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-high-density-solver.ts
@@ -6,7 +6,7 @@ import {
   type HighDensityRouteObstacle,
   type NodeWithPortPoints as B01NodeWithPortPoints,
 } from "@tscircuit/high-density-b01"
-import type { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
 import type { GraphicsObject } from "graphics-debug"
 import type { CapacityMeshNodeId } from "lib/types/capacity-mesh-types"
 import type {
@@ -30,8 +30,9 @@ import {
   spliceFixedRouteSectionWithMutationMask,
 } from "./pipeline9-regional-fallback"
 import { Pipeline9RegionalFallbackSolver } from "./pipeline9-regional-fallback-solver"
+import { projectPipeline9OrdinaryHighDensityInput } from "./project-pipeline9-ordinary-high-density-input"
 
-type Pipeline9HighDensitySolverParams = {
+export type Pipeline9HighDensitySolverParams = {
   nodePortPoints: NodeWithPortPoints[]
   fixedHdRoutes: PreloadedHighDensityRoute[]
   connMap: ConnectivityMap
@@ -278,7 +279,7 @@ const addTerminalPcbPortIds = (
   })
 }
 
-const normalizeNodeRootConnectionNames = (
+export const normalizePipeline9NodeRootConnectionNames = (
   node: NodeWithPortPoints,
   connMap: ConnectivityMap,
 ): NodeWithPortPoints => {
@@ -406,7 +407,7 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
     })
   }
 
-  private finishActiveNode(routes: HighDensityIntraNodeRoute[]) {
+  protected finishActiveNode(routes: HighDensityIntraNodeRoute[]): void {
     const solvedRoutes = this.activeNode
       ? restoreRootConnectionNames(routes, this.activeNode)
       : routes
@@ -426,18 +427,32 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
     this.activeNode = null
   }
 
-  private startRegularSolver(node: NodeWithPortPoints): void {
+  protected startRegularSolver(node: NodeWithPortPoints): void {
+    const projectedInput = projectPipeline9OrdinaryHighDensityInput({
+      nodeWithPortPoints: node,
+      connMap: this.connMap,
+      colorMap: this.colorMap,
+      obstacles: this.obstacles,
+      obstacleMargin: this.obstacleMargin,
+      traceWidth: this.traceWidth,
+      viaDiameter: this.viaDiameter,
+    })
+    const projectedConnMap = new ConnectivityMap(
+      projectedInput.connectivityNetMap,
+    )
     this.activeNode = node
     this.activeRegularSolver = new HighDensitySolver({
-      nodePortPoints: [normalizeNodeRootConnectionNames(node, this.connMap)],
-      colorMap: this.colorMap,
-      connMap: this.connMap,
+      nodePortPoints: [
+        normalizePipeline9NodeRootConnectionNames(node, projectedConnMap),
+      ],
+      colorMap: projectedInput.colorMap,
+      connMap: projectedConnMap,
       viaDiameter: this.viaDiameter,
       traceWidth: this.traceWidth,
       obstacleMargin: this.obstacleMargin,
       effort: this.effort,
       nodePfById: this.nodePfById,
-      obstacles: this.obstacles,
+      obstacles: projectedInput.obstacles,
       layerCount: this.layerCount,
       useGrowShrinkHighDensityIntraNodeSolver: true,
       preserveTerminalPcbPortIds: false,
@@ -447,7 +462,7 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
     this.stats.regularNodeCount = Number(this.stats.regularNodeCount ?? 0) + 1
   }
 
-  private startRegionalFallback(
+  protected startRegionalFallback(
     promotedFixedRouteConnectionNames: ReadonlySet<string> = new Set(),
   ): void {
     if (!this.activeNode) {
@@ -456,7 +471,7 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
       )
     }
 
-    const normalizedNode = normalizeNodeRootConnectionNames(
+    const normalizedNode = normalizePipeline9NodeRootConnectionNames(
       this.activeNode,
       this.connMap,
     )
@@ -738,7 +753,10 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
     // future fallback never has to replay this node's now-stale bounds.
     const postSpliceProblem = createRegionalFallbackProblem(
       {
-        ...normalizeNodeRootConnectionNames(this.activeNode, this.connMap),
+        ...normalizePipeline9NodeRootConnectionNames(
+          this.activeNode,
+          this.connMap,
+        ),
         portPoints: [],
         portPointsInPairs: [],
         availableZ: Array.from({ length: this.layerCount }, (_, z) => z),
@@ -837,6 +855,18 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
       Number(regionalStats.repairCandidateRejectionCount ?? 0)
   }
 
+  protected finishRegularSolverFailure(error: string): void {
+    this.activeFallbackReason = `regular high-density routing failed: ${error}`
+    this.activeRegularSolver = null
+    if (!this.enableRegionalFallback) {
+      this.error = `Pipeline9 ${this.activeFallbackReason}`
+      this.failed = true
+      this.activeNode = null
+      return
+    }
+    this.startRegionalFallback()
+  }
+
   override _step(): void {
     if (this.activeFallbackSolver) {
       this.activeFallbackSolver.step()
@@ -863,15 +893,9 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
     if (this.activeRegularSolver) {
       this.activeRegularSolver.step()
       if (this.activeRegularSolver.failed) {
-        this.activeFallbackReason = `regular high-density routing failed: ${this.activeRegularSolver.error ?? "unknown error"}`
-        this.activeRegularSolver = null
-        if (!this.enableRegionalFallback) {
-          this.error = `Pipeline9 ${this.activeFallbackReason}`
-          this.failed = true
-          this.activeNode = null
-          return
-        }
-        this.startRegionalFallback()
+        this.finishRegularSolverFailure(
+          this.activeRegularSolver.error ?? "unknown error",
+        )
         return
       }
       if (!this.activeRegularSolver.solved) return
@@ -945,7 +969,10 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
       return
     }
 
-    const normalizedNode = normalizeNodeRootConnectionNames(node, this.connMap)
+    const normalizedNode = normalizePipeline9NodeRootConnectionNames(
+      node,
+      this.connMap,
+    )
     this.stats.b01NodeCount = Number(this.stats.b01NodeCount ?? 0) + 1
     this.activeB01Solver = new HighDensitySolverB01({
       ...defaultB01Params,

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/project-pipeline9-ordinary-high-density-input.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/project-pipeline9-ordinary-high-density-input.ts
@@ -1,0 +1,180 @@
+import type { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { DEFAULT_MAX_GROWTH_ATTEMPTS } from "lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver"
+import type {
+  NodeWithPortPoints,
+  PortPoint,
+} from "lib/types/high-density-types"
+import type { Obstacle } from "lib/types/srj-types"
+import { getBoundsFromNodeWithPortPoints } from "lib/utils/getBoundsFromNodeWithPortPoints"
+
+const MAX_PIPELINE9_ORDINARY_NODE_SCALE =
+  2 ** DEFAULT_MAX_GROWTH_ATTEMPTS
+const OBSTACLE_OVERLAP_TOLERANCE = 1e-6
+
+export type Pipeline9OrdinaryHighDensityProjection = {
+  connectivityNetMap: Record<string, string[]>
+  colorMap: Record<string, string>
+  obstacles: Obstacle[]
+}
+
+/**
+ * Reduces board-wide inputs to the information Pipeline9's ordinary node
+ * solver can observe. The overlap envelope covers all 1x/2x/4x/8x
+ * grow-shrink attempts and both the rotated geometry and the through-obstacle
+ * solver's intentionally unrotated containment check.
+ */
+export function projectPipeline9OrdinaryHighDensityInput({
+  nodeWithPortPoints,
+  connMap,
+  colorMap,
+  obstacles,
+  obstacleMargin,
+  traceWidth,
+  viaDiameter,
+}: {
+  nodeWithPortPoints: NodeWithPortPoints
+  connMap: ConnectivityMap
+  colorMap?: Record<string, string>
+  obstacles: Obstacle[]
+  obstacleMargin: number
+  traceWidth: number
+  viaDiameter: number
+}): Pipeline9OrdinaryHighDensityProjection {
+  const nodeBounds = getBoundsFromNodeWithPortPoints(nodeWithPortPoints)
+  const clearance =
+    obstacleMargin +
+    Math.max(traceWidth, viaDiameter) / 2 +
+    OBSTACLE_OVERLAP_TOLERANCE
+  const grownNodeBounds = {
+    minX:
+      nodeWithPortPoints.center.x +
+      (nodeBounds.minX - nodeWithPortPoints.center.x) *
+        MAX_PIPELINE9_ORDINARY_NODE_SCALE -
+      clearance,
+    maxX:
+      nodeWithPortPoints.center.x +
+      (nodeBounds.maxX - nodeWithPortPoints.center.x) *
+        MAX_PIPELINE9_ORDINARY_NODE_SCALE +
+      clearance,
+    minY:
+      nodeWithPortPoints.center.y +
+      (nodeBounds.minY - nodeWithPortPoints.center.y) *
+        MAX_PIPELINE9_ORDINARY_NODE_SCALE -
+      clearance,
+    maxY:
+      nodeWithPortPoints.center.y +
+      (nodeBounds.maxY - nodeWithPortPoints.center.y) *
+        MAX_PIPELINE9_ORDINARY_NODE_SCALE +
+      clearance,
+  }
+  const nodeConnectionNames = [
+    ...new Set(
+      nodeWithPortPoints.portPoints.map(
+        (portPoint) => portPoint.connectionName,
+      ),
+    ),
+  ]
+
+  const projectedObstacles = obstacles.flatMap((obstacle) => {
+    const rotationRadians =
+      ((obstacle.ccwRotationDegrees ?? 0) * Math.PI) / 180
+    const cos = Math.abs(Math.cos(rotationRadians))
+    const sin = Math.abs(Math.sin(rotationRadians))
+    const rawHalfWidth = obstacle.width / 2
+    const rawHalfHeight = obstacle.height / 2
+    const halfWidth = Math.max(
+      rawHalfWidth,
+      rawHalfWidth * cos + rawHalfHeight * sin,
+    )
+    const halfHeight = Math.max(
+      rawHalfHeight,
+      rawHalfWidth * sin + rawHalfHeight * cos,
+    )
+    const overlapsMaximumNodeEnvelope =
+      obstacle.center.x - halfWidth <= grownNodeBounds.maxX &&
+      obstacle.center.x + halfWidth >= grownNodeBounds.minX &&
+      obstacle.center.y - halfHeight <= grownNodeBounds.maxY &&
+      obstacle.center.y + halfHeight >= grownNodeBounds.minY
+    if (!overlapsMaximumNodeEnvelope) return []
+
+    const matchingConnectionNames = nodeConnectionNames.filter(
+      (connectionName) =>
+        obstacle.connectedTo.some(
+          (connectedId) =>
+            connectedId === connectionName ||
+            connMap.areIdsConnected(connectionName, connectedId),
+        ),
+    )
+    if (matchingConnectionNames.length === 0) return []
+
+    return [
+      {
+        type: "rect" as const,
+        layers: obstacle.layers,
+        ...(obstacle.zLayers === undefined
+          ? {}
+          : { zLayers: obstacle.zLayers }),
+        ...(obstacle.__zLayers === undefined
+          ? {}
+          : { __zLayers: obstacle.__zLayers }),
+        center: obstacle.center,
+        width: obstacle.width,
+        height: obstacle.height,
+        connectedTo: matchingConnectionNames,
+        ...(obstacle.circuitJsonMetadata === undefined
+          ? {}
+          : { circuitJsonMetadata: obstacle.circuitJsonMetadata }),
+      },
+    ]
+  })
+
+  const relevantIds = new Set<string>()
+  const addPortPointIds = (portPoint: PortPoint): void => {
+    for (const id of [
+      portPoint.connectionName,
+      portPoint.rootConnectionName,
+      portPoint.portPointId,
+      portPoint.pcb_port_id,
+      portPoint.prevPortPointId,
+      portPoint.nextPortPointId,
+    ]) {
+      if (id !== undefined) relevantIds.add(id)
+    }
+  }
+  for (const portPoint of nodeWithPortPoints.portPoints) {
+    addPortPointIds(portPoint)
+  }
+  for (const pair of nodeWithPortPoints.portPointsInPairs ?? []) {
+    addPortPointIds(pair[0])
+    addPortPointIds(pair[1])
+  }
+  for (const obstacle of projectedObstacles) {
+    for (const id of [
+      obstacle.circuitJsonMetadata?.pcb_smtpad_id,
+      obstacle.circuitJsonMetadata?.pcb_plated_hole_id,
+      obstacle.circuitJsonMetadata?.pcb_port_id,
+      obstacle.circuitJsonMetadata?.pcb_via_id,
+      ...(obstacle.connectedTo ?? []),
+    ]) {
+      if (id !== undefined) relevantIds.add(id)
+    }
+  }
+
+  const connectivityNetMap = Object.fromEntries(
+    Object.entries(connMap.netMap).flatMap(([netId, ids]) => {
+      const relevantConnectedIds = ids.filter((id) => relevantIds.has(id))
+      return relevantConnectedIds.length > 0 || relevantIds.has(netId)
+        ? [[netId, relevantConnectedIds]]
+        : []
+    }),
+  )
+  const projectedColorMap = Object.fromEntries(
+    Object.entries(colorMap ?? {}).filter(([id]) => relevantIds.has(id)),
+  )
+
+  return {
+    connectivityNetMap,
+    colorMap: projectedColorMap,
+    obstacles: projectedObstacles,
+  }
+}

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/project-pipeline9-ordinary-high-density-input.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/project-pipeline9-ordinary-high-density-input.ts
@@ -7,8 +7,7 @@ import type {
 import type { Obstacle } from "lib/types/srj-types"
 import { getBoundsFromNodeWithPortPoints } from "lib/utils/getBoundsFromNodeWithPortPoints"
 
-const MAX_PIPELINE9_ORDINARY_NODE_SCALE =
-  2 ** DEFAULT_MAX_GROWTH_ATTEMPTS
+const MAX_PIPELINE9_ORDINARY_NODE_SCALE = 2 ** DEFAULT_MAX_GROWTH_ATTEMPTS
 const OBSTACLE_OVERLAP_TOLERANCE = 1e-6
 
 export type Pipeline9OrdinaryHighDensityProjection = {
@@ -76,8 +75,7 @@ export function projectPipeline9OrdinaryHighDensityInput({
   ]
 
   const projectedObstacles = obstacles.flatMap((obstacle) => {
-    const rotationRadians =
-      ((obstacle.ccwRotationDegrees ?? 0) * Math.PI) / 180
+    const rotationRadians = ((obstacle.ccwRotationDegrees ?? 0) * Math.PI) / 180
     const cos = Math.abs(Math.cos(rotationRadians))
     const sin = Math.abs(Math.sin(rotationRadians))
     const rawHalfWidth = obstacle.width / 2

--- a/lib/autorouter-pipelines/index.ts
+++ b/lib/autorouter-pipelines/index.ts
@@ -22,4 +22,8 @@ export {
 } from "./AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph"
 export { AutoroutingPipelineSolver8 } from "./AutoroutingPipeline8/AutoroutingPipelineSolver8"
 export { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "./AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph"
+export {
+  AutoroutingPipelineSolver9_Networked,
+  type AutoroutingPipelineSolver9NetworkedOptions,
+} from "./AutoroutingPipeline9_Networked/autorouting-pipeline-solver9-networked"
 export { AutoroutingPipelineSolver10_BgaFanout } from "./AutoroutingPipeline10_BgaFanout/AutoroutingPipelineSolver10_BgaFanout"

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -24,6 +24,24 @@ export {
 } from "./autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph"
 export { AutoroutingPipelineSolver8 } from "./autorouter-pipelines/AutoroutingPipeline8/AutoroutingPipelineSolver8"
 export { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "./autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph"
+export {
+  AutoroutingPipelineSolver9_Networked,
+  type AutoroutingPipelineSolver9NetworkedOptions,
+} from "./autorouter-pipelines/AutoroutingPipeline9_Networked/autorouting-pipeline-solver9-networked"
+export { AUTOROUTER_VERSION } from "./autorouter-pipelines/AutoroutingPipeline9_Networked/autorouter-version"
+export {
+  DEFAULT_PIPELINE9_NETWORKED_CACHE_URL,
+  DEFAULT_PIPELINE9_NETWORKED_TIMEOUT_MS,
+  DEFAULT_PIPELINE9_NETWORKED_TRANSPORT_TIMEOUT_MS,
+} from "./autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-high-density-solver"
+export type {
+  Pipeline9NetworkedCacheSource,
+  Pipeline9NetworkedHighDensityNodeInput,
+  Pipeline9NetworkedHighDensityNodeOutput,
+  Pipeline9NetworkedSolveRequest,
+  Pipeline9NetworkedSolveResponse,
+} from "./autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-types"
+export { solvePipeline9NetworkedHighDensityNode } from "./autorouter-pipelines/AutoroutingPipeline9_Networked/solve-pipeline9-networked-high-density-node"
 export { AutoroutingPipelineSolver10_BgaFanout } from "./autorouter-pipelines/AutoroutingPipeline10_BgaFanout/AutoroutingPipelineSolver10_BgaFanout"
 export { PolyHighDensitySolver } from "./autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/PolyHighDensitySolver"
 export { PolySingleIntraNodeSolver } from "./autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/PolySingleIntraNodeSolver"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "start": "cosmos",
     "build": "tsup ./lib/index.ts --minify terser --external @tscircuit/core --external circuit-to-svg --format esm --dts --sourcemap",
+    "prepack": "bun run build",
     "bench": "bun test tests/spatial-index-bench.test.ts",
     "format": "biome format --write .",
     "format:check": "biome format .",

--- a/tests/features/pipeline9-networked-background-request.test.ts
+++ b/tests/features/pipeline9-networked-background-request.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "bun:test"
+import type { Pipeline9NetworkedSolveRequest } from "lib"
+import {
+  asNetworkedFetch,
+  createDeferred,
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+  createNetworkedRoute,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9 falls back logically while a late cache request finishes in the background", async () => {
+  const node = createNetworkedNode({
+    nodeId: "cmn_background_request",
+    connectionName: "A",
+  })
+  const releaseResponse = createDeferred<Response>()
+  const responseBodyRead = createDeferred<void>()
+  const requestStarted = createDeferred<AbortSignal>()
+  const solver = createNetworkedHighDensitySolver({
+    nodes: [node],
+    requestTimeoutMs: 5,
+    transportTimeoutMs: 1_000,
+    fetchImpl: asNetworkedFetch(async (_url, init) => {
+      requestStarted.resolve(init?.signal as AbortSignal)
+      const request = JSON.parse(
+        String(init?.body),
+      ) as Pipeline9NetworkedSolveRequest
+      await releaseResponse.promise
+      return {
+        ok: true,
+        status: 200,
+        text: async () => {
+          responseBodyRead.resolve()
+          return JSON.stringify({
+            ok: true,
+            autorouterVersion: request.autorouterVersion,
+            source: "solver",
+            status: "solved",
+            routes: [createNetworkedRoute(request.input.nodeWithPortPoints)],
+          })
+        },
+      } as Response
+    }),
+  })
+
+  solver.step()
+  const requestSignal = await requestStarted.promise
+  await solver.pendingEffects![0]!.promise
+  expect(requestSignal.aborted).toBeFalse()
+
+  solver.step()
+  expect(solver.activeRegularSolver).not.toBeNull()
+  expect(solver.stats.remoteTransportFallbacks).toBe(1)
+
+  releaseResponse.resolve(new Response())
+  await responseBodyRead.promise
+  await Promise.resolve()
+  expect(requestSignal.aborted).toBeFalse()
+})

--- a/tests/features/pipeline9-networked-cached-failure.test.ts
+++ b/tests/features/pipeline9-networked-cached-failure.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test"
+import {
+  asNetworkedFetch,
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+  createNetworkedResponse,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9 networked treats a cached solver failure like an ordinary local solver failure", async () => {
+  const node = createNetworkedNode({
+    nodeId: "cmn_cached_failure",
+    connectionName: "A",
+  })
+  const solver = createNetworkedHighDensitySolver({
+    nodes: [node],
+    fetchImpl: asNetworkedFetch(async () =>
+      createNetworkedResponse({
+        status: "failed",
+        error: "deterministically unsolved",
+      }),
+    ),
+    enableRegionalFallback: false,
+  })
+
+  solver.step()
+  await solver.pendingEffects![0]!.promise
+  solver.step()
+
+  expect(solver.failed).toBeTrue()
+  expect(solver.activeRegularSolver).toBeNull()
+  expect(solver.error).toContain(
+    "regular high-density routing failed: deterministically unsolved",
+  )
+  expect(solver.stats.remoteFailedResults).toBe(1)
+  expect(solver.stats.remoteTransportFallbacks).toBe(0)
+})

--- a/tests/features/pipeline9-networked-delayed-node-result.test.ts
+++ b/tests/features/pipeline9-networked-delayed-node-result.test.ts
@@ -1,0 +1,66 @@
+import { expect, test } from "bun:test"
+import type { Pipeline9NetworkedSolveRequest } from "lib"
+import {
+  asNetworkedFetch,
+  createDeferred,
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+  createNetworkedResponse,
+  createNetworkedRoute,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9 uses a speculative result that finishes before its node is consumed", async () => {
+  const delayedNode = createNetworkedNode({
+    nodeId: "cmn_delayed_result",
+    connectionName: "delayed",
+    xOffset: -5,
+  })
+  const currentNode = createNetworkedNode({
+    nodeId: "cmn_current_result",
+    connectionName: "current",
+    xOffset: 5,
+  })
+  const releaseDelayedResponse = createDeferred<void>()
+  const delayedResponseFinished = createDeferred<void>()
+  const solver = createNetworkedHighDensitySolver({
+    nodes: [delayedNode, currentNode],
+    requestTimeoutMs: 5,
+    transportTimeoutMs: 1_000,
+    fetchImpl: asNetworkedFetch(async (_url, init) => {
+      const request = JSON.parse(
+        String(init?.body),
+      ) as Pipeline9NetworkedSolveRequest
+      if (
+        request.input.nodeWithPortPoints.capacityMeshNodeId ===
+        delayedNode.capacityMeshNodeId
+      ) {
+        await releaseDelayedResponse.promise
+        delayedResponseFinished.resolve()
+      }
+      return createNetworkedResponse({
+        status: "solved",
+        routes: [createNetworkedRoute(request.input.nodeWithPortPoints)],
+      })
+    }),
+  })
+
+  solver.step()
+  await solver.pendingEffects![0]!.promise
+  await new Promise((resolve) => setTimeout(resolve, 15))
+  releaseDelayedResponse.resolve()
+  await delayedResponseFinished.promise
+  while (solver.stats.remoteRequestsCompleted < 2) {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+
+  solver.step()
+  solver.step()
+
+  expect(solver.activeRegularSolver).toBeNull()
+  expect(solver.routes.map((route) => route.connectionName)).toEqual([
+    "current",
+    "delayed",
+  ])
+  expect(solver.stats.remoteSolvedResults).toBe(2)
+  expect(solver.stats.remoteLogicalTimeoutFallbacks).toBe(0)
+})

--- a/tests/features/pipeline9-networked-fail-open.test.ts
+++ b/tests/features/pipeline9-networked-fail-open.test.ts
@@ -39,10 +39,11 @@ test("Pipeline9 networked falls back locally for transport and invalid protocol 
     },
     {
       name: "HTTP error",
-      fetchImpl: asNetworkedFetch(async () =>
-        new Response(JSON.stringify({ ok: false, message: "unavailable" }), {
-          status: 503,
-        }),
+      fetchImpl: asNetworkedFetch(
+        async () =>
+          new Response(JSON.stringify({ ok: false, message: "unavailable" }), {
+            status: 503,
+          }),
       ),
     },
     {
@@ -57,17 +58,18 @@ test("Pipeline9 networked falls back locally for transport and invalid protocol 
     },
     {
       name: "malformed solved routes",
-      fetchImpl: asNetworkedFetch(async () =>
-        new Response(
-          JSON.stringify({
-            ok: true,
-            autorouterVersion: AUTOROUTER_VERSION,
-            source: "cache",
-            status: "solved",
-            routes: [{}],
-          }),
-          { status: 200 },
-        ),
+      fetchImpl: asNetworkedFetch(
+        async () =>
+          new Response(
+            JSON.stringify({
+              ok: true,
+              autorouterVersion: AUTOROUTER_VERSION,
+              source: "cache",
+              status: "solved",
+              routes: [{}],
+            }),
+            { status: 200 },
+          ),
       ),
     },
     {
@@ -125,9 +127,7 @@ test("Pipeline9 networked falls back locally for transport and invalid protocol 
     {
       name: "timeout",
       requestTimeoutMs: 5,
-      fetchImpl: asNetworkedFetch(
-        async () => new Promise<Response>(() => {}),
-      ),
+      fetchImpl: asNetworkedFetch(async () => new Promise<Response>(() => {})),
     },
   ]
 

--- a/tests/features/pipeline9-networked-fail-open.test.ts
+++ b/tests/features/pipeline9-networked-fail-open.test.ts
@@ -1,0 +1,185 @@
+import { expect, test } from "bun:test"
+import { AUTOROUTER_VERSION } from "lib"
+import type { Pipeline9NetworkedSolveRequest } from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-types"
+import type { HighDensityIntraNodeRoute } from "lib/types/high-density-types"
+import {
+  asNetworkedFetch,
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+  createNetworkedResponse,
+  createNetworkedRoute,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+const createMalformedRouteFetch = (
+  mutateRoute: (
+    route: HighDensityIntraNodeRoute,
+    request: Pipeline9NetworkedSolveRequest,
+  ) => void,
+): typeof fetch =>
+  asNetworkedFetch(async (_input, init) => {
+    const request = JSON.parse(
+      String(init?.body),
+    ) as Pipeline9NetworkedSolveRequest
+    const route = createNetworkedRoute(request.input.nodeWithPortPoints)
+    mutateRoute(route, request)
+    return createNetworkedResponse({ status: "solved", routes: [route] })
+  })
+
+test("Pipeline9 networked falls back locally for transport and invalid protocol results", async () => {
+  const cases: Array<{
+    name: string
+    requestTimeoutMs?: number
+    fetchImpl: typeof fetch
+  }> = [
+    {
+      name: "transport error",
+      fetchImpl: asNetworkedFetch(async () => {
+        throw new Error("offline")
+      }),
+    },
+    {
+      name: "HTTP error",
+      fetchImpl: asNetworkedFetch(async () =>
+        new Response(JSON.stringify({ ok: false, message: "unavailable" }), {
+          status: 503,
+        }),
+      ),
+    },
+    {
+      name: "version mismatch",
+      fetchImpl: asNetworkedFetch(async () =>
+        createNetworkedResponse({
+          autorouterVersion: "0.0.0-mismatch",
+          status: "failed",
+          error: "wrong solver version",
+        }),
+      ),
+    },
+    {
+      name: "malformed solved routes",
+      fetchImpl: asNetworkedFetch(async () =>
+        new Response(
+          JSON.stringify({
+            ok: true,
+            autorouterVersion: AUTOROUTER_VERSION,
+            source: "cache",
+            status: "solved",
+            routes: [{}],
+          }),
+          { status: 200 },
+        ),
+      ),
+    },
+    {
+      name: "foreign route connection",
+      fetchImpl: createMalformedRouteFetch((route) => {
+        route.connectionName = "foreign_connection"
+      }),
+    },
+    {
+      name: "out of range route layer",
+      fetchImpl: createMalformedRouteFetch((route, request) => {
+        route.route[0]!.z = request.input.layerCount
+      }),
+    },
+    {
+      name: "mismatched route trace width",
+      fetchImpl: createMalformedRouteFetch((route, request) => {
+        route.traceThickness = request.input.traceWidth + 0.05
+      }),
+    },
+    {
+      name: "mismatched route via diameter",
+      fetchImpl: createMalformedRouteFetch((route, request) => {
+        route.viaDiameter = request.input.viaDiameter + 0.05
+      }),
+    },
+    {
+      name: "non endpoint route",
+      fetchImpl: createMalformedRouteFetch((route) => {
+        route.route[0]!.x += 0.01
+      }),
+    },
+    {
+      name: "array route metadata",
+      fetchImpl: createMalformedRouteFetch((route) => {
+        route.route[0]!.toNextSegmentCircuitJsonMetadata = [] as never
+      }),
+    },
+    {
+      name: "unknown route metadata field",
+      fetchImpl: createMalformedRouteFetch((route) => {
+        route.route[0]!.toNextSegmentCircuitJsonMetadata = {
+          unknown_id: "unknown",
+        } as never
+      }),
+    },
+    {
+      name: "non string route metadata value",
+      fetchImpl: createMalformedRouteFetch((route) => {
+        route.route[0]!.toNextSegmentCircuitJsonMetadata = {
+          pcb_port_id: 123,
+        } as never
+      }),
+    },
+    {
+      name: "timeout",
+      requestTimeoutMs: 5,
+      fetchImpl: asNetworkedFetch(
+        async () => new Promise<Response>(() => {}),
+      ),
+    },
+  ]
+
+  for (const testCase of cases) {
+    const node = createNetworkedNode({
+      nodeId: `cmn_${testCase.name.replaceAll(" ", "_")}`,
+      connectionName: "A",
+    })
+    const solver = createNetworkedHighDensitySolver({
+      nodes: [node],
+      fetchImpl: testCase.fetchImpl,
+      requestTimeoutMs: testCase.requestTimeoutMs,
+    })
+
+    solver.step()
+    expect(solver.pendingEffects, testCase.name).toHaveLength(1)
+    await solver.pendingEffects![0]!.promise
+    solver.step()
+
+    expect(solver.activeRegularSolver, testCase.name).not.toBeNull()
+    expect(solver.failed, testCase.name).toBeFalse()
+    expect(solver.stats.remoteTransportFallbacks, testCase.name).toBe(1)
+  }
+
+  const validMetadataNode = createNetworkedNode({
+    nodeId: "cmn_valid_metadata",
+    connectionName: "valid_metadata",
+  })
+  const validMetadataSolver = createNetworkedHighDensitySolver({
+    nodes: [validMetadataNode],
+    fetchImpl: asNetworkedFetch(async () => {
+      const route = createNetworkedRoute(validMetadataNode)
+      route.route[0] = {
+        ...route.route[0]!,
+        toNextSegmentType: "through_obstacle",
+        toNextSegmentCircuitJsonMetadata: {
+          pcb_smtpad_id: "smtpad_1",
+          pcb_plated_hole_id: "plated_hole_1",
+          pcb_port_id: "port_1",
+          pcb_via_id: "via_1",
+          source_component_name: "U1",
+          source_port_name: "A1",
+        },
+      }
+      return createNetworkedResponse({ status: "solved", routes: [route] })
+    }),
+  })
+
+  validMetadataSolver.step()
+  await validMetadataSolver.pendingEffects![0]!.promise
+  validMetadataSolver.step()
+
+  expect(validMetadataSolver.routes).toHaveLength(1)
+  expect(validMetadataSolver.stats.remoteTransportFallbacks).toBe(0)
+})

--- a/tests/features/pipeline9-networked-fixed-node-does-not-block.test.ts
+++ b/tests/features/pipeline9-networked-fixed-node-does-not-block.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test"
+import {
+  asNetworkedFetch,
+  createDeferred,
+  createNetworkedFixedRoute,
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+  createNetworkedResponse,
+  createNetworkedRoute,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9 networked does not await a speculative fixed-copper node request", async () => {
+  const node = createNetworkedNode({
+    nodeId: "cmn_fixed_overlap",
+    connectionName: "A",
+  })
+  const deferredResponse = createDeferred<Response>()
+  let fetchCallCount = 0
+  const solver = createNetworkedHighDensitySolver({
+    nodes: [node],
+    fixedHdRoutes: [createNetworkedFixedRoute()],
+    fetchImpl: asNetworkedFetch(async () => {
+      fetchCallCount += 1
+      return deferredResponse.promise
+    }),
+  })
+
+  solver.step()
+
+  expect(fetchCallCount).toBe(1)
+  expect(solver.pendingEffects).toEqual([])
+  expect(solver.activeB01Solver).not.toBeNull()
+  const b01Solver = solver.activeB01Solver!
+  const b01IterationsBefore = b01Solver.iterations
+  solver.step()
+  expect(b01Solver.iterations).toBeGreaterThan(b01IterationsBefore)
+
+  deferredResponse.resolve(
+    createNetworkedResponse({
+      status: "solved",
+      routes: [createNetworkedRoute(node)],
+    }),
+  )
+  await Promise.resolve()
+  expect(solver.routes).toEqual([])
+})

--- a/tests/features/pipeline9-networked-node-input-projection.test.ts
+++ b/tests/features/pipeline9-networked-node-input-projection.test.ts
@@ -1,0 +1,192 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import {
+  normalizePipeline9NodeRootConnectionNames,
+  Pipeline9HighDensitySolver,
+} from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-high-density-solver"
+import { projectPipeline9OrdinaryHighDensityInput } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/project-pipeline9-ordinary-high-density-input"
+import { solvePipeline9NetworkedHighDensityNode } from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/solve-pipeline9-networked-high-density-node"
+import { HighDensitySolver } from "lib/solvers/HighDensitySolver/HighDensitySolver"
+import type { NodeWithPortPoints } from "lib/types/high-density-types"
+import type { Obstacle } from "lib/types/srj-types"
+
+test("Pipeline9 projects ordinary node obstacles and connectivity without changing the solve", () => {
+  const noiseIds = Array.from({ length: 2_310 }, (_, index) => `noise_${index}`)
+  const node: NodeWithPortPoints = {
+    capacityMeshNodeId: "cmn_projected",
+    center: { x: 0, y: 0 },
+    width: 1,
+    height: 1,
+    availableZ: [0, 1],
+    portPoints: [
+      {
+        x: -0.2,
+        y: 0,
+        z: 0,
+        connectionName: "route_A",
+        rootConnectionName: "root_A",
+        portPointId: "port_point_A0",
+      },
+      {
+        x: 0.2,
+        y: 0,
+        z: 1,
+        connectionName: "route_A",
+        rootConnectionName: "root_A",
+        portPointId: "port_point_A1",
+      },
+    ],
+  }
+  const connectedToWithBoardNoise = ["pcb_pad_A", ...noiseIds]
+  const obstacles: Obstacle[] = [
+    {
+      obstacleId: "near_rotated_through_obstacle",
+      type: "rect",
+      layers: ["top", "bottom"],
+      center: { x: 0, y: 0 },
+      width: 0.6,
+      height: 0.1,
+      ccwRotationDegrees: 90,
+      connectedTo: connectedToWithBoardNoise,
+      circuitJsonMetadata: { pcb_plated_hole_id: "plated_hole_A" },
+    },
+    {
+      obstacleId: "eight_x_envelope_obstacle",
+      type: "rect",
+      layers: ["top", "bottom"],
+      center: { x: 3.9, y: 0 },
+      width: 0.2,
+      height: 0.2,
+      connectedTo: connectedToWithBoardNoise,
+    },
+    {
+      obstacleId: "overlapping_foreign_obstacle",
+      type: "rect",
+      layers: ["top", "bottom"],
+      center: { x: 0, y: 0 },
+      width: 1,
+      height: 1,
+      connectedTo: ["foreign_route"],
+    },
+    {
+      obstacleId: "far_same_net_obstacle",
+      type: "rect",
+      layers: ["top", "bottom"],
+      center: { x: 100, y: 100 },
+      width: 1,
+      height: 1,
+      connectedTo: connectedToWithBoardNoise,
+    },
+  ]
+  const connMap = new ConnectivityMap({
+    original_net_A: [
+      "route_A",
+      "root_A",
+      "pcb_pad_A",
+      "port_point_A0",
+      "port_point_A1",
+      "plated_hole_A",
+    ],
+    original_noise_net: noiseIds,
+    original_foreign_net: ["foreign_route"],
+  })
+  const projection = projectPipeline9OrdinaryHighDensityInput({
+    nodeWithPortPoints: node,
+    connMap,
+    colorMap: { route_A: "blue", foreign_route: "red" },
+    obstacles,
+    obstacleMargin: 0.15,
+    traceWidth: 0.15,
+    viaDiameter: 0.3,
+  })
+
+  expect(
+    projection.obstacles.map((obstacle) => obstacle.center),
+  ).toEqual([
+    { x: 0, y: 0 },
+    { x: 3.9, y: 0 },
+  ])
+  expect(
+    projection.obstacles.map((obstacle) => obstacle.connectedTo),
+  ).toEqual([["route_A"], ["route_A"]])
+  expect(projection.obstacles[0]!.ccwRotationDegrees).toBeUndefined()
+  expect(projection.obstacles[0]!.circuitJsonMetadata).toEqual({
+    pcb_plated_hole_id: "plated_hole_A",
+  })
+  expect(projection.connectivityNetMap).toEqual({
+    original_net_A: [
+      "route_A",
+      "root_A",
+      "port_point_A0",
+      "port_point_A1",
+      "plated_hole_A",
+    ],
+  })
+  expect(projection.colorMap).toEqual({ route_A: "blue" })
+
+  const unprojectedJsonSize = JSON.stringify({
+    node,
+    connectivityNetMap: connMap.netMap,
+    obstacles,
+  }).length
+  const projectedJsonSize = JSON.stringify({ node, ...projection }).length
+  expect(projectedJsonSize).toBeLessThan(unprojectedJsonSize / 20)
+
+  const fullInputSolver = new HighDensitySolver({
+    nodePortPoints: [normalizePipeline9NodeRootConnectionNames(node, connMap)],
+    connMap,
+    colorMap: { route_A: "blue", foreign_route: "red" },
+    obstacles,
+    layerCount: 2,
+    viaDiameter: 0.3,
+    traceWidth: 0.15,
+    obstacleMargin: 0.15,
+    effort: 1,
+    nodePfById: { cmn_projected: 0.1 },
+    useGrowShrinkHighDensityIntraNodeSolver: true,
+    preserveTerminalPcbPortIds: false,
+    growShrinkFallbackToInvalidGeometryOnFailure: false,
+    captureSearchDebug: false,
+  })
+  fullInputSolver.solve()
+  const projectedResult = solvePipeline9NetworkedHighDensityNode({
+    nodeWithPortPoints: node,
+    connectivityNetMap: projection.connectivityNetMap,
+    colorMap: projection.colorMap,
+    viaDiameter: 0.3,
+    traceWidth: 0.15,
+    obstacleMargin: 0.15,
+    effort: 1,
+    obstacles: projection.obstacles,
+    layerCount: 2,
+    nodePf: 0.1,
+  })
+
+  expect(fullInputSolver.solved).toBeTrue()
+  expect(projectedResult).toEqual({
+    status: "solved",
+    routes: fullInputSolver.routes,
+  })
+
+  const localPipeline9Solver = new Pipeline9HighDensitySolver({
+    nodePortPoints: [node],
+    fixedHdRoutes: [],
+    connMap,
+    colorMap: { route_A: "blue", foreign_route: "red" },
+    obstacles,
+    layerCount: 2,
+    viaDiameter: 0.3,
+    traceWidth: 0.15,
+    obstacleMargin: 0.15,
+    effort: 1,
+    nodePfById: { cmn_projected: 0.1 },
+    enableRegionalFallback: false,
+  })
+  localPipeline9Solver.step()
+  expect(localPipeline9Solver.activeRegularSolver?.obstacles).toEqual(
+    projection.obstacles,
+  )
+  expect(localPipeline9Solver.activeRegularSolver?.connMap?.netMap).toEqual(
+    projection.connectivityNetMap,
+  )
+})

--- a/tests/features/pipeline9-networked-node-input-projection.test.ts
+++ b/tests/features/pipeline9-networked-node-input-projection.test.ts
@@ -100,15 +100,14 @@ test("Pipeline9 projects ordinary node obstacles and connectivity without changi
     viaDiameter: 0.3,
   })
 
-  expect(
-    projection.obstacles.map((obstacle) => obstacle.center),
-  ).toEqual([
+  expect(projection.obstacles.map((obstacle) => obstacle.center)).toEqual([
     { x: 0, y: 0 },
     { x: 3.9, y: 0 },
   ])
-  expect(
-    projection.obstacles.map((obstacle) => obstacle.connectedTo),
-  ).toEqual([["route_A"], ["route_A"]])
+  expect(projection.obstacles.map((obstacle) => obstacle.connectedTo)).toEqual([
+    ["route_A"],
+    ["route_A"],
+  ])
   expect(projection.obstacles[0]!.ccwRotationDegrees).toBeUndefined()
   expect(projection.obstacles[0]!.circuitJsonMetadata).toEqual({
     pcb_plated_hole_id: "plated_hole_A",

--- a/tests/features/pipeline9-networked-parallel-node-requests.test.ts
+++ b/tests/features/pipeline9-networked-parallel-node-requests.test.ts
@@ -24,7 +24,9 @@ test("Pipeline9 networked launches every node request in parallel and preserves 
   const releaseRequests = createDeferred<void>()
   const requestBodies: Pipeline9NetworkedSolveRequest[] = []
   const fetchImpl = asNetworkedFetch(async (_input, init) => {
-    const request = JSON.parse(String(init?.body)) as Pipeline9NetworkedSolveRequest
+    const request = JSON.parse(
+      String(init?.body),
+    ) as Pipeline9NetworkedSolveRequest
     requestBodies.push(request)
     await releaseRequests.promise
     return createNetworkedResponse({

--- a/tests/features/pipeline9-networked-parallel-node-requests.test.ts
+++ b/tests/features/pipeline9-networked-parallel-node-requests.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "bun:test"
+import { AUTOROUTER_VERSION } from "lib"
+import type { Pipeline9NetworkedSolveRequest } from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-types"
+import {
+  asNetworkedFetch,
+  createDeferred,
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+  createNetworkedResponse,
+  createNetworkedRoute,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9 networked launches every node request in parallel and preserves sequential output metadata", async () => {
+  const firstNode = createNetworkedNode({
+    nodeId: "cmn_first",
+    connectionName: "A",
+    xOffset: -5,
+  })
+  const secondNode = createNetworkedNode({
+    nodeId: "cmn_second",
+    connectionName: "B",
+    xOffset: 5,
+  })
+  const releaseRequests = createDeferred<void>()
+  const requestBodies: Pipeline9NetworkedSolveRequest[] = []
+  const fetchImpl = asNetworkedFetch(async (_input, init) => {
+    const request = JSON.parse(String(init?.body)) as Pipeline9NetworkedSolveRequest
+    requestBodies.push(request)
+    await releaseRequests.promise
+    return createNetworkedResponse({
+      status: "solved",
+      routes: [createNetworkedRoute(request.input.nodeWithPortPoints)],
+    })
+  })
+  const solver = createNetworkedHighDensitySolver({
+    nodes: [firstNode, secondNode],
+    fetchImpl,
+  })
+
+  solver.step()
+
+  expect(requestBodies).toHaveLength(2)
+  expect(requestBodies.map((request) => request.autorouterVersion)).toEqual([
+    AUTOROUTER_VERSION,
+    AUTOROUTER_VERSION,
+  ])
+  expect(requestBodies.map((request) => request.input.effort)).toEqual([1, 1])
+  expect(solver.pendingEffects).toHaveLength(1)
+
+  releaseRequests.resolve()
+  await solver.pendingEffects![0]!.promise
+  while (!solver.solved && !solver.failed) solver.step()
+
+  expect(solver.solved).toBeTrue()
+  expect(solver.failed).toBeFalse()
+  expect(solver.routes.map((route) => route.connectionName)).toEqual(["B", "A"])
+  expect(solver.routes.map((route) => route.rootConnectionName)).toEqual([
+    "root_B",
+    "root_A",
+  ])
+  expect(solver.routes.map((route) => route.startPcbPortId)).toEqual([
+    "cmn_second_start",
+    "cmn_first_start",
+  ])
+  expect(solver.routes.map((route) => route.endPcbPortId)).toEqual([
+    "cmn_second_end",
+    "cmn_first_end",
+  ])
+  expect(solver.stats.remoteRequestsStarted).toBe(2)
+  expect(solver.stats.remoteCacheHits).toBe(2)
+})

--- a/tests/features/pipeline9-networked-pipeline-contract.test.ts
+++ b/tests/features/pipeline9-networked-pipeline-contract.test.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "bun:test"
+import {
+  AutoroutingPipelineSolver9_Networked,
+  AutoroutingPipelineSolver9_PreloadedTraceGraph,
+} from "lib"
+import {
+  AutoroutingPipelineSolver9_Networked as NetworkedPipelineFromPipelineIndex,
+  type AutoroutingPipelineSolver9NetworkedOptions,
+} from "lib/autorouter-pipelines"
+import { Pipeline9NetworkedHighDensitySolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-high-density-solver"
+import type { SimpleRouteJson } from "lib/types"
+
+const emptySrj: SimpleRouteJson = {
+  layerCount: 2,
+  minTraceWidth: 0.15,
+  obstacles: [],
+  connections: [],
+  bounds: { minX: -5, maxX: 5, minY: -5, maxY: 5 },
+}
+
+test("Pipeline9 networked is effort-1-only, async-only, and replaces only the high-density stage", () => {
+  expect(
+    () =>
+      new AutoroutingPipelineSolver9_Networked(emptySrj, {
+        effort: 2,
+      } as any),
+  ).toThrow("only available at effort=1")
+  expect(
+    () =>
+      new AutoroutingPipelineSolver9_Networked(emptySrj, {
+        hdCacheTimeoutMs: 20,
+        hdCacheTransportTimeoutMs: 10,
+      }),
+  ).toThrow("transport timeout must be at least the logical request timeout")
+
+  const networkedSolver = new AutoroutingPipelineSolver9_Networked(emptySrj)
+  const pipelineIndexOptions: AutoroutingPipelineSolver9NetworkedOptions = {
+    effort: 1,
+  }
+  const localSolver = new AutoroutingPipelineSolver9_PreloadedTraceGraph(
+    emptySrj,
+  )
+  const highDensityStepIndex = networkedSolver.pipelineDef.findIndex(
+    (step) => step.solverName === "highDensityRouteSolver",
+  )
+
+  expect(
+    networkedSolver.pipelineDef[highDensityStepIndex]!.solverClass,
+  ).toBe(Pipeline9NetworkedHighDensitySolver)
+  expect(NetworkedPipelineFromPipelineIndex).toBe(
+    AutoroutingPipelineSolver9_Networked,
+  )
+  expect(pipelineIndexOptions.effort).toBe(1)
+  expect(networkedSolver.getSolverName()).toBe(
+    "AutoroutingPipelineSolver9_Networked",
+  )
+  for (const [stepIndex, step] of networkedSolver.pipelineDef.entries()) {
+    if (stepIndex === highDensityStepIndex) continue
+    expect(step.solverClass).toBe(localSolver.pipelineDef[stepIndex]!.solverClass)
+  }
+  expect(() => networkedSolver.solve()).toThrow("requires async execution")
+  expect(() => networkedSolver.solveUntilPhase("none")).toThrow(
+    "requires solveUntilPhaseAsync",
+  )
+})

--- a/tests/features/pipeline9-networked-pipeline-contract.test.ts
+++ b/tests/features/pipeline9-networked-pipeline-contract.test.ts
@@ -44,9 +44,9 @@ test("Pipeline9 networked is effort-1-only, async-only, and replaces only the hi
     (step) => step.solverName === "highDensityRouteSolver",
   )
 
-  expect(
-    networkedSolver.pipelineDef[highDensityStepIndex]!.solverClass,
-  ).toBe(Pipeline9NetworkedHighDensitySolver)
+  expect(networkedSolver.pipelineDef[highDensityStepIndex]!.solverClass).toBe(
+    Pipeline9NetworkedHighDensitySolver,
+  )
   expect(NetworkedPipelineFromPipelineIndex).toBe(
     AutoroutingPipelineSolver9_Networked,
   )
@@ -56,7 +56,9 @@ test("Pipeline9 networked is effort-1-only, async-only, and replaces only the hi
   )
   for (const [stepIndex, step] of networkedSolver.pipelineDef.entries()) {
     if (stepIndex === highDensityStepIndex) continue
-    expect(step.solverClass).toBe(localSolver.pipelineDef[stepIndex]!.solverClass)
+    expect(step.solverClass).toBe(
+      localSolver.pipelineDef[stepIndex]!.solverClass,
+    )
   }
   expect(() => networkedSolver.solve()).toThrow("requires async execution")
   expect(() => networkedSolver.solveUntilPhase("none")).toThrow(

--- a/tests/features/pipeline9-networked-transport-timeout.test.ts
+++ b/tests/features/pipeline9-networked-transport-timeout.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test"
+import {
+  asNetworkedFetch,
+  createDeferred,
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9 eventually aborts a hung background cache transport", async () => {
+  const transportAborted = createDeferred<void>()
+  const requestStarted = createDeferred<AbortSignal>()
+  const solver = createNetworkedHighDensitySolver({
+    nodes: [
+      createNetworkedNode({
+        nodeId: "cmn_transport_timeout",
+        connectionName: "A",
+      }),
+    ],
+    requestTimeoutMs: 5,
+    transportTimeoutMs: 50,
+    fetchImpl: asNetworkedFetch(
+      async (_url, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          const requestSignal = init?.signal as AbortSignal
+          requestStarted.resolve(requestSignal)
+          requestSignal.addEventListener(
+            "abort",
+            () => {
+              transportAborted.resolve()
+              reject(requestSignal.reason)
+            },
+            { once: true },
+          )
+        }),
+    ),
+  })
+
+  solver.step()
+  const requestSignal = await requestStarted.promise
+  await solver.pendingEffects![0]!.promise
+  expect(requestSignal.aborted).toBeFalse()
+
+  solver.step()
+  expect(solver.activeRegularSolver).not.toBeNull()
+  await transportAborted.promise
+  expect(requestSignal.aborted).toBeTrue()
+})

--- a/tests/features/pipeline9-networked-version.test.ts
+++ b/tests/features/pipeline9-networked-version.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from "bun:test"
+import { AUTOROUTER_VERSION } from "lib"
+import packageJson from "../../package.json" with { type: "json" }
+
+test("Pipeline9 network cache version matches the package version", () => {
+  expect(AUTOROUTER_VERSION).toBe(packageJson.version)
+  expect(packageJson.scripts.prepack).toBe("bun run build")
+})

--- a/tests/fixtures/pipeline9-networked-fixtures.ts
+++ b/tests/fixtures/pipeline9-networked-fixtures.ts
@@ -1,0 +1,168 @@
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { AUTOROUTER_VERSION } from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/autorouter-version"
+import {
+  Pipeline9NetworkedHighDensitySolver,
+  type Pipeline9NetworkedHighDensitySolverParams,
+} from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-high-density-solver"
+import type { Pipeline9NetworkedHighDensityNodeOutput } from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-types"
+import type { PreloadedHighDensityRoute } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/convert-preloaded-traces-to-hd-routes"
+import type {
+  HighDensityIntraNodeRoute,
+  NodeWithPortPoints,
+} from "lib/types/high-density-types"
+
+export const createNetworkedNode = ({
+  nodeId,
+  connectionName,
+  rootConnectionName = `root_${connectionName}`,
+  xOffset = 0,
+}: {
+  nodeId: string
+  connectionName: string
+  rootConnectionName?: string
+  xOffset?: number
+}): NodeWithPortPoints => ({
+  capacityMeshNodeId: nodeId,
+  center: { x: xOffset, y: 0 },
+  width: 4,
+  height: 4,
+  availableZ: [0, 1],
+  portPoints: [
+    {
+      x: xOffset - 2,
+      y: 0,
+      z: 0,
+      connectionName,
+      rootConnectionName,
+      pcb_port_id: `${nodeId}_start`,
+    },
+    {
+      x: xOffset + 2,
+      y: 0,
+      z: 0,
+      connectionName,
+      rootConnectionName,
+      pcb_port_id: `${nodeId}_end`,
+    },
+  ],
+})
+
+export const createNetworkedRoute = (
+  node: NodeWithPortPoints,
+): HighDensityIntraNodeRoute => ({
+  connectionName: node.portPoints[0]!.connectionName,
+  traceThickness: 0.15,
+  viaDiameter: 0.3,
+  route: node.portPoints.map(({ x, y, z }) => ({ x, y, z })),
+  vias: [],
+})
+
+export const createNetworkedFixedRoute = (): PreloadedHighDensityRoute => ({
+  connectionName: "fixed_foreign",
+  rootConnectionName: "root_fixed_foreign",
+  traceThickness: 0.15,
+  viaDiameter: 0.3,
+  route: [
+    { x: 0, y: -2, z: 0 },
+    { x: 0, y: 2, z: 0 },
+  ],
+  vias: [],
+  preloadedTraceIndex: 0,
+  preloadedRouteIndex: 0,
+})
+
+export const createNetworkedResponse = (
+  response: Pipeline9NetworkedHighDensityNodeOutput & {
+    autorouterVersion?: string
+    source?: "cache" | "solver"
+  },
+): Response =>
+  new Response(
+    JSON.stringify({
+      ok: true,
+      autorouterVersion: response.autorouterVersion ?? AUTOROUTER_VERSION,
+      source: response.source ?? "cache",
+      ...response,
+    }),
+    {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    },
+  )
+
+export const asNetworkedFetch = (
+  implementation: (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ) => Promise<Response>,
+): typeof fetch => implementation as unknown as typeof fetch
+
+export const createDeferred = <T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (error: unknown) => void
+} => {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+export const createNetworkedHighDensitySolver = ({
+  nodes,
+  fetchImpl,
+  fixedHdRoutes = [],
+  requestTimeoutMs = 1_000,
+  transportTimeoutMs,
+  enableRegionalFallback = false,
+  preserveTerminalPcbPortIds = true,
+}: {
+  nodes: NodeWithPortPoints[]
+  fetchImpl: typeof fetch
+  fixedHdRoutes?: PreloadedHighDensityRoute[]
+  requestTimeoutMs?: number
+  transportTimeoutMs?: number
+  enableRegionalFallback?: boolean
+  preserveTerminalPcbPortIds?: boolean
+}): Pipeline9NetworkedHighDensitySolver => {
+  const connectivityNetMap: Record<string, string[]> = {
+    root_fixed_foreign: ["root_fixed_foreign", "fixed_foreign"],
+  }
+  for (const node of nodes) {
+    for (const point of node.portPoints) {
+      const root = point.rootConnectionName ?? point.connectionName
+      connectivityNetMap[root] ??= [root]
+      if (!connectivityNetMap[root]!.includes(point.connectionName)) {
+        connectivityNetMap[root]!.push(point.connectionName)
+      }
+    }
+  }
+
+  const params: Pipeline9NetworkedHighDensitySolverParams = {
+    nodePortPoints: nodes,
+    fixedHdRoutes,
+    connMap: new ConnectivityMap(connectivityNetMap),
+    colorMap: Object.fromEntries(
+      nodes.flatMap((node) =>
+        node.portPoints.map((point) => [point.connectionName, "blue"]),
+      ),
+    ),
+    obstacles: [],
+    layerCount: 2,
+    viaDiameter: 0.3,
+    traceWidth: 0.15,
+    obstacleMargin: 0.15,
+    effort: 1,
+    nodePfById: new Map(nodes.map((node) => [node.capacityMeshNodeId, 0.1])),
+    preserveTerminalPcbPortIds,
+    enableRegionalFallback,
+    autorouterVersion: AUTOROUTER_VERSION,
+    fetchImpl,
+    requestTimeoutMs,
+    transportTimeoutMs,
+  }
+  return new Pipeline9NetworkedHighDensitySolver(params)
+}


### PR DESCRIPTION
## Summary

- add an effort-1-only `AutoroutingPipelineSolver9_Networked`
- launch exact high-density node cache requests in parallel while preserving Pipeline9's sequential fixed-copper fallback semantics
- fail open to the local ordinary solver on network, timeout, version, or protocol errors
- export an exact-version server helper and cache request/response contracts
- project board-wide obstacle/connectivity inputs to the conservative 8x grow/shrink envelope for compact, behavior-matched local and remote solves
- keep cold remote solves alive in the background after the 30s logical fallback, with a 310s transport cap

## Cache contract

- client sends the exact `AUTOROUTER_VERSION`
- remote solving is available only at `effort: 1`
- cached solved and deterministic failed results follow the same ordinary-node fallback behavior as local Pipeline9
- fixed-copper/B01 nodes still use Pipeline9's existing sequential behavior; their speculative request can warm the cache but is not consumed

## Validation

- 10 focused network tests (131 assertions)
- direct Pipeline9 high-density regressions, including regional fallback, splice, through-obstacle reconstruction, and Pipeline10 terminal ownership
- `bunx tsc --noEmit`
- `bun run build`
- `npm pack --dry-run` and built dist export/version checks
- `git diff --check`

The companion KV Worker is prepared separately in the private `tscircuit/hd-cache2.tscircuit.com` repository and will pin the exact package version published from this PR.
