### PR TITLE
perf: batch Pipeline9 networked requests

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/autorouting-pipeline-solver9-networked.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/autorouting-pipeline-solver9-networked.ts
@@ -7,6 +7,8 @@ import {
 import { AUTOROUTER_VERSION } from "./autorouter-version"
 import {
   DEFAULT_PIPELINE9_NETWORKED_CACHE_URL,
+  DEFAULT_PIPELINE9_NETWORKED_MAX_BATCH_BODY_BYTES,
+  DEFAULT_PIPELINE9_NETWORKED_MAX_BATCH_ITEMS,
   DEFAULT_PIPELINE9_NETWORKED_TIMEOUT_MS,
   DEFAULT_PIPELINE9_NETWORKED_TRANSPORT_TIMEOUT_MS,
   Pipeline9NetworkedHighDensitySolver,
@@ -21,6 +23,8 @@ export type AutoroutingPipelineSolver9NetworkedOptions = Omit<
   hdCacheFetch?: typeof fetch
   hdCacheTimeoutMs?: number
   hdCacheTransportTimeoutMs?: number
+  hdCacheMaxBatchItems?: number
+  hdCacheMaxBatchBodyBytes?: number
 }
 
 /** Pipeline9 with exact, version-scoped remote ordinary-node solving. */
@@ -29,6 +33,8 @@ export class AutoroutingPipelineSolver9_Networked extends AutoroutingPipelineSol
   readonly hdCacheFetch?: typeof fetch
   readonly hdCacheTimeoutMs: number
   readonly hdCacheTransportTimeoutMs: number
+  readonly hdCacheMaxBatchItems: number
+  readonly hdCacheMaxBatchBodyBytes: number
 
   override getSolverName(): string {
     return "AutoroutingPipelineSolver9_Networked"
@@ -53,6 +59,11 @@ export class AutoroutingPipelineSolver9_Networked extends AutoroutingPipelineSol
     this.hdCacheTransportTimeoutMs =
       opts.hdCacheTransportTimeoutMs ??
       DEFAULT_PIPELINE9_NETWORKED_TRANSPORT_TIMEOUT_MS
+    this.hdCacheMaxBatchItems =
+      opts.hdCacheMaxBatchItems ?? DEFAULT_PIPELINE9_NETWORKED_MAX_BATCH_ITEMS
+    this.hdCacheMaxBatchBodyBytes =
+      opts.hdCacheMaxBatchBodyBytes ??
+      DEFAULT_PIPELINE9_NETWORKED_MAX_BATCH_BODY_BYTES
     if (!Number.isFinite(this.hdCacheTimeoutMs) || this.hdCacheTimeoutMs <= 0) {
       throw new Error(
         `Pipeline9 network request timeout must be a positive number, received ${this.hdCacheTimeoutMs}`,
@@ -64,6 +75,25 @@ export class AutoroutingPipelineSolver9_Networked extends AutoroutingPipelineSol
     ) {
       throw new Error(
         `Pipeline9 network transport timeout must be at least the logical request timeout (${this.hdCacheTimeoutMs}ms), received ${this.hdCacheTransportTimeoutMs}`,
+      )
+    }
+    if (
+      !Number.isInteger(this.hdCacheMaxBatchItems) ||
+      this.hdCacheMaxBatchItems <= 0 ||
+      this.hdCacheMaxBatchItems > DEFAULT_PIPELINE9_NETWORKED_MAX_BATCH_ITEMS
+    ) {
+      throw new Error(
+        `Pipeline9 network max batch items must be a positive integer no greater than ${DEFAULT_PIPELINE9_NETWORKED_MAX_BATCH_ITEMS}, received ${this.hdCacheMaxBatchItems}`,
+      )
+    }
+    if (
+      !Number.isInteger(this.hdCacheMaxBatchBodyBytes) ||
+      this.hdCacheMaxBatchBodyBytes <= 0 ||
+      this.hdCacheMaxBatchBodyBytes >
+        DEFAULT_PIPELINE9_NETWORKED_MAX_BATCH_BODY_BYTES
+    ) {
+      throw new Error(
+        `Pipeline9 network max batch body bytes must be a positive integer no greater than ${DEFAULT_PIPELINE9_NETWORKED_MAX_BATCH_BODY_BYTES}, received ${this.hdCacheMaxBatchBodyBytes}`,
       )
     }
     this.replaceHighDensityPipelineStep()
@@ -92,6 +122,8 @@ export class AutoroutingPipelineSolver9_Networked extends AutoroutingPipelineSol
             fetchImpl: solver.hdCacheFetch,
             requestTimeoutMs: solver.hdCacheTimeoutMs,
             transportTimeoutMs: solver.hdCacheTransportTimeoutMs,
+            maxBatchItems: solver.hdCacheMaxBatchItems,
+            maxBatchBodyBytes: solver.hdCacheMaxBatchBodyBytes,
           },
         ]
       },

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-high-density-solver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-high-density-solver.ts
@@ -10,6 +10,9 @@ import {
 import { projectPipeline9OrdinaryHighDensityInput } from "../AutoroutingPipeline9_PreloadedTraceGraph/project-pipeline9-ordinary-high-density-input"
 import type {
   Pipeline9NetworkedHighDensityNodeInput,
+  Pipeline9NetworkedSolveBatchItem,
+  Pipeline9NetworkedSolveBatchRequest,
+  Pipeline9NetworkedSolveBatchResult,
   Pipeline9NetworkedSolveRequest,
   Pipeline9NetworkedSolveResponse,
 } from "./pipeline9-networked-types"
@@ -18,6 +21,10 @@ export const DEFAULT_PIPELINE9_NETWORKED_CACHE_URL =
   "https://hd-cache2.tscircuit.com"
 export const DEFAULT_PIPELINE9_NETWORKED_TIMEOUT_MS = 30_000
 export const DEFAULT_PIPELINE9_NETWORKED_TRANSPORT_TIMEOUT_MS = 310_000
+export const DEFAULT_PIPELINE9_NETWORKED_MAX_BATCH_ITEMS = 100
+export const DEFAULT_PIPELINE9_NETWORKED_MAX_BATCH_BODY_BYTES =
+  1.75 * 1024 * 1024
+const MAX_PIPELINE9_NETWORKED_RESPONSE_LINE_CHARACTERS = 16 * 1024 * 1024
 
 export type Pipeline9NetworkedHighDensitySolverParams =
   Pipeline9HighDensitySolverParams & {
@@ -26,6 +33,8 @@ export type Pipeline9NetworkedHighDensitySolverParams =
     fetchImpl?: typeof fetch
     requestTimeoutMs?: number
     transportTimeoutMs?: number
+    maxBatchItems?: number
+    maxBatchBodyBytes?: number
   }
 
 type RemoteNodeResult =
@@ -40,6 +49,42 @@ type RemoteNodeResult =
 
 type RemoteNodeRequest = {
   promise: Promise<void>
+  resolve: () => void
+  settled: boolean
+}
+
+type PreparedBatchItem = Pipeline9NetworkedSolveBatchItem & {
+  node: NodeWithPortPoints
+  serializedItem: string
+}
+
+type PreparedBatch = {
+  body: string
+  bodyBytes: number
+  items: PreparedBatchItem[]
+}
+
+export type Pipeline9NetworkedFallbackReason =
+  | "http_error"
+  | "invalid_json"
+  | "invalid_response"
+  | "logical_timeout"
+  | "missing_response"
+  | "remote_error"
+  | "request_serialization_error"
+  | "response_too_large"
+  | "transport_error"
+  | "transport_timeout"
+  | "version_mismatch"
+
+class Pipeline9NetworkedRequestError extends Error {
+  constructor(
+    readonly reason: Pipeline9NetworkedFallbackReason,
+    message: string,
+  ) {
+    super(message)
+    this.name = "Pipeline9NetworkedRequestError"
+  }
 }
 
 const getErrorMessage = (error: unknown): string =>
@@ -229,6 +274,17 @@ export const getPipeline9NetworkedSolveUrl = (baseUrl: string): string =>
     ? baseUrl.replace(/\/+$/, "")
     : `${baseUrl.replace(/\/+$/, "")}/solve`
 
+export const getPipeline9NetworkedSolveBatchUrl = (
+  baseUrl: string,
+): string => {
+  const normalizedBaseUrl = baseUrl.replace(/\/+$/, "")
+  if (/\/solve-batch$/.test(normalizedBaseUrl)) return normalizedBaseUrl
+  if (/\/solve$/.test(normalizedBaseUrl)) {
+    return normalizedBaseUrl.replace(/\/solve$/, "/solve-batch")
+  }
+  return `${normalizedBaseUrl}/solve-batch`
+}
+
 /**
  * Starts every exact-cache request together, then lets Pipeline9 consume the
  * results in its existing node order. Requests for fixed-copper nodes are
@@ -240,6 +296,8 @@ export class Pipeline9NetworkedHighDensitySolver extends Pipeline9HighDensitySol
   readonly fetchImpl: typeof fetch
   readonly requestTimeoutMs: number
   readonly transportTimeoutMs: number
+  readonly maxBatchItems: number
+  readonly maxBatchBodyBytes: number
 
   private launchedRemoteSolves = false
   private waitingForRemoteNode: NodeWithPortPoints | null = null
@@ -259,6 +317,8 @@ export class Pipeline9NetworkedHighDensitySolver extends Pipeline9HighDensitySol
     fetchImpl,
     requestTimeoutMs,
     transportTimeoutMs,
+    maxBatchItems,
+    maxBatchBodyBytes,
     ...pipeline9Params
   }: Pipeline9NetworkedHighDensitySolverParams) {
     super(pipeline9Params)
@@ -272,6 +332,10 @@ export class Pipeline9NetworkedHighDensitySolver extends Pipeline9HighDensitySol
       requestTimeoutMs ?? DEFAULT_PIPELINE9_NETWORKED_TIMEOUT_MS
     this.transportTimeoutMs =
       transportTimeoutMs ?? DEFAULT_PIPELINE9_NETWORKED_TRANSPORT_TIMEOUT_MS
+    this.maxBatchItems =
+      maxBatchItems ?? DEFAULT_PIPELINE9_NETWORKED_MAX_BATCH_ITEMS
+    this.maxBatchBodyBytes =
+      maxBatchBodyBytes ?? DEFAULT_PIPELINE9_NETWORKED_MAX_BATCH_BODY_BYTES
     if (!Number.isFinite(this.requestTimeoutMs) || this.requestTimeoutMs <= 0) {
       throw new Error(
         `Pipeline9 network request timeout must be a positive number, received ${this.requestTimeoutMs}`,
@@ -283,6 +347,25 @@ export class Pipeline9NetworkedHighDensitySolver extends Pipeline9HighDensitySol
     ) {
       throw new Error(
         `Pipeline9 network transport timeout must be at least the logical request timeout (${this.requestTimeoutMs}ms), received ${this.transportTimeoutMs}`,
+      )
+    }
+    if (
+      !Number.isInteger(this.maxBatchItems) ||
+      this.maxBatchItems <= 0 ||
+      this.maxBatchItems > DEFAULT_PIPELINE9_NETWORKED_MAX_BATCH_ITEMS
+    ) {
+      throw new Error(
+        `Pipeline9 network max batch items must be a positive integer no greater than ${DEFAULT_PIPELINE9_NETWORKED_MAX_BATCH_ITEMS}, received ${this.maxBatchItems}`,
+      )
+    }
+    if (
+      !Number.isInteger(this.maxBatchBodyBytes) ||
+      this.maxBatchBodyBytes <= 0 ||
+      this.maxBatchBodyBytes >
+        DEFAULT_PIPELINE9_NETWORKED_MAX_BATCH_BODY_BYTES
+    ) {
+      throw new Error(
+        `Pipeline9 network max batch body bytes must be a positive integer no greater than ${DEFAULT_PIPELINE9_NETWORKED_MAX_BATCH_BODY_BYTES}, received ${this.maxBatchBodyBytes}`,
       )
     }
 
@@ -297,12 +380,22 @@ export class Pipeline9NetworkedHighDensitySolver extends Pipeline9HighDensitySol
       ...this.stats,
       remoteRequestsStarted: 0,
       remoteRequestsCompleted: 0,
+      remoteBatchRequestsStarted: 0,
+      remoteBatchRequestsCompleted: 0,
+      remoteBatchItemsStarted: 0,
+      remoteBatchBodyBytesStarted: 0,
+      remoteBatchMaxBodyBytes: 0,
+      remoteSingleRequestsStarted: 0,
+      remoteBatchInvalidLines: 0,
+      remoteBatchUnknownRequestIds: 0,
+      remoteBatchDuplicateRequestIds: 0,
       remoteCacheHits: 0,
       remoteSolverResults: 0,
       remoteSolvedResults: 0,
       remoteFailedResults: 0,
       remoteTransportFallbacks: 0,
       remoteLogicalTimeoutFallbacks: 0,
+      remoteFallbackReasonCounts: {},
     }
   }
 
@@ -341,24 +434,32 @@ export class Pipeline9NetworkedHighDensitySolver extends Pipeline9HighDensitySol
     input: Pipeline9NetworkedHighDensityNodeInput,
   ): Extract<Pipeline9NetworkedSolveResponse, { ok: true }> {
     if (!value || typeof value !== "object") {
-      throw new Error("hd-cache2 returned a non-object response")
+      throw new Pipeline9NetworkedRequestError(
+        "invalid_response",
+        "hd-cache2 returned a non-object response",
+      )
     }
 
     const response = value as Record<string, unknown>
     if (response.ok !== true) {
-      throw new Error(
+      throw new Pipeline9NetworkedRequestError(
+        "remote_error",
         typeof response.message === "string"
           ? response.message
           : "hd-cache2 returned an unsuccessful response",
       )
     }
     if (response.autorouterVersion !== this.autorouterVersion) {
-      throw new Error(
+      throw new Pipeline9NetworkedRequestError(
+        "version_mismatch",
         `hd-cache2 returned autorouter version ${String(response.autorouterVersion)}, expected ${this.autorouterVersion}`,
       )
     }
     if (response.source !== "cache" && response.source !== "solver") {
-      throw new Error("hd-cache2 returned an invalid cache source")
+      throw new Pipeline9NetworkedRequestError(
+        "invalid_response",
+        "hd-cache2 returned an invalid cache source",
+      )
     }
     if (
       response.status === "solved" &&
@@ -370,14 +471,31 @@ export class Pipeline9NetworkedHighDensitySolver extends Pipeline9HighDensitySol
       return response as Extract<Pipeline9NetworkedSolveResponse, { ok: true }>
     }
 
-    throw new Error("hd-cache2 returned an invalid solve result")
+    throw new Pipeline9NetworkedRequestError(
+      "invalid_response",
+      "hd-cache2 returned an invalid solve result",
+    )
   }
 
   private async fetchNodeResult(
     request: Pipeline9NetworkedSolveRequest,
   ): Promise<Extract<Pipeline9NetworkedSolveResponse, { ok: true }>> {
     const controller = new AbortController()
-    const requestPromise = (async () => {
+    let didTransportTimeout = false
+    const transportTimeoutId = setTimeout(() => {
+      didTransportTimeout = true
+      controller.abort(
+        new Error(
+          `hd-cache2 transport timed out after ${this.transportTimeoutMs}ms`,
+        ),
+      )
+    }, this.transportTimeoutMs)
+    const backgroundTimer = transportTimeoutId as ReturnType<
+      typeof setTimeout
+    > & { unref?: () => void }
+    backgroundTimer.unref?.()
+
+    try {
       const response = await this.fetchImpl(
         getPipeline9NetworkedSolveUrl(this.hdCacheBaseUrl),
         {
@@ -391,11 +509,18 @@ export class Pipeline9NetworkedHighDensitySolver extends Pipeline9HighDensitySol
         },
       )
       const responseText = await response.text()
-      let responseBody: unknown
+      let responseBody: unknown = null
       try {
         responseBody = responseText ? JSON.parse(responseText) : null
       } catch {
-        throw new Error(
+        if (!response.ok) {
+          throw new Pipeline9NetworkedRequestError(
+            "http_error",
+            `hd-cache2 request failed with status ${response.status}`,
+          )
+        }
+        throw new Pipeline9NetworkedRequestError(
+          "invalid_json",
           `hd-cache2 returned invalid JSON with status ${response.status}`,
         )
       }
@@ -404,17 +529,228 @@ export class Pipeline9NetworkedHighDensitySolver extends Pipeline9HighDensitySol
           responseBody &&
           typeof responseBody === "object" &&
           "message" in responseBody &&
-          typeof responseBody.message === "string"
+            typeof responseBody.message === "string"
             ? responseBody.message
             : `hd-cache2 request failed with status ${response.status}`
-        throw new Error(message)
+        throw new Pipeline9NetworkedRequestError("http_error", message)
       }
       return this.parseSuccessfulResponse(responseBody, request.input)
-    })()
+    } catch (error) {
+      if (error instanceof Pipeline9NetworkedRequestError) throw error
+      throw new Pipeline9NetworkedRequestError(
+        didTransportTimeout ? "transport_timeout" : "transport_error",
+        getErrorMessage(error),
+      )
+    } finally {
+      clearTimeout(transportTimeoutId)
+    }
+  }
+
+  private recordFallbackReason(
+    reason: Pipeline9NetworkedFallbackReason,
+  ): void {
+    const counts = this.stats.remoteFallbackReasonCounts as Record<
+      Pipeline9NetworkedFallbackReason,
+      number
+    >
+    counts[reason] = (counts[reason] ?? 0) + 1
+  }
+
+  private createRemoteNodeRequest(node: NodeWithPortPoints): RemoteNodeRequest {
+    let resolve!: () => void
+    const promise = new Promise<void>((resolvePromise) => {
+      resolve = resolvePromise
+    })
+    const request: RemoteNodeRequest = { promise, resolve, settled: false }
+    this.remoteRequestByNode.set(node, request)
+    this.stats.remoteRequestsStarted += 1
+    return request
+  }
+
+  private completeNodeWithRemoteResult(
+    node: NodeWithPortPoints,
+    response: Extract<Pipeline9NetworkedSolveResponse, { ok: true }>,
+  ): void {
+    const request = this.remoteRequestByNode.get(node)
+    if (!request || request.settled) return
+    request.settled = true
+    if (!this.logicallyTimedOutNodes.has(node)) {
+      this.remoteResultByNode.set(node, { kind: "remote", response })
+    }
+    if (response.source === "cache") this.stats.remoteCacheHits += 1
+    if (response.source === "solver") this.stats.remoteSolverResults += 1
+    if (response.status === "solved") this.stats.remoteSolvedResults += 1
+    if (response.status === "failed") this.stats.remoteFailedResults += 1
+    this.stats.remoteRequestsCompleted += 1
+    request.resolve()
+  }
+
+  private completeNodeWithLocalFallback(
+    node: NodeWithPortPoints,
+    error: string,
+    reason: Pipeline9NetworkedFallbackReason,
+  ): void {
+    const request = this.remoteRequestByNode.get(node)
+    if (!request || request.settled) return
+    request.settled = true
+    if (!this.logicallyTimedOutNodes.has(node)) {
+      this.remoteResultByNode.set(node, { kind: "local-fallback", error })
+      this.stats.remoteTransportFallbacks += 1
+      this.recordFallbackReason(reason)
+    }
+    this.stats.remoteRequestsCompleted += 1
+    request.resolve()
+  }
+
+  private async solveNodeRemotely(
+    node: NodeWithPortPoints,
+    input: Pipeline9NetworkedHighDensityNodeInput,
+  ): Promise<void> {
+    try {
+      const response = await this.fetchNodeResult({
+        autorouterVersion: this.autorouterVersion,
+        input,
+      })
+      this.completeNodeWithRemoteResult(node, response)
+    } catch (error) {
+      const reason =
+        error instanceof Pipeline9NetworkedRequestError
+          ? error.reason
+          : "transport_error"
+      this.completeNodeWithLocalFallback(node, getErrorMessage(error), reason)
+    }
+  }
+
+  private handleBatchResponseLine(
+    line: string,
+    itemsByRequestId: ReadonlyMap<string, PreparedBatchItem>,
+    responseRequestIds: Set<string>,
+  ): void {
+    if (line.trim().length === 0) return
+    if (line.length > MAX_PIPELINE9_NETWORKED_RESPONSE_LINE_CHARACTERS) {
+      throw new Pipeline9NetworkedRequestError(
+        "response_too_large",
+        "hd-cache2 returned an oversized batch result line",
+      )
+    }
+
+    let value: unknown
+    try {
+      value = JSON.parse(line)
+    } catch {
+      this.stats.remoteBatchInvalidLines += 1
+      return
+    }
+    if (!value || typeof value !== "object") {
+      this.stats.remoteBatchInvalidLines += 1
+      return
+    }
+
+    const requestId = (value as Record<string, unknown>).requestId
+    if (typeof requestId !== "string") {
+      this.stats.remoteBatchInvalidLines += 1
+      return
+    }
+    const item = itemsByRequestId.get(requestId)
+    if (!item) {
+      this.stats.remoteBatchUnknownRequestIds += 1
+      return
+    }
+    if (responseRequestIds.has(requestId)) {
+      this.stats.remoteBatchDuplicateRequestIds += 1
+      return
+    }
+    responseRequestIds.add(requestId)
+
+    try {
+      const response = this.parseSuccessfulResponse(value, item.input)
+      this.completeNodeWithRemoteResult(item.node, response)
+    } catch (error) {
+      const reason =
+        error instanceof Pipeline9NetworkedRequestError
+          ? error.reason
+          : "invalid_response"
+      this.stats.remoteBatchInvalidLines += 1
+      this.completeNodeWithLocalFallback(
+        item.node,
+        getErrorMessage(error),
+        reason,
+      )
+    }
+  }
+
+  private async readBatchResponse(
+    response: Response,
+    batch: PreparedBatch,
+  ): Promise<void> {
+    if (!response.body) {
+      throw new Pipeline9NetworkedRequestError(
+        "invalid_response",
+        "hd-cache2 returned an empty batch response body",
+      )
+    }
+
+    const itemsByRequestId = new Map(
+      batch.items.map((item) => [item.requestId, item]),
+    )
+    const responseRequestIds = new Set<string>()
+    const decoder = new TextDecoder()
+    const reader = response.body.getReader()
+    let buffer = ""
+
+    while (responseRequestIds.size < batch.items.length) {
+      const { done, value } = await reader.read()
+      buffer += decoder.decode(value, { stream: !done })
+      if (
+        buffer.length > MAX_PIPELINE9_NETWORKED_RESPONSE_LINE_CHARACTERS &&
+        !buffer.includes("\n")
+      ) {
+        throw new Pipeline9NetworkedRequestError(
+          "response_too_large",
+          "hd-cache2 returned an oversized unterminated batch result line",
+        )
+      }
+
+      let newlineIndex = buffer.indexOf("\n")
+      while (newlineIndex >= 0) {
+        const line = buffer.slice(0, newlineIndex)
+        buffer = buffer.slice(newlineIndex + 1)
+        this.handleBatchResponseLine(line, itemsByRequestId, responseRequestIds)
+        newlineIndex = buffer.indexOf("\n")
+      }
+      if (!done) continue
+      if (buffer.trim().length > 0) {
+        this.handleBatchResponseLine(
+          buffer,
+          itemsByRequestId,
+          responseRequestIds,
+        )
+      }
+      break
+    }
+
+    if (responseRequestIds.size === batch.items.length) {
+      await reader.cancel().catch(() => {})
+      return
+    }
+    for (const item of batch.items) {
+      if (responseRequestIds.has(item.requestId)) continue
+      this.completeNodeWithLocalFallback(
+        item.node,
+        `hd-cache2 batch ended without result ${item.requestId}`,
+        "missing_response",
+      )
+    }
+  }
+
+  private async solveBatchRemotely(batch: PreparedBatch): Promise<void> {
+    const controller = new AbortController()
+    let didTransportTimeout = false
     const transportTimeoutId = setTimeout(() => {
+      didTransportTimeout = true
       controller.abort(
         new Error(
-          `hd-cache2 transport timed out after ${this.transportTimeoutMs}ms`,
+          `hd-cache2 batch transport timed out after ${this.transportTimeoutMs}ms`,
         ),
       )
     }, this.transportTimeoutMs)
@@ -422,52 +758,136 @@ export class Pipeline9NetworkedHighDensitySolver extends Pipeline9HighDensitySol
       typeof setTimeout
     > & { unref?: () => void }
     backgroundTimer.unref?.()
-    const observedRequestPromise = requestPromise.then(
-      (response) => {
-        clearTimeout(transportTimeoutId)
-        return { kind: "response" as const, response }
-      },
-      (error: unknown) => {
-        clearTimeout(transportTimeoutId)
-        return { kind: "error" as const, error }
-      },
-    )
-    const result = await observedRequestPromise
-    if (result.kind === "error") throw result.error
-    return result.response
-  }
 
-  private async solveNodeRemotely(node: NodeWithPortPoints): Promise<void> {
     try {
-      const response = await this.fetchNodeResult({
-        autorouterVersion: this.autorouterVersion,
-        input: this.createNodeInput(node),
-      })
-      if (!this.logicallyTimedOutNodes.has(node)) {
-        this.remoteResultByNode.set(node, { kind: "remote", response })
+      const response = await this.fetchImpl(
+        getPipeline9NetworkedSolveBatchUrl(this.hdCacheBaseUrl),
+        {
+          method: "POST",
+          headers: {
+            accept: "application/x-ndjson",
+            "content-type": "application/json",
+          },
+          body: batch.body,
+          signal: controller.signal,
+        },
+      )
+      if (!response.ok) {
+        const responseText = await response.text().catch(() => "")
+        let message = `hd-cache2 batch request failed with status ${response.status}`
+        try {
+          const responseBody = responseText ? JSON.parse(responseText) : null
+          if (
+            responseBody &&
+            typeof responseBody === "object" &&
+            "message" in responseBody &&
+            typeof responseBody.message === "string"
+          ) {
+            message = responseBody.message
+          }
+        } catch {}
+        throw new Pipeline9NetworkedRequestError("http_error", message)
       }
-      if (response.source === "cache") this.stats.remoteCacheHits += 1
-      if (response.source === "solver") this.stats.remoteSolverResults += 1
-      if (response.status === "solved") this.stats.remoteSolvedResults += 1
-      if (response.status === "failed") this.stats.remoteFailedResults += 1
+      await this.readBatchResponse(response, batch)
     } catch (error) {
-      if (!this.logicallyTimedOutNodes.has(node)) {
-        this.remoteResultByNode.set(node, {
-          kind: "local-fallback",
-          error: getErrorMessage(error),
-        })
-        this.stats.remoteTransportFallbacks += 1
+      const reason =
+        error instanceof Pipeline9NetworkedRequestError
+          ? error.reason
+          : didTransportTimeout
+            ? "transport_timeout"
+            : "transport_error"
+      for (const item of batch.items) {
+        this.completeNodeWithLocalFallback(
+          item.node,
+          getErrorMessage(error),
+          reason,
+        )
       }
     } finally {
-      this.stats.remoteRequestsCompleted += 1
+      clearTimeout(transportTimeoutId)
+      this.stats.remoteBatchRequestsCompleted += 1
     }
   }
 
+  private prepareBatches(items: PreparedBatchItem[]): {
+    batches: PreparedBatch[]
+    singleItems: PreparedBatchItem[]
+  } {
+    const encoder = new TextEncoder()
+    const prefix = `{"autorouterVersion":${JSON.stringify(this.autorouterVersion)},"items":[`
+    const suffix = "]}"
+    const fixedBytes = encoder.encode(prefix + suffix).byteLength
+    const batches: PreparedBatch[] = []
+    const singleItems: PreparedBatchItem[] = []
+    let currentItems: PreparedBatchItem[] = []
+    let currentBytes = fixedBytes
+
+    const flushCurrentBatch = (): void => {
+      if (currentItems.length === 0) return
+      batches.push({
+        body: `${prefix}${currentItems.map((item) => item.serializedItem).join(",")}${suffix}`,
+        bodyBytes: currentBytes,
+        items: currentItems,
+      })
+      currentItems = []
+      currentBytes = fixedBytes
+    }
+
+    for (const item of items) {
+      const itemBytes = encoder.encode(item.serializedItem).byteLength
+      const separatorBytes = currentItems.length === 0 ? 0 : 1
+      if (fixedBytes + itemBytes > this.maxBatchBodyBytes) {
+        flushCurrentBatch()
+        singleItems.push(item)
+        continue
+      }
+      if (
+        currentItems.length >= this.maxBatchItems ||
+        currentBytes + separatorBytes + itemBytes >
+          this.maxBatchBodyBytes
+      ) {
+        flushCurrentBatch()
+      }
+      currentItems.push(item)
+      currentBytes += (currentItems.length === 1 ? 0 : 1) + itemBytes
+    }
+    flushCurrentBatch()
+    return { batches, singleItems }
+  }
+
   private launchRemoteSolves(): void {
-    for (const node of this.unsolvedNodePortPoints) {
-      const promise = this.solveNodeRemotely(node)
-      this.remoteRequestByNode.set(node, { promise })
-      this.stats.remoteRequestsStarted += 1
+    const preparedItems: PreparedBatchItem[] = []
+    const nodesInConsumptionOrder = [...this.unsolvedNodePortPoints].reverse()
+    for (const [nodeIndex, node] of nodesInConsumptionOrder.entries()) {
+      this.createRemoteNodeRequest(node)
+      try {
+        const input = this.createNodeInput(node)
+        const requestId = String(nodeIndex)
+        const serializedItem = JSON.stringify({ requestId, input })
+        preparedItems.push({ requestId, input, node, serializedItem })
+      } catch (error) {
+        this.completeNodeWithLocalFallback(
+          node,
+          getErrorMessage(error),
+          "request_serialization_error",
+        )
+      }
+    }
+
+    const { batches, singleItems } = this.prepareBatches(preparedItems)
+    for (const batch of batches) {
+      this.stats.remoteBatchRequestsStarted += 1
+      this.stats.remoteBatchItemsStarted += batch.items.length
+      this.stats.remoteBatchBodyBytesStarted += batch.bodyBytes
+      this.stats.remoteBatchMaxBodyBytes = Math.max(
+        this.stats.remoteBatchMaxBodyBytes,
+        batch.bodyBytes,
+      )
+      void this.solveBatchRemotely(batch)
+    }
+    for (const item of singleItems) {
+      this.stats.remoteSingleRequestsStarted += 1
+      void this.solveNodeRemotely(item.node, item.input)
     }
   }
 
@@ -491,6 +911,7 @@ export class Pipeline9NetworkedHighDensitySolver extends Pipeline9HighDensitySol
     this.logicallyTimedOutNodes.add(node)
     this.stats.remoteLogicalTimeoutFallbacks += 1
     this.stats.remoteTransportFallbacks += 1
+    this.recordFallbackReason("logical_timeout")
   }
 
   protected override startRegularSolver(node: NodeWithPortPoints): void {

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-high-density-solver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-high-density-solver.ts
@@ -11,6 +11,7 @@ import { projectPipeline9OrdinaryHighDensityInput } from "../AutoroutingPipeline
 import type {
   Pipeline9NetworkedHighDensityNodeInput,
   Pipeline9NetworkedSolveBatchItem,
+  Pipeline9NetworkedSolveBatchCacheMiss,
   Pipeline9NetworkedSolveBatchRequest,
   Pipeline9NetworkedSolveBatchResult,
   Pipeline9NetworkedSolveRequest,
@@ -308,6 +309,7 @@ export class Pipeline9NetworkedHighDensitySolver extends Pipeline9HighDensitySol
     RemoteNodeResult
   >()
   private readonly logicallyTimedOutNodes = new Set<NodeWithPortPoints>()
+  private readonly remoteSingleSolveNodes = new Set<NodeWithPortPoints>()
 
   constructor({
     autorouterVersion,
@@ -382,6 +384,7 @@ export class Pipeline9NetworkedHighDensitySolver extends Pipeline9HighDensitySol
       remoteBatchItemsStarted: 0,
       remoteBatchBodyBytesStarted: 0,
       remoteBatchMaxBodyBytes: 0,
+      remoteBatchCacheMisses: 0,
       remoteSingleRequestsStarted: 0,
       remoteBatchInvalidLines: 0,
       remoteBatchUnknownRequestIds: 0,
@@ -616,6 +619,32 @@ export class Pipeline9NetworkedHighDensitySolver extends Pipeline9HighDensitySol
     }
   }
 
+  private parseBatchCacheMiss(
+    value: Record<string, unknown>,
+  ): Pipeline9NetworkedSolveBatchCacheMiss | null {
+    if (value.ok !== false || value.code !== "CACHE_MISS") return null
+    if (value.autorouterVersion !== this.autorouterVersion) {
+      throw new Pipeline9NetworkedRequestError(
+        "version_mismatch",
+        `hd-cache2 returned autorouter version ${String(value.autorouterVersion)}, expected ${this.autorouterVersion}`,
+      )
+    }
+    if (typeof value.message !== "string") {
+      throw new Pipeline9NetworkedRequestError(
+        "invalid_response",
+        "hd-cache2 returned an invalid cache miss response",
+      )
+    }
+    return value as Pipeline9NetworkedSolveBatchCacheMiss
+  }
+
+  private launchSingleSolve(item: PreparedBatchItem): void {
+    if (this.remoteSingleSolveNodes.has(item.node)) return
+    this.remoteSingleSolveNodes.add(item.node)
+    this.stats.remoteSingleRequestsStarted += 1
+    void this.solveNodeRemotely(item.node, item.input)
+  }
+
   private handleBatchResponseLine(
     line: string,
     itemsByRequestId: ReadonlyMap<string, PreparedBatchItem>,
@@ -636,12 +665,13 @@ export class Pipeline9NetworkedHighDensitySolver extends Pipeline9HighDensitySol
       this.stats.remoteBatchInvalidLines += 1
       return
     }
-    if (!value || typeof value !== "object") {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
       this.stats.remoteBatchInvalidLines += 1
       return
     }
 
-    const requestId = (value as Record<string, unknown>).requestId
+    const responseValue = value as Record<string, unknown>
+    const requestId = responseValue.requestId
     if (typeof requestId !== "string") {
       this.stats.remoteBatchInvalidLines += 1
       return
@@ -658,7 +688,13 @@ export class Pipeline9NetworkedHighDensitySolver extends Pipeline9HighDensitySol
     responseRequestIds.add(requestId)
 
     try {
-      const response = this.parseSuccessfulResponse(value, item.input)
+      const cacheMiss = this.parseBatchCacheMiss(responseValue)
+      if (cacheMiss) {
+        this.stats.remoteBatchCacheMisses += 1
+        this.launchSingleSolve(item)
+        return
+      }
+      const response = this.parseSuccessfulResponse(responseValue, item.input)
       this.completeNodeWithRemoteResult(item.node, response)
     } catch (error) {
       const reason =
@@ -792,6 +828,7 @@ export class Pipeline9NetworkedHighDensitySolver extends Pipeline9HighDensitySol
             ? "transport_timeout"
             : "transport_error"
       for (const item of batch.items) {
+        if (this.remoteSingleSolveNodes.has(item.node)) continue
         this.completeNodeWithLocalFallback(
           item.node,
           getErrorMessage(error),
@@ -880,8 +917,7 @@ export class Pipeline9NetworkedHighDensitySolver extends Pipeline9HighDensitySol
       void this.solveBatchRemotely(batch)
     }
     for (const item of singleItems) {
-      this.stats.remoteSingleRequestsStarted += 1
-      void this.solveNodeRemotely(item.node, item.input)
+      this.launchSingleSolve(item)
     }
   }
 

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-high-density-solver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-high-density-solver.ts
@@ -274,9 +274,7 @@ export const getPipeline9NetworkedSolveUrl = (baseUrl: string): string =>
     ? baseUrl.replace(/\/+$/, "")
     : `${baseUrl.replace(/\/+$/, "")}/solve`
 
-export const getPipeline9NetworkedSolveBatchUrl = (
-  baseUrl: string,
-): string => {
+export const getPipeline9NetworkedSolveBatchUrl = (baseUrl: string): string => {
   const normalizedBaseUrl = baseUrl.replace(/\/+$/, "")
   if (/\/solve-batch$/.test(normalizedBaseUrl)) return normalizedBaseUrl
   if (/\/solve$/.test(normalizedBaseUrl)) {
@@ -361,8 +359,7 @@ export class Pipeline9NetworkedHighDensitySolver extends Pipeline9HighDensitySol
     if (
       !Number.isInteger(this.maxBatchBodyBytes) ||
       this.maxBatchBodyBytes <= 0 ||
-      this.maxBatchBodyBytes >
-        DEFAULT_PIPELINE9_NETWORKED_MAX_BATCH_BODY_BYTES
+      this.maxBatchBodyBytes > DEFAULT_PIPELINE9_NETWORKED_MAX_BATCH_BODY_BYTES
     ) {
       throw new Error(
         `Pipeline9 network max batch body bytes must be a positive integer no greater than ${DEFAULT_PIPELINE9_NETWORKED_MAX_BATCH_BODY_BYTES}, received ${this.maxBatchBodyBytes}`,
@@ -529,7 +526,7 @@ export class Pipeline9NetworkedHighDensitySolver extends Pipeline9HighDensitySol
           responseBody &&
           typeof responseBody === "object" &&
           "message" in responseBody &&
-            typeof responseBody.message === "string"
+          typeof responseBody.message === "string"
             ? responseBody.message
             : `hd-cache2 request failed with status ${response.status}`
         throw new Pipeline9NetworkedRequestError("http_error", message)
@@ -546,9 +543,7 @@ export class Pipeline9NetworkedHighDensitySolver extends Pipeline9HighDensitySol
     }
   }
 
-  private recordFallbackReason(
-    reason: Pipeline9NetworkedFallbackReason,
-  ): void {
+  private recordFallbackReason(reason: Pipeline9NetworkedFallbackReason): void {
     const counts = this.stats.remoteFallbackReasonCounts as Record<
       Pipeline9NetworkedFallbackReason,
       number
@@ -843,8 +838,7 @@ export class Pipeline9NetworkedHighDensitySolver extends Pipeline9HighDensitySol
       }
       if (
         currentItems.length >= this.maxBatchItems ||
-        currentBytes + separatorBytes + itemBytes >
-          this.maxBatchBodyBytes
+        currentBytes + separatorBytes + itemBytes > this.maxBatchBodyBytes
       ) {
         flushCurrentBatch()
       }

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-types.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-types.ts
@@ -61,7 +61,15 @@ export type Pipeline9NetworkedSolveResponse =
       message: string
     }
 
-/** One independently consumable NDJSON line returned by POST /solve-batch. */
-export type Pipeline9NetworkedSolveBatchResult = {
+export type Pipeline9NetworkedSolveBatchCacheMiss = {
   requestId: string
-} & Pipeline9NetworkedSolveResponse
+  ok: false
+  autorouterVersion: string
+  code: "CACHE_MISS"
+  message: string
+}
+
+/** One independently consumable NDJSON line returned by POST /solve-batch. */
+export type Pipeline9NetworkedSolveBatchResult =
+  | ({ requestId: string } & Pipeline9NetworkedSolveResponse)
+  | Pipeline9NetworkedSolveBatchCacheMiss

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-types.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-types.ts
@@ -39,6 +39,16 @@ export type Pipeline9NetworkedSolveRequest = {
   input: Pipeline9NetworkedHighDensityNodeInput
 }
 
+export type Pipeline9NetworkedSolveBatchItem = {
+  requestId: string
+  input: Pipeline9NetworkedHighDensityNodeInput
+}
+
+export type Pipeline9NetworkedSolveBatchRequest = {
+  autorouterVersion: string
+  items: Pipeline9NetworkedSolveBatchItem[]
+}
+
 export type Pipeline9NetworkedSolveResponse =
   | ({
       ok: true
@@ -50,3 +60,8 @@ export type Pipeline9NetworkedSolveResponse =
       autorouterVersion?: string
       message: string
     }
+
+/** One independently consumable NDJSON line returned by POST /solve-batch. */
+export type Pipeline9NetworkedSolveBatchResult = {
+  requestId: string
+} & Pipeline9NetworkedSolveResponse

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -31,13 +31,19 @@ export {
 export { AUTOROUTER_VERSION } from "./autorouter-pipelines/AutoroutingPipeline9_Networked/autorouter-version"
 export {
   DEFAULT_PIPELINE9_NETWORKED_CACHE_URL,
+  DEFAULT_PIPELINE9_NETWORKED_MAX_BATCH_BODY_BYTES,
+  DEFAULT_PIPELINE9_NETWORKED_MAX_BATCH_ITEMS,
   DEFAULT_PIPELINE9_NETWORKED_TIMEOUT_MS,
   DEFAULT_PIPELINE9_NETWORKED_TRANSPORT_TIMEOUT_MS,
+  type Pipeline9NetworkedFallbackReason,
 } from "./autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-high-density-solver"
 export type {
   Pipeline9NetworkedCacheSource,
   Pipeline9NetworkedHighDensityNodeInput,
   Pipeline9NetworkedHighDensityNodeOutput,
+  Pipeline9NetworkedSolveBatchItem,
+  Pipeline9NetworkedSolveBatchRequest,
+  Pipeline9NetworkedSolveBatchResult,
   Pipeline9NetworkedSolveRequest,
   Pipeline9NetworkedSolveResponse,
 } from "./autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-types"

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -41,6 +41,7 @@ export type {
   Pipeline9NetworkedCacheSource,
   Pipeline9NetworkedHighDensityNodeInput,
   Pipeline9NetworkedHighDensityNodeOutput,
+  Pipeline9NetworkedSolveBatchCacheMiss,
   Pipeline9NetworkedSolveBatchItem,
   Pipeline9NetworkedSolveBatchRequest,
   Pipeline9NetworkedSolveBatchResult,

--- a/lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver/GrowShrinkHighDensityIntraNodeSolver.ts
+++ b/lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver/GrowShrinkHighDensityIntraNodeSolver.ts
@@ -68,11 +68,15 @@ const scaleRoute = (
   ...route,
   route: route.route.map((point) => scalePoint(point, center, scaleFactor)),
   vias: route.vias.map((via) => scalePoint(via, center, scaleFactor)),
-  jumpers: route.jumpers?.map((jumper) => ({
-    ...jumper,
-    start: scalePoint(jumper.start, center, scaleFactor),
-    end: scalePoint(jumper.end, center, scaleFactor),
-  })),
+  ...(route.jumpers
+    ? {
+        jumpers: route.jumpers.map((jumper) => ({
+          ...jumper,
+          start: scalePoint(jumper.start, center, scaleFactor),
+          end: scalePoint(jumper.end, center, scaleFactor),
+        })),
+      }
+    : {}),
 })
 
 const routeColors = [

--- a/lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver.ts
+++ b/lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver.ts
@@ -476,6 +476,7 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
       return new SingleTransitionIntraNodeSolver({
         nodeWithPortPoints: this.nodeWithPortPoints,
         viaDiameter: this.constructorParams.viaDiameter,
+        traceThickness: this.constructorParams.traceWidth,
       }) as any
     }
     if (hyperParameters.THROUGH_OBSTACLE) {

--- a/scripts/benchmark/benchmark-run-task.ts
+++ b/scripts/benchmark/benchmark-run-task.ts
@@ -52,12 +52,17 @@ type SolverInstance = PipelineStageTimingSource & {
   }
   highDensityRouteSolver?: {
     iterations?: number
+    stats?: Record<string, unknown>
   }
   timeSpentOnPhase: Record<string, number>
 }
 
 type SolverOptions = {
   effort?: number
+  cacheProvider?: null
+  hdCacheBaseUrl?: string
+  hdCacheMaxBatchItems?: number
+  hdCacheMaxBatchBodyBytes?: number
 }
 
 type SolverConstructor = new (
@@ -97,6 +102,7 @@ const countTraceVias = (traces: SimplifiedPcbTrace[]) =>
 
 export const getBenchmarkSolverOptions = (
   scenario: SimpleRouteJson,
+  solverName?: string,
 ): SolverOptions | undefined => {
   const rawEffort = (scenario as SimpleRouteJson & { effort?: number }).effort
   const effort =
@@ -104,13 +110,42 @@ export const getBenchmarkSolverOptions = (
       ? rawEffort
       : undefined
 
-  if (effort === undefined) {
-    return undefined
+  const options: SolverOptions = {}
+  if (effort !== undefined) {
+    options.effort = effort
   }
 
-  return {
-    effort,
+  if (
+    solverName === "AutoroutingPipelineSolver9_PreloadedTraceGraph" ||
+    solverName === "AutoroutingPipelineSolver9_Networked"
+  ) {
+    options.cacheProvider = null
   }
+
+  if (solverName === "AutoroutingPipelineSolver9_Networked") {
+    const cacheUrl = process.env.PIPELINE9_NETWORKED_BENCHMARK_CACHE_URL?.trim()
+    if (cacheUrl) options.hdCacheBaseUrl = cacheUrl
+    options.hdCacheMaxBatchItems = getPositiveIntegerEnvironmentOverride(
+      "PIPELINE9_NETWORKED_BENCHMARK_MAX_BATCH_ITEMS",
+    )
+    options.hdCacheMaxBatchBodyBytes = getPositiveIntegerEnvironmentOverride(
+      "PIPELINE9_NETWORKED_BENCHMARK_MAX_BATCH_BODY_BYTES",
+    )
+  }
+
+  return Object.keys(options).length === 0 ? undefined : options
+}
+
+const getPositiveIntegerEnvironmentOverride = (
+  name: string,
+): number | undefined => {
+  const rawValue = process.env[name]?.trim()
+  if (!rawValue) return undefined
+  const value = Number(rawValue)
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer, received ${rawValue}`)
+  }
+  return value
 }
 
 const getSolverConstructor = (solverName: string): SolverConstructor => {
@@ -129,7 +164,7 @@ export const createSolverForTask = (task: BenchmarkTask): SolverInstance => {
   const SolverConstructor = getSolverConstructor(task.solverName)
   return new SolverConstructor(
     task.scenario,
-    getBenchmarkSolverOptions(task.scenario),
+    getBenchmarkSolverOptions(task.scenario, task.solverName),
   )
 }
 
@@ -285,10 +320,53 @@ const getProgressKey = (progress: WorkerProgress) =>
 const getRoutingBenchmarkMetrics = (
   solver: SolverInstance,
 ): RoutingBenchmarkMetrics => {
+  const highDensityStats = solver.highDensityRouteSolver?.stats
+  const getCounter = (name: string): number | undefined => {
+    const value = highDensityStats?.[name]
+    return typeof value === "number" && Number.isFinite(value)
+      ? value
+      : undefined
+  }
+  const fallbackReasonCounts = highDensityStats?.remoteFallbackReasonCounts
   return {
     tinyHypergraph:
       solver.portPointPathingSolver?.getSolveGraphBenchmarkMetrics?.(),
     highDensityIterations: solver.highDensityRouteSolver?.iterations,
+    nodeCount: getCounter("nodeCount"),
+    solvedNodeCount: getCounter("solvedNodeCount"),
+    regularNodeCount: getCounter("regularNodeCount"),
+    b01NodeCount: getCounter("b01NodeCount"),
+    fallbackNodeCount: getCounter("fallbackNodeCount"),
+    promotedFallbackAttemptCount: getCounter("promotedFallbackAttemptCount"),
+    remoteRequestsStarted: getCounter("remoteRequestsStarted"),
+    remoteRequestsCompleted: getCounter("remoteRequestsCompleted"),
+    remoteBatchRequestsStarted: getCounter("remoteBatchRequestsStarted"),
+    remoteBatchRequestsCompleted: getCounter("remoteBatchRequestsCompleted"),
+    remoteBatchItemsStarted: getCounter("remoteBatchItemsStarted"),
+    remoteBatchBodyBytesStarted: getCounter("remoteBatchBodyBytesStarted"),
+    remoteBatchMaxBodyBytes: getCounter("remoteBatchMaxBodyBytes"),
+    remoteSingleRequestsStarted: getCounter("remoteSingleRequestsStarted"),
+    remoteBatchInvalidLines: getCounter("remoteBatchInvalidLines"),
+    remoteBatchUnknownRequestIds: getCounter(
+      "remoteBatchUnknownRequestIds",
+    ),
+    remoteBatchDuplicateRequestIds: getCounter(
+      "remoteBatchDuplicateRequestIds",
+    ),
+    remoteCacheHits: getCounter("remoteCacheHits"),
+    remoteSolverResults: getCounter("remoteSolverResults"),
+    remoteSolvedResults: getCounter("remoteSolvedResults"),
+    remoteFailedResults: getCounter("remoteFailedResults"),
+    remoteTransportFallbacks: getCounter("remoteTransportFallbacks"),
+    remoteLogicalTimeoutFallbacks: getCounter(
+      "remoteLogicalTimeoutFallbacks",
+    ),
+    remoteFallbackReasonCounts:
+      fallbackReasonCounts &&
+      typeof fallbackReasonCounts === "object" &&
+      !Array.isArray(fallbackReasonCounts)
+        ? (fallbackReasonCounts as Record<string, number>)
+        : undefined,
     phaseTimeMs: solver.timeSpentOnPhase,
   }
 }

--- a/scripts/benchmark/benchmark-run-task.ts
+++ b/scripts/benchmark/benchmark-run-task.ts
@@ -347,9 +347,7 @@ const getRoutingBenchmarkMetrics = (
     remoteBatchMaxBodyBytes: getCounter("remoteBatchMaxBodyBytes"),
     remoteSingleRequestsStarted: getCounter("remoteSingleRequestsStarted"),
     remoteBatchInvalidLines: getCounter("remoteBatchInvalidLines"),
-    remoteBatchUnknownRequestIds: getCounter(
-      "remoteBatchUnknownRequestIds",
-    ),
+    remoteBatchUnknownRequestIds: getCounter("remoteBatchUnknownRequestIds"),
     remoteBatchDuplicateRequestIds: getCounter(
       "remoteBatchDuplicateRequestIds",
     ),
@@ -358,9 +356,7 @@ const getRoutingBenchmarkMetrics = (
     remoteSolvedResults: getCounter("remoteSolvedResults"),
     remoteFailedResults: getCounter("remoteFailedResults"),
     remoteTransportFallbacks: getCounter("remoteTransportFallbacks"),
-    remoteLogicalTimeoutFallbacks: getCounter(
-      "remoteLogicalTimeoutFallbacks",
-    ),
+    remoteLogicalTimeoutFallbacks: getCounter("remoteLogicalTimeoutFallbacks"),
     remoteFallbackReasonCounts:
       fallbackReasonCounts &&
       typeof fallbackReasonCounts === "object" &&

--- a/scripts/benchmark/benchmark-run-task.ts
+++ b/scripts/benchmark/benchmark-run-task.ts
@@ -345,6 +345,7 @@ const getRoutingBenchmarkMetrics = (
     remoteBatchItemsStarted: getCounter("remoteBatchItemsStarted"),
     remoteBatchBodyBytesStarted: getCounter("remoteBatchBodyBytesStarted"),
     remoteBatchMaxBodyBytes: getCounter("remoteBatchMaxBodyBytes"),
+    remoteBatchCacheMisses: getCounter("remoteBatchCacheMisses"),
     remoteSingleRequestsStarted: getCounter("remoteSingleRequestsStarted"),
     remoteBatchInvalidLines: getCounter("remoteBatchInvalidLines"),
     remoteBatchUnknownRequestIds: getCounter("remoteBatchUnknownRequestIds"),

--- a/scripts/benchmark/benchmark-types.ts
+++ b/scripts/benchmark/benchmark-types.ts
@@ -106,6 +106,7 @@ export type RoutingBenchmarkMetrics = {
   remoteBatchItemsStarted?: number
   remoteBatchBodyBytesStarted?: number
   remoteBatchMaxBodyBytes?: number
+  remoteBatchCacheMisses?: number
   remoteSingleRequestsStarted?: number
   remoteBatchInvalidLines?: number
   remoteBatchUnknownRequestIds?: number

--- a/scripts/benchmark/benchmark-types.ts
+++ b/scripts/benchmark/benchmark-types.ts
@@ -93,6 +93,30 @@ export type TinyHypergraphBenchmarkMetrics = {
 export type RoutingBenchmarkMetrics = {
   tinyHypergraph?: TinyHypergraphBenchmarkMetrics
   highDensityIterations?: number
+  nodeCount?: number
+  solvedNodeCount?: number
+  regularNodeCount?: number
+  b01NodeCount?: number
+  fallbackNodeCount?: number
+  promotedFallbackAttemptCount?: number
+  remoteRequestsStarted?: number
+  remoteRequestsCompleted?: number
+  remoteBatchRequestsStarted?: number
+  remoteBatchRequestsCompleted?: number
+  remoteBatchItemsStarted?: number
+  remoteBatchBodyBytesStarted?: number
+  remoteBatchMaxBodyBytes?: number
+  remoteSingleRequestsStarted?: number
+  remoteBatchInvalidLines?: number
+  remoteBatchUnknownRequestIds?: number
+  remoteBatchDuplicateRequestIds?: number
+  remoteCacheHits?: number
+  remoteSolverResults?: number
+  remoteSolvedResults?: number
+  remoteFailedResults?: number
+  remoteTransportFallbacks?: number
+  remoteLogicalTimeoutFallbacks?: number
+  remoteFallbackReasonCounts?: Record<string, number>
   phaseTimeMs?: Record<string, number>
 }
 

--- a/tests/features/never-fail-growth-high-density/shrinks-solution.test.ts
+++ b/tests/features/never-fail-growth-high-density/shrinks-solution.test.ts
@@ -28,4 +28,5 @@ test("GrowShrinkHighDensityIntraNodeSolver shrinks solved routes back to the ori
     { x: 10.5, y: 20, z: 0 },
   ])
   expect(solver.solvedRoutes[0].vias).toEqual([{ x: 10, y: 21 }])
+  expect(Object.hasOwn(solver.solvedRoutes[0], "jumpers")).toBe(false)
 })

--- a/tests/features/pipeline9-networked-batch-body-limit.test.ts
+++ b/tests/features/pipeline9-networked-batch-body-limit.test.ts
@@ -23,11 +23,15 @@ test("Pipeline9 greedily keeps every batch within its configured byte limit", as
       requestBodies.push(body)
       const request = JSON.parse(body) as Pipeline9NetworkedSolveBatchRequest
       return new Response(
-        `${request.items.map((item) => JSON.stringify({
-          requestId: item.requestId,
-          ok: false,
-          message: "fixture miss",
-        })).join("\n")}\n`,
+        `${request.items
+          .map((item) =>
+            JSON.stringify({
+              requestId: item.requestId,
+              ok: false,
+              message: "fixture miss",
+            }),
+          )
+          .join("\n")}\n`,
         {
           status: 200,
           headers: { "content-type": "application/x-ndjson" },
@@ -47,8 +51,7 @@ test("Pipeline9 greedily keeps every batch within its configured byte limit", as
   ).toBeTrue()
   expect(
     requestBodies.flatMap(
-      (body) =>
-        (JSON.parse(body) as Pipeline9NetworkedSolveBatchRequest).items,
+      (body) => (JSON.parse(body) as Pipeline9NetworkedSolveBatchRequest).items,
     ),
   ).toHaveLength(20)
   expect(solver.stats.remoteSingleRequestsStarted).toBe(0)

--- a/tests/features/pipeline9-networked-batch-body-limit.test.ts
+++ b/tests/features/pipeline9-networked-batch-body-limit.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "bun:test"
+import type { Pipeline9NetworkedSolveBatchRequest } from "lib"
+import {
+  asNetworkedBatchFetch,
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9 greedily keeps every batch within its configured byte limit", async () => {
+  const maxBatchBodyBytes = 50_000
+  const requestBodies: string[] = []
+  const solver = createNetworkedHighDensitySolver({
+    nodes: Array.from({ length: 20 }, (_, index) =>
+      createNetworkedNode({
+        nodeId: `cmn_batch_bytes_${index}`,
+        connectionName: `connection_${index}_${"x".repeat(500)}`,
+        xOffset: index * 5,
+      }),
+    ),
+    maxBatchBodyBytes,
+    fetchImpl: asNetworkedBatchFetch(async (_input, init) => {
+      const body = String(init?.body)
+      requestBodies.push(body)
+      const request = JSON.parse(body) as Pipeline9NetworkedSolveBatchRequest
+      return new Response(
+        `${request.items.map((item) => JSON.stringify({
+          requestId: item.requestId,
+          ok: false,
+          message: "fixture miss",
+        })).join("\n")}\n`,
+        {
+          status: 200,
+          headers: { "content-type": "application/x-ndjson" },
+        },
+      )
+    }),
+  })
+
+  solver.step()
+  await solver.pendingEffects![0]!.promise
+
+  expect(requestBodies.length).toBeGreaterThan(1)
+  expect(
+    requestBodies.every(
+      (body) => new TextEncoder().encode(body).byteLength <= maxBatchBodyBytes,
+    ),
+  ).toBeTrue()
+  expect(
+    requestBodies.flatMap(
+      (body) =>
+        (JSON.parse(body) as Pipeline9NetworkedSolveBatchRequest).items,
+    ),
+  ).toHaveLength(20)
+  expect(solver.stats.remoteSingleRequestsStarted).toBe(0)
+  expect(solver.stats.remoteBatchMaxBodyBytes).toBeLessThanOrEqual(
+    maxBatchBodyBytes,
+  )
+  expect(solver.stats.remoteBatchBodyBytesStarted).toBe(
+    requestBodies.reduce(
+      (total, body) => total + new TextEncoder().encode(body).byteLength,
+      0,
+    ),
+  )
+})

--- a/tests/features/pipeline9-networked-batch-consumption-order.test.ts
+++ b/tests/features/pipeline9-networked-batch-consumption-order.test.ts
@@ -46,11 +46,7 @@ test("Pipeline9 batches cold solves in node consumption order", async () => {
     request.items.map(
       (item) => item.input.nodeWithPortPoints.capacityMeshNodeId,
     ),
-  ).toEqual([
-    "cmn_consumed_first",
-    "cmn_consumed_second",
-    "cmn_consumed_third",
-  ])
+  ).toEqual(["cmn_consumed_first", "cmn_consumed_second", "cmn_consumed_third"])
 
   const firstItem = request.items[0]!
   batchStream.write({

--- a/tests/features/pipeline9-networked-batch-consumption-order.test.ts
+++ b/tests/features/pipeline9-networked-batch-consumption-order.test.ts
@@ -1,0 +1,95 @@
+import { expect, test } from "bun:test"
+import type { Pipeline9NetworkedSolveBatchRequest } from "lib"
+import {
+  asNetworkedBatchFetch,
+  createDeferred,
+  createNetworkedBatchStream,
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+  createNetworkedRoute,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9 batches cold solves in node consumption order", async () => {
+  const nodes = [
+    createNetworkedNode({
+      nodeId: "cmn_consumed_third",
+      connectionName: "third",
+      xOffset: -10,
+    }),
+    createNetworkedNode({
+      nodeId: "cmn_consumed_second",
+      connectionName: "second",
+    }),
+    createNetworkedNode({
+      nodeId: "cmn_consumed_first",
+      connectionName: "first",
+      xOffset: 10,
+    }),
+  ]
+  const batchStream = createNetworkedBatchStream()
+  const requestStarted = createDeferred<Pipeline9NetworkedSolveBatchRequest>()
+  const solver = createNetworkedHighDensitySolver({
+    nodes,
+    requestTimeoutMs: 100,
+    transportTimeoutMs: 1_000,
+    fetchImpl: asNetworkedBatchFetch(async (_input, init) => {
+      requestStarted.resolve(
+        JSON.parse(String(init?.body)) as Pipeline9NetworkedSolveBatchRequest,
+      )
+      return batchStream.response
+    }),
+  })
+
+  solver.step()
+  const request = await requestStarted.promise
+  expect(
+    request.items.map(
+      (item) => item.input.nodeWithPortPoints.capacityMeshNodeId,
+    ),
+  ).toEqual([
+    "cmn_consumed_first",
+    "cmn_consumed_second",
+    "cmn_consumed_third",
+  ])
+
+  const firstItem = request.items[0]!
+  batchStream.write({
+    requestId: firstItem.requestId,
+    ok: true,
+    autorouterVersion: request.autorouterVersion,
+    source: "solver",
+    status: "solved",
+    routes: [createNetworkedRoute(firstItem.input.nodeWithPortPoints)],
+  })
+  await solver.pendingEffects![0]!.promise
+  solver.step()
+
+  expect(solver.routes.map((route) => route.connectionName)).toEqual(["first"])
+  expect(solver.stats.remoteLogicalTimeoutFallbacks).toBe(0)
+  expect(solver.activeRegularSolver).toBeNull()
+
+  for (const item of request.items.slice(1)) {
+    batchStream.write({
+      requestId: item.requestId,
+      ok: true,
+      autorouterVersion: request.autorouterVersion,
+      source: "solver",
+      status: "solved",
+      routes: [createNetworkedRoute(item.input.nodeWithPortPoints)],
+    })
+  }
+  batchStream.close()
+  while (solver.stats.remoteRequestsCompleted < nodes.length) {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+  while (!solver.solved && !solver.failed) solver.step()
+
+  expect(solver.solved).toBeTrue()
+  expect(solver.routes.map((route) => route.connectionName)).toEqual([
+    "first",
+    "second",
+    "third",
+  ])
+  expect(solver.stats.remoteSolverResults).toBe(3)
+  expect(solver.stats.remoteLogicalTimeoutFallbacks).toBe(0)
+})

--- a/tests/features/pipeline9-networked-batch-item-limit.test.ts
+++ b/tests/features/pipeline9-networked-batch-item-limit.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test"
+import type { Pipeline9NetworkedSolveBatchRequest } from "lib"
+import {
+  asNetworkedBatchFetch,
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9 launches no more than 100 items in each batch", async () => {
+  const requests: Pipeline9NetworkedSolveBatchRequest[] = []
+  const solver = createNetworkedHighDensitySolver({
+    nodes: Array.from({ length: 101 }, (_, index) =>
+      createNetworkedNode({
+        nodeId: `cmn_batch_limit_${index}`,
+        connectionName: `connection_${index}`,
+        xOffset: index * 5,
+      }),
+    ),
+    fetchImpl: asNetworkedBatchFetch(async (_input, init) => {
+      const request = JSON.parse(
+        String(init?.body),
+      ) as Pipeline9NetworkedSolveBatchRequest
+      requests.push(request)
+      return new Response(
+        `${request.items.map((item) => JSON.stringify({
+          requestId: item.requestId,
+          ok: false,
+          message: "fixture miss",
+        })).join("\n")}\n`,
+        {
+          status: 200,
+          headers: { "content-type": "application/x-ndjson" },
+        },
+      )
+    }),
+  })
+
+  solver.step()
+  await solver.pendingEffects![0]!.promise
+
+  expect(requests.map((request) => request.items.length)).toEqual([100, 1])
+  expect(requests.flatMap((request) => request.items)).toHaveLength(101)
+  expect(solver.stats.remoteBatchRequestsStarted).toBe(2)
+  expect(solver.stats.remoteBatchItemsStarted).toBe(101)
+  expect(solver.stats.remoteSingleRequestsStarted).toBe(0)
+})

--- a/tests/features/pipeline9-networked-batch-item-limit.test.ts
+++ b/tests/features/pipeline9-networked-batch-item-limit.test.ts
@@ -22,11 +22,15 @@ test("Pipeline9 launches no more than 100 items in each batch", async () => {
       ) as Pipeline9NetworkedSolveBatchRequest
       requests.push(request)
       return new Response(
-        `${request.items.map((item) => JSON.stringify({
-          requestId: item.requestId,
-          ok: false,
-          message: "fixture miss",
-        })).join("\n")}\n`,
+        `${request.items
+          .map((item) =>
+            JSON.stringify({
+              requestId: item.requestId,
+              ok: false,
+              message: "fixture miss",
+            }),
+          )
+          .join("\n")}\n`,
         {
           status: 200,
           headers: { "content-type": "application/x-ndjson" },

--- a/tests/features/pipeline9-networked-batch-logical-timeout.test.ts
+++ b/tests/features/pipeline9-networked-batch-logical-timeout.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "bun:test"
+import type { Pipeline9NetworkedSolveBatchRequest } from "lib"
+import {
+  asNetworkedBatchFetch,
+  createDeferred,
+  createNetworkedBatchStream,
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+  createNetworkedRoute,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9 logical timeout leaves the shared batch alive for sibling results", async () => {
+  const batchStream = createNetworkedBatchStream()
+  const requestStarted = createDeferred<{
+    request: Pipeline9NetworkedSolveBatchRequest
+    signal: AbortSignal
+  }>()
+  const solver = createNetworkedHighDensitySolver({
+    nodes: [
+      createNetworkedNode({
+        nodeId: "cmn_batch_timeout_first",
+        connectionName: "first",
+        xOffset: -5,
+      }),
+      createNetworkedNode({
+        nodeId: "cmn_batch_timeout_second",
+        connectionName: "second",
+        xOffset: 5,
+      }),
+    ],
+    requestTimeoutMs: 5,
+    transportTimeoutMs: 1_000,
+    fetchImpl: asNetworkedBatchFetch(async (_input, init) => {
+      requestStarted.resolve({
+        request: JSON.parse(
+          String(init?.body),
+        ) as Pipeline9NetworkedSolveBatchRequest,
+        signal: init?.signal as AbortSignal,
+      })
+      return batchStream.response
+    }),
+  })
+
+  solver.step()
+  const { request, signal } = await requestStarted.promise
+  await solver.pendingEffects![0]!.promise
+  expect(signal.aborted).toBeFalse()
+
+  for (const item of request.items) {
+    batchStream.write({
+      requestId: item.requestId,
+      ok: true,
+      autorouterVersion: request.autorouterVersion,
+      source: "cache",
+      status: "solved",
+      routes: [createNetworkedRoute(item.input.nodeWithPortPoints)],
+    })
+  }
+  batchStream.close()
+  while (solver.stats.remoteRequestsCompleted < 2) {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+  while (!solver.solved && !solver.failed) solver.step()
+
+  expect(solver.solved).toBeTrue()
+  expect(signal.aborted).toBeFalse()
+  expect(solver.stats.remoteCacheHits).toBe(2)
+  expect(solver.stats.remoteLogicalTimeoutFallbacks).toBe(1)
+  expect(solver.stats.remoteTransportFallbacks).toBe(1)
+  expect(solver.stats.remoteFallbackReasonCounts).toEqual({
+    logical_timeout: 1,
+  })
+})

--- a/tests/features/pipeline9-networked-batch-misses-parallel.test.ts
+++ b/tests/features/pipeline9-networked-batch-misses-parallel.test.ts
@@ -1,0 +1,120 @@
+import { expect, test } from "bun:test"
+import type {
+  Pipeline9NetworkedSolveBatchRequest,
+  Pipeline9NetworkedSolveRequest,
+} from "lib"
+import {
+  asNetworkedBatchFetch,
+  createDeferred,
+  createNetworkedBatchStream,
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+  createNetworkedResponse,
+  createNetworkedRoute,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9 streams multiple cache misses into concurrent out-of-order legacy solves", async () => {
+  const nodes = [
+    createNetworkedNode({
+      nodeId: "cmn_miss_consumed_third",
+      connectionName: "third",
+      xOffset: -10,
+    }),
+    createNetworkedNode({
+      nodeId: "cmn_miss_consumed_second",
+      connectionName: "second",
+    }),
+    createNetworkedNode({
+      nodeId: "cmn_miss_consumed_first",
+      connectionName: "first",
+      xOffset: 10,
+    }),
+  ]
+  const batchStream = createNetworkedBatchStream()
+  const batchStarted = createDeferred<Pipeline9NetworkedSolveBatchRequest>()
+  const releasesByNodeId = new Map(
+    nodes.map((node) => [node.capacityMeshNodeId, createDeferred<void>()]),
+  )
+  const singleStartOrder: string[] = []
+  const singleCompletionOrder: string[] = []
+  const solver = createNetworkedHighDensitySolver({
+    nodes,
+    requestTimeoutMs: 1_000,
+    transportTimeoutMs: 5_000,
+    fetchImpl: asNetworkedBatchFetch(async (input, init) => {
+      if (String(input).endsWith("/solve-batch")) {
+        batchStarted.resolve(
+          JSON.parse(String(init?.body)) as Pipeline9NetworkedSolveBatchRequest,
+        )
+        return batchStream.response
+      }
+
+      const request = JSON.parse(
+        String(init?.body),
+      ) as Pipeline9NetworkedSolveRequest
+      const nodeId = request.input.nodeWithPortPoints.capacityMeshNodeId
+      singleStartOrder.push(nodeId)
+      await releasesByNodeId.get(nodeId)!.promise
+      singleCompletionOrder.push(nodeId)
+      return createNetworkedResponse({
+        source: "solver",
+        status: "solved",
+        routes: [createNetworkedRoute(request.input.nodeWithPortPoints)],
+      })
+    }),
+  })
+
+  solver.step()
+  const batchRequest = await batchStarted.promise
+  for (const [itemIndex, item] of batchRequest.items.entries()) {
+    batchStream.write({
+      requestId: item.requestId,
+      ok: false,
+      autorouterVersion: batchRequest.autorouterVersion,
+      code: "CACHE_MISS",
+      message: "exact key not found",
+    })
+    while (singleStartOrder.length < itemIndex + 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    }
+  }
+  expect(singleStartOrder).toEqual([
+    "cmn_miss_consumed_first",
+    "cmn_miss_consumed_second",
+    "cmn_miss_consumed_third",
+  ])
+  expect(singleCompletionOrder).toEqual([])
+
+  releasesByNodeId.get("cmn_miss_consumed_third")!.resolve()
+  while (singleCompletionOrder.length < 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+  releasesByNodeId.get("cmn_miss_consumed_first")!.resolve()
+  while (singleCompletionOrder.length < 2) {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+  releasesByNodeId.get("cmn_miss_consumed_second")!.resolve()
+  while (solver.stats.remoteRequestsCompleted < nodes.length) {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+  while (!solver.solved && !solver.failed) solver.step()
+
+  expect(singleCompletionOrder).toEqual([
+    "cmn_miss_consumed_third",
+    "cmn_miss_consumed_first",
+    "cmn_miss_consumed_second",
+  ])
+  expect(solver.solved).toBeTrue()
+  expect(solver.routes.map((route) => route.connectionName)).toEqual([
+    "first",
+    "second",
+    "third",
+  ])
+  expect(solver.stats.remoteBatchCacheMisses).toBe(3)
+  expect(solver.stats.remoteSingleRequestsStarted).toBe(3)
+  expect(solver.stats.remoteRequestsStarted).toBe(3)
+  expect(solver.stats.remoteRequestsCompleted).toBe(3)
+  expect(solver.stats.remoteSolverResults).toBe(3)
+  expect(solver.stats.remoteBatchInvalidLines).toBe(0)
+  expect(solver.stats.remoteTransportFallbacks).toBe(0)
+})

--- a/tests/features/pipeline9-networked-batch-mixed-hit-miss.test.ts
+++ b/tests/features/pipeline9-networked-batch-mixed-hit-miss.test.ts
@@ -60,7 +60,9 @@ test("Pipeline9 fans a batch cache miss out to legacy solve without losing hit c
               code: "CACHE_MISS",
               message: "exact key not found",
             },
-          ].map((line) => JSON.stringify(line)).join("\n")}\n`,
+          ]
+            .map((line) => JSON.stringify(line))
+            .join("\n")}\n`,
           {
             status: 200,
             headers: { "content-type": "application/x-ndjson" },
@@ -85,14 +87,14 @@ test("Pipeline9 fans a batch cache miss out to legacy solve without losing hit c
   while (!solver.solved && !solver.failed) solver.step()
 
   expect(solver.solved).toBeTrue()
-  expect(requestUrls.filter((url) => url.endsWith("/solve-batch"))).toHaveLength(
-    1,
-  )
+  expect(
+    requestUrls.filter((url) => url.endsWith("/solve-batch")),
+  ).toHaveLength(1)
   expect(requestUrls.filter((url) => url.endsWith("/solve"))).toHaveLength(1)
   expect(singleRequests).toHaveLength(1)
-  expect(
-    singleRequests[0]!.input.nodeWithPortPoints.capacityMeshNodeId,
-  ).toBe(missNode.capacityMeshNodeId)
+  expect(singleRequests[0]!.input.nodeWithPortPoints.capacityMeshNodeId).toBe(
+    missNode.capacityMeshNodeId,
+  )
   expect(solver.routes.map((route) => route.connectionName)).toEqual([
     "miss",
     "hit",

--- a/tests/features/pipeline9-networked-batch-mixed-hit-miss.test.ts
+++ b/tests/features/pipeline9-networked-batch-mixed-hit-miss.test.ts
@@ -1,0 +1,108 @@
+import { expect, test } from "bun:test"
+import type {
+  Pipeline9NetworkedSolveBatchRequest,
+  Pipeline9NetworkedSolveRequest,
+} from "lib"
+import {
+  asNetworkedBatchFetch,
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+  createNetworkedResponse,
+  createNetworkedRoute,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9 fans a batch cache miss out to legacy solve without losing hit correlation", async () => {
+  const hitNode = createNetworkedNode({
+    nodeId: "cmn_batch_hit",
+    connectionName: "hit",
+    xOffset: -5,
+  })
+  const missNode = createNetworkedNode({
+    nodeId: "cmn_batch_miss",
+    connectionName: "miss",
+    xOffset: 5,
+  })
+  const requestUrls: string[] = []
+  const singleRequests: Pipeline9NetworkedSolveRequest[] = []
+  const solver = createNetworkedHighDensitySolver({
+    nodes: [hitNode, missNode],
+    fetchImpl: asNetworkedBatchFetch(async (input, init) => {
+      const requestUrl = String(input)
+      requestUrls.push(requestUrl)
+      if (requestUrl.endsWith("/solve-batch")) {
+        const request = JSON.parse(
+          String(init?.body),
+        ) as Pipeline9NetworkedSolveBatchRequest
+        const hitItem = request.items.find(
+          (item) =>
+            item.input.nodeWithPortPoints.capacityMeshNodeId ===
+            hitNode.capacityMeshNodeId,
+        )!
+        const missItem = request.items.find(
+          (item) =>
+            item.input.nodeWithPortPoints.capacityMeshNodeId ===
+            missNode.capacityMeshNodeId,
+        )!
+        return new Response(
+          `${[
+            {
+              requestId: hitItem.requestId,
+              ok: true,
+              autorouterVersion: request.autorouterVersion,
+              source: "cache",
+              status: "solved",
+              routes: [createNetworkedRoute(hitItem.input.nodeWithPortPoints)],
+            },
+            {
+              requestId: missItem.requestId,
+              ok: false,
+              autorouterVersion: request.autorouterVersion,
+              code: "CACHE_MISS",
+              message: "exact key not found",
+            },
+          ].map((line) => JSON.stringify(line)).join("\n")}\n`,
+          {
+            status: 200,
+            headers: { "content-type": "application/x-ndjson" },
+          },
+        )
+      }
+
+      const request = JSON.parse(
+        String(init?.body),
+      ) as Pipeline9NetworkedSolveRequest
+      singleRequests.push(request)
+      return createNetworkedResponse({
+        source: "solver",
+        status: "solved",
+        routes: [createNetworkedRoute(request.input.nodeWithPortPoints)],
+      })
+    }),
+  })
+
+  solver.step()
+  await solver.pendingEffects![0]!.promise
+  while (!solver.solved && !solver.failed) solver.step()
+
+  expect(solver.solved).toBeTrue()
+  expect(requestUrls.filter((url) => url.endsWith("/solve-batch"))).toHaveLength(
+    1,
+  )
+  expect(requestUrls.filter((url) => url.endsWith("/solve"))).toHaveLength(1)
+  expect(singleRequests).toHaveLength(1)
+  expect(
+    singleRequests[0]!.input.nodeWithPortPoints.capacityMeshNodeId,
+  ).toBe(missNode.capacityMeshNodeId)
+  expect(solver.routes.map((route) => route.connectionName)).toEqual([
+    "miss",
+    "hit",
+  ])
+  expect(solver.stats.remoteBatchCacheMisses).toBe(1)
+  expect(solver.stats.remoteSingleRequestsStarted).toBe(1)
+  expect(solver.stats.remoteRequestsStarted).toBe(2)
+  expect(solver.stats.remoteRequestsCompleted).toBe(2)
+  expect(solver.stats.remoteCacheHits).toBe(1)
+  expect(solver.stats.remoteSolverResults).toBe(1)
+  expect(solver.stats.remoteBatchInvalidLines).toBe(0)
+  expect(solver.stats.remoteTransportFallbacks).toBe(0)
+})

--- a/tests/features/pipeline9-networked-batch-partial-failure.test.ts
+++ b/tests/features/pipeline9-networked-batch-partial-failure.test.ts
@@ -44,9 +44,7 @@ test("Pipeline9 batch results fail open per node without discarding valid siblin
             autorouterVersion: request.autorouterVersion,
             source: "cache",
             status: "solved",
-            routes: [
-              createNetworkedRoute(validItem.input.nodeWithPortPoints),
-            ],
+            routes: [createNetworkedRoute(validItem.input.nodeWithPortPoints)],
           }),
           JSON.stringify({
             requestId: invalidItem.requestId,

--- a/tests/features/pipeline9-networked-batch-partial-failure.test.ts
+++ b/tests/features/pipeline9-networked-batch-partial-failure.test.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "bun:test"
+import type { Pipeline9NetworkedSolveBatchRequest } from "lib"
+import {
+  asNetworkedBatchFetch,
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+  createNetworkedRoute,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9 batch results fail open per node without discarding valid siblings", async () => {
+  const nodes = [
+    createNetworkedNode({
+      nodeId: "cmn_batch_valid",
+      connectionName: "valid",
+      xOffset: -10,
+    }),
+    createNetworkedNode({
+      nodeId: "cmn_batch_invalid",
+      connectionName: "invalid",
+    }),
+    createNetworkedNode({
+      nodeId: "cmn_batch_missing",
+      connectionName: "missing",
+      xOffset: 10,
+    }),
+  ]
+  const solver = createNetworkedHighDensitySolver({
+    nodes,
+    fetchImpl: asNetworkedBatchFetch(async (_input, init) => {
+      const request = JSON.parse(
+        String(init?.body),
+      ) as Pipeline9NetworkedSolveBatchRequest
+      const validItem = request.items.find((item) =>
+        item.input.nodeWithPortPoints.capacityMeshNodeId.endsWith("_valid"),
+      )!
+      const invalidItem = request.items.find((item) =>
+        item.input.nodeWithPortPoints.capacityMeshNodeId.endsWith("_invalid"),
+      )!
+      return new Response(
+        [
+          JSON.stringify({
+            requestId: validItem.requestId,
+            ok: true,
+            autorouterVersion: request.autorouterVersion,
+            source: "cache",
+            status: "solved",
+            routes: [
+              createNetworkedRoute(validItem.input.nodeWithPortPoints),
+            ],
+          }),
+          JSON.stringify({
+            requestId: invalidItem.requestId,
+            ok: true,
+            autorouterVersion: request.autorouterVersion,
+            source: "cache",
+            status: "solved",
+            routes: [{}],
+          }),
+        ].join("\n"),
+        {
+          status: 200,
+          headers: { "content-type": "application/x-ndjson" },
+        },
+      )
+    }),
+  })
+
+  solver.step()
+  await solver.pendingEffects![0]!.promise
+  while (!solver.solved && !solver.failed) solver.step()
+
+  expect(solver.solved).toBeTrue()
+  expect(solver.stats.remoteRequestsCompleted).toBe(3)
+  expect(solver.stats.remoteCacheHits).toBe(1)
+  expect(solver.stats.remoteTransportFallbacks).toBe(2)
+  expect(solver.stats.remoteBatchInvalidLines).toBe(1)
+  expect(solver.stats.remoteFallbackReasonCounts).toEqual({
+    invalid_response: 1,
+    missing_response: 1,
+  })
+})

--- a/tests/features/pipeline9-networked-batch-transport-timeout.test.ts
+++ b/tests/features/pipeline9-networked-batch-transport-timeout.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test"
+import {
+  asNetworkedBatchFetch,
+  createDeferred,
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9 batch transport timeout settles only unresolved nodes after a logical fallback", async () => {
+  const transportAborted = createDeferred<void>()
+  const requestStarted = createDeferred<AbortSignal>()
+  const solver = createNetworkedHighDensitySolver({
+    nodes: [
+      createNetworkedNode({
+        nodeId: "cmn_batch_transport_first",
+        connectionName: "first",
+        xOffset: -5,
+      }),
+      createNetworkedNode({
+        nodeId: "cmn_batch_transport_second",
+        connectionName: "second",
+        xOffset: 5,
+      }),
+    ],
+    requestTimeoutMs: 5,
+    transportTimeoutMs: 50,
+    fetchImpl: asNetworkedBatchFetch(
+      async (_input, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          const signal = init?.signal as AbortSignal
+          requestStarted.resolve(signal)
+          signal.addEventListener(
+            "abort",
+            () => {
+              transportAborted.resolve()
+              reject(signal.reason)
+            },
+            { once: true },
+          )
+        }),
+    ),
+  })
+
+  solver.step()
+  const signal = await requestStarted.promise
+  await solver.pendingEffects![0]!.promise
+  expect(signal.aborted).toBeFalse()
+
+  solver.step()
+  expect(solver.activeRegularSolver).not.toBeNull()
+  await transportAborted.promise
+  while (solver.stats.remoteRequestsCompleted < 2) {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+
+  expect(signal.aborted).toBeTrue()
+  expect(solver.stats.remoteRequestsCompleted).toBe(2)
+  expect(solver.stats.remoteTransportFallbacks).toBe(2)
+  expect(solver.stats.remoteFallbackReasonCounts).toEqual({
+    logical_timeout: 1,
+    transport_timeout: 1,
+  })
+})

--- a/tests/features/pipeline9-networked-delayed-node-result.test.ts
+++ b/tests/features/pipeline9-networked-delayed-node-result.test.ts
@@ -1,11 +1,11 @@
 import { expect, test } from "bun:test"
-import type { Pipeline9NetworkedSolveRequest } from "lib"
+import type { Pipeline9NetworkedSolveBatchRequest } from "lib"
 import {
-  asNetworkedFetch,
+  asNetworkedBatchFetch,
+  createNetworkedBatchStream,
   createDeferred,
   createNetworkedHighDensitySolver,
   createNetworkedNode,
-  createNetworkedResponse,
   createNetworkedRoute,
 } from "tests/fixtures/pipeline9-networked-fixtures"
 
@@ -20,35 +20,52 @@ test("Pipeline9 uses a speculative result that finishes before its node is consu
     connectionName: "current",
     xOffset: 5,
   })
-  const releaseDelayedResponse = createDeferred<void>()
-  const delayedResponseFinished = createDeferred<void>()
+  const requestStarted = createDeferred<Pipeline9NetworkedSolveBatchRequest>()
+  const batchStream = createNetworkedBatchStream()
   const solver = createNetworkedHighDensitySolver({
     nodes: [delayedNode, currentNode],
     requestTimeoutMs: 5,
     transportTimeoutMs: 1_000,
-    fetchImpl: asNetworkedFetch(async (_url, init) => {
+    fetchImpl: asNetworkedBatchFetch(async (_url, init) => {
       const request = JSON.parse(
         String(init?.body),
-      ) as Pipeline9NetworkedSolveRequest
-      if (
-        request.input.nodeWithPortPoints.capacityMeshNodeId ===
-        delayedNode.capacityMeshNodeId
-      ) {
-        await releaseDelayedResponse.promise
-        delayedResponseFinished.resolve()
-      }
-      return createNetworkedResponse({
-        status: "solved",
-        routes: [createNetworkedRoute(request.input.nodeWithPortPoints)],
-      })
+      ) as Pipeline9NetworkedSolveBatchRequest
+      requestStarted.resolve(request)
+      return batchStream.response
     }),
   })
 
   solver.step()
+  const request = await requestStarted.promise
+  const currentItem = request.items.find(
+    (item) =>
+      item.input.nodeWithPortPoints.capacityMeshNodeId ===
+      currentNode.capacityMeshNodeId,
+  )!
+  const delayedItem = request.items.find(
+    (item) =>
+      item.input.nodeWithPortPoints.capacityMeshNodeId ===
+      delayedNode.capacityMeshNodeId,
+  )!
+  batchStream.write({
+    requestId: currentItem.requestId,
+    ok: true,
+    autorouterVersion: request.autorouterVersion,
+    source: "cache",
+    status: "solved",
+    routes: [createNetworkedRoute(currentNode)],
+  })
   await solver.pendingEffects![0]!.promise
   await new Promise((resolve) => setTimeout(resolve, 15))
-  releaseDelayedResponse.resolve()
-  await delayedResponseFinished.promise
+  batchStream.write({
+    requestId: delayedItem.requestId,
+    ok: true,
+    autorouterVersion: request.autorouterVersion,
+    source: "cache",
+    status: "solved",
+    routes: [createNetworkedRoute(delayedNode)],
+  })
+  batchStream.close()
   while (solver.stats.remoteRequestsCompleted < 2) {
     await new Promise((resolve) => setTimeout(resolve, 0))
   }

--- a/tests/features/pipeline9-networked-parallel-node-requests.test.ts
+++ b/tests/features/pipeline9-networked-parallel-node-requests.test.ts
@@ -30,17 +30,24 @@ test("Pipeline9 networked launches every node request in parallel and preserves 
     ) as Pipeline9NetworkedSolveBatchRequest
     requestBodies.push(request)
     await releaseRequests.promise
-    return new Response(`${request.items.map((item) => JSON.stringify({
-      requestId: item.requestId,
-      ok: true,
-      autorouterVersion: request.autorouterVersion,
-      source: "cache",
-      status: "solved",
-      routes: [createNetworkedRoute(item.input.nodeWithPortPoints)],
-    })).join("\n")}\n`, {
-      status: 200,
-      headers: { "content-type": "application/x-ndjson" },
-    })
+    return new Response(
+      `${request.items
+        .map((item) =>
+          JSON.stringify({
+            requestId: item.requestId,
+            ok: true,
+            autorouterVersion: request.autorouterVersion,
+            source: "cache",
+            status: "solved",
+            routes: [createNetworkedRoute(item.input.nodeWithPortPoints)],
+          }),
+        )
+        .join("\n")}\n`,
+      {
+        status: 200,
+        headers: { "content-type": "application/x-ndjson" },
+      },
+    )
   })
   const solver = createNetworkedHighDensitySolver({
     nodes: [firstNode, secondNode],
@@ -53,7 +60,9 @@ test("Pipeline9 networked launches every node request in parallel and preserves 
   expect(requestUrls[0]).toEndWith("/solve-batch")
   expect(requestBodies[0]!.autorouterVersion).toBe(AUTOROUTER_VERSION)
   expect(requestBodies[0]!.items).toHaveLength(2)
-  expect(requestBodies[0]!.items.map((item) => item.input.effort)).toEqual([1, 1])
+  expect(requestBodies[0]!.items.map((item) => item.input.effort)).toEqual([
+    1, 1,
+  ])
   expect(solver.pendingEffects).toHaveLength(1)
 
   releaseRequests.resolve()

--- a/tests/features/pipeline9-networked-parallel-node-requests.test.ts
+++ b/tests/features/pipeline9-networked-parallel-node-requests.test.ts
@@ -88,5 +88,6 @@ test("Pipeline9 networked launches every node request in parallel and preserves 
   expect(solver.stats.remoteCacheHits).toBe(2)
   expect(solver.stats.remoteBatchRequestsStarted).toBe(1)
   expect(solver.stats.remoteBatchItemsStarted).toBe(2)
+  expect(solver.stats.remoteBatchCacheMisses).toBe(0)
   expect(solver.stats.remoteSingleRequestsStarted).toBe(0)
 })

--- a/tests/features/pipeline9-networked-parallel-node-requests.test.ts
+++ b/tests/features/pipeline9-networked-parallel-node-requests.test.ts
@@ -1,12 +1,11 @@
 import { expect, test } from "bun:test"
 import { AUTOROUTER_VERSION } from "lib"
-import type { Pipeline9NetworkedSolveRequest } from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-types"
+import type { Pipeline9NetworkedSolveBatchRequest } from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-types"
 import {
-  asNetworkedFetch,
+  asNetworkedBatchFetch,
   createDeferred,
   createNetworkedHighDensitySolver,
   createNetworkedNode,
-  createNetworkedResponse,
   createNetworkedRoute,
 } from "tests/fixtures/pipeline9-networked-fixtures"
 
@@ -22,16 +21,25 @@ test("Pipeline9 networked launches every node request in parallel and preserves 
     xOffset: 5,
   })
   const releaseRequests = createDeferred<void>()
-  const requestBodies: Pipeline9NetworkedSolveRequest[] = []
-  const fetchImpl = asNetworkedFetch(async (_input, init) => {
+  const requestBodies: Pipeline9NetworkedSolveBatchRequest[] = []
+  const requestUrls: string[] = []
+  const fetchImpl = asNetworkedBatchFetch(async (input, init) => {
+    requestUrls.push(String(input))
     const request = JSON.parse(
       String(init?.body),
-    ) as Pipeline9NetworkedSolveRequest
+    ) as Pipeline9NetworkedSolveBatchRequest
     requestBodies.push(request)
     await releaseRequests.promise
-    return createNetworkedResponse({
+    return new Response(`${request.items.map((item) => JSON.stringify({
+      requestId: item.requestId,
+      ok: true,
+      autorouterVersion: request.autorouterVersion,
+      source: "cache",
       status: "solved",
-      routes: [createNetworkedRoute(request.input.nodeWithPortPoints)],
+      routes: [createNetworkedRoute(item.input.nodeWithPortPoints)],
+    })).join("\n")}\n`, {
+      status: 200,
+      headers: { "content-type": "application/x-ndjson" },
     })
   })
   const solver = createNetworkedHighDensitySolver({
@@ -41,12 +49,11 @@ test("Pipeline9 networked launches every node request in parallel and preserves 
 
   solver.step()
 
-  expect(requestBodies).toHaveLength(2)
-  expect(requestBodies.map((request) => request.autorouterVersion)).toEqual([
-    AUTOROUTER_VERSION,
-    AUTOROUTER_VERSION,
-  ])
-  expect(requestBodies.map((request) => request.input.effort)).toEqual([1, 1])
+  expect(requestBodies).toHaveLength(1)
+  expect(requestUrls[0]).toEndWith("/solve-batch")
+  expect(requestBodies[0]!.autorouterVersion).toBe(AUTOROUTER_VERSION)
+  expect(requestBodies[0]!.items).toHaveLength(2)
+  expect(requestBodies[0]!.items.map((item) => item.input.effort)).toEqual([1, 1])
   expect(solver.pendingEffects).toHaveLength(1)
 
   releaseRequests.resolve()
@@ -70,4 +77,7 @@ test("Pipeline9 networked launches every node request in parallel and preserves 
   ])
   expect(solver.stats.remoteRequestsStarted).toBe(2)
   expect(solver.stats.remoteCacheHits).toBe(2)
+  expect(solver.stats.remoteBatchRequestsStarted).toBe(1)
+  expect(solver.stats.remoteBatchItemsStarted).toBe(2)
+  expect(solver.stats.remoteSingleRequestsStarted).toBe(0)
 })

--- a/tests/features/pipeline9-networked-pipeline-contract.test.ts
+++ b/tests/features/pipeline9-networked-pipeline-contract.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "bun:test"
 import {
   AutoroutingPipelineSolver9_Networked,
   AutoroutingPipelineSolver9_PreloadedTraceGraph,
+  DEFAULT_PIPELINE9_NETWORKED_MAX_BATCH_BODY_BYTES,
 } from "lib"
 import {
   AutoroutingPipelineSolver9_Networked as NetworkedPipelineFromPipelineIndex,
@@ -32,11 +33,30 @@ test("Pipeline9 networked is effort-1-only, async-only, and replaces only the hi
         hdCacheTransportTimeoutMs: 10,
       }),
   ).toThrow("transport timeout must be at least the logical request timeout")
+  expect(
+    () =>
+      new AutoroutingPipelineSolver9_Networked(emptySrj, {
+        hdCacheMaxBatchItems: 101,
+      }),
+  ).toThrow("max batch items must be a positive integer no greater than 100")
+  expect(
+    () =>
+      new AutoroutingPipelineSolver9_Networked(emptySrj, {
+        hdCacheMaxBatchBodyBytes:
+          DEFAULT_PIPELINE9_NETWORKED_MAX_BATCH_BODY_BYTES + 1,
+      }),
+  ).toThrow("max batch body bytes must be a positive integer no greater than")
 
   const networkedSolver = new AutoroutingPipelineSolver9_Networked(emptySrj)
   const pipelineIndexOptions: AutoroutingPipelineSolver9NetworkedOptions = {
     effort: 1,
+    hdCacheMaxBatchItems: 25,
+    hdCacheMaxBatchBodyBytes: 500_000,
   }
+  const customBatchSolver = new AutoroutingPipelineSolver9_Networked(
+    emptySrj,
+    pipelineIndexOptions,
+  )
   const localSolver = new AutoroutingPipelineSolver9_PreloadedTraceGraph(
     emptySrj,
   )
@@ -51,6 +71,8 @@ test("Pipeline9 networked is effort-1-only, async-only, and replaces only the hi
     AutoroutingPipelineSolver9_Networked,
   )
   expect(pipelineIndexOptions.effort).toBe(1)
+  expect(customBatchSolver.hdCacheMaxBatchItems).toBe(25)
+  expect(customBatchSolver.hdCacheMaxBatchBodyBytes).toBe(500_000)
   expect(networkedSolver.getSolverName()).toBe(
     "AutoroutingPipelineSolver9_Networked",
   )

--- a/tests/features/portfolio-single-transition-trace-width.test.ts
+++ b/tests/features/portfolio-single-transition-trace-width.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "bun:test"
+import { SingleTransitionIntraNodeSolver } from "lib/solvers/HighDensitySolver/SingleTransitionIntraNodeSolver"
+import { PortfolioSingleIntraNodeSolver } from "lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver"
+
+test("the portfolio single-transition candidate preserves the requested trace width", () => {
+  const portfolioSolver = new PortfolioSingleIntraNodeSolver({
+    nodeWithPortPoints: {
+      capacityMeshNodeId: "single-transition-trace-width",
+      center: { x: 0, y: 0 },
+      width: 2,
+      height: 2,
+      availableZ: [0, 1],
+      portPoints: [
+        { connectionName: "route_A", x: -0.5, y: 0, z: 0 },
+        { connectionName: "route_A", x: 0.5, y: 0, z: 1 },
+      ],
+    },
+    traceWidth: 0.1,
+    viaDiameter: 0.3,
+    obstacleMargin: 0.15,
+    effort: 1,
+  })
+  const transitionSolver = portfolioSolver.generateSolver({
+    CLOSED_FORM_SINGLE_TRANSITION: true,
+  })
+
+  expect(transitionSolver).toBeInstanceOf(SingleTransitionIntraNodeSolver)
+  if (!(transitionSolver instanceof SingleTransitionIntraNodeSolver)) {
+    throw new Error("Expected the closed-form single-transition candidate")
+  }
+  expect(transitionSolver.solved).toBe(true)
+  expect(transitionSolver.solvedRoutes).toHaveLength(1)
+  expect(transitionSolver.solvedRoutes[0]!.traceThickness).toBe(0.1)
+})

--- a/tests/fixtures/pipeline9-networked-fixtures.ts
+++ b/tests/fixtures/pipeline9-networked-fixtures.ts
@@ -4,7 +4,12 @@ import {
   Pipeline9NetworkedHighDensitySolver,
   type Pipeline9NetworkedHighDensitySolverParams,
 } from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-high-density-solver"
-import type { Pipeline9NetworkedHighDensityNodeOutput } from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-types"
+import type {
+  Pipeline9NetworkedHighDensityNodeOutput,
+  Pipeline9NetworkedSolveBatchRequest,
+  Pipeline9NetworkedSolveBatchResult,
+  Pipeline9NetworkedSolveResponse,
+} from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-types"
 import type { PreloadedHighDensityRoute } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/convert-preloaded-traces-to-hd-routes"
 import type {
   HighDensityIntraNodeRoute,
@@ -95,7 +100,84 @@ export const asNetworkedFetch = (
     input: string | URL | Request,
     init?: RequestInit,
   ) => Promise<Response>,
+): typeof fetch =>
+  (async (input: string | URL | Request, init?: RequestInit) => {
+    if (!String(input).replace(/\/+$/, "").endsWith("/solve-batch")) {
+      return implementation(input, init)
+    }
+
+    const batchRequest = JSON.parse(
+      String(init?.body),
+    ) as Pipeline9NetworkedSolveBatchRequest
+    const resultLines = await Promise.all(
+      batchRequest.items.map(async (item) => {
+        const response = await implementation(
+          String(input).replace(/\/solve-batch\/?$/, "/solve"),
+          {
+            ...init,
+            headers: {
+              accept: "application/json",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              autorouterVersion: batchRequest.autorouterVersion,
+              input: item.input,
+            }),
+          },
+        )
+        const responseText = await response.text()
+        let responseBody: Pipeline9NetworkedSolveResponse
+        try {
+          responseBody = JSON.parse(responseText)
+        } catch {
+          responseBody = {
+            ok: false,
+            message: `Invalid fixture response with status ${response.status}`,
+          }
+        }
+        if (!response.ok && responseBody.ok !== false) {
+          responseBody = {
+            ok: false,
+            message: `Fixture request failed with status ${response.status}`,
+          }
+        }
+        return JSON.stringify({ requestId: item.requestId, ...responseBody })
+      }),
+    )
+    return new Response(`${resultLines.join("\n")}\n`, {
+      status: 200,
+      headers: { "content-type": "application/x-ndjson" },
+    })
+  }) as unknown as typeof fetch
+
+export const asNetworkedBatchFetch = (
+  implementation: (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ) => Promise<Response>,
 ): typeof fetch => implementation as unknown as typeof fetch
+
+export const createNetworkedBatchStream = (): {
+  response: Response
+  write: (result: Pipeline9NetworkedSolveBatchResult) => void
+  close: () => void
+} => {
+  const encoder = new TextEncoder()
+  let controller!: ReadableStreamDefaultController<Uint8Array>
+  const body = new ReadableStream<Uint8Array>({
+    start(streamController) {
+      controller = streamController
+    },
+  })
+  return {
+    response: new Response(body, {
+      status: 200,
+      headers: { "content-type": "application/x-ndjson" },
+    }),
+    write: (result) => controller.enqueue(encoder.encode(`${JSON.stringify(result)}\n`)),
+    close: () => controller.close(),
+  }
+}
 
 export const createDeferred = <T>(): {
   promise: Promise<T>
@@ -117,6 +199,8 @@ export const createNetworkedHighDensitySolver = ({
   fixedHdRoutes = [],
   requestTimeoutMs = 1_000,
   transportTimeoutMs,
+  maxBatchItems,
+  maxBatchBodyBytes,
   enableRegionalFallback = false,
   preserveTerminalPcbPortIds = true,
 }: {
@@ -125,6 +209,8 @@ export const createNetworkedHighDensitySolver = ({
   fixedHdRoutes?: PreloadedHighDensityRoute[]
   requestTimeoutMs?: number
   transportTimeoutMs?: number
+  maxBatchItems?: number
+  maxBatchBodyBytes?: number
   enableRegionalFallback?: boolean
   preserveTerminalPcbPortIds?: boolean
 }): Pipeline9NetworkedHighDensitySolver => {
@@ -163,6 +249,8 @@ export const createNetworkedHighDensitySolver = ({
     fetchImpl,
     requestTimeoutMs,
     transportTimeoutMs,
+    maxBatchItems,
+    maxBatchBodyBytes,
   }
   return new Pipeline9NetworkedHighDensitySolver(params)
 }

--- a/tests/fixtures/pipeline9-networked-fixtures.ts
+++ b/tests/fixtures/pipeline9-networked-fixtures.ts
@@ -174,7 +174,8 @@ export const createNetworkedBatchStream = (): {
       status: 200,
       headers: { "content-type": "application/x-ndjson" },
     }),
-    write: (result) => controller.enqueue(encoder.encode(`${JSON.stringify(result)}\n`)),
+    write: (result) =>
+      controller.enqueue(encoder.encode(`${JSON.stringify(result)}\n`)),
     close: () => controller.close(),
   }
 }


### PR DESCRIPTION
## Summary

- batch speculative Pipeline9 high-density cache lookups into streaming NDJSON requests
- pack at most 100 items and 1.75 MiB per batch, with exact UTF-8 accounting
- resolve items independently and out of order while preserving Pipeline9's sequential consumption semantics
- fan explicit cache misses out through parallel legacy `/solve` requests
- retain per-node logical timeouts, longer background transport timeouts, and fail-open local solving
- expose batch, item, byte, cache-miss, hit, solver, and fallback-reason counters to benchmarks
- fix two pre-existing outputs that prevented exact cache reuse: `jumpers: undefined` and the closed-form solver's incorrect trace thickness

The Networked pipeline remains available only at `effort: 1`, and every cache identity remains scoped to the exact autorouter package version.

## Protocol

`POST /solve-batch` accepts `{ autorouterVersion, items: [{ requestId, input }] }` and streams one NDJSON line per item. Cache hits are consumed immediately. A `CACHE_MISS` line launches that item through `/solve` without blocking the rest of the batch.

The backward-compatible service side is in [hd-cache2 PR #2](https://github.com/tscircuit/hd-cache2.tscircuit.com/pull/2) and is deployed.

## Validation

- 18/18 Pipeline9 Networked tests, 205 assertions
- focused output regressions: 2/2
- TypeScript check and build pass
- direct isolated SRJ18 samples 1, 2, 7, 11: end-to-end total 614.6s to 577.0s (6.1% faster); high-density total 225.1s to 192.7s (14.4% faster)
- exact completion, via-count, and relaxed-DRC parity in the paired benchmark

The current deployed 0.0.852 cache still contains/encounters the two pre-existing output defects, including a sample-11 regression. This PR fixes those causes; the next exact version receives a fresh versioned cache-key prefix.
