### PR TITLE
perf(pipeline9): cache terminal regional fallback results

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/autorouting-pipeline-solver9-networked.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/autorouting-pipeline-solver9-networked.ts
@@ -27,7 +27,7 @@ export type AutoroutingPipelineSolver9NetworkedOptions = Omit<
   hdCacheMaxBatchBodyBytes?: number
 }
 
-/** Pipeline9 with exact, version-scoped remote ordinary-node solving. */
+/** Pipeline9 with exact, version-scoped remote terminal node solving. */
 export class AutoroutingPipelineSolver9_Networked extends AutoroutingPipelineSolver9_PreloadedTraceGraph {
   readonly hdCacheBaseUrl: string
   readonly hdCacheFetch?: typeof fetch

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-high-density-solver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-high-density-solver.ts
@@ -4,10 +4,16 @@ import type {
 } from "../../types/high-density-types"
 import type { PendingEffect } from "../../solvers/BaseSolver"
 import {
+  normalizePipeline9NodeRootConnectionNames,
   Pipeline9HighDensitySolver,
   type Pipeline9HighDensitySolverParams,
 } from "../AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-high-density-solver"
-import { projectPipeline9OrdinaryHighDensityInput } from "../AutoroutingPipeline9_PreloadedTraceGraph/project-pipeline9-ordinary-high-density-input"
+import { createRegionalFallbackProblem } from "../AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-regional-fallback"
+import {
+  mergePipeline9ProjectedConnectivityNetMaps,
+  projectPipeline9OrdinaryHighDensityInput,
+  projectPipeline9RegionalHighDensityInput,
+} from "../AutoroutingPipeline9_PreloadedTraceGraph/project-pipeline9-ordinary-high-density-input"
 import type {
   Pipeline9NetworkedHighDensityNodeInput,
   Pipeline9NetworkedSolveBatchItem,
@@ -17,6 +23,7 @@ import type {
   Pipeline9NetworkedSolveRequest,
   Pipeline9NetworkedSolveResponse,
 } from "./pipeline9-networked-types"
+import { PIPELINE9_NETWORKED_SOLVE_POLICY } from "./pipeline9-networked-types"
 
 export const DEFAULT_PIPELINE9_NETWORKED_CACHE_URL =
   "https://hd-cache2.tscircuit.com"
@@ -114,6 +121,7 @@ const nearlyEqual = (left: number, right: number): boolean =>
 const isValidRemoteRoutes = (
   value: unknown,
   input: Pipeline9NetworkedHighDensityNodeInput,
+  solutionStage: "ordinary" | "regional-fallback",
 ): value is HighDensityIntraNodeRoute[] => {
   if (!Array.isArray(value)) return false
   const portPointsByConnectionName = new Map<
@@ -224,8 +232,9 @@ const isValidRemoteRoutes = (
     }
     const routePoints = route.route as Record<string, unknown>[]
     if (
-      !isPortPointForConnection(routePoints[0]!, route.connectionName) ||
-      !isPortPointForConnection(routePoints.at(-1)!, route.connectionName)
+      solutionStage === "ordinary" &&
+      (!isPortPointForConnection(routePoints[0]!, route.connectionName) ||
+        !isPortPointForConnection(routePoints.at(-1)!, route.connectionName))
     ) {
       return false
     }
@@ -395,6 +404,10 @@ export class Pipeline9NetworkedHighDensitySolver extends Pipeline9HighDensitySol
       remoteSolverResults: 0,
       remoteSolvedResults: 0,
       remoteFailedResults: 0,
+      remoteOrdinaryResults: 0,
+      remoteRegionalFallbackResults: 0,
+      remoteRegionalFallbackResultsApplied: 0,
+      remoteRegionalFallbackResultsDeferredToLocal: 0,
       remoteTransportFallbacks: 0,
       remoteLogicalTimeoutFallbacks: 0,
       remoteFallbackReasonCounts: {},
@@ -408,24 +421,44 @@ export class Pipeline9NetworkedHighDensitySolver extends Pipeline9HighDensitySol
   private createNodeInput(
     node: NodeWithPortPoints,
   ): Pipeline9NetworkedHighDensityNodeInput {
+    const regionalInput = this.enableRegionalFallback
+      ? projectPipeline9RegionalHighDensityInput({
+          nodeWithPortPoints: node,
+          connMap: this.connMap,
+          obstacles: this.obstacles,
+          obstacleMargin: this.obstacleMargin,
+          traceWidth: this.traceWidth,
+          viaDiameter: this.viaDiameter,
+        })
+      : { connectivityNetMap: {}, obstacles: [] }
     const projectedInput = projectPipeline9OrdinaryHighDensityInput({
       nodeWithPortPoints: node,
       connMap: this.connMap,
       colorMap: this.colorMap,
-      obstacles: this.obstacles,
+      // The regional projection already conservatively retains every obstacle
+      // in the ordinary 8x envelope, so avoid scanning the full board twice.
+      obstacles: this.enableRegionalFallback
+        ? regionalInput.obstacles
+        : this.obstacles,
       obstacleMargin: this.obstacleMargin,
       traceWidth: this.traceWidth,
       viaDiameter: this.viaDiameter,
     })
     return {
+      solvePolicy: PIPELINE9_NETWORKED_SOLVE_POLICY,
+      enableRegionalFallback: this.enableRegionalFallback,
       nodeWithPortPoints: node,
-      connectivityNetMap: projectedInput.connectivityNetMap,
+      connectivityNetMap: mergePipeline9ProjectedConnectivityNetMaps(
+        projectedInput.connectivityNetMap,
+        regionalInput.connectivityNetMap,
+      ),
       colorMap: projectedInput.colorMap,
       viaDiameter: this.viaDiameter,
       traceWidth: this.traceWidth,
       obstacleMargin: this.obstacleMargin,
       effort: 1,
       obstacles: projectedInput.obstacles,
+      regionalObstacles: regionalInput.obstacles,
       layerCount: this.layerCount,
       nodePf: this.nodePfById.get(node.capacityMeshNodeId) ?? null,
     }
@@ -464,12 +497,55 @@ export class Pipeline9NetworkedHighDensitySolver extends Pipeline9HighDensitySol
       )
     }
     if (
+      response.solutionStage !== "ordinary" &&
+      response.solutionStage !== "regional-fallback"
+    ) {
+      throw new Pipeline9NetworkedRequestError(
+        "invalid_response",
+        "hd-cache2 returned an invalid solution stage",
+      )
+    }
+    if (
+      response.solutionStage === "regional-fallback" &&
+      (!input.enableRegionalFallback ||
+        typeof response.ordinaryFailure !== "string" ||
+        response.ordinaryFailure.length === 0)
+    ) {
+      throw new Pipeline9NetworkedRequestError(
+        "invalid_response",
+        "hd-cache2 returned invalid regional fallback metadata",
+      )
+    }
+    if (
+      response.solutionStage === "ordinary" &&
+      Object.prototype.hasOwnProperty.call(response, "ordinaryFailure")
+    ) {
+      throw new Pipeline9NetworkedRequestError(
+        "invalid_response",
+        "hd-cache2 returned regional metadata on an ordinary result",
+      )
+    }
+    if (
+      response.solutionStage === "ordinary" &&
+      response.status === "failed" &&
+      input.enableRegionalFallback
+    ) {
+      throw new Pipeline9NetworkedRequestError(
+        "invalid_response",
+        "hd-cache2 returned an intermediate ordinary failure",
+      )
+    }
+    if (
       response.status === "solved" &&
-      isValidRemoteRoutes(response.routes, input)
+      isValidRemoteRoutes(response.routes, input, response.solutionStage)
     ) {
       return response as Extract<Pipeline9NetworkedSolveResponse, { ok: true }>
     }
-    if (response.status === "failed" && typeof response.error === "string") {
+    if (
+      response.status === "failed" &&
+      typeof response.error === "string" &&
+      response.error.length > 0
+    ) {
       return response as Extract<Pipeline9NetworkedSolveResponse, { ok: true }>
     }
 
@@ -983,12 +1059,56 @@ export class Pipeline9NetworkedHighDensitySolver extends Pipeline9HighDensitySol
 
     this.stats.regularNodeCount = Number(this.stats.regularNodeCount ?? 0) + 1
     this.activeNode = node
+    if (result.response.solutionStage === "regional-fallback") {
+      this.stats.remoteRegionalFallbackResults =
+        Number(this.stats.remoteRegionalFallbackResults ?? 0) + 1
+      if (!this.canUseNoFixedCopperRegionalResult(node)) {
+        this.stats.remoteRegionalFallbackResultsDeferredToLocal =
+          Number(
+            this.stats.remoteRegionalFallbackResultsDeferredToLocal ?? 0,
+          ) + 1
+        this.finishRegularSolverFailure(result.response.ordinaryFailure)
+        return
+      }
+      this.stats.remoteRegionalFallbackResultsApplied =
+        Number(this.stats.remoteRegionalFallbackResultsApplied ?? 0) + 1
+      this.stats.fallbackNodeCount =
+        Number(this.stats.fallbackNodeCount ?? 0) + 1
+    } else {
+      this.stats.remoteOrdinaryResults =
+        Number(this.stats.remoteOrdinaryResults ?? 0) + 1
+    }
     if (result.response.status === "failed") {
-      this.finishRegularSolverFailure(result.response.error)
+      this.error = result.response.error
+      this.failed = true
+      this.activeNode = null
       return
     }
 
     this.finishActiveNode(result.response.routes)
+  }
+
+  /**
+   * A node may have no fixed copper on its assigned layers while the regional
+   * fallback, which opens every board layer, would still observe a preloaded
+   * route. Re-prove independence against the current mutation state before
+   * consuming a no-fixed-copper regional result.
+   */
+  private canUseNoFixedCopperRegionalResult(
+    node: NodeWithPortPoints,
+  ): boolean {
+    const regionalNode = {
+      ...normalizePipeline9NodeRootConnectionNames(node, this.connMap),
+      availableZ: Array.from({ length: this.layerCount }, (_, z) => z),
+    }
+    const problem = createRegionalFallbackProblem(
+      regionalNode,
+      this.getUpdatedFixedHdRoutes(),
+    )
+    return (
+      problem.fixedRouteSectionsByConnectionName.size === 0 &&
+      problem.fixedObstacleRoutes.length === 0
+    )
   }
 
   override _step(): void {

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-high-density-solver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-high-density-solver.ts
@@ -1064,9 +1064,8 @@ export class Pipeline9NetworkedHighDensitySolver extends Pipeline9HighDensitySol
         Number(this.stats.remoteRegionalFallbackResults ?? 0) + 1
       if (!this.canUseNoFixedCopperRegionalResult(node)) {
         this.stats.remoteRegionalFallbackResultsDeferredToLocal =
-          Number(
-            this.stats.remoteRegionalFallbackResultsDeferredToLocal ?? 0,
-          ) + 1
+          Number(this.stats.remoteRegionalFallbackResultsDeferredToLocal ?? 0) +
+          1
         this.finishRegularSolverFailure(result.response.ordinaryFailure)
         return
       }
@@ -1094,9 +1093,7 @@ export class Pipeline9NetworkedHighDensitySolver extends Pipeline9HighDensitySol
    * route. Re-prove independence against the current mutation state before
    * consuming a no-fixed-copper regional result.
    */
-  private canUseNoFixedCopperRegionalResult(
-    node: NodeWithPortPoints,
-  ): boolean {
+  private canUseNoFixedCopperRegionalResult(node: NodeWithPortPoints): boolean {
     const regionalNode = {
       ...normalizePipeline9NodeRootConnectionNames(node, this.connMap),
       availableZ: Array.from({ length: this.layerCount }, (_, z) => z),

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-types.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-types.ts
@@ -6,12 +6,18 @@ import type { Obstacle } from "../../types/srj-types"
 
 export type Pipeline9NetworkedCacheSource = "cache" | "solver"
 
+export const PIPELINE9_NETWORKED_SOLVE_POLICY =
+  "ordinary_then_regional_without_fixed_copper_v1" as const
+
 /**
- * Every solution-affecting input for Pipeline9's ordinary single-node
- * high-density solver. The shape is JSON-serializable so the exact same helper
- * can run in the cache service.
+ * Every solution-affecting input for Pipeline9's terminal single-node policy:
+ * ordinary high-density routing followed, when enabled, by the regional
+ * no-fixed-copper fallback. The shape is JSON-serializable so the exact same
+ * helper can run in the cache service.
  */
 export type Pipeline9NetworkedHighDensityNodeInput = {
+  solvePolicy: typeof PIPELINE9_NETWORKED_SOLVE_POLICY
+  enableRegionalFallback: boolean
   nodeWithPortPoints: NodeWithPortPoints
   connectivityNetMap: Record<string, string[]>
   colorMap: Record<string, string>
@@ -20,6 +26,7 @@ export type Pipeline9NetworkedHighDensityNodeInput = {
   obstacleMargin: number
   effort: 1
   obstacles: Obstacle[]
+  regionalObstacles: Obstacle[]
   layerCount: number
   nodePf: number | null
 }
@@ -27,10 +34,24 @@ export type Pipeline9NetworkedHighDensityNodeInput = {
 export type Pipeline9NetworkedHighDensityNodeOutput =
   | {
       status: "solved"
+      solutionStage: "ordinary"
+      routes: HighDensityIntraNodeRoute[]
+    }
+  | {
+      status: "solved"
+      solutionStage: "regional-fallback"
+      ordinaryFailure: string
       routes: HighDensityIntraNodeRoute[]
     }
   | {
       status: "failed"
+      solutionStage: "ordinary"
+      error: string
+    }
+  | {
+      status: "failed"
+      solutionStage: "regional-fallback"
+      ordinaryFailure: string
       error: string
     }
 

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/solve-pipeline9-networked-high-density-node.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/solve-pipeline9-networked-high-density-node.ts
@@ -1,26 +1,36 @@
 import { ConnectivityMap } from "circuit-json-to-connectivity-map"
 import { HighDensitySolver } from "../../solvers/HighDensitySolver/HighDensitySolver"
-import { normalizePipeline9NodeRootConnectionNames } from "../AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-high-density-solver"
+import {
+  normalizePipeline9NodeRootConnectionNames,
+} from "../AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-high-density-solver"
+import { createRegionalFallbackProblem } from "../AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-regional-fallback"
+import { Pipeline9RegionalFallbackSolver } from "../AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-regional-fallback-solver"
 import type {
   Pipeline9NetworkedHighDensityNodeInput,
   Pipeline9NetworkedHighDensityNodeOutput,
 } from "./pipeline9-networked-types"
+import { PIPELINE9_NETWORKED_SOLVE_POLICY } from "./pipeline9-networked-types"
 
-/**
- * Runs the exact ordinary-node solver used by Pipeline9. hd-cache2 calls this
- * exported helper so a cache entry can only be produced by its installed
- * autorouter implementation.
- */
-export function solvePipeline9NetworkedHighDensityNode(
-  input: Pipeline9NetworkedHighDensityNodeInput,
-): Pipeline9NetworkedHighDensityNodeOutput {
-  if (input.effort !== 1) {
-    throw new Error(
-      `Pipeline9 networked high-density solving requires effort=1, received ${input.effort}`,
-    )
-  }
+type Pipeline9OrdinaryNodeResult =
+  | {
+      status: "solved"
+      routes: Extract<
+        Pipeline9NetworkedHighDensityNodeOutput,
+        { status: "solved" }
+      >["routes"]
+    }
+  | {
+      status: "failed"
+      error: string
+    }
 
-  const connMap = new ConnectivityMap(input.connectivityNetMap)
+const solvePipeline9OrdinaryHighDensityNode = ({
+  input,
+  connMap,
+}: {
+  input: Pipeline9NetworkedHighDensityNodeInput
+  connMap: ConnectivityMap
+}): Pipeline9OrdinaryNodeResult => {
   const solver = new HighDensitySolver({
     nodePortPoints: [
       normalizePipeline9NodeRootConnectionNames(
@@ -44,14 +54,100 @@ export function solvePipeline9NetworkedHighDensityNode(
     growShrinkFallbackToInvalidGeometryOnFailure: false,
     captureSearchDebug: false,
   })
-
   solver.solve()
-  if (solver.solved) {
-    return { status: "solved", routes: solver.routes }
+  return solver.solved
+    ? { status: "solved", routes: solver.routes }
+    : {
+        status: "failed",
+        error: solver.error || "Pipeline9 ordinary high-density solver failed",
+      }
+}
+
+/**
+ * Runs Pipeline9's terminal no-fixed-copper node policy. hd-cache2 calls this
+ * exported helper so ordinary and regional cache entries can only be produced
+ * by its installed autorouter implementation.
+ */
+export function solvePipeline9NetworkedHighDensityNode(
+  input: Pipeline9NetworkedHighDensityNodeInput,
+): Pipeline9NetworkedHighDensityNodeOutput {
+  if (input.solvePolicy !== PIPELINE9_NETWORKED_SOLVE_POLICY) {
+    throw new Error(
+      `Unsupported Pipeline9 networked solve policy ${String(input.solvePolicy)}`,
+    )
+  }
+  if (input.effort !== 1) {
+    throw new Error(
+      `Pipeline9 networked high-density solving requires effort=1, received ${input.effort}`,
+    )
   }
 
+  const connMap = new ConnectivityMap(input.connectivityNetMap)
+  const ordinaryResult = solvePipeline9OrdinaryHighDensityNode({
+    input,
+    connMap,
+  })
+  if (ordinaryResult.status === "solved") {
+    return {
+      status: "solved",
+      solutionStage: "ordinary",
+      routes: ordinaryResult.routes,
+    }
+  }
+
+  const ordinaryFailure = ordinaryResult.error
+  if (!input.enableRegionalFallback) {
+    return {
+      status: "failed",
+      solutionStage: "ordinary",
+      error: `Pipeline9 regular high-density routing failed: ${ordinaryFailure}`,
+    }
+  }
+
+  const normalizedNode = normalizePipeline9NodeRootConnectionNames(
+    input.nodeWithPortPoints,
+    connMap,
+  )
+  const regionalProblem = createRegionalFallbackProblem(
+    {
+      ...normalizedNode,
+      availableZ: Array.from({ length: input.layerCount }, (_, z) => z),
+    },
+    [],
+  )
+  const regionalSolver = new Pipeline9RegionalFallbackSolver({
+    nodeWithPortPoints: regionalProblem.nodeWithPortPoints,
+    colorMap: input.colorMap,
+    connMap,
+    viaDiameter: input.viaDiameter,
+    traceWidth: input.traceWidth,
+    obstacleMargin: input.obstacleMargin,
+    effort: input.effort,
+    nodePfById: {
+      [input.nodeWithPortPoints.capacityMeshNodeId]: input.nodePf,
+    },
+    obstacles: input.regionalObstacles,
+    layerCount: input.layerCount,
+  })
+  regionalSolver.solve()
+  if (regionalSolver.solved) {
+    return {
+      status: "solved",
+      solutionStage: "regional-fallback",
+      ordinaryFailure,
+      routes: regionalSolver.getOutput(),
+    }
+  }
+
+  const regionalFailure =
+    regionalSolver.error || "Pipeline9 regional fallback solver failed"
   return {
     status: "failed",
-    error: solver.error ?? "Pipeline9 ordinary high-density solver failed",
+    solutionStage: "regional-fallback",
+    ordinaryFailure,
+    error: [
+      `Pipeline9 primary high-density routing failed: regular high-density routing failed: ${ordinaryFailure}`,
+      `regional fallback failed: ${regionalFailure}`,
+    ].join("; "),
   }
 }

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/solve-pipeline9-networked-high-density-node.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/solve-pipeline9-networked-high-density-node.ts
@@ -1,8 +1,6 @@
 import { ConnectivityMap } from "circuit-json-to-connectivity-map"
 import { HighDensitySolver } from "../../solvers/HighDensitySolver/HighDensitySolver"
-import {
-  normalizePipeline9NodeRootConnectionNames,
-} from "../AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-high-density-solver"
+import { normalizePipeline9NodeRootConnectionNames } from "../AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-high-density-solver"
 import { createRegionalFallbackProblem } from "../AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-regional-fallback"
 import { Pipeline9RegionalFallbackSolver } from "../AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-regional-fallback-solver"
 import type {

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/project-pipeline9-ordinary-high-density-input.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/project-pipeline9-ordinary-high-density-input.ts
@@ -68,7 +68,10 @@ const getMaximumPipeline9NodeBounds = ({
   }
 }
 
-const obstacleOverlapsBounds = (obstacle: Obstacle, bounds: Bounds): boolean => {
+const obstacleOverlapsBounds = (
+  obstacle: Obstacle,
+  bounds: Bounds,
+): boolean => {
   const rotationRadians = ((obstacle.ccwRotationDegrees ?? 0) * Math.PI) / 180
   const cos = Math.abs(Math.cos(rotationRadians))
   const sin = Math.abs(Math.sin(rotationRadians))
@@ -96,13 +99,14 @@ const getNodeConnectionNames = (
   nodeWithPortPoints: NodeWithPortPoints,
 ): string[] => [
   ...new Set(
-    nodeWithPortPoints.portPoints.map(
-      (portPoint) => portPoint.connectionName,
-    ),
+    nodeWithPortPoints.portPoints.map((portPoint) => portPoint.connectionName),
   ),
 ]
 
-const addPortPointIds = (relevantIds: Set<string>, portPoint: PortPoint): void => {
+const addPortPointIds = (
+  relevantIds: Set<string>,
+  portPoint: PortPoint,
+): void => {
   for (const id of [
     portPoint.connectionName,
     portPoint.rootConnectionName,

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/project-pipeline9-ordinary-high-density-input.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/project-pipeline9-ordinary-high-density-input.ts
@@ -16,6 +16,284 @@ export type Pipeline9OrdinaryHighDensityProjection = {
   obstacles: Obstacle[]
 }
 
+export type Pipeline9RegionalHighDensityProjection = {
+  connectivityNetMap: Record<string, string[]>
+  obstacles: Obstacle[]
+}
+
+type Bounds = {
+  minX: number
+  maxX: number
+  minY: number
+  maxY: number
+}
+
+const getMaximumPipeline9NodeBounds = ({
+  nodeWithPortPoints,
+  obstacleMargin,
+  traceWidth,
+  viaDiameter,
+}: {
+  nodeWithPortPoints: NodeWithPortPoints
+  obstacleMargin: number
+  traceWidth: number
+  viaDiameter: number
+}): Bounds => {
+  const nodeBounds = getBoundsFromNodeWithPortPoints(nodeWithPortPoints)
+  const clearance =
+    obstacleMargin +
+    Math.max(traceWidth, viaDiameter) / 2 +
+    OBSTACLE_OVERLAP_TOLERANCE
+  return {
+    minX:
+      nodeWithPortPoints.center.x +
+      (nodeBounds.minX - nodeWithPortPoints.center.x) *
+        MAX_PIPELINE9_ORDINARY_NODE_SCALE -
+      clearance,
+    maxX:
+      nodeWithPortPoints.center.x +
+      (nodeBounds.maxX - nodeWithPortPoints.center.x) *
+        MAX_PIPELINE9_ORDINARY_NODE_SCALE +
+      clearance,
+    minY:
+      nodeWithPortPoints.center.y +
+      (nodeBounds.minY - nodeWithPortPoints.center.y) *
+        MAX_PIPELINE9_ORDINARY_NODE_SCALE -
+      clearance,
+    maxY:
+      nodeWithPortPoints.center.y +
+      (nodeBounds.maxY - nodeWithPortPoints.center.y) *
+        MAX_PIPELINE9_ORDINARY_NODE_SCALE +
+      clearance,
+  }
+}
+
+const obstacleOverlapsBounds = (obstacle: Obstacle, bounds: Bounds): boolean => {
+  const rotationRadians = ((obstacle.ccwRotationDegrees ?? 0) * Math.PI) / 180
+  const cos = Math.abs(Math.cos(rotationRadians))
+  const sin = Math.abs(Math.sin(rotationRadians))
+  const rawHalfWidth = obstacle.width / 2
+  const rawHalfHeight = obstacle.height / 2
+  // Some Pipeline9 consumers intentionally use the unrotated bounds while
+  // others use the rotated rectangle. The larger envelope preserves both.
+  const halfWidth = Math.max(
+    rawHalfWidth,
+    rawHalfWidth * cos + rawHalfHeight * sin,
+  )
+  const halfHeight = Math.max(
+    rawHalfHeight,
+    rawHalfWidth * sin + rawHalfHeight * cos,
+  )
+  return (
+    obstacle.center.x - halfWidth <= bounds.maxX &&
+    obstacle.center.x + halfWidth >= bounds.minX &&
+    obstacle.center.y - halfHeight <= bounds.maxY &&
+    obstacle.center.y + halfHeight >= bounds.minY
+  )
+}
+
+const getNodeConnectionNames = (
+  nodeWithPortPoints: NodeWithPortPoints,
+): string[] => [
+  ...new Set(
+    nodeWithPortPoints.portPoints.map(
+      (portPoint) => portPoint.connectionName,
+    ),
+  ),
+]
+
+const addPortPointIds = (relevantIds: Set<string>, portPoint: PortPoint): void => {
+  for (const id of [
+    portPoint.connectionName,
+    portPoint.rootConnectionName,
+    portPoint.portPointId,
+    portPoint.pcb_port_id,
+    portPoint.prevPortPointId,
+    portPoint.nextPortPointId,
+  ]) {
+    if (id !== undefined) relevantIds.add(id)
+  }
+}
+
+const projectConnectivityNetMap = (
+  connMap: ConnectivityMap,
+  relevantIds: ReadonlySet<string>,
+): Record<string, string[]> =>
+  Object.fromEntries(
+    Object.entries(connMap.netMap).flatMap(([netId, ids]) => {
+      const relevantConnectedIds = ids.filter((id) => relevantIds.has(id))
+      return relevantConnectedIds.length > 0 || relevantIds.has(netId)
+        ? [[netId, relevantConnectedIds]]
+        : []
+    }),
+  )
+
+const getMinimalProjectedObstacle = ({
+  obstacle,
+  connectedTo,
+  preserveRotation,
+}: {
+  obstacle: Obstacle
+  connectedTo: string[]
+  preserveRotation: boolean
+}): Obstacle => ({
+  type: "rect",
+  layers: obstacle.layers,
+  ...(obstacle.zLayers === undefined ? {} : { zLayers: obstacle.zLayers }),
+  ...(obstacle.__zLayers === undefined
+    ? {}
+    : { __zLayers: obstacle.__zLayers }),
+  center: obstacle.center,
+  width: obstacle.width,
+  height: obstacle.height,
+  ...(preserveRotation && obstacle.ccwRotationDegrees !== undefined
+    ? { ccwRotationDegrees: obstacle.ccwRotationDegrees }
+    : {}),
+  connectedTo,
+  ...(obstacle.circuitJsonMetadata === undefined
+    ? {}
+    : { circuitJsonMetadata: obstacle.circuitJsonMetadata }),
+})
+
+const getRelevantObstacleConnectionRepresentatives = ({
+  obstacle,
+  nodeWithPortPoints,
+  connMap,
+}: {
+  obstacle: Obstacle
+  nodeWithPortPoints: NodeWithPortPoints
+  connMap: ConnectivityMap
+}): string[] => {
+  const directRouteIds = new Set(
+    nodeWithPortPoints.portPoints.flatMap((portPoint) => {
+      const rootConnectionName =
+        connMap.getNetConnectedToId(
+          portPoint.rootConnectionName ?? portPoint.connectionName,
+        ) ??
+        portPoint.rootConnectionName ??
+        portPoint.connectionName
+      return [portPoint.connectionName, rootConnectionName]
+    }),
+  )
+  // The repair stage compares these IDs directly, without a ConnectivityMap.
+  // Preserve every exact route/root identity so that direct semantics cannot
+  // be changed by projection.
+  const representatives = new Set(
+    obstacle.connectedTo.filter((id) => directRouteIds.has(id)),
+  )
+
+  const idsByNet = new Map<string, string[]>()
+  for (const routeId of directRouteIds) {
+    const netId = connMap.getNetConnectedToId(routeId) ?? routeId
+    const routeIds = idsByNet.get(netId) ?? []
+    routeIds.push(routeId)
+    idsByNet.set(netId, routeIds)
+  }
+
+  for (const routeIds of idsByNet.values()) {
+    const alreadyRepresented = [...representatives].some((representative) =>
+      routeIds.some(
+        (routeId) =>
+          routeId === representative ||
+          connMap.areIdsConnected(routeId, representative),
+      ),
+    )
+    if (alreadyRepresented) continue
+
+    const connectedId = obstacle.connectedTo.find((candidateId) =>
+      routeIds.some(
+        (routeId) =>
+          routeId === candidateId ||
+          connMap.areIdsConnected(routeId, candidateId),
+      ),
+    )
+    if (connectedId !== undefined) {
+      representatives.add(connectedId)
+    }
+  }
+
+  return [...representatives]
+}
+
+/**
+ * Projects the board obstacles observable by the no-fixed-copper regional
+ * fallback. Unlike the ordinary projection, foreign obstacles must remain:
+ * Pipeline4HighDensityRepairSolver consumes every obstacle near the node.
+ *
+ * Connection IDs require special care. The route stage uses ConnectivityMap,
+ * while the repair stage checks connectionName/rootConnectionName by direct
+ * equality. Exact route IDs are therefore preserved, plus at most one alias
+ * representative per relevant net for route-stage equivalence.
+ */
+export function projectPipeline9RegionalHighDensityInput({
+  nodeWithPortPoints,
+  connMap,
+  obstacles,
+  obstacleMargin,
+  traceWidth,
+  viaDiameter,
+}: {
+  nodeWithPortPoints: NodeWithPortPoints
+  connMap: ConnectivityMap
+  obstacles: Obstacle[]
+  obstacleMargin: number
+  traceWidth: number
+  viaDiameter: number
+}): Pipeline9RegionalHighDensityProjection {
+  const maximumNodeBounds = getMaximumPipeline9NodeBounds({
+    nodeWithPortPoints,
+    obstacleMargin,
+    traceWidth,
+    viaDiameter,
+  })
+  const relevantIds = new Set<string>()
+  for (const portPoint of nodeWithPortPoints.portPoints) {
+    addPortPointIds(relevantIds, portPoint)
+  }
+  for (const pair of nodeWithPortPoints.portPointsInPairs ?? []) {
+    addPortPointIds(relevantIds, pair[0])
+    addPortPointIds(relevantIds, pair[1])
+  }
+
+  const projectedObstacles = obstacles.flatMap((obstacle) => {
+    if (!obstacleOverlapsBounds(obstacle, maximumNodeBounds)) return []
+    const connectedTo = getRelevantObstacleConnectionRepresentatives({
+      obstacle,
+      nodeWithPortPoints,
+      connMap,
+    })
+    for (const id of connectedTo) relevantIds.add(id)
+    return [
+      getMinimalProjectedObstacle({
+        obstacle,
+        connectedTo,
+        preserveRotation: true,
+      }),
+    ]
+  })
+
+  return {
+    connectivityNetMap: projectConnectivityNetMap(connMap, relevantIds),
+    obstacles: projectedObstacles,
+  }
+}
+
+export const mergePipeline9ProjectedConnectivityNetMaps = (
+  ...netMaps: Array<Record<string, string[]>>
+): Record<string, string[]> => {
+  const merged = new Map<string, Set<string>>()
+  for (const netMap of netMaps) {
+    for (const [netId, ids] of Object.entries(netMap)) {
+      const mergedIds = merged.get(netId) ?? new Set<string>()
+      for (const id of ids) mergedIds.add(id)
+      merged.set(netId, mergedIds)
+    }
+  }
+  return Object.fromEntries(
+    [...merged].map(([netId, ids]) => [netId, [...ids]]),
+  )
+}
+
 /**
  * Reduces board-wide inputs to the information Pipeline9's ordinary node
  * solver can observe. The overlap envelope covers all 1x/2x/4x/8x
@@ -39,61 +317,16 @@ export function projectPipeline9OrdinaryHighDensityInput({
   traceWidth: number
   viaDiameter: number
 }): Pipeline9OrdinaryHighDensityProjection {
-  const nodeBounds = getBoundsFromNodeWithPortPoints(nodeWithPortPoints)
-  const clearance =
-    obstacleMargin +
-    Math.max(traceWidth, viaDiameter) / 2 +
-    OBSTACLE_OVERLAP_TOLERANCE
-  const grownNodeBounds = {
-    minX:
-      nodeWithPortPoints.center.x +
-      (nodeBounds.minX - nodeWithPortPoints.center.x) *
-        MAX_PIPELINE9_ORDINARY_NODE_SCALE -
-      clearance,
-    maxX:
-      nodeWithPortPoints.center.x +
-      (nodeBounds.maxX - nodeWithPortPoints.center.x) *
-        MAX_PIPELINE9_ORDINARY_NODE_SCALE +
-      clearance,
-    minY:
-      nodeWithPortPoints.center.y +
-      (nodeBounds.minY - nodeWithPortPoints.center.y) *
-        MAX_PIPELINE9_ORDINARY_NODE_SCALE -
-      clearance,
-    maxY:
-      nodeWithPortPoints.center.y +
-      (nodeBounds.maxY - nodeWithPortPoints.center.y) *
-        MAX_PIPELINE9_ORDINARY_NODE_SCALE +
-      clearance,
-  }
-  const nodeConnectionNames = [
-    ...new Set(
-      nodeWithPortPoints.portPoints.map(
-        (portPoint) => portPoint.connectionName,
-      ),
-    ),
-  ]
+  const grownNodeBounds = getMaximumPipeline9NodeBounds({
+    nodeWithPortPoints,
+    obstacleMargin,
+    traceWidth,
+    viaDiameter,
+  })
+  const nodeConnectionNames = getNodeConnectionNames(nodeWithPortPoints)
 
   const projectedObstacles = obstacles.flatMap((obstacle) => {
-    const rotationRadians = ((obstacle.ccwRotationDegrees ?? 0) * Math.PI) / 180
-    const cos = Math.abs(Math.cos(rotationRadians))
-    const sin = Math.abs(Math.sin(rotationRadians))
-    const rawHalfWidth = obstacle.width / 2
-    const rawHalfHeight = obstacle.height / 2
-    const halfWidth = Math.max(
-      rawHalfWidth,
-      rawHalfWidth * cos + rawHalfHeight * sin,
-    )
-    const halfHeight = Math.max(
-      rawHalfHeight,
-      rawHalfWidth * sin + rawHalfHeight * cos,
-    )
-    const overlapsMaximumNodeEnvelope =
-      obstacle.center.x - halfWidth <= grownNodeBounds.maxX &&
-      obstacle.center.x + halfWidth >= grownNodeBounds.minX &&
-      obstacle.center.y - halfHeight <= grownNodeBounds.maxY &&
-      obstacle.center.y + halfHeight >= grownNodeBounds.minY
-    if (!overlapsMaximumNodeEnvelope) return []
+    if (!obstacleOverlapsBounds(obstacle, grownNodeBounds)) return []
 
     const matchingConnectionNames = nodeConnectionNames.filter(
       (connectionName) =>
@@ -106,45 +339,21 @@ export function projectPipeline9OrdinaryHighDensityInput({
     if (matchingConnectionNames.length === 0) return []
 
     return [
-      {
-        type: "rect" as const,
-        layers: obstacle.layers,
-        ...(obstacle.zLayers === undefined
-          ? {}
-          : { zLayers: obstacle.zLayers }),
-        ...(obstacle.__zLayers === undefined
-          ? {}
-          : { __zLayers: obstacle.__zLayers }),
-        center: obstacle.center,
-        width: obstacle.width,
-        height: obstacle.height,
+      getMinimalProjectedObstacle({
+        obstacle,
         connectedTo: matchingConnectionNames,
-        ...(obstacle.circuitJsonMetadata === undefined
-          ? {}
-          : { circuitJsonMetadata: obstacle.circuitJsonMetadata }),
-      },
+        preserveRotation: false,
+      }),
     ]
   })
 
   const relevantIds = new Set<string>()
-  const addPortPointIds = (portPoint: PortPoint): void => {
-    for (const id of [
-      portPoint.connectionName,
-      portPoint.rootConnectionName,
-      portPoint.portPointId,
-      portPoint.pcb_port_id,
-      portPoint.prevPortPointId,
-      portPoint.nextPortPointId,
-    ]) {
-      if (id !== undefined) relevantIds.add(id)
-    }
-  }
   for (const portPoint of nodeWithPortPoints.portPoints) {
-    addPortPointIds(portPoint)
+    addPortPointIds(relevantIds, portPoint)
   }
   for (const pair of nodeWithPortPoints.portPointsInPairs ?? []) {
-    addPortPointIds(pair[0])
-    addPortPointIds(pair[1])
+    addPortPointIds(relevantIds, pair[0])
+    addPortPointIds(relevantIds, pair[1])
   }
   for (const obstacle of projectedObstacles) {
     for (const id of [
@@ -158,14 +367,7 @@ export function projectPipeline9OrdinaryHighDensityInput({
     }
   }
 
-  const connectivityNetMap = Object.fromEntries(
-    Object.entries(connMap.netMap).flatMap(([netId, ids]) => {
-      const relevantConnectedIds = ids.filter((id) => relevantIds.has(id))
-      return relevantConnectedIds.length > 0 || relevantIds.has(netId)
-        ? [[netId, relevantConnectedIds]]
-        : []
-    }),
-  )
+  const connectivityNetMap = projectConnectivityNetMap(connMap, relevantIds)
   const projectedColorMap = Object.fromEntries(
     Object.entries(colorMap ?? {}).filter(([id]) => relevantIds.has(id)),
   )

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -48,6 +48,7 @@ export type {
   Pipeline9NetworkedSolveRequest,
   Pipeline9NetworkedSolveResponse,
 } from "./autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-types"
+export { PIPELINE9_NETWORKED_SOLVE_POLICY } from "./autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-types"
 export { solvePipeline9NetworkedHighDensityNode } from "./autorouter-pipelines/AutoroutingPipeline9_Networked/solve-pipeline9-networked-high-density-node"
 export { AutoroutingPipelineSolver10_BgaFanout } from "./autorouter-pipelines/AutoroutingPipeline10_BgaFanout/AutoroutingPipelineSolver10_BgaFanout"
 export { PolyHighDensitySolver } from "./autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/PolyHighDensitySolver"

--- a/tests/features/pipeline9-networked-batch-mixed-hit-miss.test.ts
+++ b/tests/features/pipeline9-networked-batch-mixed-hit-miss.test.ts
@@ -51,6 +51,7 @@ test("Pipeline9 fans a batch cache miss out to legacy solve without losing hit c
               autorouterVersion: request.autorouterVersion,
               source: "cache",
               status: "solved",
+              solutionStage: "ordinary",
               routes: [createNetworkedRoute(hitItem.input.nodeWithPortPoints)],
             },
             {

--- a/tests/features/pipeline9-networked-batch-partial-failure.test.ts
+++ b/tests/features/pipeline9-networked-batch-partial-failure.test.ts
@@ -44,6 +44,7 @@ test("Pipeline9 batch results fail open per node without discarding valid siblin
             autorouterVersion: request.autorouterVersion,
             source: "cache",
             status: "solved",
+            solutionStage: "ordinary",
             routes: [createNetworkedRoute(validItem.input.nodeWithPortPoints)],
           }),
           JSON.stringify({
@@ -52,6 +53,7 @@ test("Pipeline9 batch results fail open per node without discarding valid siblin
             autorouterVersion: request.autorouterVersion,
             source: "cache",
             status: "solved",
+            solutionStage: "ordinary",
             routes: [{}],
           }),
         ].join("\n"),

--- a/tests/features/pipeline9-networked-cached-terminal-regional-failure.test.ts
+++ b/tests/features/pipeline9-networked-cached-terminal-regional-failure.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test"
+import {
+  asNetworkedFetch,
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+  createNetworkedResponse,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9 networked consumes a cached terminal regional failure without repeating local work", async () => {
+  const node = createNetworkedNode({
+    nodeId: "cmn_cached_terminal_regional_failure",
+    connectionName: "A",
+  })
+  const terminalError =
+    "Pipeline9 primary high-density routing failed: regular high-density routing failed: ordinary exhausted; regional fallback failed: regional exhausted"
+  const solver = createNetworkedHighDensitySolver({
+    nodes: [node],
+    fetchImpl: asNetworkedFetch(async () =>
+      createNetworkedResponse({
+        status: "failed",
+        solutionStage: "regional-fallback",
+        ordinaryFailure: "ordinary exhausted",
+        error: terminalError,
+      }),
+    ),
+    enableRegionalFallback: true,
+  })
+
+  solver.step()
+  await solver.pendingEffects![0]!.promise
+  solver.step()
+
+  expect(solver.failed).toBeTrue()
+  expect(solver.error).toBe(terminalError)
+  expect(solver.activeRegularSolver).toBeNull()
+  expect(solver.activeFallbackSolver).toBeNull()
+  expect(solver.stats.remoteRegionalFallbackResults).toBe(1)
+  expect(solver.stats.remoteRegionalFallbackResultsApplied).toBe(1)
+  expect(solver.stats.remoteRegionalFallbackResultsDeferredToLocal).toBe(0)
+})

--- a/tests/features/pipeline9-networked-cached-terminal-regional.test.ts
+++ b/tests/features/pipeline9-networked-cached-terminal-regional.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "bun:test"
+import {
+  asNetworkedFetch,
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+  createNetworkedResponse,
+  createNetworkedRoute,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9 networked applies a cached terminal regional result without local fallback work", async () => {
+  const node = createNetworkedNode({
+    nodeId: "cmn_cached_terminal_regional",
+    connectionName: "A",
+  })
+  const route = createNetworkedRoute(node)
+  const solver = createNetworkedHighDensitySolver({
+    nodes: [node],
+    fetchImpl: asNetworkedFetch(async () =>
+      createNetworkedResponse({
+        status: "solved",
+        solutionStage: "regional-fallback",
+        ordinaryFailure: "ordinary solver exhausted its candidates",
+        routes: [route],
+      }),
+    ),
+    enableRegionalFallback: true,
+  })
+
+  solver.step()
+  await solver.pendingEffects![0]!.promise
+  solver.step()
+  solver.step()
+
+  expect(solver.solved).toBeTrue()
+  expect(solver.activeRegularSolver).toBeNull()
+  expect(solver.activeFallbackSolver).toBeNull()
+  expect(solver.routes).toHaveLength(1)
+  expect(solver.routes[0]).toMatchObject(route)
+  expect(solver.stats.fallbackNodeCount).toBe(1)
+  expect(solver.stats.remoteRegionalFallbackResults).toBe(1)
+  expect(solver.stats.remoteRegionalFallbackResultsApplied).toBe(1)
+  expect(solver.stats.remoteRegionalFallbackResultsDeferredToLocal).toBe(0)
+})

--- a/tests/features/pipeline9-networked-disabled-regional-policy.test.ts
+++ b/tests/features/pipeline9-networked-disabled-regional-policy.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { Pipeline9HighDensitySolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-high-density-solver"
+import { solvePipeline9NetworkedHighDensityNode } from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/solve-pipeline9-networked-high-density-node"
+import { PIPELINE9_NETWORKED_SOLVE_POLICY } from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-types"
+import type { NodeWithPortPoints } from "lib/types/high-density-types"
+
+test("Pipeline9 networked terminal helper respects disabled regional fallback", () => {
+  const portPoints = [
+    { x: -1, y: 0, z: 0, connectionName: "horizontal" },
+    { x: 1, y: 0, z: 0, connectionName: "horizontal" },
+    { x: 0, y: -1, z: 0, connectionName: "vertical" },
+    { x: 0, y: 1, z: 0, connectionName: "vertical" },
+  ]
+  const node: NodeWithPortPoints = {
+    capacityMeshNodeId: "cmn_disabled_terminal_regional",
+    center: { x: 0, y: 0 },
+    width: 2,
+    height: 2,
+    availableZ: [0],
+    portPoints,
+    portPointsInPairs: [
+      [portPoints[0]!, portPoints[1]!],
+      [portPoints[2]!, portPoints[3]!],
+    ],
+  }
+  const connMap = new ConnectivityMap({
+    horizontal: ["horizontal"],
+    vertical: ["vertical"],
+  })
+  const localSolver = new Pipeline9HighDensitySolver({
+    nodePortPoints: [node],
+    fixedHdRoutes: [],
+    connMap,
+    colorMap: {},
+    obstacles: [],
+    layerCount: 2,
+    viaDiameter: 0.3,
+    traceWidth: 0.1,
+    obstacleMargin: 0.15,
+    effort: 1,
+    nodePfById: { cmn_disabled_terminal_regional: 0.1 },
+    enableRegionalFallback: false,
+  })
+  localSolver.solve()
+  const result = solvePipeline9NetworkedHighDensityNode({
+    solvePolicy: PIPELINE9_NETWORKED_SOLVE_POLICY,
+    enableRegionalFallback: false,
+    nodeWithPortPoints: node,
+    connectivityNetMap: connMap.netMap,
+    colorMap: {},
+    viaDiameter: 0.3,
+    traceWidth: 0.1,
+    obstacleMargin: 0.15,
+    effort: 1,
+    obstacles: [],
+    regionalObstacles: [],
+    layerCount: 2,
+    nodePf: 0.1,
+  })
+
+  expect(localSolver.failed).toBeTrue()
+  expect(result).toEqual({
+    status: "failed",
+    solutionStage: "ordinary",
+    error: localSolver.error!,
+  })
+})

--- a/tests/features/pipeline9-networked-fail-open.test.ts
+++ b/tests/features/pipeline9-networked-fail-open.test.ts
@@ -29,6 +29,7 @@ test("Pipeline9 networked falls back locally for transport and invalid protocol 
   const cases: Array<{
     name: string
     requestTimeoutMs?: number
+    enableRegionalFallback?: boolean
     fetchImpl: typeof fetch
   }> = [
     {
@@ -73,9 +74,90 @@ test("Pipeline9 networked falls back locally for transport and invalid protocol 
       ),
     },
     {
+      name: "empty terminal error",
+      fetchImpl: asNetworkedFetch(
+        async () =>
+          new Response(
+            JSON.stringify({
+              ok: true,
+              autorouterVersion: AUTOROUTER_VERSION,
+              source: "cache",
+              status: "failed",
+              solutionStage: "ordinary",
+              error: "",
+            }),
+            { status: 200 },
+          ),
+      ),
+    },
+    {
+      name: "regional metadata on ordinary result",
+      fetchImpl: asNetworkedFetch(async (_input, init) => {
+        const request = JSON.parse(
+          String(init?.body),
+        ) as Pipeline9NetworkedSolveRequest
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            autorouterVersion: AUTOROUTER_VERSION,
+            source: "cache",
+            status: "solved",
+            solutionStage: "ordinary",
+            ordinaryFailure: "must not be present",
+            routes: [createNetworkedRoute(request.input.nodeWithPortPoints)],
+          }),
+          { status: 200 },
+        )
+      }),
+    },
+    {
+      name: "empty regional ordinary failure",
+      enableRegionalFallback: true,
+      fetchImpl: asNetworkedFetch(async (_input, init) => {
+        const request = JSON.parse(
+          String(init?.body),
+        ) as Pipeline9NetworkedSolveRequest
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            autorouterVersion: AUTOROUTER_VERSION,
+            source: "cache",
+            status: "solved",
+            solutionStage: "regional-fallback",
+            ordinaryFailure: "",
+            routes: [createNetworkedRoute(request.input.nodeWithPortPoints)],
+          }),
+          { status: 200 },
+        )
+      }),
+    },
+    {
       name: "foreign route connection",
       fetchImpl: createMalformedRouteFetch((route) => {
         route.connectionName = "foreign_connection"
+      }),
+    },
+    {
+      name: "one point route",
+      fetchImpl: createMalformedRouteFetch((route) => {
+        route.route = route.route.slice(0, 1)
+      }),
+    },
+    {
+      name: "one point regional route",
+      enableRegionalFallback: true,
+      fetchImpl: asNetworkedFetch(async (_input, init) => {
+        const request = JSON.parse(
+          String(init?.body),
+        ) as Pipeline9NetworkedSolveRequest
+        const route = createNetworkedRoute(request.input.nodeWithPortPoints)
+        route.route = route.route.slice(0, 1)
+        return createNetworkedResponse({
+          status: "solved",
+          solutionStage: "regional-fallback",
+          ordinaryFailure: "ordinary failed",
+          routes: [route],
+        })
       }),
     },
     {
@@ -140,6 +222,7 @@ test("Pipeline9 networked falls back locally for transport and invalid protocol 
       nodes: [node],
       fetchImpl: testCase.fetchImpl,
       requestTimeoutMs: testCase.requestTimeoutMs,
+      enableRegionalFallback: testCase.enableRegionalFallback,
     })
 
     solver.step()

--- a/tests/features/pipeline9-networked-node-input-projection.test.ts
+++ b/tests/features/pipeline9-networked-node-input-projection.test.ts
@@ -6,6 +6,7 @@ import {
 } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-high-density-solver"
 import { projectPipeline9OrdinaryHighDensityInput } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/project-pipeline9-ordinary-high-density-input"
 import { solvePipeline9NetworkedHighDensityNode } from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/solve-pipeline9-networked-high-density-node"
+import { PIPELINE9_NETWORKED_SOLVE_POLICY } from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-types"
 import { HighDensitySolver } from "lib/solvers/HighDensitySolver/HighDensitySolver"
 import type { NodeWithPortPoints } from "lib/types/high-density-types"
 import type { Obstacle } from "lib/types/srj-types"
@@ -149,6 +150,8 @@ test("Pipeline9 projects ordinary node obstacles and connectivity without changi
   })
   fullInputSolver.solve()
   const projectedResult = solvePipeline9NetworkedHighDensityNode({
+    solvePolicy: PIPELINE9_NETWORKED_SOLVE_POLICY,
+    enableRegionalFallback: false,
     nodeWithPortPoints: node,
     connectivityNetMap: projection.connectivityNetMap,
     colorMap: projection.colorMap,
@@ -157,6 +160,7 @@ test("Pipeline9 projects ordinary node obstacles and connectivity without changi
     obstacleMargin: 0.15,
     effort: 1,
     obstacles: projection.obstacles,
+    regionalObstacles: [],
     layerCount: 2,
     nodePf: 0.1,
   })
@@ -164,6 +168,7 @@ test("Pipeline9 projects ordinary node obstacles and connectivity without changi
   expect(fullInputSolver.solved).toBeTrue()
   expect(projectedResult).toEqual({
     status: "solved",
+    solutionStage: "ordinary",
     routes: fullInputSolver.routes,
   })
 

--- a/tests/features/pipeline9-networked-other-layer-fixed-copper-ordinary.test.ts
+++ b/tests/features/pipeline9-networked-other-layer-fixed-copper-ordinary.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test"
+import type { PreloadedHighDensityRoute } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/convert-preloaded-traces-to-hd-routes"
+import {
+  asNetworkedFetch,
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+  createNetworkedResponse,
+  createNetworkedRoute,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9 networked still applies an ordinary result when fixed copper overlaps only other layers", async () => {
+  const node = createNetworkedNode({
+    nodeId: "cmn_other_layer_fixed_ordinary",
+    connectionName: "A",
+  })
+  node.availableZ = [0]
+  const otherLayerFixedRoute: PreloadedHighDensityRoute = {
+    connectionName: "fixed_on_z1",
+    rootConnectionName: "fixed_on_z1",
+    traceThickness: 0.15,
+    viaDiameter: 0.3,
+    route: [
+      { x: 0, y: -2, z: 1 },
+      { x: 0, y: 2, z: 1 },
+    ],
+    vias: [],
+    preloadedTraceIndex: 0,
+    preloadedRouteIndex: 0,
+  }
+  const solver = createNetworkedHighDensitySolver({
+    nodes: [node],
+    fixedHdRoutes: [otherLayerFixedRoute],
+    fetchImpl: asNetworkedFetch(async () =>
+      createNetworkedResponse({
+        status: "solved",
+        solutionStage: "ordinary",
+        routes: [createNetworkedRoute(node)],
+      }),
+    ),
+    enableRegionalFallback: true,
+  })
+
+  solver.step()
+  await solver.pendingEffects![0]!.promise
+  solver.step()
+
+  expect(solver.routes).toHaveLength(1)
+  expect(solver.activeRegularSolver).toBeNull()
+  expect(solver.activeFallbackSolver).toBeNull()
+  expect(solver.stats.remoteOrdinaryResults).toBe(1)
+  expect(solver.stats.remoteRegionalFallbackResults).toBe(0)
+})

--- a/tests/features/pipeline9-networked-other-layer-fixed-copper.test.ts
+++ b/tests/features/pipeline9-networked-other-layer-fixed-copper.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "bun:test"
+import type { PreloadedHighDensityRoute } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/convert-preloaded-traces-to-hd-routes"
+import {
+  asNetworkedFetch,
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+  createNetworkedResponse,
+  createNetworkedRoute,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9 networked defers a terminal regional result when fixed copper overlaps only its opened layers", async () => {
+  const node = createNetworkedNode({
+    nodeId: "cmn_other_layer_fixed_copper",
+    connectionName: "A",
+  })
+  node.availableZ = [0]
+  const otherLayerFixedRoute: PreloadedHighDensityRoute = {
+    connectionName: "fixed_on_z1",
+    rootConnectionName: "fixed_on_z1",
+    traceThickness: 0.15,
+    viaDiameter: 0.3,
+    route: [
+      { x: 0, y: -2, z: 1 },
+      { x: 0, y: 2, z: 1 },
+    ],
+    vias: [],
+    preloadedTraceIndex: 0,
+    preloadedRouteIndex: 0,
+  }
+  const solver = createNetworkedHighDensitySolver({
+    nodes: [node],
+    fixedHdRoutes: [otherLayerFixedRoute],
+    fetchImpl: asNetworkedFetch(async () =>
+      createNetworkedResponse({
+        status: "solved",
+        solutionStage: "regional-fallback",
+        ordinaryFailure: "ordinary solver could not cross on z0",
+        routes: [createNetworkedRoute(node)],
+      }),
+    ),
+    enableRegionalFallback: true,
+  })
+
+  solver.step()
+  await solver.pendingEffects![0]!.promise
+  solver.step()
+
+  expect(solver.routes).toEqual([])
+  expect(solver.activeRegularSolver).toBeNull()
+  expect(solver.activeFallbackSolver).not.toBeNull()
+  expect(solver.activeFallbackFixedObstacleRoutes).toEqual([
+    otherLayerFixedRoute,
+  ])
+  expect(solver.stats.remoteRegionalFallbackResults).toBe(1)
+  expect(solver.stats.remoteRegionalFallbackResultsApplied).toBe(0)
+  expect(solver.stats.remoteRegionalFallbackResultsDeferredToLocal).toBe(1)
+  expect(solver.stats.remoteTransportFallbacks).toBe(0)
+})

--- a/tests/features/pipeline9-networked-parallel-node-requests.test.ts
+++ b/tests/features/pipeline9-networked-parallel-node-requests.test.ts
@@ -39,6 +39,7 @@ test("Pipeline9 networked launches every node request in parallel and preserves 
             autorouterVersion: request.autorouterVersion,
             source: "cache",
             status: "solved",
+            solutionStage: "ordinary",
             routes: [createNetworkedRoute(item.input.nodeWithPortPoints)],
           }),
         )

--- a/tests/features/pipeline9-networked-regional-obstacle-connectivity-projection.test.ts
+++ b/tests/features/pipeline9-networked-regional-obstacle-connectivity-projection.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { projectPipeline9RegionalHighDensityInput } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/project-pipeline9-ordinary-high-density-input"
+import type { Obstacle } from "lib/types/srj-types"
+import { createNetworkedNode } from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9 regional projection preserves direct identities and one original net alias without synthesizing obstacleId", () => {
+  const node = createNetworkedNode({
+    nodeId: "cmn_regional_obstacle_projection",
+    connectionName: "route_A",
+    rootConnectionName: "root_alias_A",
+  })
+  const connMap = new ConnectivityMap({
+    canonical_net_A: [
+      "route_A",
+      "root_alias_A",
+      "pad_alias_A",
+      "obstacle_id_alias_A",
+    ],
+    foreign_net: ["foreign_A", "foreign_B"],
+  })
+  const createObstacle = (
+    obstacleId: string,
+    connectedTo: string[],
+    x: number,
+  ): Obstacle => ({
+    obstacleId,
+    type: "rect",
+    layers: ["top", "bottom"],
+    center: { x, y: 0 },
+    width: 0.2,
+    height: 0.2,
+    connectedTo,
+  })
+  const projection = projectPipeline9RegionalHighDensityInput({
+    nodeWithPortPoints: node,
+    connMap,
+    obstacles: [
+      createObstacle("alias_only", ["pad_alias_A", "foreign_A"], -1),
+      createObstacle("exact_connection", ["route_A", "foreign_A"], 0),
+      createObstacle("exact_normalized_root", ["canonical_net_A"], 1),
+      createObstacle("obstacle_id_alias_A", ["foreign_B"], 1.5),
+      createObstacle("far_away", ["route_A"], 100),
+    ],
+    obstacleMargin: 0.15,
+    traceWidth: 0.15,
+    viaDiameter: 0.3,
+  })
+
+  expect(projection.obstacles.map((obstacle) => obstacle.connectedTo)).toEqual([
+    ["pad_alias_A"],
+    ["route_A"],
+    ["canonical_net_A"],
+    [],
+  ])
+  expect(projection.connectivityNetMap).toEqual({
+    canonical_net_A: [
+      "route_A",
+      "root_alias_A",
+      "pad_alias_A",
+    ],
+  })
+})

--- a/tests/features/pipeline9-networked-regional-obstacle-connectivity-projection.test.ts
+++ b/tests/features/pipeline9-networked-regional-obstacle-connectivity-projection.test.ts
@@ -54,10 +54,6 @@ test("Pipeline9 regional projection preserves direct identities and one original
     [],
   ])
   expect(projection.connectivityNetMap).toEqual({
-    canonical_net_A: [
-      "route_A",
-      "root_alias_A",
-      "pad_alias_A",
-    ],
+    canonical_net_A: ["route_A", "root_alias_A", "pad_alias_A"],
   })
 })

--- a/tests/features/pipeline9-networked-regional-obstacle-projection-parity.test.ts
+++ b/tests/features/pipeline9-networked-regional-obstacle-projection-parity.test.ts
@@ -1,0 +1,116 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { normalizePipeline9NodeRootConnectionNames } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-high-density-solver"
+import { Pipeline9RegionalFallbackSolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-regional-fallback-solver"
+import {
+  projectPipeline9OrdinaryHighDensityInput,
+  projectPipeline9RegionalHighDensityInput,
+} from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/project-pipeline9-ordinary-high-density-input"
+import type { Obstacle } from "lib/types/srj-types"
+import { createNetworkedNode } from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9 regional obstacle projection matches the full board fallback solve", () => {
+  const node = createNetworkedNode({
+    nodeId: "cmn_regional_projection_parity",
+    connectionName: "route_A",
+    rootConnectionName: "root_A",
+  })
+  const noiseIds = Array.from({ length: 2_310 }, (_, index) => `noise_${index}`)
+  const connMap = new ConnectivityMap({
+    canonical_A: ["route_A", "root_A", "pad_A", ...noiseIds],
+    foreign_net: ["foreign_A"],
+  })
+  const obstacles: Obstacle[] = [
+    {
+      obstacleId: "same_net_pad",
+      type: "rect",
+      layers: ["top", "bottom"],
+      center: { x: -2, y: 0 },
+      width: 0.4,
+      height: 0.4,
+      ccwRotationDegrees: 15,
+      connectedTo: ["pad_A", ...noiseIds],
+    },
+    {
+      obstacleId: "nearby_foreign_pad",
+      type: "rect",
+      layers: ["top", "bottom"],
+      center: { x: 0, y: 1.5 },
+      width: 0.4,
+      height: 0.4,
+      connectedTo: ["foreign_A"],
+    },
+    {
+      obstacleId: "far_board_noise",
+      type: "rect",
+      layers: ["top", "bottom"],
+      center: { x: 100, y: 100 },
+      width: 1,
+      height: 1,
+      connectedTo: ["foreign_A"],
+    },
+  ]
+  const projection = projectPipeline9RegionalHighDensityInput({
+    nodeWithPortPoints: node,
+    connMap,
+    obstacles,
+    obstacleMargin: 0.15,
+    traceWidth: 0.15,
+    viaDiameter: 0.3,
+  })
+  const ordinaryFromFullBoard = projectPipeline9OrdinaryHighDensityInput({
+    nodeWithPortPoints: node,
+    connMap,
+    colorMap: { route_A: "blue" },
+    obstacles,
+    obstacleMargin: 0.15,
+    traceWidth: 0.15,
+    viaDiameter: 0.3,
+  })
+  const ordinaryFromRegionalProjection =
+    projectPipeline9OrdinaryHighDensityInput({
+      nodeWithPortPoints: node,
+      connMap,
+      colorMap: { route_A: "blue" },
+      obstacles: projection.obstacles,
+      obstacleMargin: 0.15,
+      traceWidth: 0.15,
+      viaDiameter: 0.3,
+    })
+  const normalizedNode = {
+    ...normalizePipeline9NodeRootConnectionNames(node, connMap),
+    availableZ: [0, 1],
+  }
+  const createSolver = (
+    projectedObstacles: Obstacle[],
+    projectedConnMap: ConnectivityMap,
+  ): Pipeline9RegionalFallbackSolver =>
+    new Pipeline9RegionalFallbackSolver({
+      nodeWithPortPoints: normalizedNode,
+      colorMap: { route_A: "blue" },
+      connMap: projectedConnMap,
+      viaDiameter: 0.3,
+      traceWidth: 0.15,
+      obstacleMargin: 0.15,
+      effort: 1,
+      nodePfById: { cmn_regional_projection_parity: 0.1 },
+      obstacles: projectedObstacles,
+      layerCount: 2,
+    })
+  const fullSolver = createSolver(obstacles, connMap)
+  const projectedSolver = createSolver(
+    projection.obstacles,
+    new ConnectivityMap(projection.connectivityNetMap),
+  )
+
+  fullSolver.solve()
+  projectedSolver.solve()
+
+  expect(projection.obstacles).toHaveLength(2)
+  expect(ordinaryFromRegionalProjection).toEqual(ordinaryFromFullBoard)
+  expect(JSON.stringify(projection)).not.toContain("noise_2309")
+  expect(projectedSolver.solved).toBe(fullSolver.solved)
+  expect(projectedSolver.failed).toBe(fullSolver.failed)
+  expect(projectedSolver.error).toBe(fullSolver.error)
+  expect(projectedSolver.getOutput()).toEqual(fullSolver.getOutput())
+})

--- a/tests/features/pipeline9-networked-regional-shifted-endpoints.test.ts
+++ b/tests/features/pipeline9-networked-regional-shifted-endpoints.test.ts
@@ -4,36 +4,38 @@ import {
   createNetworkedHighDensitySolver,
   createNetworkedNode,
   createNetworkedResponse,
+  createNetworkedRoute,
 } from "tests/fixtures/pipeline9-networked-fixtures"
 
-test("Pipeline9 networked consumes a cached terminal failure without launching local regional work", async () => {
+test("Pipeline9 networked accepts regional cleanup routes with shifted endpoints", async () => {
   const node = createNetworkedNode({
-    nodeId: "cmn_cached_failure",
+    nodeId: "cmn_regional_shifted_endpoints",
     connectionName: "A",
   })
+  const shiftedRoute = createNetworkedRoute(node)
+  shiftedRoute.route[0]!.x += 0.01
+  shiftedRoute.route.at(-1)!.x -= 0.01
   const solver = createNetworkedHighDensitySolver({
     nodes: [node],
     fetchImpl: asNetworkedFetch(async () =>
       createNetworkedResponse({
-        status: "failed",
-        error:
-          "Pipeline9 regular high-density routing failed: deterministically unsolved",
+        status: "solved",
+        solutionStage: "regional-fallback",
+        ordinaryFailure: "ordinary solver exhausted its candidates",
+        routes: [shiftedRoute],
       }),
     ),
-    enableRegionalFallback: false,
+    enableRegionalFallback: true,
   })
 
   solver.step()
   await solver.pendingEffects![0]!.promise
   solver.step()
 
-  expect(solver.failed).toBeTrue()
+  expect(solver.routes).toHaveLength(1)
+  expect(solver.routes[0]).toMatchObject(shiftedRoute)
   expect(solver.activeRegularSolver).toBeNull()
   expect(solver.activeFallbackSolver).toBeNull()
-  expect(solver.error).toBe(
-    "Pipeline9 regular high-density routing failed: deterministically unsolved",
-  )
-  expect(solver.stats.remoteOrdinaryResults).toBe(1)
-  expect(solver.stats.remoteFailedResults).toBe(1)
+  expect(solver.stats.remoteRegionalFallbackResultsApplied).toBe(1)
   expect(solver.stats.remoteTransportFallbacks).toBe(0)
 })

--- a/tests/features/pipeline9-networked-terminal-regional-failure-parity.test.ts
+++ b/tests/features/pipeline9-networked-terminal-regional-failure-parity.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { Pipeline9HighDensitySolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-high-density-solver"
+import { solvePipeline9NetworkedHighDensityNode } from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/solve-pipeline9-networked-high-density-node"
+import { PIPELINE9_NETWORKED_SOLVE_POLICY } from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-types"
+import type { NodeWithPortPoints } from "lib/types/high-density-types"
+
+test("Pipeline9 networked terminal regional failure matches the local error", () => {
+  const portPoints = [
+    { x: -1, y: 0, z: 0, connectionName: "horizontal" },
+    { x: 1, y: 0, z: 0, connectionName: "horizontal" },
+    { x: 0, y: -1, z: 0, connectionName: "vertical" },
+    { x: 0, y: 1, z: 0, connectionName: "vertical" },
+  ]
+  const node: NodeWithPortPoints = {
+    capacityMeshNodeId: "cmn_terminal_regional_failure_parity",
+    center: { x: 0, y: 0 },
+    width: 2,
+    height: 2,
+    availableZ: [0],
+    portPoints,
+    portPointsInPairs: [
+      [portPoints[0]!, portPoints[1]!],
+      [portPoints[2]!, portPoints[3]!],
+    ],
+  }
+  const connMap = new ConnectivityMap({
+    horizontal: ["horizontal"],
+    vertical: ["vertical"],
+  })
+  const localSolver = new Pipeline9HighDensitySolver({
+    nodePortPoints: [node],
+    fixedHdRoutes: [],
+    connMap,
+    colorMap: {},
+    obstacles: [],
+    layerCount: 1,
+    viaDiameter: 0.3,
+    traceWidth: 0.1,
+    obstacleMargin: 0.15,
+    effort: 1,
+    nodePfById: { cmn_terminal_regional_failure_parity: 0.1 },
+  })
+  localSolver.solve()
+  const result = solvePipeline9NetworkedHighDensityNode({
+    solvePolicy: PIPELINE9_NETWORKED_SOLVE_POLICY,
+    enableRegionalFallback: true,
+    nodeWithPortPoints: node,
+    connectivityNetMap: connMap.netMap,
+    colorMap: {},
+    viaDiameter: 0.3,
+    traceWidth: 0.1,
+    obstacleMargin: 0.15,
+    effort: 1,
+    obstacles: [],
+    regionalObstacles: [],
+    layerCount: 1,
+    nodePf: 0.1,
+  })
+
+  expect(localSolver.failed).toBeTrue()
+  if (!localSolver.error) throw new Error("expected local terminal failure")
+  expect(result.status).toBe("failed")
+  if (result.status !== "failed") throw new Error("expected terminal failure")
+  expect(result.solutionStage).toBe("regional-fallback")
+  expect(result.error).toBe(localSolver.error)
+})

--- a/tests/features/pipeline9-networked-terminal-regional-parity.test.ts
+++ b/tests/features/pipeline9-networked-terminal-regional-parity.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { Pipeline9HighDensitySolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-high-density-solver"
+import { solvePipeline9NetworkedHighDensityNode } from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/solve-pipeline9-networked-high-density-node"
+import { PIPELINE9_NETWORKED_SOLVE_POLICY } from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-types"
+import type { NodeWithPortPoints } from "lib/types/high-density-types"
+
+test("Pipeline9 networked terminal helper matches local ordinary plus regional fallback", () => {
+  const portPoints = [
+    { x: -1, y: 0, z: 0, connectionName: "horizontal" },
+    { x: 1, y: 0, z: 0, connectionName: "horizontal" },
+    { x: 0, y: -1, z: 0, connectionName: "vertical" },
+    { x: 0, y: 1, z: 0, connectionName: "vertical" },
+  ]
+  const node: NodeWithPortPoints = {
+    capacityMeshNodeId: "cmn_terminal_regional_parity",
+    center: { x: 0, y: 0 },
+    width: 2,
+    height: 2,
+    availableZ: [0],
+    portPoints,
+    portPointsInPairs: [
+      [portPoints[0]!, portPoints[1]!],
+      [portPoints[2]!, portPoints[3]!],
+    ],
+  }
+  const connMap = new ConnectivityMap({
+    horizontal: ["horizontal"],
+    vertical: ["vertical"],
+  })
+  const localSolver = new Pipeline9HighDensitySolver({
+    nodePortPoints: [node],
+    fixedHdRoutes: [],
+    connMap,
+    colorMap: { horizontal: "red", vertical: "blue" },
+    obstacles: [],
+    layerCount: 2,
+    viaDiameter: 0.3,
+    traceWidth: 0.1,
+    obstacleMargin: 0.15,
+    effort: 1,
+    nodePfById: { cmn_terminal_regional_parity: 0.1 },
+  })
+
+  localSolver.solve()
+  const remoteResult = solvePipeline9NetworkedHighDensityNode({
+    solvePolicy: PIPELINE9_NETWORKED_SOLVE_POLICY,
+    enableRegionalFallback: true,
+    nodeWithPortPoints: node,
+    connectivityNetMap: connMap.netMap,
+    colorMap: { horizontal: "red", vertical: "blue" },
+    viaDiameter: 0.3,
+    traceWidth: 0.1,
+    obstacleMargin: 0.15,
+    effort: 1,
+    obstacles: [],
+    regionalObstacles: [],
+    layerCount: 2,
+    nodePf: 0.1,
+  })
+
+  expect(localSolver.solved).toBeTrue()
+  expect(localSolver.stats.fallbackNodeCount).toBe(1)
+  expect(remoteResult).toEqual({
+    status: "solved",
+    solutionStage: "regional-fallback",
+    ordinaryFailure: expect.any(String),
+    routes: localSolver.routes,
+  })
+})

--- a/tests/fixtures/pipeline9-networked-fixtures.ts
+++ b/tests/fixtures/pipeline9-networked-fixtures.ts
@@ -76,8 +76,28 @@ export const createNetworkedFixedRoute = (): PreloadedHighDensityRoute => ({
   preloadedRouteIndex: 0,
 })
 
+type NetworkedFixtureNodeOutput =
+  | (Omit<
+      Extract<
+        Pipeline9NetworkedHighDensityNodeOutput,
+        { status: "solved"; solutionStage: "ordinary" }
+      >,
+      "solutionStage"
+    > & { solutionStage?: "ordinary" })
+  | (Omit<
+      Extract<
+        Pipeline9NetworkedHighDensityNodeOutput,
+        { status: "failed"; solutionStage: "ordinary" }
+      >,
+      "solutionStage"
+    > & { solutionStage?: "ordinary" })
+  | Extract<
+      Pipeline9NetworkedHighDensityNodeOutput,
+      { solutionStage: "regional-fallback" }
+    >
+
 export const createNetworkedResponse = (
-  response: Pipeline9NetworkedHighDensityNodeOutput & {
+  response: NetworkedFixtureNodeOutput & {
     autorouterVersion?: string
     source?: "cache" | "solver"
   },
@@ -87,6 +107,7 @@ export const createNetworkedResponse = (
       ok: true,
       autorouterVersion: response.autorouterVersion ?? AUTOROUTER_VERSION,
       source: response.source ?? "cache",
+      solutionStage: response.solutionStage ?? "ordinary",
       ...response,
     }),
     {
@@ -159,7 +180,7 @@ export const asNetworkedBatchFetch = (
 
 export const createNetworkedBatchStream = (): {
   response: Response
-  write: (result: Pipeline9NetworkedSolveBatchResult) => void
+  write: (result: Pipeline9NetworkedSolveBatchResult | object) => void
   close: () => void
 } => {
   const encoder = new TextEncoder()
@@ -174,8 +195,16 @@ export const createNetworkedBatchStream = (): {
       status: 200,
       headers: { "content-type": "application/x-ndjson" },
     }),
-    write: (result) =>
-      controller.enqueue(encoder.encode(`${JSON.stringify(result)}\n`)),
+    write: (result) => {
+      const responseResult = result as Record<string, unknown>
+      const serializedResult =
+        responseResult.ok === true && responseResult.solutionStage === undefined
+          ? { solutionStage: "ordinary", ...responseResult }
+          : responseResult
+      controller.enqueue(
+        encoder.encode(`${JSON.stringify(serializedResult)}\n`),
+      )
+    },
     close: () => controller.close(),
   }
 }


### PR DESCRIPTION
## Summary
- make Pipeline9_Networked remote solves terminal: ordinary routing followed by the no-fixed-copper regional fallback
- preserve parallel speculative requests while re-proving all-layer fixed-copper independence at consumption time
- add a compact, semantics-preserving regional obstacle/connectivity projection and explicit cache policy/stage metadata
- keep malformed one-point geometry and transport/protocol failures on the existing local fail-open path

## Validation
- 29 Pipeline9 networked tests, 282 assertions
- TypeScript typecheck
- package build
- real SRJ18 sample6: 35/35 projected regional solves byte-identical to full-board direct solves; 1,752/1,754 outputs accepted, with only two unsafe one-point outputs intentionally rejected
- sample6 payload: 18 batches, max 1,617,470 bytes, no singleton or body-cap overflow