### PR TITLE
feat: report high-density growths in benchmarks

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-high-density-solver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-high-density-solver.ts
@@ -18,6 +18,7 @@ import type { Obstacle } from "lib/types/srj-types"
 import { mapLayerNameToZ } from "lib/utils/mapLayerNameToZ"
 import { BaseSolver } from "../../solvers/BaseSolver"
 import { HighDensitySolver } from "../../solvers/HighDensitySolver/HighDensitySolver"
+import { GrowShrinkHighDensityIntraNodeSolver } from "../../solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver"
 import type { PreloadedHighDensityRoute } from "./convert-preloaded-traces-to-hd-routes"
 import {
   arePipeline9RoutesOnSameNet,
@@ -345,6 +346,7 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
   readonly preloadedTraceMutationMasks = new Map<string, boolean[]>()
 
   activeRegularSolver: HighDensitySolver | null = null
+  private completedHighDensityGrowthCount = 0
   activeB01Solver: HighDensitySolverB01 | null = null
   activeFallbackSolver: Pipeline9RegionalFallbackSolver | null = null
   activeFallbackFixedRouteSections = new Map<string, FixedRouteSection>()
@@ -391,7 +393,34 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
       regionalPreloadedViaCandidateRejectionCount: 0,
       regionalForceImproveCandidateRejectionCount: 0,
       regionalRepairCandidateRejectionCount: 0,
+      highDensityResizeCount: 0,
     }
+  }
+
+  private getGrowthCount(solver: HighDensitySolver): number {
+    const completedCount = Number(solver.stats.highDensityResizeCount ?? 0)
+    const activeCount =
+      solver.activeSubSolver instanceof GrowShrinkHighDensityIntraNodeSolver
+        ? solver.activeSubSolver.growthAttempts
+        : 0
+    return completedCount + activeCount
+  }
+
+  private updateHighDensityGrowthCount(): void {
+    const activeGrowthCount = this.activeRegularSolver
+      ? this.getGrowthCount(this.activeRegularSolver)
+      : this.activeFallbackSolver
+        ? this.getGrowthCount(this.activeFallbackSolver.highDensitySolver)
+        : 0
+    this.stats.highDensityResizeCount =
+      this.completedHighDensityGrowthCount + activeGrowthCount
+  }
+
+  private commitActiveHighDensityGrowthCount(): void {
+    this.updateHighDensityGrowthCount()
+    this.completedHighDensityGrowthCount = Number(
+      this.stats.highDensityResizeCount ?? 0,
+    )
   }
 
   override getSolverName(): string {
@@ -408,6 +437,7 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
   }
 
   protected finishActiveNode(routes: HighDensityIntraNodeRoute[]): void {
+    this.commitActiveHighDensityGrowthCount()
     const solvedRoutes = this.activeNode
       ? restoreRootConnectionNames(routes, this.activeNode)
       : routes
@@ -471,6 +501,9 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
       )
     }
 
+    if (this.activeFallbackSolver) {
+      this.commitActiveHighDensityGrowthCount()
+    }
     const normalizedNode = normalizePipeline9NodeRootConnectionNames(
       this.activeNode,
       this.connMap,
@@ -857,6 +890,7 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
 
   protected finishRegularSolverFailure(error: string): void {
     this.activeFallbackReason = `regular high-density routing failed: ${error}`
+    this.commitActiveHighDensityGrowthCount()
     this.activeRegularSolver = null
     if (!this.enableRegionalFallback) {
       this.error = `Pipeline9 ${this.activeFallbackReason}`
@@ -870,8 +904,10 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
   override _step(): void {
     if (this.activeFallbackSolver) {
       this.activeFallbackSolver.step()
+      this.updateHighDensityGrowthCount()
       if (this.activeFallbackSolver.failed) {
         this.recordRegionalCandidateRejections()
+        this.commitActiveHighDensityGrowthCount()
         this.error = [
           `Pipeline9 primary high-density routing failed: ${this.activeFallbackReason ?? "unknown error"}`,
           `regional fallback failed: ${this.activeFallbackSolver.error ?? "unknown error"}`,
@@ -892,6 +928,7 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
 
     if (this.activeRegularSolver) {
       this.activeRegularSolver.step()
+      this.updateHighDensityGrowthCount()
       if (this.activeRegularSolver.failed) {
         this.finishRegularSolverFailure(
           this.activeRegularSolver.error ?? "unknown error",

--- a/scripts/benchmark/benchmark-run-task.ts
+++ b/scripts/benchmark/benchmark-run-task.ts
@@ -311,6 +311,7 @@ const getProgressInfo = (
     activeSubSolverProgress: activeSubSolver?.progress,
     activeSubSolverIterations: activeSubSolver?.iterations,
     stageTiming: extractBenchmarkStageTiming(solver, "partial"),
+    routingMetrics: getRoutingBenchmarkMetrics(solver),
   }
 }
 
@@ -332,6 +333,7 @@ const getRoutingBenchmarkMetrics = (
     tinyHypergraph:
       solver.portPointPathingSolver?.getSolveGraphBenchmarkMetrics?.(),
     highDensityIterations: solver.highDensityRouteSolver?.iterations,
+    highDensityGrowthCount: getCounter("highDensityResizeCount"),
     nodeCount: getCounter("nodeCount"),
     solvedNodeCount: getCounter("solvedNodeCount"),
     regularNodeCount: getCounter("regularNodeCount"),

--- a/scripts/benchmark/benchmark-types.ts
+++ b/scripts/benchmark/benchmark-types.ts
@@ -52,6 +52,7 @@ export type WorkerProgress = {
   activeSubSolverProgress?: number
   activeSubSolverIterations?: number
   stageTiming?: BenchmarkStageTimingBreakdown
+  routingMetrics?: RoutingBenchmarkMetrics
 }
 
 export type TinyHypergraphBenchmarkMetrics = {
@@ -93,6 +94,7 @@ export type TinyHypergraphBenchmarkMetrics = {
 export type RoutingBenchmarkMetrics = {
   tinyHypergraph?: TinyHypergraphBenchmarkMetrics
   highDensityIterations?: number
+  highDensityGrowthCount?: number
   nodeCount?: number
   solvedNodeCount?: number
   regularNodeCount?: number
@@ -181,6 +183,7 @@ export type SolverRunSummary = {
   p90TimeMs?: number | null
   p95TimeMs: number | null
   avgVia: number | null
+  highDensityGrowthCount?: number | null
 }
 
 export type BestViaCountRecord = {

--- a/scripts/benchmark/index.ts
+++ b/scripts/benchmark/index.ts
@@ -843,6 +843,7 @@ const formatTable = (rows: SolverRunSummary[]) => {
     "P90 Time",
     "P95 Time",
     "Avg Via",
+    "HD Growths",
   ]
 
   const body = rows.map((row) => [
@@ -857,6 +858,7 @@ const formatTable = (rows: SolverRunSummary[]) => {
     formatTime(row.p90TimeMs ?? null),
     formatTime(row.p95TimeMs),
     formatAverage(row.avgVia),
+    row.highDensityGrowthCount?.toString() ?? "n/a",
   ])
 
   const widths = headers.map((header, columnIndex) => {
@@ -1107,6 +1109,7 @@ export const createFailedResult = (
     progressElapsedTimeMs: latestProgress?.elapsedTimeMs,
     finalElapsedTimeMs: elapsedTimeMs,
   }),
+  routingMetrics: latestProgress?.routingMetrics,
 })
 
 const getTaskEffort = (task: BenchmarkTask) => {
@@ -1468,6 +1471,18 @@ export const summarizeSolverResults = (
       ? null
       : viaCounts.reduce((sum, viaCount) => sum + viaCount, 0) /
         viaCounts.length
+  const highDensityGrowthCounts = results
+    .map((result) => result.routingMetrics?.highDensityGrowthCount)
+    .filter(
+      (growthCount): growthCount is number => typeof growthCount === "number",
+    )
+  const highDensityGrowthCount =
+    highDensityGrowthCounts.length === 0
+      ? null
+      : highDensityGrowthCounts.reduce(
+          (total, growthCount) => total + growthCount,
+          0,
+        )
 
   return {
     solverName,
@@ -1489,6 +1504,7 @@ export const summarizeSolverResults = (
     p90TimeMs: getPercentileMs(elapsedForSolvedAndTimedOut, 0.9),
     p95TimeMs: getPercentileMs(elapsedForSolvedAndTimedOut, 0.95),
     avgVia,
+    highDensityGrowthCount,
   } satisfies SolverRunSummary
 }
 

--- a/tests/benchmark-summary-percentiles.test.ts
+++ b/tests/benchmark-summary-percentiles.test.ts
@@ -19,8 +19,12 @@ test("benchmark timing percentiles include solved and timed-out samples", () => 
     ...overrides,
   })
   const results = [
-    makeResult(1, 100),
-    makeResult(2, 200),
+    makeResult(1, 100, {
+      routingMetrics: { highDensityGrowthCount: 2 },
+    }),
+    makeResult(2, 200, {
+      routingMetrics: { highDensityGrowthCount: 3 },
+    }),
     makeResult(3, 300),
     makeResult(4, 400),
     makeResult(5, 1_000, {
@@ -42,4 +46,5 @@ test("benchmark timing percentiles include solved and timed-out samples", () => 
   expect(summary.p80TimeMs).toBeCloseTo(520)
   expect(summary.p90TimeMs).toBeCloseTo(760)
   expect(summary.p95TimeMs).toBeCloseTo(880)
+  expect(summary.highDensityGrowthCount).toBe(5)
 })

--- a/tests/benchmark-timeout-stage-timings.test.ts
+++ b/tests/benchmark-timeout-stage-timings.test.ts
@@ -26,6 +26,9 @@ test("timeout and crash results retain the latest partial stage timing", () => {
         { stageName: "routeSolver", elapsedTimeMs: 60 },
       ],
     },
+    routingMetrics: {
+      highDensityGrowthCount: 4,
+    },
   }
 
   const timedOut = createFailedResult(
@@ -43,6 +46,7 @@ test("timeout and crash results retain the latest partial stage timing", () => {
       { stageName: "routeSolver", elapsedTimeMs: 110 },
     ],
   })
+  expect(timedOut.routingMetrics?.highDensityGrowthCount).toBe(4)
 
   const crashed = createFailedResult(task, 140, "Child crashed", false, {
     ...latestProgress,

--- a/tests/features/pipeline9-high-density-growth-stats.test.ts
+++ b/tests/features/pipeline9-high-density-growth-stats.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { Pipeline9HighDensitySolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-high-density-solver"
+import { HighDensitySolver } from "lib/solvers/HighDensitySolver/HighDensitySolver"
+import { GrowShrinkHighDensityIntraNodeSolver } from "lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver"
+import {
+  makeNode,
+  makeStraightRoute,
+} from "./never-fail-growth-high-density/test-helpers"
+
+test("Pipeline9 exposes ordinary high-density growths in its stage stats", () => {
+  const growShrinkSolver = new GrowShrinkHighDensityIntraNodeSolver({
+    nodeWithPortPoints: makeNode(),
+  })
+  growShrinkSolver.solved = true
+  growShrinkSolver.solvedRoutes = [makeStraightRoute()]
+  growShrinkSolver.growthAttempts = 2
+
+  const regularSolver = new HighDensitySolver({
+    nodePortPoints: [],
+    useGrowShrinkHighDensityIntraNodeSolver: true,
+  })
+  regularSolver.activeSubSolver = growShrinkSolver
+
+  const pipeline9Solver = new Pipeline9HighDensitySolver({
+    nodePortPoints: [],
+    fixedHdRoutes: [],
+    connMap: new ConnectivityMap({}),
+    obstacles: [],
+    layerCount: 2,
+    viaDiameter: 0.3,
+    traceWidth: 0.15,
+    obstacleMargin: 0.15,
+    effort: 1,
+  })
+  pipeline9Solver.activeRegularSolver = regularSolver
+
+  pipeline9Solver.step()
+
+  expect(pipeline9Solver.stats.highDensityResizeCount).toBe(2)
+})


### PR DESCRIPTION
## Summary

- expose Pipeline 9 grow/shrink attempts through high-density stage stats
- retain routing metrics in timeout and crash results so completed work is not lost
- add per-sample `highDensityGrowthCount` metrics and an aggregate `HD Growths` benchmark column
- cover Pipeline 9 aggregation, benchmark summary aggregation, and timeout metric retention

## Benchmark analysis

Blacksmith run: `./benchmark.sh --pipeline 9 --dataset srj18 --concurrency 4`

- 16 scenarios at 1x effort
- **28 high-density growths performed**
- 9/16 completed; 7/16 timed out
- growth-heavy samples: 4 (7), 2 (6), and 8/11/16 (3 each)
- timeout records preserve the last observed growth count, including sample 8 timing out inside the high-density stage

## Validation

- `bun test tests/benchmark-summary-percentiles.test.ts tests/benchmark-timeout-stage-timings.test.ts tests/features/never-fail-growth-high-density/resize-stats.test.ts tests/features/pipeline9-high-density-growth-stats.test.ts --timeout 9999999`
- `bun run build`
- `git diff --check`

## Stack

This PR is intentionally based on #2284 so it contains only the benchmark-growth reporting changes.