### PR TITLE
feat: add bounded capacity-mesh routing analysis

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -76,7 +76,7 @@ import { getPowerTraceExpansionConnectionNames } from "./getPowerTraceExpansionC
 import { lockHdRouteTerminals } from "./lock-hd-route-terminals"
 import { preparePipeline7PowerTraceExpansionInput } from "./prepare-pipeline7-power-trace-expansion-input"
 
-interface CapacityMeshSolverOptions {
+export interface CapacityMeshSolverOptions {
   capacityDepth?: number
   targetMinCapacity?: number
   cacheProvider?: CacheProvider | null

--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -917,7 +917,11 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
   }
 
   solveUntilPhase(phase: string) {
-    while (this.getCurrentPhase() !== phase) {
+    while (
+      this.getCurrentPhase() !== phase &&
+      !this.solved &&
+      !this.failed
+    ) {
       this.step()
     }
   }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -86,6 +86,7 @@ export type {
   HighDensityIntraNodeRouteWithJumpers,
 } from "./types/high-density-types"
 export { PortfolioSingleIntraNodeSolver } from "./solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver"
+export { CapacityMeshRoutingAnalysisSolver } from "./solvers/CapacityMeshRoutingAnalysisSolver/CapacityMeshRoutingAnalysisSolver"
 /** @deprecated Use `PortfolioSingleIntraNodeSolver` instead. */
 export { HyperSingleIntraNodeSolver } from "./solvers/HyperHighDensitySolver/HyperSingleIntraNodeSolver"
 export { GrowShrinkHighDensityIntraNodeSolver } from "./solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver"

--- a/lib/solvers/CapacityMeshRoutingAnalysisSolver/CapacityMeshRoutingAnalysisSolver.ts
+++ b/lib/solvers/CapacityMeshRoutingAnalysisSolver/CapacityMeshRoutingAnalysisSolver.ts
@@ -1,0 +1,168 @@
+import type { GraphicsObject } from "graphics-debug"
+import {
+  AutoroutingPipelineSolver7_MultiGraph,
+  type AutoroutingPipelineSolverOptions,
+} from "lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph"
+import type {
+  CapacityMeshNode,
+  SimpleRouteJson,
+} from "lib/types"
+import type { NodeWithPortPoints } from "lib/types/high-density-types"
+import { BaseSolver } from "../BaseSolver"
+import { CapacityPathingSolver } from "../CapacityPathingSolver/CapacityPathingSolver"
+import { CapacityEdgeToPortSegmentSolver } from "../CapacityMeshSolver/CapacityEdgeToPortSegmentSolver"
+import { CapacitySegmentToPointSolver } from "../CapacityMeshSolver/CapacitySegmentToPointSolver"
+
+type RoutingAnalysisPhase =
+  | "topology"
+  | "capacityPathing"
+  | "edgeToPortSegments"
+  | "segmentToPoints"
+  | "done"
+
+/**
+ * Routes every connection through the capacity mesh without rejecting
+ * over-capacity nodes. Over-capacity traffic is the signal this analysis is
+ * intended to measure; obstacle and layer connectivity constraints still
+ * apply.
+ */
+class UnboundedCapacityPathingSolver extends CapacityPathingSolver {
+  override doesNodeHaveCapacityForTrace(
+    _node: CapacityMeshNode,
+    _prevNode: CapacityMeshNode,
+  ): boolean {
+    return true
+  }
+}
+
+/**
+ * Produces coarse global-routing traffic for routing-difficulty analysis.
+ * This deliberately stops before detailed port-point and high-density
+ * routing, which require a conflict-free physical route rather than a demand
+ * estimate.
+ */
+export class CapacityMeshRoutingAnalysisSolver extends BaseSolver {
+  private phase: RoutingAnalysisPhase = "topology"
+  readonly topologySolver: AutoroutingPipelineSolver7_MultiGraph
+  capacityPathingSolver?: UnboundedCapacityPathingSolver
+  edgeToPortSegmentSolver?: CapacityEdgeToPortSegmentSolver
+  segmentToPointSolver?: CapacitySegmentToPointSolver
+
+  constructor(
+    private readonly simpleRouteJson: SimpleRouteJson,
+    private readonly options: AutoroutingPipelineSolverOptions = {},
+  ) {
+    super()
+    this.topologySolver = new AutoroutingPipelineSolver7_MultiGraph(
+      simpleRouteJson,
+      options,
+    )
+    this.activeSubSolver = this.topologySolver
+    this.MAX_ITERATIONS = this.topologySolver.MAX_ITERATIONS + 1_200_000
+  }
+
+  override getSolverName(): string {
+    return "CapacityMeshRoutingAnalysisSolver"
+  }
+
+  getCurrentPhase(): RoutingAnalysisPhase {
+    return this.phase
+  }
+
+  private failFrom(solver: BaseSolver): void {
+    this.error = solver.error
+    this.failed = true
+    this.activeSubSolver = null
+  }
+
+  override _step(): void {
+    if (this.phase === "topology") {
+      if (
+        this.topologySolver.getCurrentPhase() === "portPointPathingSolver"
+      ) {
+        this.capacityPathingSolver = new UnboundedCapacityPathingSolver({
+          simpleRouteJson: this.topologySolver.srjWithPointPairs!,
+          nodes: this.topologySolver.capacityNodes!,
+          edges: this.topologySolver.capacityEdges!,
+          colorMap: this.topologySolver.colorMap,
+        })
+        this.phase = "capacityPathing"
+        this.activeSubSolver = this.capacityPathingSolver
+        return
+      }
+
+      this.topologySolver.step()
+      if (this.topologySolver.failed) this.failFrom(this.topologySolver)
+      return
+    }
+
+    if (this.phase === "capacityPathing") {
+      this.capacityPathingSolver!.step()
+      if (this.capacityPathingSolver!.failed) {
+        this.failFrom(this.capacityPathingSolver!)
+        return
+      }
+      if (!this.capacityPathingSolver!.solved) return
+
+      this.edgeToPortSegmentSolver = new CapacityEdgeToPortSegmentSolver({
+        nodes: this.topologySolver.capacityNodes!,
+        edges: this.topologySolver.capacityEdges!,
+        capacityPaths: this.capacityPathingSolver!.getCapacityPaths(),
+        colorMap: this.topologySolver.colorMap,
+      })
+      this.phase = "edgeToPortSegments"
+      this.activeSubSolver = this.edgeToPortSegmentSolver
+      return
+    }
+
+    if (this.phase === "edgeToPortSegments") {
+      this.edgeToPortSegmentSolver!.step()
+      if (this.edgeToPortSegmentSolver!.failed) {
+        this.failFrom(this.edgeToPortSegmentSolver!)
+        return
+      }
+      if (!this.edgeToPortSegmentSolver!.solved) return
+
+      this.segmentToPointSolver = new CapacitySegmentToPointSolver({
+        segments: [
+          ...this.edgeToPortSegmentSolver!.nodePortSegments.values(),
+        ].flat(),
+        colorMap: this.topologySolver.colorMap,
+        nodes: this.topologySolver.capacityNodes!,
+      })
+      this.phase = "segmentToPoints"
+      this.activeSubSolver = this.segmentToPointSolver
+      return
+    }
+
+    if (this.phase === "segmentToPoints") {
+      this.segmentToPointSolver!.step()
+      if (this.segmentToPointSolver!.failed) {
+        this.failFrom(this.segmentToPointSolver!)
+        return
+      }
+      if (!this.segmentToPointSolver!.solved) return
+
+      this.phase = "done"
+      this.activeSubSolver = null
+      this.solved = true
+    }
+  }
+
+  getOutput(): NodeWithPortPoints[] {
+    if (!this.solved || !this.segmentToPointSolver) {
+      throw new Error(
+        "CapacityMeshRoutingAnalysisSolver must finish before getOutput()",
+      )
+    }
+    return this.segmentToPointSolver.getNodesWithPortPoints()
+  }
+
+  override getConstructorParams() {
+    return [this.simpleRouteJson, this.options] as const
+  }
+
+  override visualize(): GraphicsObject {
+    return this.activeSubSolver?.visualize() ?? { points: [], lines: [] }
+  }
+}

--- a/lib/solvers/CapacityMeshSolver/CapacitySegmentToPointSolver.ts
+++ b/lib/solvers/CapacityMeshSolver/CapacitySegmentToPointSolver.ts
@@ -175,12 +175,14 @@ export class CapacitySegmentToPointSolver extends BaseSolver {
           center: node.center,
           width: node.width,
           height: node.height,
+          availableZ: node.availableZ,
         })
       }
       map.get(nodeId)!.portPoints.push(
         ...seg.assignedPoints.map((ap) => ({
           ...ap.point,
           connectionName: ap.connectionName,
+          rootConnectionName: ap.rootConnectionName,
         })),
       )
     }

--- a/tests/repro/am625sip-capacity-mesh-routing-analysis.test.ts
+++ b/tests/repro/am625sip-capacity-mesh-routing-analysis.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { gunzipSync } from "node:zlib"
+import {
+  CapacityMeshRoutingAnalysisSolver,
+  type SimpleRouteJson,
+} from "../../lib/index"
+
+const fixtureUrl = new URL(
+  "./assets/am625sip-linux-board.simple-route.json.gz",
+  import.meta.url,
+)
+const simpleRouteJson = JSON.parse(
+  gunzipSync(readFileSync(fixtureUrl)).toString(),
+) as SimpleRouteJson
+
+test("estimates AM625SIP capacity demand without requiring a physical route", () => {
+  const solver = new CapacityMeshRoutingAnalysisSolver(simpleRouteJson)
+
+  solver.solve()
+  const output = solver.getOutput()
+
+  expect(solver.failed).toBeFalse()
+  expect(solver.getCurrentPhase()).toBe("done")
+  expect(solver.capacityPathingSolver?.getCapacityPaths()).toHaveLength(432)
+  expect(output.length).toBeGreaterThan(0)
+  expect(
+    Math.max(...output.map((node) => node.portPoints.length)),
+  ).toBeGreaterThan(1)
+  expect(output.every((node) => node.availableZ?.length)).toBeTrue()
+  expect(
+    output.some((node) =>
+      node.portPoints.some((point) => point.rootConnectionName),
+    ),
+  ).toBeTrue()
+})


### PR DESCRIPTION
## Summary

- adds `CapacityMeshRoutingAnalysisSolver` for routing-difficulty checks
- reuses the default Pipeline 7 topology, then routes every demand through the capacity mesh without rejecting over-capacity nodes
- preserves obstacle and layer connectivity constraints while treating over-capacity traffic as the measured signal
- converts coarse paths into capacity-node port points with layer and root-net metadata
- keeps `solveUntilPhase` terminal-safe so ordinary callers cannot spin after a solver failure

## Why this is the real fix

The routing-difficulty checker needs a demand estimate, not a conflict-free fabrication route. The AM625SIP input contains 432 point-pair demands; detailed port-point routing can legitimately fail before the requested phase. The analysis solver represents all 432 demands and completes in about 3.1 seconds instead of returning an empty result or hanging.

## Stack

Depends on reproduction PR #2289.

## Validation

- `bun test tests/repro/am625sip-capacity-mesh-routing-analysis.test.ts`
- `bun test tests/repro/am625sip-solve-until-phase-hang.test.ts`
- `bun test tests/pipeline7-trace-simplification-net-colors.test.ts`
- `bun run build`
- consumer integration: the real 45,597-element Circuit JSON routing-analysis test passed in 3.5 seconds using the locally built package