### PR TITLE
feat(pipeline9): reintroduce network cache and 9net benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -91,6 +91,11 @@ jobs:
           github-token: ${{ secrets.TSCIRCUIT_BOT_GITHUB_TOKEN }}
           script: |
             const allSolversAliases = new Set(['all', '_'])
+            const usesNetworkedPipeline9 = (args) => args.some(
+              (arg, index) =>
+                arg === '--pipeline' &&
+                String(args[index + 1] || '').toLowerCase() === '9net',
+            )
 
             let benchmarkArgs = []
             let benchmarkConcurrency = ''
@@ -224,8 +229,25 @@ jobs:
             core.setOutput('benchmark_concurrency', benchmarkConcurrency)
             core.setOutput('profile_solvers', profileSolvers ? 'true' : 'false')
             core.setOutput('profile_solvers_args_json', JSON.stringify(buildProfileSolversArgs(benchmarkArgs)))
+            core.setOutput('pipeline9_networked', usesNetworkedPipeline9(benchmarkArgs) ? 'true' : 'false')
             core.setOutput('ref', ref)
             core.setOutput('status_comment_id', statusCommentId)
+
+      - name: Create Pipeline9 network cache benchmark namespace
+        id: networked-cache
+        if: steps.parse.outputs.pipeline9_networked == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { randomUUID } = require('node:crypto')
+            const repositoryId = String(context.payload.repository.id)
+            const runId = String(process.env.GITHUB_RUN_ID)
+            const runAttempt = String(process.env.GITHUB_RUN_ATTEMPT)
+            if (![repositoryId, runId, runAttempt].every((value) => /^\d+$/.test(value))) {
+              throw new Error('GitHub repository/run identifiers are unavailable')
+            }
+            const cacheVersion = `benchmark-${repositoryId}-${runId}-${runAttempt}-${randomUUID()}`
+            core.setOutput('cache_version', cacheVersion)
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -240,6 +262,46 @@ jobs:
 
       - name: Install dependencies
         run: bun install
+
+      - name: Verify production Pipeline9 network cache support
+        if: steps.parse.outputs.pipeline9_networked == 'true'
+        env:
+          HD_CACHE2_SERVER_URL: https://hd-cache2.tscircuit.com
+          HD_CACHE2_CACHE_VERSION: ${{ steps.networked-cache.outputs.cache_version }}
+        run: |
+          node <<'NODE'
+          const { readFileSync } = require('node:fs')
+
+          const run = async () => {
+            const autorouterVersion = JSON.parse(readFileSync('package.json', 'utf8')).version
+            const cacheVersion = process.env.HD_CACHE2_CACHE_VERSION
+            const response = await fetch(`${process.env.HD_CACHE2_SERVER_URL}/health`, {
+              headers: { accept: 'application/json' },
+            })
+            const responseText = await response.text()
+            let body
+            try {
+              body = responseText ? JSON.parse(responseText) : null
+            } catch {
+              throw new Error(`hd-cache2 preflight returned invalid JSON (${response.status})`)
+            }
+            if (
+              !response.ok ||
+              body?.ok !== true ||
+              body.autorouterVersion !== autorouterVersion ||
+              body.benchmarkCacheVersionSupported !== true ||
+              body.benchmarkCacheVersionAccess !== 'open'
+            ) {
+              throw new Error(`hd-cache2 preflight failed (${response.status}): ${body?.message || 'invalid response'}`)
+            }
+            console.log(`hd-cache2 supports autorouter ${autorouterVersion}; using fresh benchmark namespace ${cacheVersion}`)
+          }
+
+          run().catch((error) => {
+            console.error(error.message)
+            process.exit(1)
+          })
+          NODE
 
       - name: Load main branch benchmark datasets
         id: main-datasets
@@ -276,6 +338,9 @@ jobs:
           BENCHMARK_TASK_TIMEOUT_PER_EFFORT_MS: ${{ vars.BENCHMARK_TASK_TIMEOUT_PER_EFFORT_MS || vars.BENCHMARK_TASK_TIMEOUT_MS || '60000' }}
           BENCHMARK_HEARTBEAT_INTERVAL_MS: ${{ vars.BENCHMARK_HEARTBEAT_INTERVAL_MS || '30000' }}
           BENCHMARK_TERMINATE_TIMEOUT_MS: ${{ vars.BENCHMARK_TERMINATE_TIMEOUT_MS || '1000' }}
+          BENCHMARK_NETWORKED_CACHE_PROPAGATION_DELAY_MS: '65000'
+          HD_CACHE2_SERVER_URL: https://hd-cache2.tscircuit.com
+          HD_CACHE2_CACHE_VERSION: ${{ steps.networked-cache.outputs.cache_version }}
         run: |
           chmod +x ./benchmark.sh
           node <<'NODE'
@@ -495,7 +560,16 @@ jobs:
             const comparisonUrl = pathToFileURL(
               `${process.env.GITHUB_WORKSPACE}/scripts/benchmark/benchmark-comment-comparison.js`,
             ).href
-            const { renderBenchmarkComparison } = await import(comparisonUrl)
+            const comparisonModule = await import(comparisonUrl)
+            const { renderBenchmarkComparison } = comparisonModule
+            const isNetworkedColdHotReport =
+              typeof comparisonModule.isNetworkedColdHotReport === 'function'
+                ? comparisonModule.isNetworkedColdHotReport
+                : (report) => {
+                    if (!Array.isArray(report?.summary)) return false
+                    const names = new Set(report.summary.map((row) => row.solverName))
+                    return names.has('Pipeline9_Networked Cold') && names.has('Pipeline9_Networked Hot')
+                  }
             const maxLength = 60000
             const truncate = (s, max) => s.length > max ? `${s.slice(0, max)}\n\n...truncated...` : s
             const formatTime = (timeMs) => {
@@ -723,6 +797,7 @@ jobs:
             const runUrl = `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`
             const profileEnabled = '${{ steps.parse.outputs.profile_solvers }}' === 'true'
             const benchmarkLabel = process.env.BENCHMARK_DATASET === 'dataset01' ? 'Default Benchmark' : (process.env.BENCHMARK_DATASET || 'Benchmark')
+            const networkedColdHot = isNetworkedColdHotReport(prReport)
 
             const renderBody = (options = {}) => [
               `## ${benchmarkLabel} Results`,
@@ -733,7 +808,9 @@ jobs:
                     '',
                   ]
                 : []),
-              '### Main vs PR',
+              networkedColdHot
+                ? '### Pipeline9_Networked Cold vs Hot'
+                : '### Main vs PR',
               '',
               ...renderBenchmarkComparison({
                 mainReport: mainDatasetReport,
@@ -742,15 +819,17 @@ jobs:
                 maxLength,
               }),
               '',
-              ...renderReport(mainDatasetReport, '', {
-                detailsLabel: 'Previous main run details',
-                omitSummary: true,
-              }),
+              ...(networkedColdHot
+                ? []
+                : renderReport(mainDatasetReport, '', {
+                    detailsLabel: 'Previous main run details',
+                    omitSummary: true,
+                  })),
               '',
               ...renderReport(prReport, prText ?? '(benchmark results were not produced)', {
-                detailsLabel: 'PR run details',
+                detailsLabel: networkedColdHot ? 'Cold/hot run details' : 'PR run details',
                 omitSummary: true,
-                includeDelta: true,
+                includeDelta: !networkedColdHot,
                 mainIndex,
                 viaCellIndex,
                 omitUnchangedPassingSamples: Boolean(options.omitUnchangedPassingSamples),
@@ -989,7 +1068,16 @@ jobs:
             const comparisonUrl = pathToFileURL(
               `${process.env.GITHUB_WORKSPACE}/scripts/benchmark/benchmark-comment-comparison.js`,
             ).href
-            const { renderBenchmarkComparison } = await import(comparisonUrl)
+            const comparisonModule = await import(comparisonUrl)
+            const { renderBenchmarkComparison } = comparisonModule
+            const isNetworkedColdHotReport =
+              typeof comparisonModule.isNetworkedColdHotReport === 'function'
+                ? comparisonModule.isNetworkedColdHotReport
+                : (report) => {
+                    if (!Array.isArray(report?.summary)) return false
+                    const names = new Set(report.summary.map((row) => row.solverName))
+                    return names.has('Pipeline9_Networked Cold') && names.has('Pipeline9_Networked Hot')
+                  }
             const maxLength = 60000
             const truncate = (s, max) => s.length > max ? `${s.slice(0, max)}\n\n...truncated...` : s
             const formatTime = (timeMs) => {
@@ -1328,6 +1416,7 @@ jobs:
                 prProfileSolversReport,
             )
             const benchmarkLabel = process.env.BENCHMARK_DATASET === 'dataset01' ? 'Default Benchmark' : (process.env.BENCHMARK_DATASET || 'Benchmark')
+            const networkedColdHot = isNetworkedColdHotReport(prReport)
 
             const renderBody = (options = {}) => [
               benchmarkFailed ? `## ${benchmarkLabel} Failed` : `## ${benchmarkLabel} Results`,
@@ -1348,7 +1437,9 @@ jobs:
                     '',
                   ]
                 : []),
-              '### Main vs PR',
+              networkedColdHot
+                ? '### Pipeline9_Networked Cold vs Hot'
+                : '### Main vs PR',
               '',
               ...renderBenchmarkComparison({
                 mainReport: mainDatasetReport,
@@ -1357,10 +1448,12 @@ jobs:
                 maxLength,
               }),
               '',
-              ...renderReport(mainDatasetReport, '', {
-                detailsLabel: 'Previous main run details',
-                omitSummary: true,
-              }),
+              ...(networkedColdHot
+                ? []
+                : renderReport(mainDatasetReport, '', {
+                    detailsLabel: 'Previous main run details',
+                    omitSummary: true,
+                  })),
               ...(hasProfileSolvers
                 ? renderProfileSolversDetails(
                     'Previous main profile details',
@@ -1369,9 +1462,9 @@ jobs:
                 : []),
               '',
               ...renderReport(prReport, prText ?? '(benchmark results were not produced)', {
-                detailsLabel: 'PR run details',
+                detailsLabel: networkedColdHot ? 'Cold/hot run details' : 'PR run details',
                 omitSummary: true,
-                includeDelta: true,
+                includeDelta: !networkedColdHot,
                 mainIndex,
                 viaCellIndex,
                 omitUnchangedPassingSamples: Boolean(options.omitUnchangedPassingSamples),

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -10,6 +10,7 @@ INCLUDE_ASSIGNABLE=false
 DATASET="dataset01"
 DEFAULT_SOLVER_NAME="AutoroutingPipelineSolver7_MultiGraph"
 PIPELINE_ID=""
+NETWORKED_COLD_HOT=false
 
 resolve_pipeline_solver_name() {
   case "$1" in
@@ -21,6 +22,7 @@ resolve_pipeline_solver_name() {
     6) echo "AutoroutingPipelineSolver6" ;;
     7) echo "AutoroutingPipelineSolver7_MultiGraph" ;;
     9) echo "AutoroutingPipelineSolver9_PreloadedTraceGraph" ;;
+    9net|9NET) echo "AutoroutingPipelineSolver9_Networked" ;;
     10) echo "AutoroutingPipelineSolver10_BgaFanout" ;;
     krt|KRT) echo "KrtAutoroutingPipelineSolver" ;;
     *)
@@ -82,7 +84,7 @@ Usage:
 
 Options:
   --solver NAME        Run only one solver (same as first positional arg)
-  --pipeline ID        Run a pipeline alias (1-7, 9, 10, or krt)
+  --pipeline ID        Run a pipeline alias (1-7, 9, 9net, 10, or krt). 9net runs cold then hot against hd-cache2.
   --limit N            Run only first N scenarios (same as second positional arg)
   --scenario-limit N   Backward-compatible alias for --limit
   --concurrency N      Number of Bun workers used per solver, or "auto"
@@ -114,6 +116,7 @@ Examples:
   ./benchmark.sh --pipeline 6
   ./benchmark.sh --pipeline 7
   ./benchmark.sh --pipeline 9
+  ./benchmark.sh --pipeline 9net --dataset 18
   ./benchmark.sh --pipeline 10 --dataset 29
   ./benchmark.sh --pipeline krt
   ./benchmark.sh --solver AutoroutingPipelineSolver7_MultiGraph --dataset srj05 --scenario-limit 20
@@ -213,6 +216,20 @@ done
 
 if [ -n "$PIPELINE_ID" ]; then
   SOLVER_NAME="$(resolve_pipeline_solver_name "$PIPELINE_ID")"
+  case "$PIPELINE_ID" in
+    9net|9NET) NETWORKED_COLD_HOT=true ;;
+  esac
+fi
+
+if [ "$NETWORKED_COLD_HOT" = true ]; then
+  if [ -n "$EFFORT" ] && [ "$EFFORT" != "1" ]; then
+    echo "Pipeline 9net only supports --effort 1" >&2
+    exit 1
+  fi
+  if [ -z "${HD_CACHE2_CACHE_VERSION:-}" ]; then
+    echo "Pipeline 9net requires HD_CACHE2_CACHE_VERSION" >&2
+    exit 1
+  fi
 fi
 
 if [ "$CONCURRENCY_WAS_SET" = false ] && [ "$SOLVER_NAME" = "AutoroutingPipelineSolver7_MultiGraph" ]; then
@@ -226,6 +243,10 @@ if [ "$CONCURRENCY_WAS_SET" = false ] && [ "$SOLVER_NAME" = "AutoroutingPipeline
 fi
 
 CMD=(bun "scripts/benchmark/index.ts" "--concurrency" "$CONCURRENCY")
+
+if [ "$NETWORKED_COLD_HOT" = true ]; then
+  CMD+=("--networked-cold-hot")
+fi
 
 if [ -z "$SOLVER_NAME" ]; then
   SOLVER_NAME="$DEFAULT_SOLVER_NAME"

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/autorouter-version.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/autorouter-version.ts
@@ -1,0 +1,4 @@
+import packageJson from "../../../package.json" with { type: "json" }
+
+/** The exact published autorouter version used to isolate network cache keys. */
+export const AUTOROUTER_VERSION = String(packageJson.version)

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/autorouting-pipeline-solver9-networked.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/autorouting-pipeline-solver9-networked.ts
@@ -1,0 +1,120 @@
+import type { SimpleRouteJson } from "../../types/srj-types"
+import { getPendingEffectsFromSolverTree } from "../../solvers/getPendingEffectsFromSolverTree"
+import {
+  AutoroutingPipelineSolver9_PreloadedTraceGraph,
+  type AutoroutingPipelineSolverOptions,
+} from "../AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph"
+import { AUTOROUTER_VERSION } from "./autorouter-version"
+import {
+  DEFAULT_HD_CACHE2_SERVER_URL,
+  Pipeline9NetworkedHighDensitySolver,
+} from "./pipeline9-networked-high-density-solver"
+
+export type AutoroutingPipelineSolver9NetworkedOptions = Omit<
+  AutoroutingPipelineSolverOptions,
+  "effort"
+> & {
+  effort?: 1
+  /** Base URL of an hd-cache2-compatible server. */
+  hdCache2ServerUrl?: string
+  /** Optional cache namespace, used to isolate cold/hot benchmark runs. */
+  hdCache2CacheVersion?: string
+}
+
+/** Pipeline9 with exact, version-scoped remote terminal node solving. */
+export class AutoroutingPipelineSolver9_Networked extends AutoroutingPipelineSolver9_PreloadedTraceGraph {
+  readonly hdCache2ServerUrl: string
+  readonly hdCache2CacheVersion?: string
+
+  override getSolverName(): string {
+    return "AutoroutingPipelineSolver9_Networked"
+  }
+
+  constructor(
+    srj: SimpleRouteJson,
+    opts: AutoroutingPipelineSolver9NetworkedOptions = {},
+  ) {
+    super(srj, opts)
+    if (this.effort !== 1) {
+      throw new Error(
+        `AutoroutingPipelineSolver9_Networked is only available at effort=1, received ${this.effort}`,
+      )
+    }
+
+    this.hdCache2ServerUrl =
+      opts.hdCache2ServerUrl ?? DEFAULT_HD_CACHE2_SERVER_URL
+    this.hdCache2CacheVersion = opts.hdCache2CacheVersion
+    this.replaceHighDensityPipelineStep()
+  }
+
+  private replaceHighDensityPipelineStep(): void {
+    const highDensityStepIndex = this.pipelineDef.findIndex(
+      (step) => step.solverName === "highDensityRouteSolver",
+    )
+    const originalStep = this.pipelineDef[highDensityStepIndex]
+    if (!originalStep) {
+      throw new Error("Pipeline9 highDensityRouteSolver step is missing")
+    }
+    const getOriginalConstructorParams = originalStep.getConstructorParams
+
+    this.pipelineDef[highDensityStepIndex] = {
+      ...originalStep,
+      solverClass: Pipeline9NetworkedHighDensitySolver as any,
+      getConstructorParams: (solver: AutoroutingPipelineSolver9_Networked) => {
+        const [params] = getOriginalConstructorParams(solver)
+        return [
+          {
+            ...params,
+            autorouterVersion: AUTOROUTER_VERSION,
+            hdCache2ServerUrl: solver.hdCache2ServerUrl,
+            hdCache2CacheVersion: solver.hdCache2CacheVersion,
+          },
+        ]
+      },
+    } as any
+  }
+
+  async stepAsync(): Promise<void> {
+    if (this.solved || this.failed) return
+    this.step()
+
+    const pendingEffects = getPendingEffectsFromSolverTree(this)
+    if (pendingEffects.length === 0) return
+    await Promise.race(
+      pendingEffects.map((effect) =>
+        effect.promise.then(
+          () => effect.name,
+          () => effect.name,
+        ),
+      ),
+    )
+
+    if (!this.solved && !this.failed) this.step()
+  }
+
+  async solveAsync(): Promise<void> {
+    const startTime = Date.now()
+    while (!this.solved && !this.failed) {
+      await this.stepAsync()
+    }
+    this.timeToSolve = Date.now() - startTime
+  }
+
+  async solveUntilPhaseAsync(phase: string): Promise<void> {
+    while (this.getCurrentPhase() !== phase && !this.solved && !this.failed) {
+      await this.stepAsync()
+    }
+  }
+
+  override solve(): void {
+    throw new Error(
+      "AutoroutingPipelineSolver9_Networked requires async execution. Use solveAsync() or stepAsync().",
+    )
+  }
+
+  override solveUntilPhase(_phase: string): void {
+    throw new Error(
+      "AutoroutingPipelineSolver9_Networked requires solveUntilPhaseAsync().",
+    )
+  }
+}

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/hd-cache2-client.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/hd-cache2-client.ts
@@ -1,0 +1,1046 @@
+import { areNodePortPointPairsConnectedByRoutes } from "../../solvers/HyperHighDensitySolver/repairDisconnectedSameRootPortPoints"
+import type {
+  HighDensityIntraNodeRoute,
+  NodeWithPortPoints,
+} from "../../types/high-density-types"
+import { getConnectionPortPointPairs } from "../../utils/getConnectionPortPointPairs"
+import { getMaximumPipeline9NodeBounds } from "./pipeline9-networked-input-projection"
+import type {
+  Pipeline9NetworkedHighDensityNodeInput,
+  Pipeline9NetworkedSolveBatchCacheMiss,
+  Pipeline9NetworkedSolveBatchItem,
+  Pipeline9NetworkedSolveRequest,
+  Pipeline9NetworkedSolveResponse,
+} from "./pipeline9-networked-types"
+
+export const DEFAULT_HD_CACHE2_SERVER_URL = "https://hd-cache2.tscircuit.com"
+export const HD_CACHE2_TRANSPORT_TIMEOUT_MS = 310_000
+export const HD_CACHE2_MAX_BATCH_ITEMS = 100
+export const HD_CACHE2_MAX_BATCH_BODY_BYTES = 1.75 * 1024 * 1024
+
+const MAX_RESPONSE_LINE_CHARACTERS = 16 * 1024 * 1024
+
+export type HdCache2FallbackReason =
+  | "http_error"
+  | "invalid_json"
+  | "invalid_response"
+  | "missing_response"
+  | "remote_error"
+  | "request_serialization_error"
+  | "response_too_large"
+  | "transport_error"
+  | "transport_timeout"
+  | "cache_version_mismatch"
+  | "version_mismatch"
+
+export type HdCache2SolveResult =
+  | {
+      kind: "remote"
+      response: Extract<Pipeline9NetworkedSolveResponse, { ok: true }>
+    }
+  | {
+      kind: "local-fallback"
+      error: string
+      reason: HdCache2FallbackReason
+    }
+
+export type HdCache2ClientStats = {
+  batchRequestsStarted: number
+  batchRequestsCompleted: number
+  batchItemsStarted: number
+  batchBodyBytesStarted: number
+  batchMaxBodyBytes: number
+  batchCacheMisses: number
+  singleRequestsStarted: number
+  batchInvalidLines: number
+  batchUnknownRequestIds: number
+  batchDuplicateRequestIds: number
+}
+
+export type HdCache2ClientOptions = {
+  cacheVersion?: string
+}
+
+type PendingSolve = Pipeline9NetworkedSolveBatchItem & {
+  serializedItem: string | null
+  promise: Promise<HdCache2SolveResult>
+  resolve: (result: HdCache2SolveResult) => void
+  settled: boolean
+  singleSolveStarted: boolean
+}
+
+type PreparedBatch = {
+  body: string
+  bodyBytes: number
+  items: PendingSolve[]
+}
+
+class HdCache2RequestError extends Error {
+  constructor(
+    readonly reason: HdCache2FallbackReason,
+    message: string,
+  ) {
+    super(message)
+    this.name = "HdCache2RequestError"
+  }
+}
+
+const getErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error)
+
+const CIRCUIT_JSON_METADATA_KEYS = new Set([
+  "pcb_smtpad_id",
+  "pcb_plated_hole_id",
+  "pcb_port_id",
+  "pcb_via_id",
+  "source_component_name",
+  "source_port_name",
+])
+
+const isValidCircuitJsonMetadata = (value: unknown): boolean => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false
+  return Object.entries(value).every(
+    ([key, metadataValue]) =>
+      CIRCUIT_JSON_METADATA_KEYS.has(key) && typeof metadataValue === "string",
+  )
+}
+
+const nearlyEqual = (left: number, right: number): boolean =>
+  Math.abs(left - right) <= 1e-9 * Math.max(1, Math.abs(left), Math.abs(right))
+
+const REGIONAL_TERMINAL_TOLERANCE_MM = 0.001
+const ORDINARY_VIA_POSITION_TOLERANCE_MM = 1e-6
+const REGIONAL_VIA_POSITION_TOLERANCE_MM = 0.001
+
+const hasValidRemoteLayerTransitions = (
+  route: HighDensityIntraNodeRoute,
+  solutionStage: "ordinary" | "regional-fallback",
+): boolean => {
+  const viaPositionTolerance =
+    solutionStage === "ordinary"
+      ? ORDINARY_VIA_POSITION_TOLERANCE_MM
+      : REGIONAL_VIA_POSITION_TOLERANCE_MM
+  const usedViaIndexes = new Set<number>()
+  for (let index = 0; index < route.route.length - 1; index++) {
+    const start = route.route[index]!
+    const end = route.route[index + 1]!
+    const changesLayer = start.z !== end.z
+    if (start.toNextSegmentType === "through_obstacle") {
+      if (!changesLayer) return false
+      continue
+    }
+    if (start.toNextSegmentCircuitJsonMetadata !== undefined) return false
+    if (!changesLayer) continue
+
+    const viaIndexesAtStart: number[] = []
+    const viaIndexesAtEnd: number[] = []
+    for (const [viaIndex, via] of route.vias.entries()) {
+      if (
+        Math.hypot(via.x - start.x, via.y - start.y) <= viaPositionTolerance
+      ) {
+        viaIndexesAtStart.push(viaIndex)
+      }
+      if (Math.hypot(via.x - end.x, via.y - end.y) <= viaPositionTolerance) {
+        viaIndexesAtEnd.push(viaIndex)
+      }
+    }
+    const transitionIsColocated =
+      Math.hypot(start.x - end.x, start.y - end.y) <=
+      ORDINARY_VIA_POSITION_TOLERANCE_MM
+    if (transitionIsColocated) {
+      if (viaIndexesAtStart.length === 0) return false
+      for (const viaIndex of viaIndexesAtStart) usedViaIndexes.add(viaIndex)
+      continue
+    }
+    if (solutionStage === "regional-fallback") return false
+    if ((viaIndexesAtStart.length === 0) === (viaIndexesAtEnd.length === 0)) {
+      return false
+    }
+    for (const viaIndex of [...viaIndexesAtStart, ...viaIndexesAtEnd]) {
+      usedViaIndexes.add(viaIndex)
+    }
+  }
+
+  const lastPoint = route.route.at(-1)!
+  if (
+    lastPoint.toNextSegmentType !== undefined ||
+    lastPoint.toNextSegmentCircuitJsonMetadata !== undefined
+  ) {
+    return false
+  }
+
+  return route.vias.every((_, viaIndex) => usedViaIndexes.has(viaIndex))
+}
+
+const hasRegionalRouteCoverage = (
+  routes: HighDensityIntraNodeRoute[],
+  node: NodeWithPortPoints,
+): boolean => {
+  type RouteEndpoint = { x: number; y: number; z: number }
+  type RouteEdge = { start: RouteEndpoint; end: RouteEndpoint }
+
+  const pointsTouch = (left: RouteEndpoint, right: RouteEndpoint): boolean => {
+    if (left.z !== right.z) return false
+    const deltaX = left.x - right.x
+    const deltaY = left.y - right.y
+    return Math.hypot(deltaX, deltaY) <= REGIONAL_TERMINAL_TOLERANCE_MM
+  }
+
+  const routeEdgesByConnection = new Map<string, RouteEdge[]>()
+  for (const route of routes) {
+    const hasNonzeroSegment = route.route.some((point, index) => {
+      const nextPoint = route.route[index + 1]
+      return (
+        nextPoint !== undefined &&
+        (!nearlyEqual(point.x, nextPoint.x) ||
+          !nearlyEqual(point.y, nextPoint.y) ||
+          point.z !== nextPoint.z)
+      )
+    })
+    const start = route.route[0]
+    const end = route.route.at(-1)
+    if (!hasNonzeroSegment || !start || !end) return false
+    const connectionPortPoints = node.portPoints.filter(
+      (portPoint) => portPoint.connectionName === route.connectionName,
+    )
+    if (
+      !connectionPortPoints.some((portPoint) =>
+        pointsTouch(start, portPoint),
+      ) ||
+      !connectionPortPoints.some((portPoint) => pointsTouch(end, portPoint))
+    ) {
+      return false
+    }
+    const edges = routeEdgesByConnection.get(route.connectionName) ?? []
+    edges.push({ start, end })
+    routeEdgesByConnection.set(route.connectionName, edges)
+  }
+
+  const arePairEndpointsConnected = (
+    connectionName: string,
+    start: RouteEndpoint,
+    end: RouteEndpoint,
+  ): boolean => {
+    if (pointsTouch(start, end)) return true
+    const edges = routeEdgesByConnection.get(connectionName) ?? []
+    const pendingEdgeIndexes: number[] = []
+    const visitedEdgeIndexes = new Set<number>()
+    for (const [index, edge] of edges.entries()) {
+      if (pointsTouch(start, edge.start) || pointsTouch(start, edge.end)) {
+        pendingEdgeIndexes.push(index)
+        visitedEdgeIndexes.add(index)
+      }
+    }
+
+    while (pendingEdgeIndexes.length > 0) {
+      const edge = edges[pendingEdgeIndexes.pop()!]!
+      if (pointsTouch(end, edge.start) || pointsTouch(end, edge.end))
+        return true
+      for (const [index, candidate] of edges.entries()) {
+        if (visitedEdgeIndexes.has(index)) continue
+        const connectsToEdge =
+          pointsTouch(edge.start, candidate.start) ||
+          pointsTouch(edge.start, candidate.end) ||
+          pointsTouch(edge.end, candidate.start) ||
+          pointsTouch(edge.end, candidate.end)
+        if (!connectsToEdge) continue
+        visitedEdgeIndexes.add(index)
+        pendingEdgeIndexes.push(index)
+      }
+    }
+    return false
+  }
+
+  const explicitPairs = node.portPointsInPairs ?? []
+  if (explicitPairs.length > 0) {
+    return explicitPairs.every(([start, end]) =>
+      arePairEndpointsConnected(start.connectionName, start, end),
+    )
+  }
+
+  const portPointsByConnection = new Map<
+    string,
+    NodeWithPortPoints["portPoints"]
+  >()
+  for (const portPoint of node.portPoints) {
+    const connectionPortPoints =
+      portPointsByConnection.get(portPoint.connectionName) ?? []
+    connectionPortPoints.push(portPoint)
+    portPointsByConnection.set(portPoint.connectionName, connectionPortPoints)
+  }
+  return [...portPointsByConnection].every(([, connectionPortPoints]) =>
+    getConnectionPortPointPairs(connectionPortPoints).every(([start, end]) =>
+      arePairEndpointsConnected(start.connectionName, start, end),
+    ),
+  )
+}
+
+const isValidRemoteRoutes = (
+  value: unknown,
+  input: Pipeline9NetworkedHighDensityNodeInput,
+  solutionStage: "ordinary" | "regional-fallback",
+): value is HighDensityIntraNodeRoute[] => {
+  if (!Array.isArray(value)) return false
+
+  const portPointsByConnectionName = new Map<
+    string,
+    NodeWithPortPoints["portPoints"]
+  >()
+  for (const portPoint of input.nodeWithPortPoints.portPoints) {
+    const portPoints =
+      portPointsByConnectionName.get(portPoint.connectionName) ?? []
+    portPoints.push(portPoint)
+    portPointsByConnectionName.set(portPoint.connectionName, portPoints)
+  }
+  const ordinaryAllowedZ = new Set(
+    input.nodeWithPortPoints.availableZ ??
+      input.nodeWithPortPoints.portPoints.map((portPoint) => portPoint.z),
+  )
+  const maximumRouteBounds = getMaximumPipeline9NodeBounds({
+    nodeWithPortPoints: input.nodeWithPortPoints,
+    obstacleMargin: input.obstacleMargin,
+    traceWidth: input.traceWidth,
+    viaDiameter: input.viaDiameter,
+  })
+  const isPortPointForConnection = (
+    point: Record<string, unknown>,
+    connectionName: string,
+  ): boolean =>
+    (portPointsByConnectionName.get(connectionName) ?? []).some(
+      (portPoint) =>
+        typeof point.x === "number" &&
+        nearlyEqual(point.x, portPoint.x) &&
+        typeof point.y === "number" &&
+        nearlyEqual(point.y, portPoint.y) &&
+        point.z === portPoint.z,
+    )
+
+  for (const routeValue of value) {
+    if (!routeValue || typeof routeValue !== "object") return false
+    const route = routeValue as Record<string, unknown>
+    if (
+      typeof route.connectionName !== "string" ||
+      route.connectionName.length === 0 ||
+      !portPointsByConnectionName.has(route.connectionName) ||
+      typeof route.traceThickness !== "number" ||
+      !Number.isFinite(route.traceThickness) ||
+      route.traceThickness <= 0 ||
+      typeof route.viaDiameter !== "number" ||
+      !Number.isFinite(route.viaDiameter) ||
+      route.viaDiameter <= 0 ||
+      !nearlyEqual(route.viaDiameter, input.viaDiameter) ||
+      !Array.isArray(route.route) ||
+      route.route.length < 2 ||
+      !Array.isArray(route.vias)
+    ) {
+      return false
+    }
+
+    for (const optionalString of [
+      route.rootConnectionName,
+      route.startPcbPortId,
+      route.endPcbPortId,
+      route.regionId,
+    ]) {
+      if (optionalString !== undefined && typeof optionalString !== "string") {
+        return false
+      }
+    }
+
+    for (const pointValue of route.route) {
+      if (!pointValue || typeof pointValue !== "object") return false
+      const point = pointValue as Record<string, unknown>
+      if (
+        typeof point.x !== "number" ||
+        !Number.isFinite(point.x) ||
+        typeof point.y !== "number" ||
+        !Number.isFinite(point.y) ||
+        point.x < maximumRouteBounds.minX ||
+        point.x > maximumRouteBounds.maxX ||
+        point.y < maximumRouteBounds.minY ||
+        point.y > maximumRouteBounds.maxY ||
+        typeof point.z !== "number" ||
+        !Number.isInteger(point.z) ||
+        point.z < 0 ||
+        point.z >= input.layerCount ||
+        (solutionStage === "ordinary" && !ordinaryAllowedZ.has(point.z))
+      ) {
+        return false
+      }
+      if (
+        point.traceThickness !== undefined &&
+        (typeof point.traceThickness !== "number" ||
+          !Number.isFinite(point.traceThickness) ||
+          point.traceThickness <= 0)
+      ) {
+        return false
+      }
+      if (
+        point.pcb_port_id !== undefined &&
+        typeof point.pcb_port_id !== "string"
+      ) {
+        return false
+      }
+      if (
+        point.insideJumperPad !== undefined &&
+        typeof point.insideJumperPad !== "boolean"
+      ) {
+        return false
+      }
+      if (
+        point.toNextSegmentType !== undefined &&
+        point.toNextSegmentType !== "through_obstacle"
+      ) {
+        return false
+      }
+      if (
+        point.toNextSegmentCircuitJsonMetadata !== undefined &&
+        !isValidCircuitJsonMetadata(point.toNextSegmentCircuitJsonMetadata)
+      ) {
+        return false
+      }
+    }
+
+    const routePoints = route.route as Record<string, unknown>[]
+    if (
+      solutionStage === "ordinary" &&
+      (!isPortPointForConnection(routePoints[0]!, route.connectionName) ||
+        !isPortPointForConnection(routePoints.at(-1)!, route.connectionName))
+    ) {
+      return false
+    }
+
+    for (const viaValue of route.vias) {
+      if (!viaValue || typeof viaValue !== "object") return false
+      const via = viaValue as Record<string, unknown>
+      if (
+        typeof via.x !== "number" ||
+        !Number.isFinite(via.x) ||
+        typeof via.y !== "number" ||
+        !Number.isFinite(via.y) ||
+        via.x < maximumRouteBounds.minX ||
+        via.x > maximumRouteBounds.maxX ||
+        via.y < maximumRouteBounds.minY ||
+        via.y > maximumRouteBounds.maxY
+      ) {
+        return false
+      }
+    }
+    if (
+      !hasValidRemoteLayerTransitions(
+        route as unknown as HighDensityIntraNodeRoute,
+        solutionStage,
+      )
+    ) {
+      return false
+    }
+
+    if (route.jumpers !== undefined) {
+      if (!Array.isArray(route.jumpers)) return false
+      for (const jumperValue of route.jumpers) {
+        if (!jumperValue || typeof jumperValue !== "object") return false
+        const jumper = jumperValue as Record<string, unknown>
+        const start = jumper.start as Record<string, unknown> | undefined
+        const end = jumper.end as Record<string, unknown> | undefined
+        if (
+          jumper.route_type !== "jumper" ||
+          (jumper.footprint !== "0603" &&
+            jumper.footprint !== "1206" &&
+            jumper.footprint !== "1206x4_pair") ||
+          !start ||
+          typeof start.x !== "number" ||
+          !Number.isFinite(start.x) ||
+          typeof start.y !== "number" ||
+          !Number.isFinite(start.y) ||
+          !end ||
+          typeof end.x !== "number" ||
+          !Number.isFinite(end.x) ||
+          typeof end.y !== "number" ||
+          !Number.isFinite(end.y) ||
+          start.x < maximumRouteBounds.minX ||
+          start.x > maximumRouteBounds.maxX ||
+          start.y < maximumRouteBounds.minY ||
+          start.y > maximumRouteBounds.maxY ||
+          end.x < maximumRouteBounds.minX ||
+          end.x > maximumRouteBounds.maxX ||
+          end.y < maximumRouteBounds.minY ||
+          end.y > maximumRouteBounds.maxY
+        ) {
+          return false
+        }
+      }
+    }
+  }
+  const routes = value as HighDensityIntraNodeRoute[]
+  return solutionStage === "ordinary"
+    ? areNodePortPointPairsConnectedByRoutes(routes, input.nodeWithPortPoints)
+    : hasRegionalRouteCoverage(routes, input.nodeWithPortPoints)
+}
+
+export const getHdCache2SolveUrl = (baseUrl: string): string =>
+  /\/solve\/?$/.test(baseUrl)
+    ? baseUrl.replace(/\/+$/, "")
+    : `${baseUrl.replace(/\/+$/, "")}/solve`
+
+export const getHdCache2SolveBatchUrl = (baseUrl: string): string => {
+  const normalizedBaseUrl = baseUrl.replace(/\/+$/, "")
+  if (/\/solve-batch$/.test(normalizedBaseUrl)) return normalizedBaseUrl
+  if (/\/solve$/.test(normalizedBaseUrl)) {
+    return normalizedBaseUrl.replace(/\/solve$/, "/solve-batch")
+  }
+  return `${normalizedBaseUrl}/solve-batch`
+}
+
+export class HdCache2Client {
+  readonly cacheVersion?: string
+  readonly stats: HdCache2ClientStats = {
+    batchRequestsStarted: 0,
+    batchRequestsCompleted: 0,
+    batchItemsStarted: 0,
+    batchBodyBytesStarted: 0,
+    batchMaxBodyBytes: 0,
+    batchCacheMisses: 0,
+    singleRequestsStarted: 0,
+    batchInvalidLines: 0,
+    batchUnknownRequestIds: 0,
+    batchDuplicateRequestIds: 0,
+  }
+
+  constructor(
+    readonly autorouterVersion: string,
+    readonly serverUrl: string = DEFAULT_HD_CACHE2_SERVER_URL,
+    options: HdCache2ClientOptions = {},
+  ) {
+    const { cacheVersion } = options
+    if (cacheVersion !== undefined && cacheVersion.trim().length === 0) {
+      throw new Error("hd-cache2 cacheVersion must not be empty")
+    }
+    this.cacheVersion = cacheVersion
+  }
+
+  /**
+   * Launches all exact-cache lookups together. Each returned promise resolves
+   * independently as its NDJSON result (or local-fallback reason) arrives.
+   */
+  solveMany(
+    inputs: readonly Pipeline9NetworkedHighDensityNodeInput[],
+  ): Array<Promise<HdCache2SolveResult>> {
+    const pendingSolves = inputs.map((input, index) =>
+      this.createPendingSolve(String(index), input),
+    )
+    const serializableSolves = pendingSolves.filter(
+      (pending): pending is PendingSolve & { serializedItem: string } =>
+        pending.serializedItem !== null,
+    )
+    const { batches, singletonSolves } = this.prepareBatches(serializableSolves)
+
+    for (const batch of batches) void this.fetchBatch(batch)
+    for (const pending of singletonSolves) this.launchSingleSolve(pending)
+
+    return pendingSolves.map((pending) => pending.promise)
+  }
+
+  private createPendingSolve(
+    requestId: string,
+    input: Pipeline9NetworkedHighDensityNodeInput,
+  ): PendingSolve {
+    let resolve!: (result: HdCache2SolveResult) => void
+    const promise = new Promise<HdCache2SolveResult>((resolvePromise) => {
+      resolve = resolvePromise
+    })
+    const pending: PendingSolve = {
+      requestId,
+      input,
+      serializedItem: null,
+      promise,
+      resolve,
+      settled: false,
+      singleSolveStarted: false,
+    }
+    try {
+      pending.serializedItem = JSON.stringify({ requestId, input })
+    } catch (error) {
+      this.settleWithFallback(
+        pending,
+        "request_serialization_error",
+        getErrorMessage(error),
+      )
+    }
+    return pending
+  }
+
+  private settle(pending: PendingSolve, result: HdCache2SolveResult): void {
+    if (pending.settled) return
+    pending.settled = true
+    pending.resolve(result)
+  }
+
+  private settleWithFallback(
+    pending: PendingSolve,
+    reason: HdCache2FallbackReason,
+    error: string,
+  ): void {
+    this.settle(pending, { kind: "local-fallback", reason, error })
+  }
+
+  private parseSuccessfulResponse(
+    value: unknown,
+    input: Pipeline9NetworkedHighDensityNodeInput,
+  ): Extract<Pipeline9NetworkedSolveResponse, { ok: true }> {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      throw new HdCache2RequestError(
+        "invalid_response",
+        "hd-cache2 returned a non-object response",
+      )
+    }
+
+    const response = value as Record<string, unknown>
+    if (response.ok !== true) {
+      throw new HdCache2RequestError(
+        "remote_error",
+        typeof response.message === "string"
+          ? response.message
+          : "hd-cache2 returned an unsuccessful response",
+      )
+    }
+    if (response.autorouterVersion !== this.autorouterVersion) {
+      throw new HdCache2RequestError(
+        "version_mismatch",
+        `hd-cache2 returned autorouter version ${String(response.autorouterVersion)}, expected ${this.autorouterVersion}`,
+      )
+    }
+    if (response.cacheVersion !== this.cacheVersion) {
+      throw new HdCache2RequestError(
+        "cache_version_mismatch",
+        `hd-cache2 returned cache version ${String(response.cacheVersion)}, expected ${String(this.cacheVersion)}`,
+      )
+    }
+    if (response.source !== "cache" && response.source !== "solver") {
+      throw new HdCache2RequestError(
+        "invalid_response",
+        "hd-cache2 returned an invalid cache source",
+      )
+    }
+    if (
+      response.solutionStage !== "ordinary" &&
+      response.solutionStage !== "regional-fallback"
+    ) {
+      throw new HdCache2RequestError(
+        "invalid_response",
+        "hd-cache2 returned an invalid solution stage",
+      )
+    }
+    if (
+      response.solutionStage === "regional-fallback" &&
+      (!input.enableRegionalFallback ||
+        typeof response.ordinaryFailure !== "string" ||
+        response.ordinaryFailure.length === 0)
+    ) {
+      throw new HdCache2RequestError(
+        "invalid_response",
+        "hd-cache2 returned invalid regional fallback metadata",
+      )
+    }
+    if (
+      response.solutionStage === "ordinary" &&
+      Object.prototype.hasOwnProperty.call(response, "ordinaryFailure")
+    ) {
+      throw new HdCache2RequestError(
+        "invalid_response",
+        "hd-cache2 returned regional metadata on an ordinary result",
+      )
+    }
+    if (
+      response.solutionStage === "ordinary" &&
+      response.status === "failed" &&
+      input.enableRegionalFallback
+    ) {
+      throw new HdCache2RequestError(
+        "invalid_response",
+        "hd-cache2 returned an intermediate ordinary failure",
+      )
+    }
+    if (
+      response.status === "solved" &&
+      isValidRemoteRoutes(response.routes, input, response.solutionStage)
+    ) {
+      return response as Extract<Pipeline9NetworkedSolveResponse, { ok: true }>
+    }
+    if (
+      response.status === "failed" &&
+      typeof response.error === "string" &&
+      response.error.length > 0
+    ) {
+      return response as Extract<Pipeline9NetworkedSolveResponse, { ok: true }>
+    }
+
+    throw new HdCache2RequestError(
+      "invalid_response",
+      "hd-cache2 returned an invalid solve result",
+    )
+  }
+
+  private parseBatchCacheMiss(
+    value: Record<string, unknown>,
+  ): Pipeline9NetworkedSolveBatchCacheMiss | null {
+    if (value.ok !== false || value.code !== "CACHE_MISS") return null
+    if (value.autorouterVersion !== this.autorouterVersion) {
+      throw new HdCache2RequestError(
+        "version_mismatch",
+        `hd-cache2 returned autorouter version ${String(value.autorouterVersion)}, expected ${this.autorouterVersion}`,
+      )
+    }
+    if (value.cacheVersion !== this.cacheVersion) {
+      throw new HdCache2RequestError(
+        "cache_version_mismatch",
+        `hd-cache2 returned cache version ${String(value.cacheVersion)}, expected ${String(this.cacheVersion)}`,
+      )
+    }
+    if (typeof value.message !== "string") {
+      throw new HdCache2RequestError(
+        "invalid_response",
+        "hd-cache2 returned an invalid cache miss response",
+      )
+    }
+    return value as Pipeline9NetworkedSolveBatchCacheMiss
+  }
+
+  private async fetchSingle(pending: PendingSolve): Promise<void> {
+    const controller = new AbortController()
+    let didTransportTimeout = false
+    const timeoutId = setTimeout(() => {
+      didTransportTimeout = true
+      controller.abort(
+        new Error(
+          `hd-cache2 transport timed out after ${HD_CACHE2_TRANSPORT_TIMEOUT_MS}ms`,
+        ),
+      )
+    }, HD_CACHE2_TRANSPORT_TIMEOUT_MS)
+    ;(
+      timeoutId as ReturnType<typeof setTimeout> & { unref?: () => void }
+    ).unref?.()
+
+    try {
+      const request: Pipeline9NetworkedSolveRequest = {
+        autorouterVersion: this.autorouterVersion,
+        ...(this.cacheVersion === undefined
+          ? {}
+          : { cacheVersion: this.cacheVersion }),
+        input: pending.input,
+      }
+      let body: string
+      try {
+        body = JSON.stringify(request)
+      } catch (error) {
+        throw new HdCache2RequestError(
+          "request_serialization_error",
+          getErrorMessage(error),
+        )
+      }
+      const response = await fetch(getHdCache2SolveUrl(this.serverUrl), {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+          "content-type": "application/json",
+        },
+        body,
+        signal: controller.signal,
+      })
+      const responseText = await response.text()
+      let responseBody: unknown = null
+      try {
+        responseBody = responseText ? JSON.parse(responseText) : null
+      } catch {
+        if (!response.ok) {
+          throw new HdCache2RequestError(
+            "http_error",
+            `hd-cache2 request failed with status ${response.status}`,
+          )
+        }
+        throw new HdCache2RequestError(
+          "invalid_json",
+          `hd-cache2 returned invalid JSON with status ${response.status}`,
+        )
+      }
+      if (!response.ok) {
+        const message =
+          responseBody &&
+          typeof responseBody === "object" &&
+          "message" in responseBody &&
+          typeof responseBody.message === "string"
+            ? responseBody.message
+            : `hd-cache2 request failed with status ${response.status}`
+        throw new HdCache2RequestError("http_error", message)
+      }
+      this.settle(pending, {
+        kind: "remote",
+        response: this.parseSuccessfulResponse(responseBody, pending.input),
+      })
+    } catch (error) {
+      const reason =
+        error instanceof HdCache2RequestError
+          ? error.reason
+          : didTransportTimeout
+            ? "transport_timeout"
+            : "transport_error"
+      this.settleWithFallback(pending, reason, getErrorMessage(error))
+    } finally {
+      clearTimeout(timeoutId)
+    }
+  }
+
+  private launchSingleSolve(pending: PendingSolve): void {
+    if (pending.singleSolveStarted || pending.settled) return
+    pending.singleSolveStarted = true
+    this.stats.singleRequestsStarted += 1
+    void this.fetchSingle(pending)
+  }
+
+  private handleBatchResponseLine(
+    line: string,
+    itemsByRequestId: ReadonlyMap<string, PendingSolve>,
+    responseRequestIds: Set<string>,
+  ): void {
+    if (line.trim().length === 0) return
+    if (line.length > MAX_RESPONSE_LINE_CHARACTERS) {
+      throw new HdCache2RequestError(
+        "response_too_large",
+        "hd-cache2 returned an oversized batch result line",
+      )
+    }
+
+    let value: unknown
+    try {
+      value = JSON.parse(line)
+    } catch {
+      this.stats.batchInvalidLines += 1
+      return
+    }
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      this.stats.batchInvalidLines += 1
+      return
+    }
+
+    const responseValue = value as Record<string, unknown>
+    const requestId = responseValue.requestId
+    if (typeof requestId !== "string") {
+      this.stats.batchInvalidLines += 1
+      return
+    }
+    const pending = itemsByRequestId.get(requestId)
+    if (!pending) {
+      this.stats.batchUnknownRequestIds += 1
+      return
+    }
+    if (responseRequestIds.has(requestId)) {
+      this.stats.batchDuplicateRequestIds += 1
+      return
+    }
+    responseRequestIds.add(requestId)
+
+    try {
+      const cacheMiss = this.parseBatchCacheMiss(responseValue)
+      if (cacheMiss) {
+        this.stats.batchCacheMisses += 1
+        this.launchSingleSolve(pending)
+        return
+      }
+      this.settle(pending, {
+        kind: "remote",
+        response: this.parseSuccessfulResponse(responseValue, pending.input),
+      })
+    } catch (error) {
+      this.stats.batchInvalidLines += 1
+      this.settleWithFallback(
+        pending,
+        error instanceof HdCache2RequestError
+          ? error.reason
+          : "invalid_response",
+        getErrorMessage(error),
+      )
+    }
+  }
+
+  private async readBatchResponse(
+    response: Response,
+    batch: PreparedBatch,
+  ): Promise<void> {
+    if (!response.body) {
+      throw new HdCache2RequestError(
+        "invalid_response",
+        "hd-cache2 returned an empty batch response body",
+      )
+    }
+
+    const itemsByRequestId = new Map(
+      batch.items.map((item) => [item.requestId, item]),
+    )
+    const responseRequestIds = new Set<string>()
+    const decoder = new TextDecoder()
+    const reader = response.body.getReader()
+    let buffer = ""
+
+    while (responseRequestIds.size < batch.items.length) {
+      const { done, value } = await reader.read()
+      buffer += decoder.decode(value, { stream: !done })
+      if (
+        buffer.length > MAX_RESPONSE_LINE_CHARACTERS &&
+        !buffer.includes("\n")
+      ) {
+        throw new HdCache2RequestError(
+          "response_too_large",
+          "hd-cache2 returned an oversized unterminated batch result line",
+        )
+      }
+
+      let newlineIndex = buffer.indexOf("\n")
+      while (newlineIndex >= 0) {
+        const line = buffer.slice(0, newlineIndex)
+        buffer = buffer.slice(newlineIndex + 1)
+        this.handleBatchResponseLine(line, itemsByRequestId, responseRequestIds)
+        newlineIndex = buffer.indexOf("\n")
+      }
+      if (!done) continue
+      if (buffer.trim().length > 0) {
+        this.handleBatchResponseLine(
+          buffer,
+          itemsByRequestId,
+          responseRequestIds,
+        )
+      }
+      break
+    }
+
+    if (responseRequestIds.size === batch.items.length) {
+      await reader.cancel().catch(() => {})
+      return
+    }
+    for (const pending of batch.items) {
+      if (responseRequestIds.has(pending.requestId)) continue
+      this.settleWithFallback(
+        pending,
+        "missing_response",
+        `hd-cache2 batch ended without result ${pending.requestId}`,
+      )
+    }
+  }
+
+  private async fetchBatch(batch: PreparedBatch): Promise<void> {
+    const controller = new AbortController()
+    let didTransportTimeout = false
+    const timeoutId = setTimeout(() => {
+      didTransportTimeout = true
+      controller.abort(
+        new Error(
+          `hd-cache2 batch transport timed out after ${HD_CACHE2_TRANSPORT_TIMEOUT_MS}ms`,
+        ),
+      )
+    }, HD_CACHE2_TRANSPORT_TIMEOUT_MS)
+    ;(
+      timeoutId as ReturnType<typeof setTimeout> & { unref?: () => void }
+    ).unref?.()
+
+    this.stats.batchRequestsStarted += 1
+    this.stats.batchItemsStarted += batch.items.length
+    this.stats.batchBodyBytesStarted += batch.bodyBytes
+    this.stats.batchMaxBodyBytes = Math.max(
+      this.stats.batchMaxBodyBytes,
+      batch.bodyBytes,
+    )
+
+    try {
+      const response = await fetch(getHdCache2SolveBatchUrl(this.serverUrl), {
+        method: "POST",
+        headers: {
+          accept: "application/x-ndjson",
+          "content-type": "application/json",
+        },
+        body: batch.body,
+        signal: controller.signal,
+      })
+      if (!response.ok) {
+        const responseText = await response.text().catch(() => "")
+        let message = `hd-cache2 batch request failed with status ${response.status}`
+        try {
+          const responseBody = responseText ? JSON.parse(responseText) : null
+          if (
+            responseBody &&
+            typeof responseBody === "object" &&
+            "message" in responseBody &&
+            typeof responseBody.message === "string"
+          ) {
+            message = responseBody.message
+          }
+        } catch {}
+        throw new HdCache2RequestError("http_error", message)
+      }
+      await this.readBatchResponse(response, batch)
+    } catch (error) {
+      const reason =
+        error instanceof HdCache2RequestError
+          ? error.reason
+          : didTransportTimeout
+            ? "transport_timeout"
+            : "transport_error"
+      for (const pending of batch.items) {
+        if (pending.singleSolveStarted) continue
+        this.settleWithFallback(pending, reason, getErrorMessage(error))
+      }
+    } finally {
+      clearTimeout(timeoutId)
+      this.stats.batchRequestsCompleted += 1
+    }
+  }
+
+  private prepareBatches(
+    items: Array<PendingSolve & { serializedItem: string }>,
+  ): {
+    batches: PreparedBatch[]
+    singletonSolves: PendingSolve[]
+  } {
+    const encoder = new TextEncoder()
+    const cacheVersionField =
+      this.cacheVersion === undefined
+        ? ""
+        : `,"cacheVersion":${JSON.stringify(this.cacheVersion)}`
+    const prefix = `{"autorouterVersion":${JSON.stringify(this.autorouterVersion)}${cacheVersionField},"items":[`
+    const suffix = "]}"
+    const fixedBytes = encoder.encode(prefix + suffix).byteLength
+    const batches: PreparedBatch[] = []
+    const singletonSolves: PendingSolve[] = []
+    let currentItems: PendingSolve[] = []
+    let currentBytes = fixedBytes
+
+    const flushCurrentBatch = (): void => {
+      if (currentItems.length === 0) return
+      batches.push({
+        body: `${prefix}${currentItems.map((item) => item.serializedItem).join(",")}${suffix}`,
+        bodyBytes: currentBytes,
+        items: currentItems,
+      })
+      currentItems = []
+      currentBytes = fixedBytes
+    }
+
+    for (const item of items) {
+      const itemBytes = encoder.encode(item.serializedItem).byteLength
+      const separatorBytes = currentItems.length === 0 ? 0 : 1
+      if (fixedBytes + itemBytes > HD_CACHE2_MAX_BATCH_BODY_BYTES) {
+        flushCurrentBatch()
+        singletonSolves.push(item)
+        continue
+      }
+      if (
+        currentItems.length >= HD_CACHE2_MAX_BATCH_ITEMS ||
+        currentBytes + separatorBytes + itemBytes >
+          HD_CACHE2_MAX_BATCH_BODY_BYTES
+      ) {
+        flushCurrentBatch()
+      }
+      currentItems.push(item)
+      currentBytes += (currentItems.length === 1 ? 0 : 1) + itemBytes
+    }
+    flushCurrentBatch()
+    return { batches, singletonSolves }
+  }
+}

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-high-density-solver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-high-density-solver.ts
@@ -1,0 +1,413 @@
+import type { NodeWithPortPoints } from "../../types/high-density-types"
+import type { PendingEffect } from "../../solvers/BaseSolver"
+import {
+  normalizePipeline9NodeRootConnectionNames,
+  Pipeline9HighDensitySolver,
+  type Pipeline9HighDensitySolverParams,
+} from "../AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-high-density-solver"
+import { createRegionalFallbackProblem } from "../AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-regional-fallback"
+import {
+  DEFAULT_HD_CACHE2_SERVER_URL,
+  HdCache2Client,
+  type HdCache2FallbackReason,
+  type HdCache2SolveResult,
+} from "./hd-cache2-client"
+import {
+  mergePipeline9ProjectedConnectivityNetMaps,
+  projectPipeline9OrdinaryHighDensityInput,
+  projectPipeline9RegionalHighDensityInput,
+} from "./pipeline9-networked-input-projection"
+import type { Pipeline9NetworkedHighDensityNodeInput } from "./pipeline9-networked-types"
+import { PIPELINE9_NETWORKED_SOLVE_POLICY } from "./pipeline9-networked-types"
+
+export { DEFAULT_HD_CACHE2_SERVER_URL } from "./hd-cache2-client"
+
+export const DEFAULT_PIPELINE9_NETWORKED_TIMEOUT_MS = 30_000
+
+export type Pipeline9NetworkedFallbackReason =
+  | HdCache2FallbackReason
+  | "logical_timeout"
+
+export type Pipeline9NetworkedHighDensitySolverParams =
+  Pipeline9HighDensitySolverParams & {
+    autorouterVersion: string
+    hdCache2ServerUrl?: string
+    hdCache2CacheVersion?: string
+    requestTimeoutMs?: number
+  }
+
+type RemoteNodeRequest = {
+  promise: Promise<void>
+  deadlineAt: number
+}
+
+/**
+ * Starts every exact-cache lookup together, then consumes each result in
+ * Pipeline9's existing node order. Fixed-copper nodes are still requested
+ * speculatively; their result is ignored when they reach Pipeline9's B01 path.
+ */
+export class Pipeline9NetworkedHighDensitySolver extends Pipeline9HighDensitySolver {
+  readonly autorouterVersion: string
+  readonly hdCache2ServerUrl: string
+  readonly hdCache2CacheVersion?: string
+  readonly requestTimeoutMs: number
+
+  private readonly hdCache2Client: HdCache2Client
+  private launchedRemoteSolves = false
+  private waitingForRemoteNode: NodeWithPortPoints | null = null
+  private readonly remoteRequestByNode = new Map<
+    NodeWithPortPoints,
+    RemoteNodeRequest
+  >()
+  private readonly remoteResultByNode = new Map<
+    NodeWithPortPoints,
+    HdCache2SolveResult
+  >()
+  private readonly logicallyTimedOutNodes = new Set<NodeWithPortPoints>()
+
+  constructor({
+    autorouterVersion,
+    hdCache2ServerUrl,
+    hdCache2CacheVersion,
+    requestTimeoutMs,
+    ...pipeline9Params
+  }: Pipeline9NetworkedHighDensitySolverParams) {
+    super(pipeline9Params)
+    if (pipeline9Params.effort !== 1) {
+      throw new Error(
+        `Pipeline9 networked high-density routing requires effort=1, received ${pipeline9Params.effort}`,
+      )
+    }
+
+    this.requestTimeoutMs =
+      requestTimeoutMs ?? DEFAULT_PIPELINE9_NETWORKED_TIMEOUT_MS
+    if (!Number.isFinite(this.requestTimeoutMs) || this.requestTimeoutMs <= 0) {
+      throw new Error(
+        `Pipeline9 network request timeout must be a positive number, received ${this.requestTimeoutMs}`,
+      )
+    }
+
+    this.autorouterVersion = autorouterVersion
+    this.hdCache2ServerUrl = hdCache2ServerUrl ?? DEFAULT_HD_CACHE2_SERVER_URL
+    this.hdCache2CacheVersion = hdCache2CacheVersion
+    this.hdCache2Client = new HdCache2Client(
+      this.autorouterVersion,
+      this.hdCache2ServerUrl,
+      {
+        cacheVersion: hdCache2CacheVersion,
+      },
+    )
+    this.pendingEffects = []
+    this.stats = {
+      ...this.stats,
+      remoteRequestsStarted: 0,
+      remoteRequestsCompleted: 0,
+      remoteBatchRequestsStarted: 0,
+      remoteBatchRequestsCompleted: 0,
+      remoteBatchItemsStarted: 0,
+      remoteBatchBodyBytesStarted: 0,
+      remoteBatchMaxBodyBytes: 0,
+      remoteBatchCacheMisses: 0,
+      remoteSingleRequestsStarted: 0,
+      remoteBatchInvalidLines: 0,
+      remoteBatchUnknownRequestIds: 0,
+      remoteBatchDuplicateRequestIds: 0,
+      remoteCacheHits: 0,
+      remoteSolverResults: 0,
+      remoteSolvedResults: 0,
+      remoteFailedResults: 0,
+      remoteOrdinaryResults: 0,
+      remoteRegionalFallbackResults: 0,
+      remoteRegionalFallbackResultsApplied: 0,
+      remoteRegionalFallbackResultsDeferredToLocal: 0,
+      remoteTransportFallbacks: 0,
+      remoteLogicalTimeoutFallbacks: 0,
+      remoteFallbackReasonCounts: {},
+    }
+  }
+
+  override getSolverName(): string {
+    return "Pipeline9NetworkedHighDensitySolver"
+  }
+
+  async waitForAllRemoteRequests(): Promise<void> {
+    const remoteRequests = [...this.remoteRequestByNode.values()]
+    if (remoteRequests.length === 0) {
+      this.syncClientStats()
+      return
+    }
+    await Promise.all(remoteRequests.map(({ promise }) => promise))
+    this.syncClientStats()
+  }
+
+  private createNodeInput(
+    node: NodeWithPortPoints,
+  ): Pipeline9NetworkedHighDensityNodeInput {
+    const regionalInput = this.enableRegionalFallback
+      ? projectPipeline9RegionalHighDensityInput({
+          nodeWithPortPoints: node,
+          connMap: this.connMap,
+          obstacles: this.obstacles,
+          obstacleMargin: this.obstacleMargin,
+          traceWidth: this.traceWidth,
+          viaDiameter: this.viaDiameter,
+        })
+      : { connectivityNetMap: {}, obstacles: [] }
+    const projectedInput = projectPipeline9OrdinaryHighDensityInput({
+      nodeWithPortPoints: node,
+      connMap: this.connMap,
+      colorMap: this.colorMap,
+      // The regional projection already conservatively retains every obstacle
+      // in the ordinary 8x envelope, so avoid scanning the full board twice.
+      obstacles: this.enableRegionalFallback
+        ? regionalInput.obstacles
+        : this.obstacles,
+      obstacleMargin: this.obstacleMargin,
+      traceWidth: this.traceWidth,
+      viaDiameter: this.viaDiameter,
+    })
+    return {
+      solvePolicy: PIPELINE9_NETWORKED_SOLVE_POLICY,
+      enableRegionalFallback: this.enableRegionalFallback,
+      nodeWithPortPoints: node,
+      connectivityNetMap: mergePipeline9ProjectedConnectivityNetMaps(
+        projectedInput.connectivityNetMap,
+        regionalInput.connectivityNetMap,
+      ),
+      colorMap: projectedInput.colorMap,
+      viaDiameter: this.viaDiameter,
+      traceWidth: this.traceWidth,
+      obstacleMargin: this.obstacleMargin,
+      effort: 1,
+      obstacles: projectedInput.obstacles,
+      regionalObstacles: regionalInput.obstacles,
+      layerCount: this.layerCount,
+      nodePf: this.nodePfById.get(node.capacityMeshNodeId) ?? null,
+    }
+  }
+
+  private syncClientStats(): void {
+    const clientStats = this.hdCache2Client.stats
+    this.stats.remoteBatchRequestsStarted = clientStats.batchRequestsStarted
+    this.stats.remoteBatchRequestsCompleted = clientStats.batchRequestsCompleted
+    this.stats.remoteBatchItemsStarted = clientStats.batchItemsStarted
+    this.stats.remoteBatchBodyBytesStarted = clientStats.batchBodyBytesStarted
+    this.stats.remoteBatchMaxBodyBytes = clientStats.batchMaxBodyBytes
+    this.stats.remoteBatchCacheMisses = clientStats.batchCacheMisses
+    this.stats.remoteSingleRequestsStarted = clientStats.singleRequestsStarted
+    this.stats.remoteBatchInvalidLines = clientStats.batchInvalidLines
+    this.stats.remoteBatchUnknownRequestIds = clientStats.batchUnknownRequestIds
+    this.stats.remoteBatchDuplicateRequestIds =
+      clientStats.batchDuplicateRequestIds
+  }
+
+  private recordFallbackReason(reason: Pipeline9NetworkedFallbackReason): void {
+    const counts = this.stats.remoteFallbackReasonCounts as Record<
+      Pipeline9NetworkedFallbackReason,
+      number
+    >
+    counts[reason] = (counts[reason] ?? 0) + 1
+  }
+
+  private trackRemoteSolve(
+    node: NodeWithPortPoints,
+    remotePromise: Promise<HdCache2SolveResult>,
+  ): void {
+    const deadlineAt = performance.now() + this.requestTimeoutMs
+    this.stats.remoteRequestsStarted += 1
+    const promise = remotePromise.then((result) => {
+      const logicallyTimedOut = this.logicallyTimedOutNodes.has(node)
+      if (!logicallyTimedOut) this.remoteResultByNode.set(node, result)
+
+      if (result.kind === "remote") {
+        if (result.response.source === "cache") this.stats.remoteCacheHits += 1
+        if (result.response.source === "solver") {
+          this.stats.remoteSolverResults += 1
+        }
+        if (result.response.status === "solved") {
+          this.stats.remoteSolvedResults += 1
+        } else {
+          this.stats.remoteFailedResults += 1
+        }
+      } else if (!logicallyTimedOut) {
+        this.stats.remoteTransportFallbacks += 1
+        this.recordFallbackReason(result.reason)
+      }
+
+      this.stats.remoteRequestsCompleted += 1
+      this.syncClientStats()
+    })
+    this.remoteRequestByNode.set(node, { promise, deadlineAt })
+  }
+
+  private launchRemoteSolves(): void {
+    const prepared: Array<{
+      node: NodeWithPortPoints
+      input: Pipeline9NetworkedHighDensityNodeInput
+    }> = []
+    const nodesInConsumptionOrder = [...this.unsolvedNodePortPoints].reverse()
+
+    for (const node of nodesInConsumptionOrder) {
+      try {
+        prepared.push({ node, input: this.createNodeInput(node) })
+      } catch (error) {
+        this.trackRemoteSolve(
+          node,
+          Promise.resolve({
+            kind: "local-fallback",
+            reason: "request_serialization_error",
+            error: error instanceof Error ? error.message : String(error),
+          }),
+        )
+      }
+    }
+
+    const promises = this.hdCache2Client.solveMany(
+      prepared.map(({ input }) => input),
+    )
+    for (const [index, promise] of promises.entries()) {
+      this.trackRemoteSolve(prepared[index]!.node, promise)
+    }
+    this.syncClientStats()
+  }
+
+  private async waitForCurrentRemoteNode(
+    node: NodeWithPortPoints,
+    request: RemoteNodeRequest,
+  ): Promise<void> {
+    const remainingTimeoutMs = request.deadlineAt - performance.now()
+    if (remainingTimeoutMs <= 0) {
+      this.recordLogicalTimeout(node)
+      return
+    }
+
+    let logicalTimeoutId: ReturnType<typeof setTimeout> | undefined
+    const result = await Promise.race([
+      request.promise.then(() => "request-settled" as const),
+      new Promise<"logical-timeout">((resolve) => {
+        logicalTimeoutId = setTimeout(
+          () => resolve("logical-timeout"),
+          remainingTimeoutMs,
+        )
+      }),
+    ])
+    if (logicalTimeoutId !== undefined) clearTimeout(logicalTimeoutId)
+    if (result !== "logical-timeout") return
+
+    this.recordLogicalTimeout(node)
+  }
+
+  private recordLogicalTimeout(node: NodeWithPortPoints): void {
+    this.logicallyTimedOutNodes.add(node)
+    this.stats.remoteLogicalTimeoutFallbacks += 1
+    this.stats.remoteTransportFallbacks += 1
+    this.recordFallbackReason("logical_timeout")
+  }
+
+  protected override startRegularSolver(node: NodeWithPortPoints): void {
+    const result = this.remoteResultByNode.get(node)
+    if (!result) {
+      const request = this.remoteRequestByNode.get(node)
+      if (request) {
+        this.waitingForRemoteNode = node
+        const waitPromise = this.waitForCurrentRemoteNode(node, request)
+        waitPromise.then(() => {
+          if (this.waitingForRemoteNode !== node) return
+          this.pendingEffects = []
+        })
+        const pendingEffect: PendingEffect = {
+          name: `hd-cache2:${node.capacityMeshNodeId}`,
+          promise: waitPromise,
+        }
+        this.pendingEffects = [pendingEffect]
+        return
+      }
+
+      super.startRegularSolver(node)
+      return
+    }
+
+    this.applyRemoteResultToRegularNode(node, result)
+  }
+
+  private applyRemoteResultToRegularNode(
+    node: NodeWithPortPoints,
+    result: HdCache2SolveResult,
+  ): void {
+    if (result.kind === "local-fallback") {
+      super.startRegularSolver(node)
+      return
+    }
+
+    this.stats.regularNodeCount = Number(this.stats.regularNodeCount ?? 0) + 1
+    this.activeNode = node
+    if (result.response.solutionStage === "regional-fallback") {
+      this.stats.remoteRegionalFallbackResults += 1
+      if (!this.canUseNoFixedCopperRegionalResult(node)) {
+        this.stats.remoteRegionalFallbackResultsDeferredToLocal += 1
+        this.finishRegularSolverFailure(result.response.ordinaryFailure)
+        return
+      }
+      this.stats.remoteRegionalFallbackResultsApplied += 1
+      this.stats.fallbackNodeCount =
+        Number(this.stats.fallbackNodeCount ?? 0) + 1
+    } else {
+      this.stats.remoteOrdinaryResults += 1
+    }
+    if (result.response.status === "failed") {
+      this.error = result.response.error
+      this.failed = true
+      this.activeNode = null
+      return
+    }
+
+    this.finishActiveNode(result.response.routes)
+  }
+
+  /**
+   * A node may have no fixed copper on its assigned layers while the regional
+   * fallback, which opens every board layer, would still observe a preloaded
+   * route. Re-prove independence against the current mutation state before
+   * consuming a no-fixed-copper regional result.
+   */
+  private canUseNoFixedCopperRegionalResult(node: NodeWithPortPoints): boolean {
+    const regionalNode = {
+      ...normalizePipeline9NodeRootConnectionNames(node, this.connMap),
+      availableZ: Array.from({ length: this.layerCount }, (_, z) => z),
+    }
+    const problem = createRegionalFallbackProblem(
+      regionalNode,
+      this.getUpdatedFixedHdRoutes(),
+    )
+    return (
+      problem.fixedRouteSectionsByConnectionName.size === 0 &&
+      problem.fixedObstacleRoutes.length === 0
+    )
+  }
+
+  override _step(): void {
+    this.syncClientStats()
+    if (!this.launchedRemoteSolves) {
+      this.launchedRemoteSolves = true
+      this.launchRemoteSolves()
+    }
+
+    if (this.waitingForRemoteNode) {
+      const node = this.waitingForRemoteNode
+      if (this.logicallyTimedOutNodes.has(node)) {
+        this.waitingForRemoteNode = null
+        this.pendingEffects = []
+        super.startRegularSolver(node)
+        return
+      }
+      const result = this.remoteResultByNode.get(node)
+      if (!result) return
+      this.waitingForRemoteNode = null
+      this.pendingEffects = []
+      this.applyRemoteResultToRegularNode(node, result)
+      return
+    }
+
+    super._step()
+  }
+}

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-input-projection.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-input-projection.ts
@@ -1,0 +1,384 @@
+import type { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { DEFAULT_MAX_GROWTH_ATTEMPTS } from "lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver"
+import type {
+  NodeWithPortPoints,
+  PortPoint,
+} from "lib/types/high-density-types"
+import type { Obstacle } from "lib/types/srj-types"
+import { getBoundsFromNodeWithPortPoints } from "lib/utils/getBoundsFromNodeWithPortPoints"
+
+const MAX_PIPELINE9_ORDINARY_NODE_SCALE = 2 ** DEFAULT_MAX_GROWTH_ATTEMPTS
+const OBSTACLE_OVERLAP_TOLERANCE = 1e-6
+
+export type Pipeline9OrdinaryHighDensityProjection = {
+  connectivityNetMap: Record<string, string[]>
+  colorMap: Record<string, string>
+  obstacles: Obstacle[]
+}
+
+export type Pipeline9RegionalHighDensityProjection = {
+  connectivityNetMap: Record<string, string[]>
+  obstacles: Obstacle[]
+}
+
+type Bounds = {
+  minX: number
+  maxX: number
+  minY: number
+  maxY: number
+}
+
+export const getMaximumPipeline9NodeBounds = ({
+  nodeWithPortPoints,
+  obstacleMargin,
+  traceWidth,
+  viaDiameter,
+}: {
+  nodeWithPortPoints: NodeWithPortPoints
+  obstacleMargin: number
+  traceWidth: number
+  viaDiameter: number
+}): Bounds => {
+  const nodeBounds = getBoundsFromNodeWithPortPoints(nodeWithPortPoints)
+  const clearance =
+    obstacleMargin +
+    Math.max(traceWidth, viaDiameter) / 2 +
+    OBSTACLE_OVERLAP_TOLERANCE
+  return {
+    minX:
+      nodeWithPortPoints.center.x +
+      (nodeBounds.minX - nodeWithPortPoints.center.x) *
+        MAX_PIPELINE9_ORDINARY_NODE_SCALE -
+      clearance,
+    maxX:
+      nodeWithPortPoints.center.x +
+      (nodeBounds.maxX - nodeWithPortPoints.center.x) *
+        MAX_PIPELINE9_ORDINARY_NODE_SCALE +
+      clearance,
+    minY:
+      nodeWithPortPoints.center.y +
+      (nodeBounds.minY - nodeWithPortPoints.center.y) *
+        MAX_PIPELINE9_ORDINARY_NODE_SCALE -
+      clearance,
+    maxY:
+      nodeWithPortPoints.center.y +
+      (nodeBounds.maxY - nodeWithPortPoints.center.y) *
+        MAX_PIPELINE9_ORDINARY_NODE_SCALE +
+      clearance,
+  }
+}
+
+const obstacleOverlapsBounds = (
+  obstacle: Obstacle,
+  bounds: Bounds,
+): boolean => {
+  const rotationRadians = ((obstacle.ccwRotationDegrees ?? 0) * Math.PI) / 180
+  const cos = Math.abs(Math.cos(rotationRadians))
+  const sin = Math.abs(Math.sin(rotationRadians))
+  const rawHalfWidth = obstacle.width / 2
+  const rawHalfHeight = obstacle.height / 2
+  // Some Pipeline9 consumers intentionally use the unrotated bounds while
+  // others use the rotated rectangle. The larger envelope preserves both.
+  const halfWidth = Math.max(
+    rawHalfWidth,
+    rawHalfWidth * cos + rawHalfHeight * sin,
+  )
+  const halfHeight = Math.max(
+    rawHalfHeight,
+    rawHalfWidth * sin + rawHalfHeight * cos,
+  )
+  return (
+    obstacle.center.x - halfWidth <= bounds.maxX &&
+    obstacle.center.x + halfWidth >= bounds.minX &&
+    obstacle.center.y - halfHeight <= bounds.maxY &&
+    obstacle.center.y + halfHeight >= bounds.minY
+  )
+}
+
+const getNodeConnectionNames = (
+  nodeWithPortPoints: NodeWithPortPoints,
+): string[] => [
+  ...new Set(
+    nodeWithPortPoints.portPoints.map((portPoint) => portPoint.connectionName),
+  ),
+]
+
+const addPortPointIds = (
+  relevantIds: Set<string>,
+  portPoint: PortPoint,
+): void => {
+  for (const id of [
+    portPoint.connectionName,
+    portPoint.rootConnectionName,
+    portPoint.portPointId,
+    portPoint.pcb_port_id,
+    portPoint.prevPortPointId,
+    portPoint.nextPortPointId,
+  ]) {
+    if (id !== undefined) relevantIds.add(id)
+  }
+}
+
+const projectConnectivityNetMap = (
+  connMap: ConnectivityMap,
+  relevantIds: ReadonlySet<string>,
+): Record<string, string[]> =>
+  Object.fromEntries(
+    Object.entries(connMap.netMap).flatMap(([netId, ids]) => {
+      const relevantConnectedIds = ids.filter((id) => relevantIds.has(id))
+      return relevantConnectedIds.length > 0 || relevantIds.has(netId)
+        ? [[netId, relevantConnectedIds]]
+        : []
+    }),
+  )
+
+const getMinimalProjectedObstacle = ({
+  obstacle,
+  connectedTo,
+  preserveRotation,
+}: {
+  obstacle: Obstacle
+  connectedTo: string[]
+  preserveRotation: boolean
+}): Obstacle => ({
+  type: "rect",
+  layers: obstacle.layers,
+  ...(obstacle.zLayers === undefined ? {} : { zLayers: obstacle.zLayers }),
+  ...(obstacle.__zLayers === undefined
+    ? {}
+    : { __zLayers: obstacle.__zLayers }),
+  center: obstacle.center,
+  width: obstacle.width,
+  height: obstacle.height,
+  ...(preserveRotation && obstacle.ccwRotationDegrees !== undefined
+    ? { ccwRotationDegrees: obstacle.ccwRotationDegrees }
+    : {}),
+  connectedTo,
+  ...(obstacle.circuitJsonMetadata === undefined
+    ? {}
+    : { circuitJsonMetadata: obstacle.circuitJsonMetadata }),
+})
+
+const getRelevantObstacleConnectionRepresentatives = ({
+  obstacle,
+  nodeWithPortPoints,
+  connMap,
+}: {
+  obstacle: Obstacle
+  nodeWithPortPoints: NodeWithPortPoints
+  connMap: ConnectivityMap
+}): string[] => {
+  const directRouteIds = new Set(
+    nodeWithPortPoints.portPoints.flatMap((portPoint) => {
+      const rootConnectionName =
+        connMap.getNetConnectedToId(
+          portPoint.rootConnectionName ?? portPoint.connectionName,
+        ) ??
+        portPoint.rootConnectionName ??
+        portPoint.connectionName
+      return [portPoint.connectionName, rootConnectionName]
+    }),
+  )
+  // The repair stage compares these IDs directly, without a ConnectivityMap.
+  // Preserve every exact route/root identity so that direct semantics cannot
+  // be changed by projection.
+  const representatives = new Set(
+    obstacle.connectedTo.filter((id) => directRouteIds.has(id)),
+  )
+
+  const idsByNet = new Map<string, string[]>()
+  for (const routeId of directRouteIds) {
+    const netId = connMap.getNetConnectedToId(routeId) ?? routeId
+    const routeIds = idsByNet.get(netId) ?? []
+    routeIds.push(routeId)
+    idsByNet.set(netId, routeIds)
+  }
+
+  for (const routeIds of idsByNet.values()) {
+    const alreadyRepresented = [...representatives].some((representative) =>
+      routeIds.some(
+        (routeId) =>
+          routeId === representative ||
+          connMap.areIdsConnected(routeId, representative),
+      ),
+    )
+    if (alreadyRepresented) continue
+
+    const connectedId = obstacle.connectedTo.find((candidateId) =>
+      routeIds.some(
+        (routeId) =>
+          routeId === candidateId ||
+          connMap.areIdsConnected(routeId, candidateId),
+      ),
+    )
+    if (connectedId !== undefined) {
+      representatives.add(connectedId)
+    }
+  }
+
+  return [...representatives]
+}
+
+/**
+ * Projects the board obstacles observable by the no-fixed-copper regional
+ * fallback. Unlike the ordinary projection, foreign obstacles must remain:
+ * Pipeline4HighDensityRepairSolver consumes every obstacle near the node.
+ *
+ * Connection IDs require special care. The route stage uses ConnectivityMap,
+ * while the repair stage checks connectionName/rootConnectionName by direct
+ * equality. Exact route IDs are therefore preserved, plus at most one alias
+ * representative per relevant net for route-stage equivalence.
+ */
+export function projectPipeline9RegionalHighDensityInput({
+  nodeWithPortPoints,
+  connMap,
+  obstacles,
+  obstacleMargin,
+  traceWidth,
+  viaDiameter,
+}: {
+  nodeWithPortPoints: NodeWithPortPoints
+  connMap: ConnectivityMap
+  obstacles: Obstacle[]
+  obstacleMargin: number
+  traceWidth: number
+  viaDiameter: number
+}): Pipeline9RegionalHighDensityProjection {
+  const maximumNodeBounds = getMaximumPipeline9NodeBounds({
+    nodeWithPortPoints,
+    obstacleMargin,
+    traceWidth,
+    viaDiameter,
+  })
+  const relevantIds = new Set<string>()
+  for (const portPoint of nodeWithPortPoints.portPoints) {
+    addPortPointIds(relevantIds, portPoint)
+  }
+  for (const pair of nodeWithPortPoints.portPointsInPairs ?? []) {
+    addPortPointIds(relevantIds, pair[0])
+    addPortPointIds(relevantIds, pair[1])
+  }
+
+  const projectedObstacles = obstacles.flatMap((obstacle) => {
+    if (!obstacleOverlapsBounds(obstacle, maximumNodeBounds)) return []
+    const connectedTo = getRelevantObstacleConnectionRepresentatives({
+      obstacle,
+      nodeWithPortPoints,
+      connMap,
+    })
+    for (const id of connectedTo) relevantIds.add(id)
+    return [
+      getMinimalProjectedObstacle({
+        obstacle,
+        connectedTo,
+        preserveRotation: true,
+      }),
+    ]
+  })
+
+  return {
+    connectivityNetMap: projectConnectivityNetMap(connMap, relevantIds),
+    obstacles: projectedObstacles,
+  }
+}
+
+export const mergePipeline9ProjectedConnectivityNetMaps = (
+  ...netMaps: Array<Record<string, string[]>>
+): Record<string, string[]> => {
+  const merged = new Map<string, Set<string>>()
+  for (const netMap of netMaps) {
+    for (const [netId, ids] of Object.entries(netMap)) {
+      const mergedIds = merged.get(netId) ?? new Set<string>()
+      for (const id of ids) mergedIds.add(id)
+      merged.set(netId, mergedIds)
+    }
+  }
+  return Object.fromEntries(
+    [...merged].map(([netId, ids]) => [netId, [...ids]]),
+  )
+}
+
+/**
+ * Reduces board-wide inputs to the information Pipeline9's ordinary node
+ * solver can observe. The overlap envelope covers all 1x/2x/4x/8x
+ * grow-shrink attempts and both the rotated geometry and the through-obstacle
+ * solver's intentionally unrotated containment check.
+ */
+export function projectPipeline9OrdinaryHighDensityInput({
+  nodeWithPortPoints,
+  connMap,
+  colorMap,
+  obstacles,
+  obstacleMargin,
+  traceWidth,
+  viaDiameter,
+}: {
+  nodeWithPortPoints: NodeWithPortPoints
+  connMap: ConnectivityMap
+  colorMap?: Record<string, string>
+  obstacles: Obstacle[]
+  obstacleMargin: number
+  traceWidth: number
+  viaDiameter: number
+}): Pipeline9OrdinaryHighDensityProjection {
+  const grownNodeBounds = getMaximumPipeline9NodeBounds({
+    nodeWithPortPoints,
+    obstacleMargin,
+    traceWidth,
+    viaDiameter,
+  })
+  const nodeConnectionNames = getNodeConnectionNames(nodeWithPortPoints)
+
+  const projectedObstacles = obstacles.flatMap((obstacle) => {
+    if (!obstacleOverlapsBounds(obstacle, grownNodeBounds)) return []
+
+    const matchingConnectionNames = nodeConnectionNames.filter(
+      (connectionName) =>
+        obstacle.connectedTo.some(
+          (connectedId) =>
+            connectedId === connectionName ||
+            connMap.areIdsConnected(connectionName, connectedId),
+        ),
+    )
+    if (matchingConnectionNames.length === 0) return []
+
+    return [
+      getMinimalProjectedObstacle({
+        obstacle,
+        connectedTo: matchingConnectionNames,
+        preserveRotation: false,
+      }),
+    ]
+  })
+
+  const relevantIds = new Set<string>()
+  for (const portPoint of nodeWithPortPoints.portPoints) {
+    addPortPointIds(relevantIds, portPoint)
+  }
+  for (const pair of nodeWithPortPoints.portPointsInPairs ?? []) {
+    addPortPointIds(relevantIds, pair[0])
+    addPortPointIds(relevantIds, pair[1])
+  }
+  for (const obstacle of projectedObstacles) {
+    for (const id of [
+      obstacle.circuitJsonMetadata?.pcb_smtpad_id,
+      obstacle.circuitJsonMetadata?.pcb_plated_hole_id,
+      obstacle.circuitJsonMetadata?.pcb_port_id,
+      obstacle.circuitJsonMetadata?.pcb_via_id,
+      ...(obstacle.connectedTo ?? []),
+    ]) {
+      if (id !== undefined) relevantIds.add(id)
+    }
+  }
+
+  const connectivityNetMap = projectConnectivityNetMap(connMap, relevantIds)
+  const projectedColorMap = Object.fromEntries(
+    Object.entries(colorMap ?? {}).filter(([id]) => relevantIds.has(id)),
+  )
+
+  return {
+    connectivityNetMap,
+    colorMap: projectedColorMap,
+    obstacles: projectedObstacles,
+  }
+}

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-types.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-types.ts
@@ -1,0 +1,103 @@
+import type {
+  HighDensityIntraNodeRoute,
+  NodeWithPortPoints,
+} from "../../types/high-density-types"
+import type { Obstacle } from "../../types/srj-types"
+
+export type Pipeline9NetworkedCacheSource = "cache" | "solver"
+
+export const PIPELINE9_NETWORKED_SOLVE_POLICY =
+  "ordinary_then_regional_without_fixed_copper_v1" as const
+
+/**
+ * Every solution-affecting input for Pipeline9's terminal single-node policy:
+ * ordinary high-density routing followed, when enabled, by the regional
+ * no-fixed-copper fallback. The shape is JSON-serializable so the exact same
+ * helper can run in the cache service.
+ */
+export type Pipeline9NetworkedHighDensityNodeInput = {
+  solvePolicy: typeof PIPELINE9_NETWORKED_SOLVE_POLICY
+  enableRegionalFallback: boolean
+  nodeWithPortPoints: NodeWithPortPoints
+  connectivityNetMap: Record<string, string[]>
+  colorMap: Record<string, string>
+  viaDiameter: number
+  traceWidth: number
+  obstacleMargin: number
+  effort: 1
+  obstacles: Obstacle[]
+  regionalObstacles: Obstacle[]
+  layerCount: number
+  nodePf: number | null
+}
+
+export type Pipeline9NetworkedHighDensityNodeOutput =
+  | {
+      status: "solved"
+      solutionStage: "ordinary"
+      routes: HighDensityIntraNodeRoute[]
+    }
+  | {
+      status: "solved"
+      solutionStage: "regional-fallback"
+      ordinaryFailure: string
+      routes: HighDensityIntraNodeRoute[]
+    }
+  | {
+      status: "failed"
+      solutionStage: "ordinary"
+      error: string
+    }
+  | {
+      status: "failed"
+      solutionStage: "regional-fallback"
+      ordinaryFailure: string
+      error: string
+    }
+
+export type Pipeline9NetworkedSolveRequest = {
+  autorouterVersion: string
+  /** Optional cache namespace used to isolate benchmark runs. */
+  cacheVersion?: string
+  input: Pipeline9NetworkedHighDensityNodeInput
+}
+
+export type Pipeline9NetworkedSolveBatchItem = {
+  requestId: string
+  input: Pipeline9NetworkedHighDensityNodeInput
+}
+
+export type Pipeline9NetworkedSolveBatchRequest = {
+  autorouterVersion: string
+  /** Optional cache namespace used to isolate benchmark runs. */
+  cacheVersion?: string
+  items: Pipeline9NetworkedSolveBatchItem[]
+}
+
+export type Pipeline9NetworkedSolveResponse =
+  | ({
+      ok: true
+      autorouterVersion: string
+      cacheVersion?: string
+      source: Pipeline9NetworkedCacheSource
+    } & Pipeline9NetworkedHighDensityNodeOutput)
+  | {
+      ok: false
+      autorouterVersion?: string
+      cacheVersion?: string
+      message: string
+    }
+
+export type Pipeline9NetworkedSolveBatchCacheMiss = {
+  requestId: string
+  ok: false
+  autorouterVersion: string
+  cacheVersion?: string
+  code: "CACHE_MISS"
+  message: string
+}
+
+/** One independently consumable NDJSON line returned by POST /solve-batch. */
+export type Pipeline9NetworkedSolveBatchResult =
+  | ({ requestId: string } & Pipeline9NetworkedSolveResponse)
+  | Pipeline9NetworkedSolveBatchCacheMiss

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/solve-pipeline9-networked-high-density-node.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/solve-pipeline9-networked-high-density-node.ts
@@ -1,0 +1,144 @@
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import {
+  createPipeline9RegularNodeSolver,
+  normalizePipeline9NodeRootConnectionNames,
+} from "../AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-high-density-solver"
+import { createRegionalFallbackProblem } from "../AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-regional-fallback"
+import { Pipeline9RegionalFallbackSolver } from "../AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-regional-fallback-solver"
+import type {
+  Pipeline9NetworkedHighDensityNodeInput,
+  Pipeline9NetworkedHighDensityNodeOutput,
+} from "./pipeline9-networked-types"
+import { PIPELINE9_NETWORKED_SOLVE_POLICY } from "./pipeline9-networked-types"
+
+type Pipeline9OrdinaryNodeResult =
+  | {
+      status: "solved"
+      routes: Extract<
+        Pipeline9NetworkedHighDensityNodeOutput,
+        { status: "solved" }
+      >["routes"]
+    }
+  | {
+      status: "failed"
+      error: string
+    }
+
+const solvePipeline9OrdinaryHighDensityNode = ({
+  input,
+  connMap,
+}: {
+  input: Pipeline9NetworkedHighDensityNodeInput
+  connMap: ConnectivityMap
+}): Pipeline9OrdinaryNodeResult => {
+  const solver = createPipeline9RegularNodeSolver({
+    nodeWithPortPoints: input.nodeWithPortPoints,
+    colorMap: input.colorMap,
+    connMap,
+    viaDiameter: input.viaDiameter,
+    traceWidth: input.traceWidth,
+    obstacleMargin: input.obstacleMargin,
+    effort: input.effort,
+    nodePfById: {
+      [input.nodeWithPortPoints.capacityMeshNodeId]: input.nodePf,
+    },
+    obstacles: input.obstacles,
+    layerCount: input.layerCount,
+  })
+  solver.solve()
+  return solver.solved
+    ? { status: "solved", routes: solver.routes }
+    : {
+        status: "failed",
+        error: solver.error || "Pipeline9 ordinary high-density solver failed",
+      }
+}
+
+/**
+ * Runs Pipeline9's terminal no-fixed-copper node policy. hd-cache2 calls this
+ * exported helper so ordinary and regional cache entries can only be produced
+ * by its installed autorouter implementation.
+ */
+export function solvePipeline9NetworkedHighDensityNode(
+  input: Pipeline9NetworkedHighDensityNodeInput,
+): Pipeline9NetworkedHighDensityNodeOutput {
+  if (input.solvePolicy !== PIPELINE9_NETWORKED_SOLVE_POLICY) {
+    throw new Error(
+      `Unsupported Pipeline9 networked solve policy ${String(input.solvePolicy)}`,
+    )
+  }
+  if (input.effort !== 1) {
+    throw new Error(
+      `Pipeline9 networked high-density solving requires effort=1, received ${input.effort}`,
+    )
+  }
+
+  const connMap = new ConnectivityMap(input.connectivityNetMap)
+  const ordinaryResult = solvePipeline9OrdinaryHighDensityNode({
+    input,
+    connMap,
+  })
+  if (ordinaryResult.status === "solved") {
+    return {
+      status: "solved",
+      solutionStage: "ordinary",
+      routes: ordinaryResult.routes,
+    }
+  }
+
+  const ordinaryFailure = ordinaryResult.error
+  if (!input.enableRegionalFallback) {
+    return {
+      status: "failed",
+      solutionStage: "ordinary",
+      error: `Pipeline9 regular high-density routing failed: ${ordinaryFailure}`,
+    }
+  }
+
+  const normalizedNode = normalizePipeline9NodeRootConnectionNames(
+    input.nodeWithPortPoints,
+    connMap,
+  )
+  const regionalProblem = createRegionalFallbackProblem(
+    {
+      ...normalizedNode,
+      availableZ: Array.from({ length: input.layerCount }, (_, z) => z),
+    },
+    [],
+  )
+  const regionalSolver = new Pipeline9RegionalFallbackSolver({
+    nodeWithPortPoints: regionalProblem.nodeWithPortPoints,
+    colorMap: input.colorMap,
+    connMap,
+    viaDiameter: input.viaDiameter,
+    traceWidth: input.traceWidth,
+    obstacleMargin: input.obstacleMargin,
+    effort: input.effort,
+    nodePfById: {
+      [input.nodeWithPortPoints.capacityMeshNodeId]: input.nodePf,
+    },
+    obstacles: input.regionalObstacles,
+    layerCount: input.layerCount,
+  })
+  regionalSolver.solve()
+  if (regionalSolver.solved) {
+    return {
+      status: "solved",
+      solutionStage: "regional-fallback",
+      ordinaryFailure,
+      routes: regionalSolver.getOutput(),
+    }
+  }
+
+  const regionalFailure =
+    regionalSolver.error || "Pipeline9 regional fallback solver failed"
+  return {
+    status: "failed",
+    solutionStage: "regional-fallback",
+    ordinaryFailure,
+    error: [
+      `Pipeline9 primary high-density routing failed: regular high-density routing failed: ${ordinaryFailure}`,
+      `regional fallback failed: ${regionalFailure}`,
+    ].join("; "),
+  }
+}

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-high-density-solver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-high-density-solver.ts
@@ -31,7 +31,7 @@ import {
 } from "./pipeline9-regional-fallback"
 import { Pipeline9RegionalFallbackSolver } from "./pipeline9-regional-fallback-solver"
 
-type Pipeline9HighDensitySolverParams = {
+export type Pipeline9HighDensitySolverParams = {
   nodePortPoints: NodeWithPortPoints[]
   fixedHdRoutes: PreloadedHighDensityRoute[]
   connMap: ConnectivityMap
@@ -278,7 +278,7 @@ const addTerminalPcbPortIds = (
   })
 }
 
-const normalizeNodeRootConnectionNames = (
+export const normalizePipeline9NodeRootConnectionNames = (
   node: NodeWithPortPoints,
   connMap: ConnectivityMap,
 ): NodeWithPortPoints => {
@@ -314,6 +314,57 @@ const restoreRootConnectionNames = (
         (portPoint) => portPoint.connectionName === route.connectionName,
       )?.rootConnectionName ?? route.rootConnectionName,
   }))
+
+export type Pipeline9RegularNodeSolverParams = {
+  nodeWithPortPoints: NodeWithPortPoints
+  connMap: ConnectivityMap
+  colorMap: Record<string, string>
+  viaDiameter: number
+  traceWidth: number
+  obstacleMargin: number
+  effort: number
+  nodePfById:
+    | Map<CapacityMeshNodeId, number | null>
+    | Record<string, number | null>
+  obstacles: Obstacle[]
+  layerCount: number
+}
+
+/**
+ * Creates the ordinary high-density solver used by Pipeline9. The networked
+ * helper calls the same factory with its projected JSON input so the local and
+ * remote algorithm configuration cannot drift.
+ */
+export const createPipeline9RegularNodeSolver = ({
+  nodeWithPortPoints,
+  connMap,
+  colorMap,
+  viaDiameter,
+  traceWidth,
+  obstacleMargin,
+  effort,
+  nodePfById,
+  obstacles,
+  layerCount,
+}: Pipeline9RegularNodeSolverParams): HighDensitySolver =>
+  new HighDensitySolver({
+    nodePortPoints: [
+      normalizePipeline9NodeRootConnectionNames(nodeWithPortPoints, connMap),
+    ],
+    colorMap,
+    connMap,
+    viaDiameter,
+    traceWidth,
+    obstacleMargin,
+    effort,
+    nodePfById,
+    obstacles,
+    layerCount,
+    useGrowShrinkHighDensityIntraNodeSolver: true,
+    preserveTerminalPcbPortIds: false,
+    growShrinkFallbackToInvalidGeometryOnFailure: false,
+    captureSearchDebug: false,
+  })
 
 /**
  * Uses Pipeline7's detailed solver for ordinary nodes and B01 where local
@@ -406,7 +457,7 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
     })
   }
 
-  private finishActiveNode(routes: HighDensityIntraNodeRoute[]) {
+  protected finishActiveNode(routes: HighDensityIntraNodeRoute[]): void {
     const solvedRoutes = this.activeNode
       ? restoreRootConnectionNames(routes, this.activeNode)
       : routes
@@ -426,10 +477,10 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
     this.activeNode = null
   }
 
-  private startRegularSolver(node: NodeWithPortPoints): void {
+  protected startRegularSolver(node: NodeWithPortPoints): void {
     this.activeNode = node
-    this.activeRegularSolver = new HighDensitySolver({
-      nodePortPoints: [normalizeNodeRootConnectionNames(node, this.connMap)],
+    this.activeRegularSolver = createPipeline9RegularNodeSolver({
+      nodeWithPortPoints: node,
       colorMap: this.colorMap,
       connMap: this.connMap,
       viaDiameter: this.viaDiameter,
@@ -439,10 +490,6 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
       nodePfById: this.nodePfById,
       obstacles: this.obstacles,
       layerCount: this.layerCount,
-      useGrowShrinkHighDensityIntraNodeSolver: true,
-      preserveTerminalPcbPortIds: false,
-      growShrinkFallbackToInvalidGeometryOnFailure: false,
-      captureSearchDebug: false,
     })
     this.stats.regularNodeCount = Number(this.stats.regularNodeCount ?? 0) + 1
   }
@@ -456,7 +503,7 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
       )
     }
 
-    const normalizedNode = normalizeNodeRootConnectionNames(
+    const normalizedNode = normalizePipeline9NodeRootConnectionNames(
       this.activeNode,
       this.connMap,
     )
@@ -738,7 +785,10 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
     // future fallback never has to replay this node's now-stale bounds.
     const postSpliceProblem = createRegionalFallbackProblem(
       {
-        ...normalizeNodeRootConnectionNames(this.activeNode, this.connMap),
+        ...normalizePipeline9NodeRootConnectionNames(
+          this.activeNode,
+          this.connMap,
+        ),
         portPoints: [],
         portPointsInPairs: [],
         availableZ: Array.from({ length: this.layerCount }, (_, z) => z),
@@ -837,6 +887,18 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
       Number(regionalStats.repairCandidateRejectionCount ?? 0)
   }
 
+  protected finishRegularSolverFailure(error: string): void {
+    this.activeFallbackReason = `regular high-density routing failed: ${error}`
+    this.activeRegularSolver = null
+    if (!this.enableRegionalFallback) {
+      this.error = `Pipeline9 ${this.activeFallbackReason}`
+      this.failed = true
+      this.activeNode = null
+      return
+    }
+    this.startRegionalFallback()
+  }
+
   override _step(): void {
     if (this.activeFallbackSolver) {
       this.activeFallbackSolver.step()
@@ -863,15 +925,9 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
     if (this.activeRegularSolver) {
       this.activeRegularSolver.step()
       if (this.activeRegularSolver.failed) {
-        this.activeFallbackReason = `regular high-density routing failed: ${this.activeRegularSolver.error ?? "unknown error"}`
-        this.activeRegularSolver = null
-        if (!this.enableRegionalFallback) {
-          this.error = `Pipeline9 ${this.activeFallbackReason}`
-          this.failed = true
-          this.activeNode = null
-          return
-        }
-        this.startRegionalFallback()
+        this.finishRegularSolverFailure(
+          this.activeRegularSolver.error ?? "unknown error",
+        )
         return
       }
       if (!this.activeRegularSolver.solved) return
@@ -945,7 +1001,10 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
       return
     }
 
-    const normalizedNode = normalizeNodeRootConnectionNames(node, this.connMap)
+    const normalizedNode = normalizePipeline9NodeRootConnectionNames(
+      node,
+      this.connMap,
+    )
     this.stats.b01NodeCount = Number(this.stats.b01NodeCount ?? 0) + 1
     this.activeB01Solver = new HighDensitySolverB01({
       ...defaultB01Params,

--- a/lib/autorouter-pipelines/index.ts
+++ b/lib/autorouter-pipelines/index.ts
@@ -22,4 +22,8 @@ export {
 } from "./AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph"
 export { AutoroutingPipelineSolver8 } from "./AutoroutingPipeline8/AutoroutingPipelineSolver8"
 export { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "./AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph"
+export {
+  AutoroutingPipelineSolver9_Networked,
+  type AutoroutingPipelineSolver9NetworkedOptions,
+} from "./AutoroutingPipeline9_Networked/autorouting-pipeline-solver9-networked"
 export { AutoroutingPipelineSolver10_BgaFanout } from "./AutoroutingPipeline10_BgaFanout/AutoroutingPipelineSolver10_BgaFanout"

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -24,6 +24,25 @@ export {
 } from "./autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph"
 export { AutoroutingPipelineSolver8 } from "./autorouter-pipelines/AutoroutingPipeline8/AutoroutingPipelineSolver8"
 export { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "./autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/autorouting-pipeline-solver9-preloaded-trace-graph"
+export {
+  AutoroutingPipelineSolver9_Networked,
+  type AutoroutingPipelineSolver9NetworkedOptions,
+} from "./autorouter-pipelines/AutoroutingPipeline9_Networked/autorouting-pipeline-solver9-networked"
+export { AUTOROUTER_VERSION } from "./autorouter-pipelines/AutoroutingPipeline9_Networked/autorouter-version"
+export { DEFAULT_HD_CACHE2_SERVER_URL } from "./autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-high-density-solver"
+export type {
+  Pipeline9NetworkedCacheSource,
+  Pipeline9NetworkedHighDensityNodeInput,
+  Pipeline9NetworkedHighDensityNodeOutput,
+  Pipeline9NetworkedSolveBatchCacheMiss,
+  Pipeline9NetworkedSolveBatchItem,
+  Pipeline9NetworkedSolveBatchRequest,
+  Pipeline9NetworkedSolveBatchResult,
+  Pipeline9NetworkedSolveRequest,
+  Pipeline9NetworkedSolveResponse,
+} from "./autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-types"
+export { PIPELINE9_NETWORKED_SOLVE_POLICY } from "./autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-types"
+export { solvePipeline9NetworkedHighDensityNode } from "./autorouter-pipelines/AutoroutingPipeline9_Networked/solve-pipeline9-networked-high-density-node"
 export { AutoroutingPipelineSolver10_BgaFanout } from "./autorouter-pipelines/AutoroutingPipeline10_BgaFanout/AutoroutingPipelineSolver10_BgaFanout"
 export { PolyHighDensitySolver } from "./autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/PolyHighDensitySolver"
 export { PolySingleIntraNodeSolver } from "./autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/PolySingleIntraNodeSolver"

--- a/lib/solvers/HyperHighDensitySolver/repairDisconnectedSameRootPortPoints.ts
+++ b/lib/solvers/HyperHighDensitySolver/repairDisconnectedSameRootPortPoints.ts
@@ -3,6 +3,7 @@ import type {
   NodeWithPortPoints,
   PortPoint,
 } from "lib/types/high-density-types"
+import { getConnectionPortPointPairs } from "lib/utils/getConnectionPortPointPairs"
 
 const pointKey = (point: { x: number; y: number; z: number }) =>
   `${point.x.toFixed(6)},${point.y.toFixed(6)},${point.z}`
@@ -51,6 +52,47 @@ const getConnectedPointKeysForConnection = (
   }
 
   return connected
+}
+
+export const areNodePortPointPairsConnectedByRoutes = (
+  routes: HighDensityIntraNodeRoute[],
+  nodeWithPortPoints: NodeWithPortPoints,
+): boolean => {
+  const explicitPairs = nodeWithPortPoints.portPointsInPairs ?? []
+  if (explicitPairs.length > 0) {
+    for (const [start, end] of explicitPairs) {
+      const connectedPointKeys = getConnectedPointKeysForConnection(
+        routes,
+        start.connectionName,
+        pointKey(start),
+      )
+      if (!connectedPointKeys.has(pointKey(end))) return false
+    }
+    return true
+  }
+
+  const portPointsByConnection = new Map<string, PortPoint[]>()
+  for (const portPoint of nodeWithPortPoints.portPoints) {
+    const connectionPortPoints =
+      portPointsByConnection.get(portPoint.connectionName) ?? []
+    connectionPortPoints.push(portPoint)
+    portPointsByConnection.set(portPoint.connectionName, connectionPortPoints)
+  }
+
+  for (const [connectionName, connectionPortPoints] of portPointsByConnection) {
+    for (const [start, end] of getConnectionPortPointPairs(
+      connectionPortPoints,
+    )) {
+      const connectedPointKeys = getConnectedPointKeysForConnection(
+        routes,
+        connectionName,
+        pointKey(start),
+      )
+      if (!connectedPointKeys.has(pointKey(end))) return false
+    }
+  }
+
+  return true
 }
 
 export const repairDisconnectedSameRootPortPoints = (

--- a/scripts/benchmark/benchmark-comment-comparison.d.ts
+++ b/scripts/benchmark/benchmark-comment-comparison.d.ts
@@ -1,5 +1,9 @@
 import type { BenchmarkReport } from "./benchmark-types"
 
+export declare const isNetworkedColdHotReport: (
+  report: BenchmarkReport | null | undefined,
+) => boolean
+
 export type BenchmarkComparisonInput = {
   mainReport: BenchmarkReport | null
   prReport: BenchmarkReport | null

--- a/scripts/benchmark/benchmark-comment-comparison.js
+++ b/scripts/benchmark/benchmark-comment-comparison.js
@@ -110,6 +110,71 @@ const formatCountDelta = (mainValue, prValue) => {
   return `${delta > 0 ? "+" : ""}${delta}`
 }
 
+const NETWORKED_COLD_NAME = "Pipeline9_Networked Cold"
+const NETWORKED_HOT_NAME = "Pipeline9_Networked Hot"
+
+export const isNetworkedColdHotReport = (report) => {
+  if (!Array.isArray(report?.summary)) return false
+  const solverNames = new Set(report.summary.map((row) => row.solverName))
+  return (
+    solverNames.has(NETWORKED_COLD_NAME) && solverNames.has(NETWORKED_HOT_NAME)
+  )
+}
+
+const renderNetworkedColdHotComparison = (report) => {
+  const coldSummary = report.summary.find(
+    (row) => row.solverName === NETWORKED_COLD_NAME,
+  )
+  const hotSummary = report.summary.find(
+    (row) => row.solverName === NETWORKED_HOT_NAME,
+  )
+  const coldTimeouts = getTimeoutCount(report, NETWORKED_COLD_NAME)
+  const hotTimeouts = getTimeoutCount(report, NETWORKED_HOT_NAME)
+  const coldDrcIssues = getDrcIssueCount(report, NETWORKED_COLD_NAME)
+  const hotDrcIssues = getDrcIssueCount(report, NETWORKED_HOT_NAME)
+  const rows = [
+    `| Completion | ${coldSummary.completedRateLabel} | ${hotSummary.completedRateLabel} | ${formatPercentPointDelta(coldSummary.completedRateLabel, hotSummary.completedRateLabel)} |`,
+    `| Relaxed DRC pass | ${coldSummary.relaxedDrcRateLabel} | ${hotSummary.relaxedDrcRateLabel} | ${formatPercentPointDelta(coldSummary.relaxedDrcRateLabel, hotSummary.relaxedDrcRateLabel)} |`,
+    `| DRC issues | ${coldDrcIssues ?? "n/a"} | ${hotDrcIssues ?? "n/a"} | ${formatCountDelta(coldDrcIssues, hotDrcIssues)} |`,
+    `| Timeouts | ${coldTimeouts ?? "n/a"} | ${hotTimeouts ?? "n/a"} | ${formatCountDelta(coldTimeouts, hotTimeouts)} |`,
+  ]
+  for (const percentile of [50, 60, 70, 80, 90, 95]) {
+    const coldTime = getTimePercentile(
+      report,
+      NETWORKED_COLD_NAME,
+      percentile / 100,
+    )
+    const hotTime = getTimePercentile(
+      report,
+      NETWORKED_HOT_NAME,
+      percentile / 100,
+    )
+    rows.push(
+      `| P${percentile} time | ${formatTime(coldTime)} | ${formatTime(hotTime)} | ${formatRelativeDelta(coldTime, hotTime)} |`,
+    )
+  }
+  rows.push(
+    `| Average vias | ${formatAverage(coldSummary.avgVia)} | ${formatAverage(hotSummary.avgVia)} | ${formatRelativeDelta(coldSummary.avgVia, hotSummary.avgVia)} |`,
+  )
+  if (coldSummary.networkCache && hotSummary.networkCache) {
+    rows.push(
+      `| HD cache hits | ${coldSummary.networkCache.cacheHits}/${coldSummary.networkCache.remoteRequests} | ${hotSummary.networkCache.cacheHits}/${hotSummary.networkCache.remoteRequests} | ${formatCountDelta(coldSummary.networkCache.cacheHits, hotSummary.networkCache.cacheHits)} |`,
+      `| HD solver results | ${coldSummary.networkCache.solverResults} | ${hotSummary.networkCache.solverResults} | ${formatCountDelta(coldSummary.networkCache.solverResults, hotSummary.networkCache.solverResults)} |`,
+      `| HD local fallbacks | ${coldSummary.networkCache.localFallbacks} | ${hotSummary.networkCache.localFallbacks} | ${formatCountDelta(coldSummary.networkCache.localFallbacks, hotSummary.networkCache.localFallbacks)} |`,
+    )
+  }
+
+  return [
+    `Dataset: ${report.datasetName} · Scenarios: ${report.scenarioCount} · Effort: ${report.effortLabel}`,
+    "",
+    "| Metric | Cold | Hot | Change |",
+    "| --- | ---: | ---: | ---: |",
+    ...rows,
+    "",
+    "_The cold pass starts with a workflow-unique cache namespace; the hot pass reuses it after the full cold pass and an unmeasured Workers KV propagation interval complete. Negative timing changes are faster._",
+  ]
+}
+
 export const renderBenchmarkComparison = ({
   mainReport,
   prReport,
@@ -122,6 +187,9 @@ export const renderBenchmarkComparison = ({
         ? `${fallbackText.slice(0, maxLength)}\n\n...truncated...`
         : fallbackText
     return ["```", truncated, "```"]
+  }
+  if (isNetworkedColdHotReport(prReport)) {
+    return renderNetworkedColdHotComparison(prReport)
   }
 
   const mainSummaries = new Map(

--- a/scripts/benchmark/benchmark-run-task.ts
+++ b/scripts/benchmark/benchmark-run-task.ts
@@ -52,12 +52,16 @@ type SolverInstance = PipelineStageTimingSource & {
   }
   highDensityRouteSolver?: {
     iterations?: number
+    stats?: Record<string, unknown>
+    waitForAllRemoteRequests?: () => Promise<void>
   }
   timeSpentOnPhase: Record<string, number>
 }
 
 type SolverOptions = {
   effort?: number
+  hdCache2ServerUrl?: string
+  hdCache2CacheVersion?: string
 }
 
 type SolverConstructor = new (
@@ -126,11 +130,24 @@ const getSolverConstructor = (solverName: string): SolverConstructor => {
 }
 
 export const createSolverForTask = (task: BenchmarkTask): SolverInstance => {
-  const SolverConstructor = getSolverConstructor(task.solverName)
-  return new SolverConstructor(
-    task.scenario,
-    getBenchmarkSolverOptions(task.scenario),
-  )
+  const constructorName = task.solverConstructorName ?? task.solverName
+  const SolverConstructor = getSolverConstructor(constructorName)
+  const scenarioOptions = getBenchmarkSolverOptions(task.scenario)
+  if (!task.networkedCachePass) {
+    return new SolverConstructor(task.scenario, scenarioOptions)
+  }
+
+  const cacheVersion = process.env.HD_CACHE2_CACHE_VERSION
+  if (!cacheVersion) {
+    throw new Error(
+      "Pipeline9_Networked benchmark requires HD_CACHE2_CACHE_VERSION",
+    )
+  }
+  return new SolverConstructor(task.scenario, {
+    ...scenarioOptions,
+    hdCache2ServerUrl: process.env.HD_CACHE2_SERVER_URL,
+    hdCache2CacheVersion: cacheVersion,
+  })
 }
 
 const getErrorMessage = (error: unknown): string | undefined => {
@@ -285,12 +302,59 @@ const getProgressKey = (progress: WorkerProgress) =>
 const getRoutingBenchmarkMetrics = (
   solver: SolverInstance,
 ): RoutingBenchmarkMetrics => {
+  const highDensityStats = solver.highDensityRouteSolver?.stats
+  const networkedHighDensity =
+    highDensityStats &&
+    typeof highDensityStats.remoteRequestsStarted === "number"
+      ? {
+          remoteRequestsStarted: highDensityStats.remoteRequestsStarted,
+          remoteRequestsCompleted: Number(
+            highDensityStats.remoteRequestsCompleted ?? 0,
+          ),
+          remoteBatchCacheMisses: Number(
+            highDensityStats.remoteBatchCacheMisses ?? 0,
+          ),
+          remoteSingleRequestsStarted: Number(
+            highDensityStats.remoteSingleRequestsStarted ?? 0,
+          ),
+          remoteCacheHits: Number(highDensityStats.remoteCacheHits ?? 0),
+          remoteSolverResults: Number(
+            highDensityStats.remoteSolverResults ?? 0,
+          ),
+          remoteTransportFallbacks: Number(
+            highDensityStats.remoteTransportFallbacks ?? 0,
+          ),
+        }
+      : undefined
   return {
     tinyHypergraph:
       solver.portPointPathingSolver?.getSolveGraphBenchmarkMetrics?.(),
     highDensityIterations: solver.highDensityRouteSolver?.iterations,
     phaseTimeMs: solver.timeSpentOnPhase,
+    networkedHighDensity,
   }
+}
+
+const getNetworkedBenchmarkValidationError = (
+  task: BenchmarkTask,
+  solver: SolverInstance,
+): string | undefined => {
+  if (!task.networkedCachePass) return undefined
+  const stats = getRoutingBenchmarkMetrics(solver).networkedHighDensity
+  if (!stats) return "Pipeline9_Networked did not expose remote cache metrics"
+  if (stats.remoteTransportFallbacks > 0) {
+    return `Pipeline9_Networked used ${stats.remoteTransportFallbacks} local transport fallback(s)`
+  }
+  if (
+    task.networkedCachePass === "hot" &&
+    (stats.remoteBatchCacheMisses > 0 ||
+      stats.remoteSingleRequestsStarted > 0 ||
+      stats.remoteSolverResults > 0 ||
+      stats.remoteCacheHits !== stats.remoteRequestsStarted)
+  ) {
+    return `Pipeline9_Networked hot pass was not fully cached (${stats.remoteCacheHits}/${stats.remoteRequestsStarted} cache hit(s), ${stats.remoteBatchCacheMisses} batch miss(es), ${stats.remoteSingleRequestsStarted} single solve(s), ${stats.remoteSolverResults} solver result(s))`
+  }
+  return undefined
 }
 
 const solveWithProgress = async (
@@ -419,6 +483,20 @@ export const runTask = async (
   }
 
   const elapsedTimeMs = performance.now() - start
+  if (task.networkedCachePass) {
+    try {
+      await solver.highDensityRouteSolver?.waitForAllRemoteRequests?.()
+      const networkedBenchmarkValidationError =
+        getNetworkedBenchmarkValidationError(task, solver)
+      if (networkedBenchmarkValidationError) {
+        throw new Error(networkedBenchmarkValidationError)
+      }
+    } catch (error) {
+      solver.solved = false
+      solveError = getErrorMessage(error)
+    }
+  }
+
   const didSolve = Boolean(solver.solved)
   const routingMetrics = getRoutingBenchmarkMetrics(solver)
   let stageTimingStatus: "complete" | "partial" = "partial"

--- a/scripts/benchmark/benchmark-types.ts
+++ b/scripts/benchmark/benchmark-types.ts
@@ -2,7 +2,10 @@ import type { SimpleRouteJson } from "../../lib/types/srj-types"
 
 export type BenchmarkTask = {
   datasetName: string
+  /** Display/report name; may differ for two passes of the same constructor. */
   solverName: string
+  solverConstructorName?: string
+  networkedCachePass?: "cold" | "hot"
   scenarioName: string
   sampleNumber: number
   scenario: SimpleRouteJson
@@ -94,6 +97,15 @@ export type RoutingBenchmarkMetrics = {
   tinyHypergraph?: TinyHypergraphBenchmarkMetrics
   highDensityIterations?: number
   phaseTimeMs?: Record<string, number>
+  networkedHighDensity?: {
+    remoteRequestsStarted: number
+    remoteRequestsCompleted: number
+    remoteBatchCacheMisses: number
+    remoteSingleRequestsStarted: number
+    remoteCacheHits: number
+    remoteSolverResults: number
+    remoteTransportFallbacks: number
+  }
 }
 
 export type WorkerResult<
@@ -156,6 +168,13 @@ export type SolverRunSummary = {
   p90TimeMs?: number | null
   p95TimeMs: number | null
   avgVia: number | null
+  networkCache?: {
+    remoteRequests: number
+    cacheHits: number
+    solverResults: number
+    batchCacheMisses: number
+    localFallbacks: number
+  }
 }
 
 export type BestViaCountRecord = {

--- a/scripts/benchmark/index.ts
+++ b/scripts/benchmark/index.ts
@@ -29,6 +29,7 @@ import {
 
 type BenchmarkOptions = {
   solverName?: string
+  networkedColdHot: boolean
   scenarioLimit?: number
   sampleNumbers?: number[]
   concurrency: number
@@ -72,7 +73,27 @@ const DEFAULT_TASK_TIMEOUT_PER_EFFORT_MS = 60 * 1000
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 30 * 1000
 const DEFAULT_TERMINATE_TIMEOUT_MS = 5 * 1000
 const DEFAULT_BENCHMARK_SOLVER_NAME = "AutoroutingPipelineSolver7_MultiGraph"
+const NETWORKED_PIPELINE9_SOLVER_NAME = "AutoroutingPipelineSolver9_Networked"
+const NETWORKED_PIPELINE9_COLD_NAME = "Pipeline9_Networked Cold"
+const NETWORKED_PIPELINE9_HOT_NAME = "Pipeline9_Networked Hot"
+export const DEFAULT_NETWORKED_CACHE_PROPAGATION_DELAY_MS = 65_000
 const BENCHMARK_SNAPSHOTS_HTML_PATH = "benchmark-snapshots.html"
+
+export const parseNetworkedCachePropagationDelayMs = (
+  rawValue: string | undefined = process.env
+    .BENCHMARK_NETWORKED_CACHE_PROPAGATION_DELAY_MS,
+): number => {
+  if (rawValue === undefined || rawValue.trim() === "") {
+    return DEFAULT_NETWORKED_CACHE_PROPAGATION_DELAY_MS
+  }
+  const delayMs = Number(rawValue)
+  if (!Number.isSafeInteger(delayMs) || delayMs < 0) {
+    throw new Error(
+      "BENCHMARK_NETWORKED_CACHE_PROPAGATION_DELAY_MS must be a non-negative integer",
+    )
+  }
+  return delayMs
+}
 
 const formatTime = (timeMs: number | null) => {
   if (timeMs === null) {
@@ -694,6 +715,7 @@ const parseArgs = (): BenchmarkOptions => {
     concurrency: defaultConcurrency,
     excludeAssignable: false,
     datasetName: "dataset01",
+    networkedColdHot: false,
   }
 
   for (let i = 0; i < args.length; i += 1) {
@@ -701,6 +723,10 @@ const parseArgs = (): BenchmarkOptions => {
     if (arg === "--solver") {
       options.solverName = args[i + 1]
       i += 1
+      continue
+    }
+    if (arg === "--networked-cold-hot") {
+      options.networkedColdHot = true
       continue
     }
     if (arg === "--scenario-limit") {
@@ -831,6 +857,7 @@ const loadSolverNames = async (
 }
 
 const formatTable = (rows: SolverRunSummary[]) => {
+  const includeNetworkCache = rows.some((row) => row.networkCache)
   const headers = [
     "Solver",
     "Completed %",
@@ -843,6 +870,9 @@ const formatTable = (rows: SolverRunSummary[]) => {
     "P90 Time",
     "P95 Time",
     "Avg Via",
+    ...(includeNetworkCache
+      ? ["HD Cache Hits", "HD Solver Results", "HD Local Fallbacks"]
+      : []),
   ]
 
   const body = rows.map((row) => [
@@ -857,6 +887,13 @@ const formatTable = (rows: SolverRunSummary[]) => {
     formatTime(row.p90TimeMs ?? null),
     formatTime(row.p95TimeMs),
     formatAverage(row.avgVia),
+    ...(includeNetworkCache
+      ? [
+          `${row.networkCache?.cacheHits ?? 0}/${row.networkCache?.remoteRequests ?? 0}`,
+          String(row.networkCache?.solverResults ?? 0),
+          String(row.networkCache?.localFallbacks ?? 0),
+        ]
+      : []),
   ])
 
   const widths = headers.map((header, columnIndex) => {
@@ -1468,6 +1505,36 @@ export const summarizeSolverResults = (
       ? null
       : viaCounts.reduce((sum, viaCount) => sum + viaCount, 0) /
         viaCounts.length
+  const networkMetrics = results.flatMap((result) =>
+    result.routingMetrics?.networkedHighDensity
+      ? [result.routingMetrics.networkedHighDensity]
+      : [],
+  )
+  const networkCache =
+    networkMetrics.length === 0
+      ? undefined
+      : {
+          remoteRequests: networkMetrics.reduce(
+            (sum, metrics) => sum + metrics.remoteRequestsStarted,
+            0,
+          ),
+          cacheHits: networkMetrics.reduce(
+            (sum, metrics) => sum + metrics.remoteCacheHits,
+            0,
+          ),
+          solverResults: networkMetrics.reduce(
+            (sum, metrics) => sum + metrics.remoteSolverResults,
+            0,
+          ),
+          batchCacheMisses: networkMetrics.reduce(
+            (sum, metrics) => sum + metrics.remoteBatchCacheMisses,
+            0,
+          ),
+          localFallbacks: networkMetrics.reduce(
+            (sum, metrics) => sum + metrics.remoteTransportFallbacks,
+            0,
+          ),
+        }
 
   return {
     solverName,
@@ -1489,12 +1556,110 @@ export const summarizeSolverResults = (
     p90TimeMs: getPercentileMs(elapsedForSolvedAndTimedOut, 0.9),
     p95TimeMs: getPercentileMs(elapsedForSolvedAndTimedOut, 0.95),
     avgVia,
+    networkCache,
   } satisfies SolverRunSummary
+}
+
+export const validateNetworkedColdPassReadyForHot = (
+  results: WorkerResult[],
+): void => {
+  const coldResults = results.filter(
+    (result) => result.solverName === NETWORKED_PIPELINE9_COLD_NAME,
+  )
+  if (coldResults.length === 0) {
+    throw new Error("Pipeline9_Networked cold pass produced no results")
+  }
+  const incompleteColdResults = coldResults.filter(
+    (result) =>
+      result.didTimeout || !result.routingMetrics?.networkedHighDensity,
+  )
+  if (incompleteColdResults.length > 0) {
+    throw new Error(
+      `Pipeline9_Networked cannot start hot pass because ${incompleteColdResults.length} cold task(s) timed out, crashed, or did not drain remote requests`,
+    )
+  }
+  const coldMetrics = coldResults.map(
+    (result) => result.routingMetrics!.networkedHighDensity!,
+  )
+  const localFallbacks = coldMetrics.reduce(
+    (sum, metrics) => sum + metrics.remoteTransportFallbacks,
+    0,
+  )
+  if (localFallbacks > 0) {
+    throw new Error(
+      `Pipeline9_Networked cold pass used ${localFallbacks} local transport fallback(s)`,
+    )
+  }
+
+  const coldRequests = coldMetrics.reduce(
+    (sum, metrics) => sum + metrics.remoteRequestsStarted,
+    0,
+  )
+  const coldSolverResults = coldMetrics.reduce(
+    (sum, metrics) => sum + metrics.remoteSolverResults,
+    0,
+  )
+  if (coldRequests > 0 && coldSolverResults === 0) {
+    throw new Error(
+      "Pipeline9_Networked cold pass did not produce any remote solver results",
+    )
+  }
+}
+
+export const validateNetworkedColdHotResults = (
+  results: WorkerResult[],
+): void => {
+  validateNetworkedColdPassReadyForHot(results)
+  const coldResultCount = results.filter(
+    (result) => result.solverName === NETWORKED_PIPELINE9_COLD_NAME,
+  ).length
+  const hotResults = results.filter(
+    (result) => result.solverName === NETWORKED_PIPELINE9_HOT_NAME,
+  )
+  const incompleteHotResults = hotResults.filter(
+    (result) =>
+      result.didTimeout || !result.routingMetrics?.networkedHighDensity,
+  )
+  if (
+    hotResults.length !== coldResultCount ||
+    incompleteHotResults.length > 0
+  ) {
+    throw new Error(
+      `Pipeline9_Networked hot pass completed ${hotResults.length - incompleteHotResults.length}/${coldResultCount} drained task(s)`,
+    )
+  }
+  const hotMetrics = hotResults.map(
+    (result) => result.routingMetrics!.networkedHighDensity!,
+  )
+  const localFallbacks = hotMetrics.reduce(
+    (sum, metrics) => sum + metrics.remoteTransportFallbacks,
+    0,
+  )
+  if (localFallbacks > 0) {
+    throw new Error(
+      `Pipeline9_Networked hot pass used ${localFallbacks} local transport fallback(s)`,
+    )
+  }
+
+  const hotRequests = hotMetrics.reduce(
+    (sum, metrics) => sum + metrics.remoteRequestsStarted,
+    0,
+  )
+  const hotCacheHits = hotMetrics.reduce(
+    (sum, metrics) => sum + metrics.remoteCacheHits,
+    0,
+  )
+  if (hotRequests !== hotCacheHits) {
+    throw new Error(
+      `Pipeline9_Networked hot pass returned ${hotCacheHits}/${hotRequests} remote cache hits`,
+    )
+  }
 }
 
 const main = async () => {
   const {
     solverName,
+    networkedColdHot,
     scenarioLimit,
     sampleNumbers,
     concurrency,
@@ -1505,6 +1670,16 @@ const main = async () => {
   } = parseArgs()
   const availableSolvers = await loadSolverNames(excludeAssignable)
   const solvers = solverName ? [solverName] : [DEFAULT_BENCHMARK_SOLVER_NAME]
+
+  if (
+    networkedColdHot &&
+    (solverName !== NETWORKED_PIPELINE9_SOLVER_NAME ||
+      (effort !== undefined && effort !== 1))
+  ) {
+    throw new Error(
+      "--networked-cold-hot requires AutoroutingPipelineSolver9_Networked at effort=1",
+    )
+  }
 
   if (solverName && !availableSolvers.includes(solverName)) {
     throw new Error(
@@ -1548,38 +1723,102 @@ const main = async () => {
     throw new Error(`No benchmark scenarios found for dataset "${datasetName}"`)
   }
 
-  const tasks: BenchmarkTask[] = solvers.flatMap((solver) =>
-    scenarios.map(
-      ({ scenarioName, sampleNumber, scenario }) =>
-        ({
-          datasetName,
-          solverName: solver,
-          scenarioName,
-          sampleNumber,
-          scenario,
-        }) satisfies BenchmarkTask,
-    ),
-  )
+  const solverRuns: Array<{
+    displayName: string
+    constructorName: string
+    networkedCachePass?: "cold" | "hot"
+  }> = networkedColdHot
+    ? [
+        {
+          displayName: NETWORKED_PIPELINE9_COLD_NAME,
+          constructorName: NETWORKED_PIPELINE9_SOLVER_NAME,
+          networkedCachePass: "cold",
+        },
+        {
+          displayName: NETWORKED_PIPELINE9_HOT_NAME,
+          constructorName: NETWORKED_PIPELINE9_SOLVER_NAME,
+          networkedCachePass: "hot",
+        },
+      ]
+    : solvers.map((solver) => ({
+        displayName: solver,
+        constructorName: solver,
+      }))
+  const taskGroups: BenchmarkTask[][] = networkedColdHot
+    ? solverRuns.map((solverRun) =>
+        scenarios.map(
+          ({ scenarioName, sampleNumber, scenario }) =>
+            ({
+              datasetName,
+              solverName: solverRun.displayName,
+              solverConstructorName: solverRun.constructorName,
+              networkedCachePass: solverRun.networkedCachePass,
+              scenarioName,
+              sampleNumber,
+              scenario,
+            }) satisfies BenchmarkTask,
+        ),
+      )
+    : [
+        solverRuns.flatMap((solverRun) =>
+          scenarios.map(
+            ({ scenarioName, sampleNumber, scenario }) =>
+              ({
+                datasetName,
+                solverName: solverRun.displayName,
+                solverConstructorName: solverRun.constructorName,
+                scenarioName,
+                sampleNumber,
+                scenario,
+              }) satisfies BenchmarkTask,
+          ),
+        ),
+      ]
+  const tasks = taskGroups.flat()
 
   console.log(
-    `Running ${tasks.length} benchmark tasks across ${concurrency} workers (${solvers.length} solver${solvers.length === 1 ? "" : "s"}, ${scenarios.length} scenario${scenarios.length === 1 ? "" : "s"}, dataset: ${datasetName})`,
+    `Running ${tasks.length} benchmark tasks across ${concurrency} workers (${solverRuns.length} solver run${solverRuns.length === 1 ? "" : "s"}, ${scenarios.length} scenario${scenarios.length === 1 ? "" : "s"}, dataset: ${datasetName})`,
   )
 
   const snapshotWriter = await createBenchmarkSnapshotWriter(
     BENCHMARK_SNAPSHOTS_HTML_PATH,
   )
-  let results: WorkerResult[]
+  const networkedCachePropagationDelayMs = networkedColdHot
+    ? parseNetworkedCachePropagationDelayMs()
+    : 0
+  const results: WorkerResult[] = []
   try {
-    results = await runBenchmarkTasks(tasks, concurrency, sampleTimeoutMs, {
-      onBenchmarkSnapshot: snapshotWriter.writeSnapshot,
-    })
+    for (const [groupIndex, taskGroup] of taskGroups.entries()) {
+      if (networkedColdHot) {
+        console.log(
+          `[benchmark] Starting Pipeline9_Networked ${groupIndex === 0 ? "cold" : "hot"} pass`,
+        )
+      }
+      results.push(
+        ...(await runBenchmarkTasks(taskGroup, concurrency, sampleTimeoutMs, {
+          onBenchmarkSnapshot: snapshotWriter.writeSnapshot,
+        })),
+      )
+      if (networkedColdHot && groupIndex === 0) {
+        validateNetworkedColdPassReadyForHot(results)
+        if (networkedCachePropagationDelayMs > 0) {
+          console.log(
+            `[benchmark] Waiting ${networkedCachePropagationDelayMs}ms for Workers KV propagation before the hot pass`,
+          )
+          await new Promise((resolve) =>
+            setTimeout(resolve, networkedCachePropagationDelayMs),
+          )
+        }
+      }
+    }
   } finally {
     await snapshotWriter.finish()
   }
-  const rows = solvers.map((solver) =>
+  if (networkedColdHot) validateNetworkedColdHotResults(results)
+  const rows = solverRuns.map((solverRun) =>
     summarizeSolverResults(
-      solver,
-      results.filter((result) => result.solverName === solver),
+      solverRun.displayName,
+      results.filter((result) => result.solverName === solverRun.displayName),
     ),
   )
 
@@ -1587,7 +1826,8 @@ const main = async () => {
     scenarios.map(({ scenario }) =>
       getTaskEffort({
         datasetName,
-        solverName: solvers[0] ?? "",
+        solverName: solverRuns[0]?.displayName ?? "",
+        solverConstructorName: solverRuns[0]?.constructorName,
         scenarioName: "",
         sampleNumber: 0,
         scenario,

--- a/scripts/benchmark/pr-benchmark-command.js
+++ b/scripts/benchmark/pr-benchmark-command.js
@@ -82,6 +82,13 @@ export const parsePrBenchmarkCommand = (body) => {
   const isProfile = /^\/profile(?:\s|$)/.test(command)
   if (isProfile) {
     const parsedArgs = splitShellArgs(command.slice("/profile".length).trim())
+    const usesNetworkedPipeline9 = parsedArgs.some(
+      (arg, index) =>
+        arg === "--pipeline" && parsedArgs[index + 1]?.toLowerCase() === "9net",
+    )
+    if (usesNetworkedPipeline9) {
+      throw new Error("Pipeline 9net is only supported by /benchmark")
+    }
     let datasetName = "dataset01"
 
     for (let index = 0; index < parsedArgs.length; index += 1) {
@@ -121,9 +128,16 @@ export const parsePrBenchmarkCommand = (body) => {
   let datasetName = "dataset01"
   let profileSolvers = false
   let sameMachineCompare = false
+  let usesNetworkedPipeline9 = false
 
   for (let index = 0; index < parsedArgs.length; index += 1) {
     const arg = parsedArgs[index]
+    if (
+      arg === "--pipeline" &&
+      parsedArgs[index + 1]?.toLowerCase() === "9net"
+    ) {
+      usesNetworkedPipeline9 = true
+    }
     if (arg === "--same-machine") {
       sameMachineCompare = true
       continue
@@ -141,6 +155,13 @@ export const parsePrBenchmarkCommand = (body) => {
       if (parsedArgs[index + 1]) datasetName = parsedArgs[index + 1]
     }
     benchmarkArgs.push(arg)
+  }
+
+  if (usesNetworkedPipeline9 && sameMachineCompare) {
+    throw new Error("Pipeline 9net does not support --same-machine")
+  }
+  if (usesNetworkedPipeline9 && profileSolvers) {
+    throw new Error("Pipeline 9net does not support --profile-solvers")
   }
 
   return {

--- a/tests/benchmark-networked-cold-hot-comparison.test.ts
+++ b/tests/benchmark-networked-cold-hot-comparison.test.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "bun:test"
+import type { BenchmarkReport } from "../scripts/benchmark/benchmark-types"
+import {
+  isNetworkedColdHotReport,
+  renderBenchmarkComparison,
+} from "../scripts/benchmark/benchmark-comment-comparison.js"
+
+test("networked benchmark comments compare the cold and hot passes", () => {
+  const report: BenchmarkReport = {
+    version: 1,
+    datasetName: "srj18",
+    scenarioCount: 1,
+    effortLabel: "1x effort",
+    summary: [
+      {
+        solverName: "Pipeline9_Networked Cold",
+        completedRateLabel: "100.0%",
+        relaxedDrcRateLabel: "100.0%",
+        timedOutLabel: "0/1",
+        p50TimeMs: 4_000,
+        p95TimeMs: 4_000,
+        avgVia: 2,
+        networkCache: {
+          remoteRequests: 3,
+          cacheHits: 0,
+          solverResults: 3,
+          batchCacheMisses: 3,
+          localFallbacks: 0,
+        },
+      },
+      {
+        solverName: "Pipeline9_Networked Hot",
+        completedRateLabel: "100.0%",
+        relaxedDrcRateLabel: "100.0%",
+        timedOutLabel: "0/1",
+        p50TimeMs: 1_000,
+        p95TimeMs: 1_000,
+        avgVia: 2,
+        networkCache: {
+          remoteRequests: 3,
+          cacheHits: 3,
+          solverResults: 0,
+          batchCacheMisses: 0,
+          localFallbacks: 0,
+        },
+      },
+    ],
+    solverFailureSummary: [],
+    timeoutSummary: [],
+    failureSummary: [],
+    snapshots: [],
+    tests: [
+      {
+        solverName: "Pipeline9_Networked Cold",
+        scenarioName: "sample001",
+        sampleNumber: 1,
+        elapsedTimeMs: 4_000,
+        didSolve: true,
+        didTimeout: false,
+        relaxedDrcPassed: true,
+        viaCount: 2,
+        drcErrorCount: 0,
+      },
+      {
+        solverName: "Pipeline9_Networked Hot",
+        scenarioName: "sample001",
+        sampleNumber: 1,
+        elapsedTimeMs: 1_000,
+        didSolve: true,
+        didTimeout: false,
+        relaxedDrcPassed: true,
+        viaCount: 2,
+        drcErrorCount: 0,
+      },
+    ],
+  }
+
+  expect(isNetworkedColdHotReport(report)).toBe(true)
+  expect(
+    renderBenchmarkComparison({ mainReport: null, prReport: report }).join(
+      "\n",
+    ),
+  ).toContain(`| P95 time | 4.0s | 1.0s | -75.0% |
+| Average vias | 2.00 | 2.00 | 0.0% |
+| HD cache hits | 0/3 | 3/3 | +3 |
+| HD solver results | 3 | 0 | -3 |
+| HD local fallbacks | 0 | 0 | 0 |`)
+  expect(
+    renderBenchmarkComparison({ mainReport: null, prReport: report }).join(
+      "\n",
+    ),
+  ).toContain("an unmeasured Workers KV propagation interval")
+})

--- a/tests/benchmark-networked-cold-hot-validation.test.ts
+++ b/tests/benchmark-networked-cold-hot-validation.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "bun:test"
+import type { WorkerResult } from "../scripts/benchmark/benchmark-types"
+import {
+  DEFAULT_NETWORKED_CACHE_PROPAGATION_DELAY_MS,
+  parseNetworkedCachePropagationDelayMs,
+  validateNetworkedColdHotResults,
+  validateNetworkedColdPassReadyForHot,
+} from "../scripts/benchmark/index"
+
+test("networked cold-hot validation requires a fresh cold solve and complete hot hits", () => {
+  const createResult = (
+    solverName: string,
+    cacheHits: number,
+    solverResults: number,
+  ): WorkerResult => ({
+    solverName,
+    scenarioName: "sample001",
+    sampleNumber: 1,
+    elapsedTimeMs: 100,
+    didSolve: true,
+    didTimeout: false,
+    relaxedDrcPassed: true,
+    routingMetrics: {
+      networkedHighDensity: {
+        remoteRequestsStarted: 3,
+        remoteRequestsCompleted: 3,
+        remoteBatchCacheMisses: solverResults,
+        remoteSingleRequestsStarted: solverResults,
+        remoteCacheHits: cacheHits,
+        remoteSolverResults: solverResults,
+        remoteTransportFallbacks: 0,
+      },
+    },
+  })
+  const cold = createResult("Pipeline9_Networked Cold", 0, 3)
+  const hot = createResult("Pipeline9_Networked Hot", 3, 0)
+
+  expect(() => validateNetworkedColdHotResults([cold, hot])).not.toThrow()
+  expect(() =>
+    validateNetworkedColdHotResults([
+      cold,
+      createResult("Pipeline9_Networked Hot", 2, 1),
+    ]),
+  ).toThrow("hot pass returned 2/3 remote cache hits")
+  expect(() =>
+    validateNetworkedColdPassReadyForHot([
+      {
+        ...cold,
+        didTimeout: true,
+        routingMetrics: undefined,
+      },
+    ]),
+  ).toThrow("cannot start hot pass")
+  expect(() =>
+    validateNetworkedColdHotResults([
+      cold,
+      { ...hot, didTimeout: true, routingMetrics: undefined },
+    ]),
+  ).toThrow("hot pass completed 0/1 drained task(s)")
+  expect(parseNetworkedCachePropagationDelayMs(undefined)).toBe(
+    DEFAULT_NETWORKED_CACHE_PROPAGATION_DELAY_MS,
+  )
+  expect(parseNetworkedCachePropagationDelayMs("0")).toBe(0)
+  expect(() => parseNetworkedCachePropagationDelayMs("1.5")).toThrow(
+    "must be a non-negative integer",
+  )
+})

--- a/tests/features/pipeline9-networked-cache-version-http.test.ts
+++ b/tests/features/pipeline9-networked-cache-version-http.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "bun:test"
+import { ExampleHdCache2Server } from "tests/fixtures/example-hd-cache2-server"
+import {
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+  solveNetworkedHighDensitySolver,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9 networked propagates and validates a benchmark cache version", async () => {
+  const cacheVersion = "benchmark-123-456-1"
+  const server = new ExampleHdCache2Server()
+
+  try {
+    const solver = createNetworkedHighDensitySolver({
+      nodes: [
+        createNetworkedNode({
+          nodeId: "cache_version_node",
+          connectionName: "cache_version_connection",
+        }),
+      ],
+      hdCache2ServerUrl: server.url,
+      hdCache2CacheVersion: cacheVersion,
+    })
+    await solveNetworkedHighDensitySolver(solver)
+
+    expect(solver.solved).toBe(true)
+    expect(server.batchRequests).toHaveLength(1)
+    expect(server.solveRequests).toHaveLength(1)
+    for (const request of server.requests) {
+      expect(request.body).toMatchObject({ cacheVersion })
+    }
+  } finally {
+    await server.close()
+  }
+
+  const mismatchedServer = new ExampleHdCache2Server({
+    batchItemMode: "solve",
+    mapBatchLine: (line) => ({ ...line, cacheVersion: "wrong-version" }),
+  })
+  try {
+    const solver = createNetworkedHighDensitySolver({
+      nodes: [
+        createNetworkedNode({
+          nodeId: "mismatched_cache_version_node",
+          connectionName: "mismatched_cache_version_connection",
+        }),
+      ],
+      hdCache2ServerUrl: mismatchedServer.url,
+      hdCache2CacheVersion: cacheVersion,
+    })
+    await solveNetworkedHighDensitySolver(solver)
+
+    expect(solver.solved).toBe(true)
+    expect(solver.stats.remoteTransportFallbacks).toBe(1)
+    expect(solver.stats.remoteFallbackReasonCounts).toEqual({
+      cache_version_mismatch: 1,
+    })
+  } finally {
+    await mismatchedServer.close()
+  }
+})

--- a/tests/features/pipeline9-networked-concurrent-logical-deadline-http.test.ts
+++ b/tests/features/pipeline9-networked-concurrent-logical-deadline-http.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "bun:test"
+import { ExampleHdCache2Server } from "tests/fixtures/example-hd-cache2-server"
+import {
+  createDeferred,
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+  solveNetworkedHighDensitySolver,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("concurrent remote solves share their request-launch logical deadline", async () => {
+  const allRequestsStarted = createDeferred<void>()
+  const releaseSolves = createDeferred<void>()
+  let startedRequestCount = 0
+  const server = new ExampleHdCache2Server({
+    beforeSolve: async () => {
+      startedRequestCount += 1
+      if (startedRequestCount === 3) allRequestsStarted.resolve()
+      await releaseSolves.promise
+    },
+  })
+  try {
+    const nodes = [
+      createNetworkedNode({
+        nodeId: "cmn_deadline_1",
+        connectionName: "deadline_1",
+        xOffset: -10,
+      }),
+      createNetworkedNode({
+        nodeId: "cmn_deadline_2",
+        connectionName: "deadline_2",
+      }),
+      createNetworkedNode({
+        nodeId: "cmn_deadline_3",
+        connectionName: "deadline_3",
+        xOffset: 10,
+      }),
+    ]
+    const solver = createNetworkedHighDensitySolver({
+      nodes,
+      hdCache2ServerUrl: server.url,
+      requestTimeoutMs: 100,
+    })
+
+    const solvePromise = solveNetworkedHighDensitySolver(solver)
+    await allRequestsStarted.promise
+    await Bun.sleep(150)
+    releaseSolves.resolve()
+    await solvePromise
+
+    expect(solver.solved).toBeTrue()
+    expect(solver.routes).toHaveLength(3)
+    expect(solver.stats.remoteLogicalTimeoutFallbacks).toBe(3)
+    expect(solver.stats.remoteTransportFallbacks).toBe(3)
+    expect(server.solveRequests).toHaveLength(3)
+  } finally {
+    releaseSolves.resolve()
+    await server.close()
+  }
+})

--- a/tests/features/pipeline9-networked-corrupted-version-http.test.ts
+++ b/tests/features/pipeline9-networked-corrupted-version-http.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "bun:test"
+import { ExampleHdCache2Server } from "tests/fixtures/example-hd-cache2-server"
+import {
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+  solveNetworkedHighDensitySolver,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9_Networked rejects a corrupted real server result per node", async () => {
+  const nodes = [
+    createNetworkedNode({
+      nodeId: "cmn_valid_http",
+      connectionName: "valid_http",
+      xOffset: -5,
+    }),
+    createNetworkedNode({
+      nodeId: "cmn_corrupt_http",
+      connectionName: "corrupt_http",
+      xOffset: 5,
+    }),
+  ]
+  const server = new ExampleHdCache2Server({
+    batchItemMode: "solve",
+    mapBatchLine: (line, item) =>
+      item.input.nodeWithPortPoints.capacityMeshNodeId === "cmn_corrupt_http"
+        ? { ...line, autorouterVersion: "corrupted-version" }
+        : line,
+  })
+  try {
+    const solver = createNetworkedHighDensitySolver({
+      nodes,
+      hdCache2ServerUrl: server.url,
+    })
+
+    await solveNetworkedHighDensitySolver(solver)
+
+    expect(solver.solved).toBeTrue()
+    expect(solver.routes).toHaveLength(2)
+    expect(solver.stats.remoteTransportFallbacks).toBe(1)
+    expect(server.batchRequests).toHaveLength(1)
+  } finally {
+    await server.close()
+  }
+})

--- a/tests/features/pipeline9-networked-degenerate-route-http.test.ts
+++ b/tests/features/pipeline9-networked-degenerate-route-http.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test"
+import { ExampleHdCache2Server } from "tests/fixtures/example-hd-cache2-server"
+import {
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+  solveNetworkedHighDensitySolver,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9_Networked rejects a route that returns to the same terminal", async () => {
+  const node = createNetworkedNode({
+    nodeId: "cmn_degenerate_route_http",
+    connectionName: "degenerate_route_http",
+  })
+  node.portPointsInPairs = [[node.portPoints[0]!, node.portPoints[1]!]]
+  const server = new ExampleHdCache2Server({
+    batchItemMode: "solve",
+    mapBatchLine: (line) => ({
+      ...line,
+      routes: Array.isArray(line.routes)
+        ? line.routes.map((route) => {
+            const typedRoute = route as {
+              route: Array<Record<string, unknown>>
+            }
+            return {
+              ...(route as Record<string, unknown>),
+              route: [typedRoute.route[0], typedRoute.route[0]],
+            }
+          })
+        : line.routes,
+    }),
+  })
+  try {
+    const solver = createNetworkedHighDensitySolver({
+      nodes: [node],
+      hdCache2ServerUrl: server.url,
+    })
+
+    await solveNetworkedHighDensitySolver(solver)
+
+    expect(solver.solved).toBeTrue()
+    expect(solver.routes[0]!.route[0]).toMatchObject({ x: -2, y: 0, z: 0 })
+    expect(solver.routes[0]!.route.at(-1)).toMatchObject({ x: 2, y: 0, z: 0 })
+    expect(solver.stats.remoteFallbackReasonCounts).toEqual({
+      invalid_response: 1,
+    })
+  } finally {
+    await server.close()
+  }
+})

--- a/tests/features/pipeline9-networked-direct-batch-solve.test.ts
+++ b/tests/features/pipeline9-networked-direct-batch-solve.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "bun:test"
+import { ExampleHdCache2Server } from "tests/fixtures/example-hd-cache2-server"
+import {
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+  solveNetworkedHighDensitySolver,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9 accepts direct solver results from the batch endpoint", async () => {
+  const server = new ExampleHdCache2Server({ batchItemMode: "solve" })
+  try {
+    const nodes = [
+      createNetworkedNode({
+        nodeId: "cmn_batch_solve_a",
+        connectionName: "A",
+        xOffset: -5,
+      }),
+      createNetworkedNode({
+        nodeId: "cmn_batch_solve_b",
+        connectionName: "B",
+        xOffset: 5,
+      }),
+    ]
+    const solver = createNetworkedHighDensitySolver({
+      nodes,
+      hdCache2ServerUrl: server.url,
+    })
+
+    await solveNetworkedHighDensitySolver(solver)
+
+    expect(solver.solved).toBeTrue()
+    expect(server.batchRequests).toHaveLength(1)
+    expect(server.solveRequests).toHaveLength(0)
+    expect(solver.routes.map(({ connectionName }) => connectionName)).toEqual([
+      "B",
+      "A",
+    ])
+    expect(solver.stats).toMatchObject({
+      remoteRequestsStarted: 2,
+      remoteRequestsCompleted: 2,
+      remoteBatchRequestsStarted: 1,
+      remoteBatchCacheMisses: 0,
+      remoteSingleRequestsStarted: 0,
+      remoteSolverResults: 2,
+      remoteTransportFallbacks: 0,
+    })
+  } finally {
+    await server.close()
+  }
+})

--- a/tests/features/pipeline9-networked-disabled-regional-policy.test.ts
+++ b/tests/features/pipeline9-networked-disabled-regional-policy.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { Pipeline9HighDensitySolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-high-density-solver"
+import type { NodeWithPortPoints } from "lib/types/high-density-types"
+import { ExampleHdCache2Server } from "tests/fixtures/example-hd-cache2-server"
+import {
+  createNetworkedHighDensitySolver,
+  solveNetworkedHighDensitySolver,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9 networked respects disabled regional fallback over HTTP", async () => {
+  const portPoints = [
+    { x: -1, y: 0, z: 0, connectionName: "horizontal" },
+    { x: 1, y: 0, z: 0, connectionName: "horizontal" },
+    { x: 0, y: -1, z: 0, connectionName: "vertical" },
+    { x: 0, y: 1, z: 0, connectionName: "vertical" },
+  ]
+  const node: NodeWithPortPoints = {
+    capacityMeshNodeId: "cmn_disabled_terminal_regional",
+    center: { x: 0, y: 0 },
+    width: 2,
+    height: 2,
+    availableZ: [0],
+    portPoints,
+    portPointsInPairs: [
+      [portPoints[0]!, portPoints[1]!],
+      [portPoints[2]!, portPoints[3]!],
+    ],
+  }
+  const connMap = new ConnectivityMap({
+    horizontal: ["horizontal"],
+    vertical: ["vertical"],
+  })
+  const localSolver = new Pipeline9HighDensitySolver({
+    nodePortPoints: [node],
+    fixedHdRoutes: [],
+    connMap,
+    colorMap: {},
+    obstacles: [],
+    layerCount: 2,
+    viaDiameter: 0.3,
+    traceWidth: 0.1,
+    obstacleMargin: 0.15,
+    effort: 1,
+    nodePfById: { cmn_disabled_terminal_regional: 0.1 },
+    enableRegionalFallback: false,
+  })
+  localSolver.solve()
+  const server = new ExampleHdCache2Server({ batchItemMode: "solve" })
+  try {
+    const networkedSolver = createNetworkedHighDensitySolver({
+      nodes: [node],
+      hdCache2ServerUrl: server.url,
+      enableRegionalFallback: false,
+      traceWidth: 0.1,
+    })
+    await solveNetworkedHighDensitySolver(networkedSolver)
+
+    expect(localSolver.failed).toBeTrue()
+    expect(networkedSolver.failed).toBeTrue()
+    expect(networkedSolver.error).toBe(localSolver.error)
+    expect(networkedSolver.stats).toMatchObject({
+      remoteOrdinaryResults: 1,
+      remoteTransportFallbacks: 0,
+    })
+  } finally {
+    await server.close()
+  }
+})

--- a/tests/features/pipeline9-networked-empty-routes-http.test.ts
+++ b/tests/features/pipeline9-networked-empty-routes-http.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test"
+import { ExampleHdCache2Server } from "tests/fixtures/example-hd-cache2-server"
+import {
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+  solveNetworkedHighDensitySolver,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9_Networked rejects an empty solved route set", async () => {
+  const node = createNetworkedNode({
+    nodeId: "cmn_empty_routes_http",
+    connectionName: "empty_routes_http",
+  })
+  const server = new ExampleHdCache2Server({
+    batchItemMode: "solve",
+    mapBatchLine: (line) => {
+      expect(line.status).toBe("solved")
+      expect(line.routes).toHaveLength(1)
+      return { ...line, status: "solved", routes: [] }
+    },
+  })
+  try {
+    const solver = createNetworkedHighDensitySolver({
+      nodes: [node],
+      hdCache2ServerUrl: server.url,
+    })
+
+    await solveNetworkedHighDensitySolver(solver)
+
+    expect(solver.solved).toBeTrue()
+    expect(solver.routes).toHaveLength(1)
+    expect(solver.stats.remoteTransportFallbacks).toBe(1)
+    expect(solver.stats.remoteFallbackReasonCounts).toEqual({
+      invalid_response: 1,
+    })
+  } finally {
+    await server.close()
+  }
+})

--- a/tests/features/pipeline9-networked-example-server.test.ts
+++ b/tests/features/pipeline9-networked-example-server.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "bun:test"
+import type {
+  Pipeline9NetworkedSolveBatchRequest,
+  Pipeline9NetworkedSolveRequest,
+} from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-types"
+import { ExampleHdCache2Server } from "tests/fixtures/example-hd-cache2-server"
+import {
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+  solveNetworkedHighDensitySolver,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9 uses the no-cache example server and preserves route metadata", async () => {
+  const server = new ExampleHdCache2Server()
+  try {
+    const node = createNetworkedNode({
+      nodeId: "cmn_example_server",
+      connectionName: "A",
+    })
+    const solver = createNetworkedHighDensitySolver({
+      nodes: [node],
+      hdCache2ServerUrl: server.url,
+    })
+
+    await solveNetworkedHighDensitySolver(solver)
+
+    expect(solver.solved).toBeTrue()
+    expect(solver.failed).toBeFalse()
+    expect(server.batchRequests).toHaveLength(1)
+    expect(server.solveRequests).toHaveLength(1)
+
+    const batchRequest = server.batchRequests[0]!
+      .body as Pipeline9NetworkedSolveBatchRequest
+    const solveRequest = server.solveRequests[0]!
+      .body as Pipeline9NetworkedSolveRequest
+    expect(batchRequest.items).toHaveLength(1)
+    expect(
+      batchRequest.items[0]!.input.nodeWithPortPoints.capacityMeshNodeId,
+    ).toBe(node.capacityMeshNodeId)
+    expect(solveRequest.input).toEqual(batchRequest.items[0]!.input)
+    expect(solveRequest.input).toMatchObject({
+      effort: 1,
+      nodeWithPortPoints: { capacityMeshNodeId: node.capacityMeshNodeId },
+    })
+
+    expect(solver.routes).toHaveLength(1)
+    expect(solver.routes[0]).toMatchObject({
+      connectionName: "A",
+      rootConnectionName: "root_A",
+      startPcbPortId: "cmn_example_server_start",
+      endPcbPortId: "cmn_example_server_end",
+      traceThickness: 0.15,
+      viaDiameter: 0.3,
+    })
+    expect(solver.routes[0]!.route[0]).toMatchObject({ x: -2, y: 0, z: 0 })
+    expect(solver.routes[0]!.route.at(-1)).toMatchObject({ x: 2, y: 0, z: 0 })
+    expect(solver.stats).toMatchObject({
+      remoteBatchCacheMisses: 1,
+      remoteSingleRequestsStarted: 1,
+      remoteSolverResults: 1,
+      remoteSolvedResults: 1,
+      remoteOrdinaryResults: 1,
+      remoteTransportFallbacks: 0,
+    })
+  } finally {
+    await server.close()
+  }
+})

--- a/tests/features/pipeline9-networked-fixed-copper-http.test.ts
+++ b/tests/features/pipeline9-networked-fixed-copper-http.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "bun:test"
+import { ExampleHdCache2Server } from "tests/fixtures/example-hd-cache2-server"
+import {
+  createDeferred,
+  createNetworkedFixedRoute,
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("a speculative HTTP request never blocks a fixed-copper B01 node", async () => {
+  const requestStarted = createDeferred<void>()
+  const releaseSolve = createDeferred<void>()
+  const server = new ExampleHdCache2Server({
+    beforeSolve: async () => {
+      requestStarted.resolve()
+      await releaseSolve.promise
+    },
+  })
+  try {
+    const node = createNetworkedNode({
+      nodeId: "cmn_fixed_overlap_http",
+      connectionName: "fixed_overlap_http",
+    })
+    const solver = createNetworkedHighDensitySolver({
+      nodes: [node],
+      fixedHdRoutes: [createNetworkedFixedRoute()],
+      hdCache2ServerUrl: server.url,
+    })
+
+    solver.step()
+    expect(solver.pendingEffects).toEqual([])
+    expect(solver.activeB01Solver).not.toBeNull()
+    const iterationsBefore = solver.activeB01Solver!.iterations
+    solver.step()
+    expect(solver.activeB01Solver!.iterations).toBeGreaterThan(iterationsBefore)
+
+    await requestStarted.promise
+    releaseSolve.resolve()
+  } finally {
+    releaseSolve.resolve()
+    await server.close()
+  }
+})

--- a/tests/features/pipeline9-networked-http-100-item-limit.test.ts
+++ b/tests/features/pipeline9-networked-http-100-item-limit.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test"
+import { HD_CACHE2_MAX_BATCH_BODY_BYTES } from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/hd-cache2-client"
+import type { Pipeline9NetworkedSolveBatchRequest } from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-types"
+import { ExampleHdCache2Server } from "tests/fixtures/example-hd-cache2-server"
+import {
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+  solveNetworkedHighDensitySolver,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9 keeps real HTTP batches within the protocol limits", async () => {
+  const server = new ExampleHdCache2Server({ batchItemMode: "solve" })
+  try {
+    const nodeCount = 101
+    const solver = createNetworkedHighDensitySolver({
+      nodes: Array.from({ length: nodeCount }, (_, index) =>
+        createNetworkedNode({
+          nodeId: `cmn_http_batch_limit_${index}`,
+          connectionName: `connection_${index}`,
+          xOffset: index * 5,
+        }),
+      ),
+      hdCache2ServerUrl: server.url,
+    })
+
+    await solveNetworkedHighDensitySolver(solver)
+
+    const batchItemCounts = server.batchRequests
+      .map(
+        ({ body }) =>
+          (body as Pipeline9NetworkedSolveBatchRequest).items.length,
+      )
+      .sort((left, right) => right - left)
+    expect(batchItemCounts).toEqual([100, 1])
+    expect(
+      server.batchRequests.every(
+        ({ bodyBytes }) => bodyBytes <= HD_CACHE2_MAX_BATCH_BODY_BYTES,
+      ),
+    ).toBeTrue()
+    expect(
+      server.batchRequests.reduce(
+        (itemCount, { body }) =>
+          itemCount +
+          (body as Pipeline9NetworkedSolveBatchRequest).items.length,
+        0,
+      ),
+    ).toBe(nodeCount)
+    expect(solver.stats.remoteBatchItemsStarted).toBe(nodeCount)
+    expect(solver.stats.remoteBatchMaxBodyBytes).toBe(
+      Math.max(...server.batchRequests.map(({ bodyBytes }) => bodyBytes)),
+    )
+    expect(solver.stats.remoteBatchBodyBytesStarted).toBe(
+      server.batchRequests.reduce(
+        (total, { bodyBytes }) => total + bodyBytes,
+        0,
+      ),
+    )
+    expect(server.solveRequests).toHaveLength(0)
+    expect(solver.solved).toBeTrue()
+  } finally {
+    await server.close()
+  }
+})

--- a/tests/features/pipeline9-networked-http-fail-open.test.ts
+++ b/tests/features/pipeline9-networked-http-fail-open.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test"
+import { ExampleHdCache2Server } from "tests/fixtures/example-hd-cache2-server"
+import {
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+  solveNetworkedHighDensitySolver,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9_Networked fails open when the cache server is unavailable", async () => {
+  const server = new ExampleHdCache2Server()
+  const serverUrl = server.url
+  await server.close()
+  const node = createNetworkedNode({
+    nodeId: "cmn_unavailable",
+    connectionName: "unavailable",
+  })
+  const solver = createNetworkedHighDensitySolver({
+    nodes: [node],
+    hdCache2ServerUrl: serverUrl,
+  })
+
+  await solveNetworkedHighDensitySolver(solver)
+
+  expect(solver.solved).toBeTrue()
+  expect(solver.routes).toHaveLength(1)
+  expect(solver.stats.remoteTransportFallbacks).toBe(1)
+})

--- a/tests/features/pipeline9-networked-http-utf8-byte-limit.test.ts
+++ b/tests/features/pipeline9-networked-http-utf8-byte-limit.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "bun:test"
+import { HD_CACHE2_MAX_BATCH_BODY_BYTES } from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/hd-cache2-client"
+import type { Pipeline9NetworkedSolveBatchRequest } from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-types"
+import { ExampleHdCache2Server } from "tests/fixtures/example-hd-cache2-server"
+import {
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+  solveNetworkedHighDensitySolver,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9 splits real HTTP batches by exact UTF-8 body bytes", async () => {
+  const server = new ExampleHdCache2Server({ batchItemMode: "solve" })
+  try {
+    const solver = createNetworkedHighDensitySolver({
+      nodes: Array.from({ length: 20 }, (_, index) =>
+        createNetworkedNode({
+          nodeId: `cmn_http_batch_bytes_${index}`,
+          connectionName: `connection_${index}_${"é".repeat(10_000)}`,
+          xOffset: index * 5,
+        }),
+      ),
+      hdCache2ServerUrl: server.url,
+    })
+
+    await solveNetworkedHighDensitySolver(solver)
+
+    expect(server.batchRequests.length).toBeGreaterThan(1)
+    expect(
+      server.batchRequests.every(
+        ({ bodyBytes }) => bodyBytes <= HD_CACHE2_MAX_BATCH_BODY_BYTES,
+      ),
+    ).toBeTrue()
+    expect(
+      server.batchRequests.reduce(
+        (count, { body }) =>
+          count + (body as Pipeline9NetworkedSolveBatchRequest).items.length,
+        0,
+      ),
+    ).toBe(20)
+    expect(server.solveRequests).toHaveLength(0)
+    expect(solver.solved).toBeTrue()
+  } finally {
+    await server.close()
+  }
+})

--- a/tests/features/pipeline9-networked-layer-transition-http.test.ts
+++ b/tests/features/pipeline9-networked-layer-transition-http.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "bun:test"
+import { ExampleHdCache2Server } from "tests/fixtures/example-hd-cache2-server"
+import {
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+  solveNetworkedHighDensitySolver,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9_Networked rejects layer changes without a via", async () => {
+  const node = createNetworkedNode({
+    nodeId: "cmn_layer_transition_http",
+    connectionName: "layer_transition_http",
+  })
+  const server = new ExampleHdCache2Server({
+    batchItemMode: "solve",
+    mapBatchLine: (line) => ({
+      ...line,
+      routes: Array.isArray(line.routes)
+        ? line.routes.map((route) => {
+            const typedRoute = route as {
+              route: Array<Record<string, unknown>>
+            }
+            const start = typedRoute.route[0]!
+            const end = typedRoute.route.at(-1)!
+            return {
+              ...(route as Record<string, unknown>),
+              route: [start, { ...end, z: 1 }, end],
+              vias: [],
+            }
+          })
+        : line.routes,
+    }),
+  })
+  try {
+    const solver = createNetworkedHighDensitySolver({
+      nodes: [node],
+      hdCache2ServerUrl: server.url,
+    })
+
+    await solveNetworkedHighDensitySolver(solver)
+
+    expect(solver.solved).toBeTrue()
+    expect(solver.routes[0]!.route).toHaveLength(2)
+    expect(solver.stats.remoteFallbackReasonCounts).toEqual({
+      invalid_response: 1,
+    })
+  } finally {
+    await server.close()
+  }
+})

--- a/tests/features/pipeline9-networked-logical-timeout-http.test.ts
+++ b/tests/features/pipeline9-networked-logical-timeout-http.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test"
+import { ExampleHdCache2Server } from "tests/fixtures/example-hd-cache2-server"
+import {
+  createDeferred,
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+  solveNetworkedHighDensitySolver,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9_Networked keeps a timed-out request warming", async () => {
+  const requestStarted = createDeferred<void>()
+  const releaseSolve = createDeferred<void>()
+  const server = new ExampleHdCache2Server({
+    beforeSolve: async () => {
+      requestStarted.resolve()
+      await releaseSolve.promise
+    },
+  })
+  try {
+    const node = createNetworkedNode({
+      nodeId: "cmn_delayed_http",
+      connectionName: "delayed_http",
+    })
+    const solver = createNetworkedHighDensitySolver({
+      nodes: [node],
+      hdCache2ServerUrl: server.url,
+      requestTimeoutMs: 30,
+    })
+
+    const solvePromise = solveNetworkedHighDensitySolver(solver)
+    await requestStarted.promise
+    await solvePromise
+
+    expect(solver.solved).toBeTrue()
+    expect(solver.stats.remoteLogicalTimeoutFallbacks).toBe(1)
+    expect(server.solveRequests[0]?.finishedAt).toBeUndefined()
+
+    releaseSolve.resolve()
+    for (let attempt = 0; attempt < 100; attempt++) {
+      if (server.solveRequests[0]?.finishedAt !== undefined) break
+      await Bun.sleep(5)
+    }
+    expect(server.solveRequests[0]?.finishedAt).toBeNumber()
+  } finally {
+    releaseSolve.resolve()
+    await server.close()
+  }
+})

--- a/tests/features/pipeline9-networked-node-input-projection.test.ts
+++ b/tests/features/pipeline9-networked-node-input-projection.test.ts
@@ -1,0 +1,210 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import {
+  createPipeline9RegularNodeSolver,
+  Pipeline9HighDensitySolver,
+} from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-high-density-solver"
+import { AUTOROUTER_VERSION } from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/autorouter-version"
+import { projectPipeline9OrdinaryHighDensityInput } from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-input-projection"
+import { PIPELINE9_NETWORKED_SOLVE_POLICY } from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-types"
+import type { NodeWithPortPoints } from "lib/types/high-density-types"
+import type { Obstacle } from "lib/types/srj-types"
+import { ExampleHdCache2Server } from "tests/fixtures/example-hd-cache2-server"
+
+test("Pipeline9 projects ordinary node inputs without changing the HTTP solve", async () => {
+  const noiseIds = Array.from({ length: 2_310 }, (_, index) => `noise_${index}`)
+  const node: NodeWithPortPoints = {
+    capacityMeshNodeId: "cmn_projected",
+    center: { x: 0, y: 0 },
+    width: 1,
+    height: 1,
+    availableZ: [0, 1],
+    portPoints: [
+      {
+        x: -0.2,
+        y: 0,
+        z: 0,
+        connectionName: "route_A",
+        rootConnectionName: "root_A",
+        portPointId: "port_point_A0",
+      },
+      {
+        x: 0.2,
+        y: 0,
+        z: 1,
+        connectionName: "route_A",
+        rootConnectionName: "root_A",
+        portPointId: "port_point_A1",
+      },
+    ],
+  }
+  const connectedToWithBoardNoise = ["pcb_pad_A", ...noiseIds]
+  const obstacles: Obstacle[] = [
+    {
+      obstacleId: "near_rotated_through_obstacle",
+      type: "rect",
+      layers: ["top", "bottom"],
+      center: { x: 0, y: 0 },
+      width: 0.6,
+      height: 0.1,
+      ccwRotationDegrees: 90,
+      connectedTo: connectedToWithBoardNoise,
+      circuitJsonMetadata: { pcb_plated_hole_id: "plated_hole_A" },
+    },
+    {
+      obstacleId: "eight_x_envelope_obstacle",
+      type: "rect",
+      layers: ["top", "bottom"],
+      center: { x: 3.9, y: 0 },
+      width: 0.2,
+      height: 0.2,
+      connectedTo: connectedToWithBoardNoise,
+    },
+    {
+      obstacleId: "overlapping_foreign_obstacle",
+      type: "rect",
+      layers: ["top", "bottom"],
+      center: { x: 0, y: 0 },
+      width: 1,
+      height: 1,
+      connectedTo: ["foreign_route"],
+    },
+    {
+      obstacleId: "far_same_net_obstacle",
+      type: "rect",
+      layers: ["top", "bottom"],
+      center: { x: 100, y: 100 },
+      width: 1,
+      height: 1,
+      connectedTo: connectedToWithBoardNoise,
+    },
+  ]
+  const connMap = new ConnectivityMap({
+    original_net_A: [
+      "route_A",
+      "root_A",
+      "pcb_pad_A",
+      "port_point_A0",
+      "port_point_A1",
+      "plated_hole_A",
+    ],
+    original_noise_net: noiseIds,
+    original_foreign_net: ["foreign_route"],
+  })
+  const projection = projectPipeline9OrdinaryHighDensityInput({
+    nodeWithPortPoints: node,
+    connMap,
+    colorMap: { route_A: "blue", foreign_route: "red" },
+    obstacles,
+    obstacleMargin: 0.15,
+    traceWidth: 0.15,
+    viaDiameter: 0.3,
+  })
+
+  expect(projection.obstacles.map((obstacle) => obstacle.center)).toEqual([
+    { x: 0, y: 0 },
+    { x: 3.9, y: 0 },
+  ])
+  expect(projection.obstacles.map((obstacle) => obstacle.connectedTo)).toEqual([
+    ["route_A"],
+    ["route_A"],
+  ])
+  expect(projection.obstacles[0]!.ccwRotationDegrees).toBeUndefined()
+  expect(projection.obstacles[0]!.circuitJsonMetadata).toEqual({
+    pcb_plated_hole_id: "plated_hole_A",
+  })
+  expect(projection.connectivityNetMap).toEqual({
+    original_net_A: [
+      "route_A",
+      "root_A",
+      "port_point_A0",
+      "port_point_A1",
+      "plated_hole_A",
+    ],
+  })
+  expect(projection.colorMap).toEqual({ route_A: "blue" })
+
+  const unprojectedJsonSize = JSON.stringify({
+    node,
+    connectivityNetMap: connMap.netMap,
+    obstacles,
+  }).length
+  const projectedJsonSize = JSON.stringify({ node, ...projection }).length
+  expect(projectedJsonSize).toBeLessThan(unprojectedJsonSize / 20)
+
+  const fullInputSolver = createPipeline9RegularNodeSolver({
+    nodeWithPortPoints: node,
+    connMap,
+    colorMap: { route_A: "blue", foreign_route: "red" },
+    obstacles,
+    layerCount: 2,
+    viaDiameter: 0.3,
+    traceWidth: 0.15,
+    obstacleMargin: 0.15,
+    effort: 1,
+    nodePfById: { cmn_projected: 0.1 },
+  })
+  fullInputSolver.solve()
+  const projectedInput = {
+    solvePolicy: PIPELINE9_NETWORKED_SOLVE_POLICY,
+    enableRegionalFallback: false,
+    nodeWithPortPoints: node,
+    connectivityNetMap: projection.connectivityNetMap,
+    colorMap: projection.colorMap,
+    viaDiameter: 0.3,
+    traceWidth: 0.15,
+    obstacleMargin: 0.15,
+    effort: 1,
+    obstacles: projection.obstacles,
+    regionalObstacles: [],
+    layerCount: 2,
+    nodePf: 0.1,
+  } as const
+  const server = new ExampleHdCache2Server()
+  let projectedResult: Record<string, unknown>
+  try {
+    const response = await fetch(`${server.url}/solve`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        autorouterVersion: AUTOROUTER_VERSION,
+        input: projectedInput,
+      }),
+    })
+    expect(response.status).toBe(200)
+    projectedResult = (await response.json()) as Record<string, unknown>
+  } finally {
+    await server.close()
+  }
+
+  expect(fullInputSolver.solved).toBeTrue()
+  expect(projectedResult).toEqual({
+    ok: true,
+    autorouterVersion: AUTOROUTER_VERSION,
+    source: "solver",
+    status: "solved",
+    solutionStage: "ordinary",
+    routes: fullInputSolver.routes,
+  })
+
+  const localPipeline9Solver = new Pipeline9HighDensitySolver({
+    nodePortPoints: [node],
+    fixedHdRoutes: [],
+    connMap,
+    colorMap: { route_A: "blue", foreign_route: "red" },
+    obstacles,
+    layerCount: 2,
+    viaDiameter: 0.3,
+    traceWidth: 0.15,
+    obstacleMargin: 0.15,
+    effort: 1,
+    nodePfById: { cmn_projected: 0.1 },
+    enableRegionalFallback: false,
+  })
+  localPipeline9Solver.step()
+  // Projection is network-only; baseline Pipeline9 keeps its full local input.
+  expect(localPipeline9Solver.activeRegularSolver?.obstacles).toEqual(obstacles)
+  expect(localPipeline9Solver.activeRegularSolver?.connMap?.netMap).toEqual(
+    connMap.netMap,
+  )
+})

--- a/tests/features/pipeline9-networked-one-point-route-http.test.ts
+++ b/tests/features/pipeline9-networked-one-point-route-http.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "bun:test"
+import { ExampleHdCache2Server } from "tests/fixtures/example-hd-cache2-server"
+import {
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+  solveNetworkedHighDensitySolver,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9_Networked rejects disconnected one-point routes from the server", async () => {
+  const node = createNetworkedNode({
+    nodeId: "cmn_one_point_http",
+    connectionName: "one_point_http",
+  })
+  const server = new ExampleHdCache2Server({
+    batchItemMode: "solve",
+    mapBatchLine: (line) => ({
+      ...line,
+      routes: Array.isArray(line.routes)
+        ? line.routes.map((route) => ({
+            ...(route as Record<string, unknown>),
+            route: [(route as { route: unknown[] }).route[0]],
+          }))
+        : line.routes,
+    }),
+  })
+  try {
+    const solver = createNetworkedHighDensitySolver({
+      nodes: [node],
+      hdCache2ServerUrl: server.url,
+    })
+
+    await solveNetworkedHighDensitySolver(solver)
+
+    expect(solver.solved).toBeTrue()
+    expect(solver.routes[0]!.route).toHaveLength(2)
+    expect(solver.stats.remoteTransportFallbacks).toBe(1)
+    expect(solver.stats.remoteFallbackReasonCounts).toEqual({
+      invalid_response: 1,
+    })
+  } finally {
+    await server.close()
+  }
+})

--- a/tests/features/pipeline9-networked-ordinary-layer-assignment-http.test.ts
+++ b/tests/features/pipeline9-networked-ordinary-layer-assignment-http.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test"
+import { ExampleHdCache2Server } from "tests/fixtures/example-hd-cache2-server"
+import {
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+  solveNetworkedHighDensitySolver,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9_Networked rejects ordinary routes outside assigned layers", async () => {
+  const node = createNetworkedNode({
+    nodeId: "cmn_ordinary_layer_assignment_http",
+    connectionName: "ordinary_layer_assignment_http",
+  })
+  node.availableZ = [0]
+  const server = new ExampleHdCache2Server({
+    batchItemMode: "solve",
+    mapBatchLine: (line) => ({
+      ...line,
+      routes: Array.isArray(line.routes)
+        ? line.routes.map((route) => {
+            const typedRoute = route as {
+              route: Array<Record<string, unknown>>
+            }
+            const start = typedRoute.route[0]!
+            const end = typedRoute.route.at(-1)!
+            return {
+              ...(route as Record<string, unknown>),
+              route: [start, { ...start, z: 1 }, { ...end, z: 1 }, end],
+            }
+          })
+        : line.routes,
+    }),
+  })
+  try {
+    const solver = createNetworkedHighDensitySolver({
+      nodes: [node],
+      hdCache2ServerUrl: server.url,
+    })
+
+    await solveNetworkedHighDensitySolver(solver)
+
+    expect(solver.solved).toBeTrue()
+    expect(
+      solver.routes.flatMap((route) => route.route).every(({ z }) => z === 0),
+    ).toBeTrue()
+    expect(solver.stats.remoteFallbackReasonCounts).toEqual({
+      invalid_response: 1,
+    })
+  } finally {
+    await server.close()
+  }
+})

--- a/tests/features/pipeline9-networked-parallel-http-correlation.test.ts
+++ b/tests/features/pipeline9-networked-parallel-http-correlation.test.ts
@@ -1,0 +1,110 @@
+import { expect, test } from "bun:test"
+import { ExampleHdCache2Server } from "tests/fixtures/example-hd-cache2-server"
+import {
+  createDeferred,
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+  solveNetworkedHighDensitySolver,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+const waitFor = async (
+  condition: () => boolean,
+  message: string,
+): Promise<void> => {
+  const deadline = performance.now() + 5_000
+  while (!condition()) {
+    if (performance.now() >= deadline) throw new Error(message)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+}
+
+test("Pipeline9 correlates parallel single solves after a batch of misses", async () => {
+  const nodes = [
+    createNetworkedNode({
+      nodeId: "cmn_parallel_a",
+      connectionName: "A",
+      xOffset: -10,
+    }),
+    createNetworkedNode({
+      nodeId: "cmn_parallel_b",
+      connectionName: "B",
+    }),
+    createNetworkedNode({
+      nodeId: "cmn_parallel_c",
+      connectionName: "C",
+      xOffset: 10,
+    }),
+  ]
+  const releases = new Map(
+    nodes.map((node) => [node.capacityMeshNodeId, createDeferred<void>()]),
+  )
+  const startOrder: string[] = []
+  const completionOrder: string[] = []
+  const server = new ExampleHdCache2Server({
+    beforeSolve: async ({ input }) => {
+      const nodeId = input.nodeWithPortPoints.capacityMeshNodeId
+      startOrder.push(nodeId)
+      await releases.get(nodeId)!.promise
+    },
+    mapSolveEnvelope: (envelope, { input }) => {
+      completionOrder.push(input.nodeWithPortPoints.capacityMeshNodeId)
+      return envelope
+    },
+  })
+
+  try {
+    const solver = createNetworkedHighDensitySolver({
+      nodes,
+      hdCache2ServerUrl: server.url,
+    })
+
+    solver.step()
+    await waitFor(
+      () => startOrder.length === nodes.length,
+      "the example server did not start every single-node solve",
+    )
+
+    expect(new Set(startOrder)).toEqual(
+      new Set(nodes.map((node) => node.capacityMeshNodeId)),
+    )
+    expect(server.batchRequests).toHaveLength(1)
+    expect(server.solveRequests).toHaveLength(nodes.length)
+    expect(
+      server.solveRequests.every(({ finishedAt }) => !finishedAt),
+    ).toBeTrue()
+
+    const releaseOrder = [nodes[1]!, nodes[2]!, nodes[0]!]
+    for (const [index, node] of releaseOrder.entries()) {
+      releases.get(node.capacityMeshNodeId)!.resolve()
+      await waitFor(
+        () => completionOrder.length === index + 1,
+        `the example server did not finish ${node.capacityMeshNodeId}`,
+      )
+    }
+    await solveNetworkedHighDensitySolver(solver)
+
+    expect(completionOrder).toEqual(
+      releaseOrder.map((node) => node.capacityMeshNodeId),
+    )
+    expect(solver.solved).toBeTrue()
+    expect(solver.routes.map(({ connectionName }) => connectionName)).toEqual([
+      "C",
+      "B",
+      "A",
+    ])
+    expect(
+      solver.routes.map(({ rootConnectionName }) => rootConnectionName),
+    ).toEqual(["root_C", "root_B", "root_A"])
+    expect(solver.stats).toMatchObject({
+      remoteRequestsStarted: 3,
+      remoteRequestsCompleted: 3,
+      remoteBatchCacheMisses: 3,
+      remoteSingleRequestsStarted: 3,
+      remoteSolverResults: 3,
+      remoteTransportFallbacks: 0,
+    })
+  } finally {
+    for (const release of releases.values()) release.resolve()
+    await server.close()
+  }
+})

--- a/tests/features/pipeline9-networked-pipeline-contract.test.ts
+++ b/tests/features/pipeline9-networked-pipeline-contract.test.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "bun:test"
+import {
+  AutoroutingPipelineSolver9_Networked,
+  AutoroutingPipelineSolver9_PreloadedTraceGraph,
+} from "lib"
+import {
+  AutoroutingPipelineSolver9_Networked as NetworkedPipelineFromPipelineIndex,
+  type AutoroutingPipelineSolver9NetworkedOptions,
+} from "lib/autorouter-pipelines"
+import { Pipeline9NetworkedHighDensitySolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-high-density-solver"
+import type { SimpleRouteJson } from "lib/types"
+import { ExampleHdCache2Server } from "tests/fixtures/example-hd-cache2-server"
+
+const emptySrj: SimpleRouteJson = {
+  layerCount: 2,
+  minTraceWidth: 0.15,
+  obstacles: [],
+  connections: [],
+  bounds: { minX: -5, maxX: 5, minY: -5, maxY: 5 },
+}
+
+test("Pipeline9 networked is effort-1-only, async-only, and replaces only the high-density stage", async () => {
+  const server = new ExampleHdCache2Server()
+  try {
+    expect(
+      () =>
+        new AutoroutingPipelineSolver9_Networked(emptySrj, {
+          effort: 2,
+        } as any),
+    ).toThrow("only available at effort=1")
+
+    const networkedSolver = new AutoroutingPipelineSolver9_Networked(emptySrj, {
+      effort: 1,
+      hdCache2ServerUrl: server.url,
+    })
+    const pipelineIndexOptions: AutoroutingPipelineSolver9NetworkedOptions = {
+      effort: 1,
+      hdCache2ServerUrl: server.url,
+    }
+    const customServerSolver = new AutoroutingPipelineSolver9_Networked(
+      emptySrj,
+      pipelineIndexOptions,
+    )
+    const localSolver = new AutoroutingPipelineSolver9_PreloadedTraceGraph(
+      emptySrj,
+    )
+    const highDensityStepIndex = networkedSolver.pipelineDef.findIndex(
+      (step) => step.solverName === "highDensityRouteSolver",
+    )
+
+    expect(networkedSolver.pipelineDef[highDensityStepIndex]!.solverClass).toBe(
+      Pipeline9NetworkedHighDensitySolver,
+    )
+    expect(NetworkedPipelineFromPipelineIndex).toBe(
+      AutoroutingPipelineSolver9_Networked,
+    )
+    expect(pipelineIndexOptions.effort).toBe(1)
+    expect(customServerSolver.hdCache2ServerUrl).toBe(server.url)
+    expect(networkedSolver.getSolverName()).toBe(
+      "AutoroutingPipelineSolver9_Networked",
+    )
+    for (const [stepIndex, step] of networkedSolver.pipelineDef.entries()) {
+      if (stepIndex === highDensityStepIndex) continue
+      expect(step.solverClass).toBe(
+        localSolver.pipelineDef[stepIndex]!.solverClass,
+      )
+    }
+    expect(() => networkedSolver.solve()).toThrow("requires async execution")
+    expect(() => networkedSolver.solveUntilPhase("none")).toThrow(
+      "requires solveUntilPhaseAsync",
+    )
+  } finally {
+    await server.close()
+  }
+})

--- a/tests/features/pipeline9-networked-regional-extra-route-http.test.ts
+++ b/tests/features/pipeline9-networked-regional-extra-route-http.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "bun:test"
+import { ExampleHdCache2Server } from "tests/fixtures/example-hd-cache2-server"
+import {
+  createNetworkedCrossingNode,
+  createNetworkedHighDensitySolver,
+  solveNetworkedHighDensitySolver,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9_Networked rejects an extra uncorrelated regional route", async () => {
+  const node = createNetworkedCrossingNode({
+    nodeId: "cmn_regional_extra_route_http",
+  })
+  const server = new ExampleHdCache2Server({
+    batchItemMode: "solve",
+    mapBatchLine: (line) => {
+      if (!Array.isArray(line.routes) || line.routes.length === 0) return line
+      return {
+        ...line,
+        routes: [
+          ...line.routes,
+          {
+            ...(line.routes[0] as Record<string, unknown>),
+            route: [
+              { x: 1000, y: 1000, z: 0 },
+              { x: 1000, y: 1000, z: 0 },
+            ],
+            vias: [{ x: 1000, y: 1000 }],
+          },
+        ],
+      }
+    },
+  })
+  try {
+    const solver = createNetworkedHighDensitySolver({
+      nodes: [node],
+      hdCache2ServerUrl: server.url,
+      enableRegionalFallback: true,
+      preserveTerminalPcbPortIds: false,
+    })
+
+    await solveNetworkedHighDensitySolver(solver)
+
+    expect(solver.solved).toBeTrue()
+    expect(
+      solver.routes.every((route) => route.route.every(({ x }) => x < 100)),
+    ).toBeTrue()
+    expect(solver.stats.remoteFallbackReasonCounts).toEqual({
+      invalid_response: 1,
+    })
+  } finally {
+    await server.close()
+  }
+})

--- a/tests/features/pipeline9-networked-regional-fixed-copper-deferral-http.test.ts
+++ b/tests/features/pipeline9-networked-regional-fixed-copper-deferral-http.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "bun:test"
+import type { PreloadedHighDensityRoute } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/convert-preloaded-traces-to-hd-routes"
+import { ExampleHdCache2Server } from "tests/fixtures/example-hd-cache2-server"
+import {
+  createNetworkedCrossingNode,
+  createNetworkedHighDensitySolver,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("fixed copper defers a remote regional result", async () => {
+  const node = createNetworkedCrossingNode({
+    nodeId: "cmn_other_layer_fixed_http",
+  })
+  const otherLayerFixedRoute: PreloadedHighDensityRoute = {
+    connectionName: "fixed_foreign",
+    rootConnectionName: "root_fixed_foreign",
+    traceThickness: 0.15,
+    viaDiameter: 0.3,
+    route: [
+      { x: 0, y: -2, z: 1 },
+      { x: 0, y: 2, z: 1 },
+    ],
+    vias: [],
+    preloadedTraceIndex: 0,
+    preloadedRouteIndex: 0,
+  }
+  const server = new ExampleHdCache2Server({ batchItemMode: "solve" })
+  try {
+    const solver = createNetworkedHighDensitySolver({
+      nodes: [node],
+      fixedHdRoutes: [otherLayerFixedRoute],
+      enableRegionalFallback: true,
+      hdCache2ServerUrl: server.url,
+      preserveTerminalPcbPortIds: false,
+    })
+
+    solver.step()
+    await solver.pendingEffects![0]!.promise
+    solver.step()
+
+    expect(solver.routes).toEqual([])
+    expect(solver.activeFallbackSolver).not.toBeNull()
+    expect(solver.activeFallbackFixedObstacleRoutes).toEqual([
+      otherLayerFixedRoute,
+    ])
+    expect(solver.stats.remoteRegionalFallbackResults).toBe(1)
+    expect(solver.stats.remoteRegionalFallbackResultsApplied).toBe(0)
+    expect(solver.stats.remoteRegionalFallbackResultsDeferredToLocal).toBe(1)
+  } finally {
+    await server.close()
+  }
+})

--- a/tests/features/pipeline9-networked-regional-obstacle-connectivity-projection.test.ts
+++ b/tests/features/pipeline9-networked-regional-obstacle-connectivity-projection.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { projectPipeline9RegionalHighDensityInput } from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-input-projection"
+import type { Obstacle } from "lib/types/srj-types"
+import { createNetworkedNode } from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9 regional projection preserves direct identities and one original net alias without synthesizing obstacleId", () => {
+  const node = createNetworkedNode({
+    nodeId: "cmn_regional_obstacle_projection",
+    connectionName: "route_A",
+    rootConnectionName: "root_alias_A",
+  })
+  const connMap = new ConnectivityMap({
+    canonical_net_A: [
+      "route_A",
+      "root_alias_A",
+      "pad_alias_A",
+      "obstacle_id_alias_A",
+    ],
+    foreign_net: ["foreign_A", "foreign_B"],
+  })
+  const createObstacle = (
+    obstacleId: string,
+    connectedTo: string[],
+    x: number,
+  ): Obstacle => ({
+    obstacleId,
+    type: "rect",
+    layers: ["top", "bottom"],
+    center: { x, y: 0 },
+    width: 0.2,
+    height: 0.2,
+    connectedTo,
+  })
+  const projection = projectPipeline9RegionalHighDensityInput({
+    nodeWithPortPoints: node,
+    connMap,
+    obstacles: [
+      createObstacle("alias_only", ["pad_alias_A", "foreign_A"], -1),
+      createObstacle("exact_connection", ["route_A", "foreign_A"], 0),
+      createObstacle("exact_normalized_root", ["canonical_net_A"], 1),
+      createObstacle("obstacle_id_alias_A", ["foreign_B"], 1.5),
+      createObstacle("far_away", ["route_A"], 100),
+    ],
+    obstacleMargin: 0.15,
+    traceWidth: 0.15,
+    viaDiameter: 0.3,
+  })
+
+  expect(projection.obstacles.map((obstacle) => obstacle.connectedTo)).toEqual([
+    ["pad_alias_A"],
+    ["route_A"],
+    ["canonical_net_A"],
+    [],
+  ])
+  expect(projection.connectivityNetMap).toEqual({
+    canonical_net_A: ["route_A", "root_alias_A", "pad_alias_A"],
+  })
+})

--- a/tests/features/pipeline9-networked-regional-obstacle-projection-parity.test.ts
+++ b/tests/features/pipeline9-networked-regional-obstacle-projection-parity.test.ts
@@ -1,0 +1,116 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { normalizePipeline9NodeRootConnectionNames } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-high-density-solver"
+import { Pipeline9RegionalFallbackSolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-regional-fallback-solver"
+import {
+  projectPipeline9OrdinaryHighDensityInput,
+  projectPipeline9RegionalHighDensityInput,
+} from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-input-projection"
+import type { Obstacle } from "lib/types/srj-types"
+import { createNetworkedNode } from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9 regional obstacle projection matches the full board fallback solve", () => {
+  const node = createNetworkedNode({
+    nodeId: "cmn_regional_projection_parity",
+    connectionName: "route_A",
+    rootConnectionName: "root_A",
+  })
+  const noiseIds = Array.from({ length: 2_310 }, (_, index) => `noise_${index}`)
+  const connMap = new ConnectivityMap({
+    canonical_A: ["route_A", "root_A", "pad_A", ...noiseIds],
+    foreign_net: ["foreign_A"],
+  })
+  const obstacles: Obstacle[] = [
+    {
+      obstacleId: "same_net_pad",
+      type: "rect",
+      layers: ["top", "bottom"],
+      center: { x: -2, y: 0 },
+      width: 0.4,
+      height: 0.4,
+      ccwRotationDegrees: 15,
+      connectedTo: ["pad_A", ...noiseIds],
+    },
+    {
+      obstacleId: "nearby_foreign_pad",
+      type: "rect",
+      layers: ["top", "bottom"],
+      center: { x: 0, y: 1.5 },
+      width: 0.4,
+      height: 0.4,
+      connectedTo: ["foreign_A"],
+    },
+    {
+      obstacleId: "far_board_noise",
+      type: "rect",
+      layers: ["top", "bottom"],
+      center: { x: 100, y: 100 },
+      width: 1,
+      height: 1,
+      connectedTo: ["foreign_A"],
+    },
+  ]
+  const projection = projectPipeline9RegionalHighDensityInput({
+    nodeWithPortPoints: node,
+    connMap,
+    obstacles,
+    obstacleMargin: 0.15,
+    traceWidth: 0.15,
+    viaDiameter: 0.3,
+  })
+  const ordinaryFromFullBoard = projectPipeline9OrdinaryHighDensityInput({
+    nodeWithPortPoints: node,
+    connMap,
+    colorMap: { route_A: "blue" },
+    obstacles,
+    obstacleMargin: 0.15,
+    traceWidth: 0.15,
+    viaDiameter: 0.3,
+  })
+  const ordinaryFromRegionalProjection =
+    projectPipeline9OrdinaryHighDensityInput({
+      nodeWithPortPoints: node,
+      connMap,
+      colorMap: { route_A: "blue" },
+      obstacles: projection.obstacles,
+      obstacleMargin: 0.15,
+      traceWidth: 0.15,
+      viaDiameter: 0.3,
+    })
+  const normalizedNode = {
+    ...normalizePipeline9NodeRootConnectionNames(node, connMap),
+    availableZ: [0, 1],
+  }
+  const createSolver = (
+    projectedObstacles: Obstacle[],
+    projectedConnMap: ConnectivityMap,
+  ): Pipeline9RegionalFallbackSolver =>
+    new Pipeline9RegionalFallbackSolver({
+      nodeWithPortPoints: normalizedNode,
+      colorMap: { route_A: "blue" },
+      connMap: projectedConnMap,
+      viaDiameter: 0.3,
+      traceWidth: 0.15,
+      obstacleMargin: 0.15,
+      effort: 1,
+      nodePfById: { cmn_regional_projection_parity: 0.1 },
+      obstacles: projectedObstacles,
+      layerCount: 2,
+    })
+  const fullSolver = createSolver(obstacles, connMap)
+  const projectedSolver = createSolver(
+    projection.obstacles,
+    new ConnectivityMap(projection.connectivityNetMap),
+  )
+
+  fullSolver.solve()
+  projectedSolver.solve()
+
+  expect(projection.obstacles).toHaveLength(2)
+  expect(ordinaryFromRegionalProjection).toEqual(ordinaryFromFullBoard)
+  expect(JSON.stringify(projection)).not.toContain("noise_2309")
+  expect(projectedSolver.solved).toBe(fullSolver.solved)
+  expect(projectedSolver.failed).toBe(fullSolver.failed)
+  expect(projectedSolver.error).toBe(fullSolver.error)
+  expect(projectedSolver.getOutput()).toEqual(fullSolver.getOutput())
+})

--- a/tests/features/pipeline9-networked-regional-route-correlation-http.test.ts
+++ b/tests/features/pipeline9-networked-regional-route-correlation-http.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test"
+import { ExampleHdCache2Server } from "tests/fixtures/example-hd-cache2-server"
+import {
+  createNetworkedCrossingNode,
+  createNetworkedHighDensitySolver,
+  solveNetworkedHighDensitySolver,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9_Networked rejects uncorrelated regional routes", async () => {
+  const node = createNetworkedCrossingNode({
+    nodeId: "cmn_regional_route_correlation_http",
+  })
+  const server = new ExampleHdCache2Server({
+    batchItemMode: "solve",
+    mapBatchLine: (line) => ({
+      ...line,
+      routes: Array.isArray(line.routes)
+        ? line.routes.map((route, index) => ({
+            ...(route as Record<string, unknown>),
+            route: [
+              { x: 1000 + index * 10, y: 1000, z: 0 },
+              { x: 1001 + index * 10, y: 1000, z: 0 },
+            ],
+            vias: [],
+          }))
+        : line.routes,
+    }),
+  })
+  try {
+    const solver = createNetworkedHighDensitySolver({
+      nodes: [node],
+      hdCache2ServerUrl: server.url,
+      enableRegionalFallback: true,
+      preserveTerminalPcbPortIds: false,
+    })
+
+    await solveNetworkedHighDensitySolver(solver)
+
+    expect(solver.solved).toBeTrue()
+    expect(
+      solver.routes.every((route) => route.route.every(({ x }) => x < 100)),
+    ).toBeTrue()
+    expect(solver.stats).toMatchObject({
+      fallbackNodeCount: 1,
+      remoteRegionalFallbackResultsApplied: 0,
+      remoteTransportFallbacks: 1,
+      remoteFallbackReasonCounts: { invalid_response: 1 },
+    })
+  } finally {
+    await server.close()
+  }
+})

--- a/tests/features/pipeline9-networked-route-bounds-http.test.ts
+++ b/tests/features/pipeline9-networked-route-bounds-http.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "bun:test"
+import { ExampleHdCache2Server } from "tests/fixtures/example-hd-cache2-server"
+import {
+  createNetworkedHighDensitySolver,
+  createNetworkedNode,
+  solveNetworkedHighDensitySolver,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9_Networked rejects route points outside the solver envelope", async () => {
+  const node = createNetworkedNode({
+    nodeId: "cmn_route_bounds_http",
+    connectionName: "route_bounds_http",
+  })
+  const server = new ExampleHdCache2Server({
+    batchItemMode: "solve",
+    mapBatchLine: (line) => ({
+      ...line,
+      routes: Array.isArray(line.routes)
+        ? line.routes.map((route) => {
+            const typedRoute = route as {
+              route: Array<Record<string, unknown>>
+            }
+            return {
+              ...(route as Record<string, unknown>),
+              route: [
+                typedRoute.route[0],
+                { x: 1000, y: 1000, z: 0 },
+                typedRoute.route.at(-1),
+              ],
+            }
+          })
+        : line.routes,
+    }),
+  })
+  try {
+    const solver = createNetworkedHighDensitySolver({
+      nodes: [node],
+      hdCache2ServerUrl: server.url,
+    })
+
+    await solveNetworkedHighDensitySolver(solver)
+
+    expect(solver.solved).toBeTrue()
+    expect(solver.routes[0]!.route).toHaveLength(2)
+    expect(solver.stats.remoteFallbackReasonCounts).toEqual({
+      invalid_response: 1,
+    })
+  } finally {
+    await server.close()
+  }
+})

--- a/tests/features/pipeline9-networked-terminal-regional-failure-parity.test.ts
+++ b/tests/features/pipeline9-networked-terminal-regional-failure-parity.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { Pipeline9HighDensitySolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-high-density-solver"
+import type { NodeWithPortPoints } from "lib/types/high-density-types"
+import { ExampleHdCache2Server } from "tests/fixtures/example-hd-cache2-server"
+import {
+  createNetworkedHighDensitySolver,
+  solveNetworkedHighDensitySolver,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9 networked terminal regional failure matches over HTTP", async () => {
+  const portPoints = [
+    { x: -1, y: 0, z: 0, connectionName: "horizontal" },
+    { x: 1, y: 0, z: 0, connectionName: "horizontal" },
+    { x: 0, y: -1, z: 0, connectionName: "vertical" },
+    { x: 0, y: 1, z: 0, connectionName: "vertical" },
+  ]
+  const node: NodeWithPortPoints = {
+    capacityMeshNodeId: "cmn_terminal_regional_failure_parity",
+    center: { x: 0, y: 0 },
+    width: 2,
+    height: 2,
+    availableZ: [0],
+    portPoints,
+    portPointsInPairs: [
+      [portPoints[0]!, portPoints[1]!],
+      [portPoints[2]!, portPoints[3]!],
+    ],
+  }
+  const connMap = new ConnectivityMap({
+    horizontal: ["horizontal"],
+    vertical: ["vertical"],
+  })
+  const localSolver = new Pipeline9HighDensitySolver({
+    nodePortPoints: [node],
+    fixedHdRoutes: [],
+    connMap,
+    colorMap: {},
+    obstacles: [],
+    layerCount: 1,
+    viaDiameter: 0.3,
+    traceWidth: 0.1,
+    obstacleMargin: 0.15,
+    effort: 1,
+    nodePfById: { cmn_terminal_regional_failure_parity: 0.1 },
+  })
+  localSolver.solve()
+  const server = new ExampleHdCache2Server({ batchItemMode: "solve" })
+  try {
+    const networkedSolver = createNetworkedHighDensitySolver({
+      nodes: [node],
+      hdCache2ServerUrl: server.url,
+      enableRegionalFallback: true,
+      layerCount: 1,
+      traceWidth: 0.1,
+    })
+    await solveNetworkedHighDensitySolver(networkedSolver)
+
+    expect(localSolver.failed).toBeTrue()
+    expect(networkedSolver.failed).toBeTrue()
+    expect(networkedSolver.error).toBe(localSolver.error)
+    expect(networkedSolver.stats).toMatchObject({
+      remoteRegionalFallbackResults: 1,
+      remoteTransportFallbacks: 0,
+    })
+  } finally {
+    await server.close()
+  }
+})

--- a/tests/features/pipeline9-networked-terminal-regional-http-parity.test.ts
+++ b/tests/features/pipeline9-networked-terminal-regional-http-parity.test.ts
@@ -1,0 +1,82 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { Pipeline9HighDensitySolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9-high-density-solver"
+import type { NodeWithPortPoints } from "lib/types/high-density-types"
+import { ExampleHdCache2Server } from "tests/fixtures/example-hd-cache2-server"
+import {
+  createNetworkedHighDensitySolver,
+  solveNetworkedHighDensitySolver,
+} from "tests/fixtures/pipeline9-networked-fixtures"
+
+test("Pipeline9 terminal regional fallback matches the local solver over HTTP", async () => {
+  const portPoints: NodeWithPortPoints["portPoints"] = [
+    { x: -1, y: 0, z: 0, connectionName: "horizontal" },
+    { x: 1, y: 0, z: 0, connectionName: "horizontal" },
+    { x: 0, y: -1, z: 0, connectionName: "vertical" },
+    { x: 0, y: 1, z: 0, connectionName: "vertical" },
+  ]
+  const node: NodeWithPortPoints = {
+    capacityMeshNodeId: "cmn_http_terminal_regional",
+    center: { x: 0, y: 0 },
+    width: 2,
+    height: 2,
+    availableZ: [0],
+    portPoints,
+    portPointsInPairs: [
+      [portPoints[0]!, portPoints[1]!],
+      [portPoints[2]!, portPoints[3]!],
+    ],
+  }
+  const connMap = new ConnectivityMap({
+    horizontal: ["horizontal"],
+    vertical: ["vertical"],
+  })
+  const localSolver = new Pipeline9HighDensitySolver({
+    nodePortPoints: [node],
+    fixedHdRoutes: [],
+    connMap,
+    colorMap: { horizontal: "blue", vertical: "blue" },
+    obstacles: [],
+    layerCount: 2,
+    viaDiameter: 0.3,
+    traceWidth: 0.15,
+    obstacleMargin: 0.15,
+    effort: 1,
+    nodePfById: { [node.capacityMeshNodeId]: 0.1 },
+    preserveTerminalPcbPortIds: false,
+    enableRegionalFallback: true,
+  })
+  localSolver.solve()
+  expect(localSolver.solved).toBeTrue()
+  expect(localSolver.stats.fallbackNodeCount).toBe(1)
+
+  const server = new ExampleHdCache2Server({ batchItemMode: "solve" })
+  try {
+    const solver = createNetworkedHighDensitySolver({
+      nodes: [node],
+      hdCache2ServerUrl: server.url,
+      enableRegionalFallback: true,
+      preserveTerminalPcbPortIds: false,
+    })
+
+    await solveNetworkedHighDensitySolver(solver)
+
+    expect(solver.solved).toBeTrue()
+    expect(server.batchRequests).toHaveLength(1)
+    expect(server.solveRequests).toHaveLength(0)
+    const localRoutesAfterJsonTransport = JSON.parse(
+      JSON.stringify(localSolver.routes),
+    )
+    expect(solver.routes).toEqual(localRoutesAfterJsonTransport)
+    expect(solver.stats).toMatchObject({
+      fallbackNodeCount: 1,
+      remoteRegionalFallbackResults: 1,
+      remoteRegionalFallbackResultsApplied: 1,
+      remoteRegionalFallbackResultsDeferredToLocal: 0,
+      remoteSolverResults: 1,
+      remoteTransportFallbacks: 0,
+    })
+  } finally {
+    await server.close()
+  }
+})

--- a/tests/features/pipeline9-networked-version.test.ts
+++ b/tests/features/pipeline9-networked-version.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from "bun:test"
+import { AUTOROUTER_VERSION } from "lib"
+import packageJson from "../../package.json" with { type: "json" }
+
+test("Pipeline9 network cache version matches the package version", () => {
+  expect(AUTOROUTER_VERSION).toBe(packageJson.version)
+})

--- a/tests/fixtures/example-hd-cache2-server.ts
+++ b/tests/fixtures/example-hd-cache2-server.ts
@@ -1,0 +1,234 @@
+import { AUTOROUTER_VERSION } from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/autorouter-version"
+import { solvePipeline9NetworkedHighDensityNode } from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/solve-pipeline9-networked-high-density-node"
+import type {
+  Pipeline9NetworkedSolveBatchItem,
+  Pipeline9NetworkedSolveBatchRequest,
+  Pipeline9NetworkedSolveRequest,
+} from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-types"
+
+export type ExampleHdCache2RequestRecord = {
+  pathname: string
+  bodyText: string
+  bodyBytes: number
+  body: unknown
+  startedAt: number
+  finishedAt?: number
+}
+
+type BatchItemMode = "miss" | "solve"
+
+export type ExampleHdCache2ServerOptions = {
+  /** Production-faithful default: batch lookup misses, then POST /solve runs. */
+  batchItemMode?: BatchItemMode
+  beforeSolve?: (
+    request: Pipeline9NetworkedSolveRequest,
+  ) => void | Promise<void>
+  mapSolveEnvelope?: (
+    envelope: Record<string, unknown>,
+    request: Pipeline9NetworkedSolveRequest,
+  ) => unknown | Promise<unknown>
+  mapBatchLine?: (
+    line: Record<string, unknown>,
+    item: Pipeline9NetworkedSolveBatchItem,
+    index: number,
+  ) => unknown | null | Promise<unknown | null>
+}
+
+const jsonResponse = (body: unknown, status = 200): Response =>
+  Response.json(body, { status })
+
+/**
+ * A real loopback HTTP implementation of the hd-cache2 protocol for tests.
+ * It deliberately has no cache: batch lookups miss and /solve executes the
+ * exported production node helper from this checkout.
+ */
+export class ExampleHdCache2Server {
+  readonly requests: ExampleHdCache2RequestRecord[] = []
+  readonly url: string
+  private readonly server: ReturnType<typeof Bun.serve>
+  private stopped = false
+
+  constructor(readonly options: ExampleHdCache2ServerOptions = {}) {
+    this.server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      idleTimeout: 0,
+      fetch: (request) => this.handleRequest(request),
+    })
+    this.url = `http://127.0.0.1:${this.server.port}`
+  }
+
+  get solveRequests(): ExampleHdCache2RequestRecord[] {
+    return this.requests.filter(({ pathname }) => pathname === "/solve")
+  }
+
+  get batchRequests(): ExampleHdCache2RequestRecord[] {
+    return this.requests.filter(({ pathname }) => pathname === "/solve-batch")
+  }
+
+  async close(): Promise<void> {
+    if (this.stopped) return
+    this.stopped = true
+    await this.server.stop(true)
+  }
+
+  async [Symbol.asyncDispose](): Promise<void> {
+    await this.close()
+  }
+
+  private async handleRequest(request: Request): Promise<Response> {
+    const pathname = new URL(request.url).pathname
+    const startedAt = performance.now()
+    const bodyText = request.method === "GET" ? "" : await request.text()
+    let body: unknown = null
+    if (bodyText) {
+      try {
+        body = JSON.parse(bodyText)
+      } catch {
+        return jsonResponse({ ok: false, message: "Invalid JSON" }, 400)
+      }
+    }
+    const record: ExampleHdCache2RequestRecord = {
+      pathname,
+      bodyText,
+      bodyBytes: new TextEncoder().encode(bodyText).byteLength,
+      body,
+      startedAt,
+    }
+    this.requests.push(record)
+
+    try {
+      return await this.handleProtocolRequest(request, pathname, body)
+    } finally {
+      record.finishedAt = performance.now()
+    }
+  }
+
+  private async handleProtocolRequest(
+    request: Request,
+    pathname: string,
+    body: unknown,
+  ): Promise<Response> {
+    if (request.method === "GET" && pathname === "/health") {
+      return jsonResponse({
+        ok: true,
+        autorouterVersion: AUTOROUTER_VERSION,
+        benchmarkCacheVersionSupported: true,
+        benchmarkCacheVersionAccess: "open",
+      })
+    }
+    if (request.method !== "POST") {
+      return jsonResponse({ ok: false, message: "Not found" }, 404)
+    }
+    if (pathname === "/solve") {
+      return this.handleSolve(body as Pipeline9NetworkedSolveRequest)
+    }
+    if (pathname === "/solve-batch") {
+      return this.handleBatch(body as Pipeline9NetworkedSolveBatchRequest)
+    }
+    return jsonResponse({ ok: false, message: "Not found" }, 404)
+  }
+
+  private validateVersion(value: unknown): Response | null {
+    if (value === AUTOROUTER_VERSION) return null
+    return jsonResponse(
+      {
+        ok: false,
+        autorouterVersion: AUTOROUTER_VERSION,
+        message: `Expected autorouter version ${AUTOROUTER_VERSION}`,
+      },
+      409,
+    )
+  }
+
+  private async handleSolve(
+    solveRequest: Pipeline9NetworkedSolveRequest,
+  ): Promise<Response> {
+    const versionError = this.validateVersion(solveRequest?.autorouterVersion)
+    if (versionError) return versionError
+    if (!solveRequest?.input) {
+      return jsonResponse({ ok: false, message: "Missing input" }, 400)
+    }
+
+    try {
+      await this.options.beforeSolve?.(solveRequest)
+      const output = solvePipeline9NetworkedHighDensityNode(solveRequest.input)
+      const envelope: Record<string, unknown> = {
+        ok: true,
+        autorouterVersion: AUTOROUTER_VERSION,
+        ...(solveRequest.cacheVersion === undefined
+          ? {}
+          : { cacheVersion: solveRequest.cacheVersion }),
+        source: "solver",
+        ...output,
+      }
+      const responseBody = this.options.mapSolveEnvelope
+        ? await this.options.mapSolveEnvelope(envelope, solveRequest)
+        : envelope
+      return jsonResponse(responseBody)
+    } catch (error) {
+      return jsonResponse(
+        {
+          ok: false,
+          autorouterVersion: AUTOROUTER_VERSION,
+          message: error instanceof Error ? error.message : String(error),
+        },
+        500,
+      )
+    }
+  }
+
+  private async handleBatch(
+    batchRequest: Pipeline9NetworkedSolveBatchRequest,
+  ): Promise<Response> {
+    const versionError = this.validateVersion(batchRequest?.autorouterVersion)
+    if (versionError) return versionError
+    if (!Array.isArray(batchRequest?.items)) {
+      return jsonResponse({ ok: false, message: "Missing batch items" }, 400)
+    }
+
+    const lines: string[] = []
+    for (const [index, item] of batchRequest.items.entries()) {
+      const mode = this.options.batchItemMode ?? "miss"
+      let line: Record<string, unknown>
+      if (mode === "solve") {
+        await this.options.beforeSolve?.({
+          autorouterVersion: batchRequest.autorouterVersion,
+          ...(batchRequest.cacheVersion === undefined
+            ? {}
+            : { cacheVersion: batchRequest.cacheVersion }),
+          input: item.input,
+        })
+        line = {
+          requestId: item.requestId,
+          ok: true,
+          autorouterVersion: AUTOROUTER_VERSION,
+          ...(batchRequest.cacheVersion === undefined
+            ? {}
+            : { cacheVersion: batchRequest.cacheVersion }),
+          source: "solver",
+          ...solvePipeline9NetworkedHighDensityNode(item.input),
+        }
+      } else {
+        line = {
+          requestId: item.requestId,
+          ok: false,
+          autorouterVersion: AUTOROUTER_VERSION,
+          ...(batchRequest.cacheVersion === undefined
+            ? {}
+            : { cacheVersion: batchRequest.cacheVersion }),
+          code: "CACHE_MISS",
+          message: "ExampleHdCache2Server does not cache results",
+        }
+      }
+      const mappedLine = this.options.mapBatchLine
+        ? await this.options.mapBatchLine(line, item, index)
+        : line
+      if (mappedLine !== null) lines.push(JSON.stringify(mappedLine))
+    }
+
+    return new Response(lines.length === 0 ? "" : `${lines.join("\n")}\n`, {
+      headers: { "content-type": "application/x-ndjson" },
+    })
+  }
+}

--- a/tests/fixtures/pipeline9-networked-fixtures.ts
+++ b/tests/fixtures/pipeline9-networked-fixtures.ts
@@ -1,0 +1,174 @@
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { AUTOROUTER_VERSION } from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/autorouter-version"
+import {
+  Pipeline9NetworkedHighDensitySolver,
+  type Pipeline9NetworkedHighDensitySolverParams,
+} from "lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9-networked-high-density-solver"
+import type { PreloadedHighDensityRoute } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/convert-preloaded-traces-to-hd-routes"
+import type { NodeWithPortPoints } from "lib/types/high-density-types"
+import type { Obstacle } from "lib/types/srj-types"
+
+export const createNetworkedNode = ({
+  nodeId,
+  connectionName,
+  rootConnectionName = `root_${connectionName}`,
+  xOffset = 0,
+}: {
+  nodeId: string
+  connectionName: string
+  rootConnectionName?: string
+  xOffset?: number
+}): NodeWithPortPoints => ({
+  capacityMeshNodeId: nodeId,
+  center: { x: xOffset, y: 0 },
+  width: 4,
+  height: 4,
+  availableZ: [0, 1],
+  portPoints: [
+    {
+      x: xOffset - 2,
+      y: 0,
+      z: 0,
+      connectionName,
+      rootConnectionName,
+      pcb_port_id: `${nodeId}_start`,
+    },
+    {
+      x: xOffset + 2,
+      y: 0,
+      z: 0,
+      connectionName,
+      rootConnectionName,
+      pcb_port_id: `${nodeId}_end`,
+    },
+  ],
+})
+
+export const createNetworkedCrossingNode = ({
+  nodeId,
+}: {
+  nodeId: string
+}): NodeWithPortPoints => {
+  const portPoints: NodeWithPortPoints["portPoints"] = [
+    { x: -1, y: 0, z: 0, connectionName: "horizontal" },
+    { x: 1, y: 0, z: 0, connectionName: "horizontal" },
+    { x: 0, y: -1, z: 0, connectionName: "vertical" },
+    { x: 0, y: 1, z: 0, connectionName: "vertical" },
+  ]
+  return {
+    capacityMeshNodeId: nodeId,
+    center: { x: 0, y: 0 },
+    width: 2,
+    height: 2,
+    availableZ: [0],
+    portPoints,
+    portPointsInPairs: [
+      [portPoints[0]!, portPoints[1]!],
+      [portPoints[2]!, portPoints[3]!],
+    ],
+  }
+}
+
+export const createNetworkedFixedRoute = (): PreloadedHighDensityRoute => ({
+  connectionName: "fixed_foreign",
+  rootConnectionName: "root_fixed_foreign",
+  traceThickness: 0.15,
+  viaDiameter: 0.3,
+  route: [
+    { x: 0, y: -2, z: 0 },
+    { x: 0, y: 2, z: 0 },
+  ],
+  vias: [],
+  preloadedTraceIndex: 0,
+  preloadedRouteIndex: 0,
+})
+
+export const createDeferred = <T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (error: unknown) => void
+} => {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+export const createNetworkedHighDensitySolver = ({
+  nodes,
+  hdCache2ServerUrl,
+  hdCache2CacheVersion,
+  fixedHdRoutes = [],
+  obstacles = [],
+  requestTimeoutMs = 1_000,
+  enableRegionalFallback = false,
+  preserveTerminalPcbPortIds = true,
+  layerCount = 2,
+  traceWidth = 0.15,
+}: {
+  nodes: NodeWithPortPoints[]
+  hdCache2ServerUrl: string
+  hdCache2CacheVersion?: string
+  fixedHdRoutes?: PreloadedHighDensityRoute[]
+  obstacles?: Obstacle[]
+  requestTimeoutMs?: number
+  enableRegionalFallback?: boolean
+  preserveTerminalPcbPortIds?: boolean
+  layerCount?: number
+  traceWidth?: number
+}): Pipeline9NetworkedHighDensitySolver => {
+  const connectivityNetMap: Record<string, string[]> = {
+    root_fixed_foreign: ["root_fixed_foreign", "fixed_foreign"],
+  }
+  for (const node of nodes) {
+    for (const point of node.portPoints) {
+      const root = point.rootConnectionName ?? point.connectionName
+      connectivityNetMap[root] ??= [root]
+      if (!connectivityNetMap[root]!.includes(point.connectionName)) {
+        connectivityNetMap[root]!.push(point.connectionName)
+      }
+    }
+  }
+
+  const params: Pipeline9NetworkedHighDensitySolverParams = {
+    nodePortPoints: nodes,
+    fixedHdRoutes,
+    connMap: new ConnectivityMap(connectivityNetMap),
+    colorMap: Object.fromEntries(
+      nodes.flatMap((node) =>
+        node.portPoints.map((point) => [point.connectionName, "blue"]),
+      ),
+    ),
+    obstacles,
+    layerCount,
+    viaDiameter: 0.3,
+    traceWidth,
+    obstacleMargin: 0.15,
+    effort: 1,
+    nodePfById: new Map(nodes.map((node) => [node.capacityMeshNodeId, 0.1])),
+    preserveTerminalPcbPortIds,
+    enableRegionalFallback,
+    autorouterVersion: AUTOROUTER_VERSION,
+    hdCache2ServerUrl,
+    hdCache2CacheVersion,
+    requestTimeoutMs,
+  }
+  return new Pipeline9NetworkedHighDensitySolver(params)
+}
+
+export const solveNetworkedHighDensitySolver = async (
+  solver: Pipeline9NetworkedHighDensitySolver,
+): Promise<void> => {
+  while (!solver.solved && !solver.failed) {
+    solver.step()
+    const pendingEffects = solver.pendingEffects ?? []
+    if (pendingEffects.length > 0) {
+      await Promise.race(
+        pendingEffects.map((effect) => effect.promise.catch(() => undefined)),
+      )
+    }
+  }
+}

--- a/tests/pr-benchmark-command.test.ts
+++ b/tests/pr-benchmark-command.test.ts
@@ -52,6 +52,25 @@ test("PR benchmark commands preserve arguments and fan-out behavior", () => {
     sameMachineCompare: false,
   })
   expect(
+    parsePrBenchmarkCommand("/benchmark --pipeline 9net --dataset 18"),
+  ).toEqual({
+    kind: "benchmark",
+    benchmarkArgs: ["--pipeline", "9net", "--dataset", "18"],
+    datasetName: "18",
+    profileSolvers: false,
+    sameMachineCompare: false,
+  })
+  expect(() =>
+    parsePrBenchmarkCommand(
+      "/benchmark --pipeline 9net --dataset 18 --same-machine",
+    ),
+  ).toThrow("does not support --same-machine")
+  expect(() =>
+    parsePrBenchmarkCommand(
+      "/benchmark --pipeline 9net --dataset 18 --profile-solvers",
+    ),
+  ).toThrow("does not support --profile-solvers")
+  expect(
     parsePrBenchmarkCommand(
       "/benchmark --pipeline 10 --dataset 29 --limit 5 --sample 2",
     ),
@@ -181,6 +200,35 @@ test("PR benchmark commands preserve arguments and fan-out behavior", () => {
     "same_machine_compare: String(command.sameMachineCompare)",
   )
   expect(benchmarkWorkflow).toContain("benchmark_args_json:")
+  expect(benchmarkWorkflow).not.toContain("HD_CACHE2_BENCHMARK_CAPABILITY")
+  expect(benchmarkWorkflow).not.toContain("createHmac")
+  expect(
+    benchmarkWorkflow.indexOf(
+      "Create Pipeline9 network cache benchmark namespace",
+    ),
+  ).toBeLessThan(benchmarkWorkflow.indexOf("Checkout code"))
+  expect(benchmarkWorkflow).toContain(
+    "Verify production Pipeline9 network cache support",
+  )
+  expect(benchmarkWorkflow).toContain("benchmarkCacheVersionSupported")
+  expect(benchmarkWorkflow).toContain(
+    "body.benchmarkCacheVersionAccess !== 'open'",
+  )
+  expect(benchmarkWorkflow).toContain("/health")
+  expect(benchmarkWorkflow).toContain("HD_CACHE2_CACHE_VERSION")
+  expect(benchmarkWorkflow).toContain(
+    "BENCHMARK_NETWORKED_CACHE_PROPAGATION_DELAY_MS: '65000'",
+  )
+  expect(benchmarkWorkflow).toContain(
+    "benchmark-${repositoryId}-${runId}-${runAttempt}-${randomUUID()}",
+  )
+  expect(benchmarkWorkflow).toContain("Pipeline9_Networked Cold vs Hot")
+  expect(benchmarkWorkflow).toContain(
+    "typeof comparisonModule.isNetworkedColdHotReport === 'function'",
+  )
+  expect(benchmarkWorkflow).toContain(
+    "names.has('Pipeline9_Networked Cold') && names.has('Pipeline9_Networked Hot')",
+  )
   expect(benchmarkWorkflow).toContain("blacksmith-8vcpu-ubuntu-2404-arm")
   expect(benchmarkWorkflow).toContain("inputs.long_benchmark && 480 || 120")
   expect(benchmarkWorkflow).toContain("same_machine_compare:")


### PR DESCRIPTION
## Human review required

This PR is intentionally a **draft**. It must not be merged or auto-merged without human review.

This is a fresh, single-commit reimplementation of the reverted Pipeline9 network-cache work, based directly on post-revert `main`. It does not replay the reverted commits.

Companion hd-cache2 service PR: https://github.com/tscircuit/hd-cache2.tscircuit.com/pull/8

## What changed

- Reintroduces `AutoroutingPipelineSolver9_Networked` with `hdCache2ServerUrl` as the public server override.
- Keeps ordinary Pipeline9 behavior unchanged behind narrow protected hooks and a shared regular-node solver factory.
- Splits HTTP batching, NDJSON correlation, byte limits, timeouts, and response validation into `HdCache2Client`.
- Preserves independent high-density node solving and the terminal policy: ordinary solve first, then regional fallback only when all-layer fixed-copper independence is proven again at consumption time.
- Validates remote topology, solution stage, terminal correlation, assigned layers, route envelope, vias/layer transitions, exact autorouter version, and benchmark cache namespace before applying a result.
- Adds `ExampleHdCache2Server`, a real Bun loopback HTTP server that does not cache. It runs the exported real high-density-node helper, and Networked behavior tests use it via `hdCache2ServerUrl`.

## `/benchmark --pipeline 9net`

- Maps `9net` to `AutoroutingPipelineSolver9_Networked` at effort 1 and targets `https://hd-cache2.tscircuit.com`.
- Creates a fresh randomized namespace from repository ID, run ID, run attempt, and a UUID. This prevents accidental reuse or collisions between benchmark attempts; the same namespace is reused only for that attempt's hot pass.
- Uses open `cacheVersion` access with no HMAC capability, authentication header, or service secret. Future tscircuit user JWT authentication can be added without changing the namespace contract.
- Preflights `GET /health` and requires the exact autorouter version, `benchmarkCacheVersionSupported: true`, and `benchmarkCacheVersionAccess: "open"`. This rejects both incompatible versions and the older capability-protected service.
- Runs every cold task first, drains all speculative remote requests after recording each task's elapsed time, validates the cold pass, then waits an unmeasured 65 seconds for Workers KV propagation before starting any hot task.
- Reuses the exact namespace for hot and fails closed unless every hot request is a cache hit with zero misses, remote solver results, timeouts, or local transport fallbacks.
- Reports separate `Pipeline9_Networked Cold` and `Pipeline9_Networked Hot` rows, timing percentiles, cache hits, solver results, and fallback counts.
- Rejects incompatible `9net` combinations such as same-machine and solver-profile runs.
- Keeps benchmark comment rendering compatible with older PR heads that do not export the new cold/hot report detector.

## Validation

- Networked HTTP/behavior suite: 28/28 passed (170 assertions).
- Benchmark and PR-command suite: 12/12 passed (281 assertions).
- `bunx tsc --noEmit`: passed.
- `bun run build`: passed, including declaration generation.
- Workflow YAML parse, `bash -n benchmark.sh`, and `git diff --check`: passed.
- Fresh GitHub CI: build, type-check, format, Testbox, Vercel, and all nine test shards passed.
- Independent cross-repository audit: no remaining auth-contract mismatch; the open-access health-mode guard is covered by the workflow test.

## Rollout dependency

Nothing is deployed and no secret is created or modified by this PR.

Production hd-cache2 currently pins autorouter `0.0.856`, while this branch is based on `0.0.857`; the preflight therefore intentionally fails closed today. After human review, rollout requires:

1. Merge and publish the reviewed autorouter release.
2. Pin the companion service to that exact published version.
3. Review and deploy the companion service.

No shared secret configuration step is required. Until the version pin and reviewed service deployment are complete, `9net` cannot report a misleading local-fallback benchmark against an incompatible production deployment.
