### PR TITLE
perf: reduce high-density portfolio overhead

### DIFF
--- a/lib/solvers/HighDensitySolver/SingleHighDensityRouteSolver6_VertHorzLayer_FutureCost.ts
+++ b/lib/solvers/HighDensitySolver/SingleHighDensityRouteSolver6_VertHorzLayer_FutureCost.ts
@@ -2,6 +2,8 @@ import { distance, pointToSegmentDistance } from "@tscircuit/math-utils"
 import { SingleHighDensityRouteSolver } from "./SingleHighDensityRouteSolver"
 import { Node } from "lib/data-structures/SingleRouteCandidatePriorityQueue"
 
+const FUTURE_CONNECTION_POINT_CACHE_SIZE = 1024
+
 export class SingleHighDensityRouteSolver6_VertHorzLayer_FutureCost extends SingleHighDensityRouteSolver {
   FUTURE_CONNECTION_PROX_TRACE_PENALTY_FACTOR = 2
   FUTURE_CONNECTION_PROX_VIA_PENALTY_FACTOR = 1
@@ -10,8 +12,11 @@ export class SingleHighDensityRouteSolver6_VertHorzLayer_FutureCost extends Sing
   VIA_PENALTY_FACTOR_2 = 1
   FLIP_TRACE_ALIGNMENT_DIRECTION = false
   FUTURE_CONNECTION_VIA_TRACE_CLEARANCE = 0.1
-  futureConnectionPoints: Array<{ x: number; y: number; z: number }>
+  futureConnectionPoints: FutureConnectionPoint[]
   futureConnectionSegmentsCache: FutureConnectionSegment[] | null = null
+  private closestFuturePointCache: Array<
+    ClosestFuturePointCacheEntry | undefined
+  > = []
 
   constructor(
     opts: ConstructorParameters<typeof SingleHighDensityRouteSolver>[0],
@@ -38,21 +43,60 @@ export class SingleHighDensityRouteSolver6_VertHorzLayer_FutureCost extends Sing
     )
   }
 
-  getClosestFutureConnectionPoint(node: Node) {
+  private getClosestFutureConnection(node: Node): ClosestFuturePointCacheEntry {
+    const nodeKey = this.getNodeKey(node)
+    const cacheIndex = nodeKey & (FUTURE_CONNECTION_POINT_CACHE_SIZE - 1)
+    const cached = this.closestFuturePointCache[cacheIndex]
+    if (
+      cached?.nodeKey === nodeKey &&
+      cached.nodeX === node.x &&
+      cached.nodeY === node.y &&
+      cached.nodeZ === node.z
+    ) {
+      return cached
+    }
+
     let minDist = Infinity
-    let closestPoint = null
+    let closestPoint: FutureConnectionPoint | null = null
+    let closestPointDistance = Infinity
+    const viaPenaltyDistance = this.viaPenaltyDistance
 
     for (const point of this.futureConnectionPoints) {
-      const dist =
-        distance(node, point) +
-        (node.z !== point.z ? this.viaPenaltyDistance : 0)
+      const dx = node.x - point.x
+      const dy = node.y - point.y
+      const pointDistance = Math.sqrt(dx * dx + dy * dy)
+      const dist = pointDistance + (node.z !== point.z ? viaPenaltyDistance : 0)
       if (dist < minDist) {
         minDist = dist
         closestPoint = point
+        closestPointDistance = pointDistance
       }
     }
 
-    return closestPoint
+    if (cached) {
+      cached.nodeKey = nodeKey
+      cached.nodeX = node.x
+      cached.nodeY = node.y
+      cached.nodeZ = node.z
+      cached.point = closestPoint
+      cached.distance = closestPointDistance
+      return cached
+    }
+
+    const entry = {
+      nodeKey,
+      nodeX: node.x,
+      nodeY: node.y,
+      nodeZ: node.z,
+      point: closestPoint,
+      distance: closestPointDistance,
+    }
+    this.closestFuturePointCache[cacheIndex] = entry
+    return entry
+  }
+
+  getClosestFutureConnectionPoint(node: Node) {
+    return this.getClosestFutureConnection(node).point
   }
 
   getFutureConnectionSegments() {
@@ -142,10 +186,11 @@ export class SingleHighDensityRouteSolver6_VertHorzLayer_FutureCost extends Sing
 
   getFutureConnectionPenalty(node: Node, isVia: boolean) {
     let futureConnectionPenalty = 0
-    const closestFuturePoint = this.getClosestFutureConnectionPoint(node)
+    const closestFutureConnection = this.getClosestFutureConnection(node)
+    const closestFuturePoint = closestFutureConnection.point
     const goalDist = distance(node, this.B)
     if (closestFuturePoint) {
-      const distToFuturePoint = distance(node, closestFuturePoint)
+      const distToFuturePoint = closestFutureConnection.distance
       if (goalDist <= distToFuturePoint) return 0
       const maxDist = this.viaDiameter * this.FUTURE_CONNECTION_PROXIMITY_VD
       const distRatio = distToFuturePoint / maxDist
@@ -236,4 +281,15 @@ type FutureConnectionSegment = {
   connectionName: string
   start: { x: number; y: number; z: number }
   end: { x: number; y: number; z: number }
+}
+
+type FutureConnectionPoint = { x: number; y: number; z: number }
+
+type ClosestFuturePointCacheEntry = {
+  nodeKey: number
+  nodeX: number
+  nodeY: number
+  nodeZ: number
+  point: FutureConnectionPoint | null
+  distance: number
 }

--- a/lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver.ts
+++ b/lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver.ts
@@ -46,13 +46,11 @@ type RankedPortfolioCandidate = {
 
 class PortfolioCandidatePriorityQueue {
   private entries: RankedPortfolioCandidate[] = []
-  comparisonCount = 0
 
   private comesBefore(
     left: RankedPortfolioCandidate,
     right: RankedPortfolioCandidate,
   ): boolean {
-    this.comparisonCount++
     if (left.candidate.solver.solved !== right.candidate.solver.solved) {
       return left.candidate.solver.solved
     }
@@ -66,7 +64,7 @@ class PortfolioCandidatePriorityQueue {
     this.entries.push(entry)
     let index = this.entries.length - 1
     while (index > 0) {
-      const parentIndex = Math.floor((index - 1) / 2)
+      const parentIndex = (index - 1) >> 1
       if (!this.comesBefore(this.entries[index]!, this.entries[parentIndex]!)) {
         break
       }
@@ -82,12 +80,7 @@ class PortfolioCandidatePriorityQueue {
     return this.entries[0]
   }
 
-  pop(): RankedPortfolioCandidate | undefined {
-    const first = this.entries[0]
-    const last = this.entries.pop()
-    if (!first || !last || this.entries.length === 0) return first
-
-    this.entries[0] = last
+  refreshRoot(): void {
     let index = 0
     while (true) {
       const leftIndex = index * 2 + 1
@@ -112,6 +105,15 @@ class PortfolioCandidatePriorityQueue {
       ]
       index = bestIndex
     }
+  }
+
+  pop(): RankedPortfolioCandidate | undefined {
+    const first = this.entries[0]
+    const last = this.entries.pop()
+    if (!first || !last || this.entries.length === 0) return first
+
+    this.entries[0] = last
+    this.refreshRoot()
     return first
   }
 }
@@ -129,7 +131,6 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
   effort: number
   adaptiveSearchExpanded = false
   private candidateQueue?: PortfolioCandidatePriorityQueue
-  private candidateOrder = new Map<PortfolioCandidate, number>()
   private nextCandidateOrder = 0
 
   private getSolvedSegmentCount(solver: unknown): number | null {
@@ -394,7 +395,6 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
     this.stats.dynamicExpansionWorkBudget = this.getDynamicExpansionWorkBudget()
     this.refreshDynamicIterationLimit()
     this.candidateQueue = undefined
-    this.candidateOrder.clear()
     this.nextCandidateOrder = 0
   }
 
@@ -403,7 +403,6 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
     this.candidateQueue = new PortfolioCandidatePriorityQueue()
     for (const candidate of this.supervisedSolvers ?? []) {
       const order = this.nextCandidateOrder++
-      this.candidateOrder.set(candidate, order)
       if (!candidate.solver.failed) {
         this.candidateQueue.push({ candidate, order })
       }
@@ -418,21 +417,12 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
     return this.candidateQueue!.peek()?.candidate ?? null
   }
 
-  private popBestCandidate(): PortfolioCandidate | null {
+  private getBestCandidate(): PortfolioCandidate | null {
     this.initializeCandidateQueue()
     while (this.candidateQueue!.peek()?.candidate.solver.failed) {
       this.candidateQueue!.pop()
     }
-    return this.candidateQueue!.pop()?.candidate ?? null
-  }
-
-  private requeueCandidate(candidate: PortfolioCandidate): void {
-    if (candidate.solver.failed || candidate.solver.solved) return
-    const order = this.candidateOrder.get(candidate)
-    if (order === undefined) {
-      throw new Error("Portfolio candidate is missing its stable queue order")
-    }
-    this.candidateQueue!.push({ candidate, order })
+    return this.candidateQueue!.peek()?.candidate ?? null
   }
 
   private addSupervisedCandidate(hyperParameters: Record<string, any>) {
@@ -449,7 +439,6 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
     this.supervisedSolvers!.push(candidate)
     if (this.candidateQueue) {
       const order = this.nextCandidateOrder++
-      this.candidateOrder.set(candidate, order)
       if (!solver.failed) this.candidateQueue.push({ candidate, order })
     }
   }
@@ -494,7 +483,7 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
       this.expandAdaptiveSearch()
     }
 
-    const candidate = this.popBestCandidate()
+    const candidate = this.getBestCandidate()
     if (!candidate) {
       this.failed = true
       this.error = this.getFailureMessage()
@@ -510,20 +499,14 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
     candidate.f = this.computeF(candidate.g, candidate.h)
 
     if (candidate.solver.solved) {
-      const order = this.candidateOrder.get(candidate)
-      if (order === undefined) {
-        throw new Error("Portfolio candidate is missing its stable queue order")
-      }
-      this.candidateQueue!.push({ candidate, order })
       this.solved = true
       this.winningSolver = candidate.solver
       this.onSolve(candidate)
+    } else if (candidate.solver.failed) {
+      this.candidateQueue!.pop()
     } else {
-      this.requeueCandidate(candidate)
+      this.candidateQueue!.refreshRoot()
     }
-
-    this.stats.priorityQueueComparisonCount =
-      this.candidateQueue?.comparisonCount ?? 0
 
     if (!this.solved && !this.failed && this.shouldExpandPortfolio()) {
       this.expandAdaptiveSearch()

--- a/lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver.ts
+++ b/lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver.ts
@@ -28,8 +28,7 @@ import { repairDisconnectedSameRootPortPoints } from "./repairDisconnectedSameRo
 // derived exploration budget or exhausts all of its candidates.
 const ORDERING_SHUFFLE_SEEDS = Array.from({ length: 6 }, (_, seed) => seed)
 
-/** Coordinates a fitness-scheduled portfolio of intra-node routing solvers. */
-export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolver<
+type PortfolioSolver =
   | IntraNodeRouteSolver
   | TwoCrossingRoutesHighDensitySolver
   | SingleTransitionCrossingRouteSolver
@@ -37,7 +36,88 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
   | SingleTransitionThroughObstacleIntraNodeSolver
   | SingleLayerNoDifferentRootIntersectionsIntraNodeSolver
   | HighDensityA03Solver
-> {
+
+type PortfolioCandidate = SupervisedSolver<PortfolioSolver>
+
+type RankedPortfolioCandidate = {
+  candidate: PortfolioCandidate
+  order: number
+}
+
+class PortfolioCandidatePriorityQueue {
+  private entries: RankedPortfolioCandidate[] = []
+  comparisonCount = 0
+
+  private comesBefore(
+    left: RankedPortfolioCandidate,
+    right: RankedPortfolioCandidate,
+  ): boolean {
+    this.comparisonCount++
+    if (left.candidate.solver.solved !== right.candidate.solver.solved) {
+      return left.candidate.solver.solved
+    }
+    if (left.candidate.f !== right.candidate.f) {
+      return left.candidate.f < right.candidate.f
+    }
+    return left.order < right.order
+  }
+
+  push(entry: RankedPortfolioCandidate): void {
+    this.entries.push(entry)
+    let index = this.entries.length - 1
+    while (index > 0) {
+      const parentIndex = Math.floor((index - 1) / 2)
+      if (!this.comesBefore(this.entries[index]!, this.entries[parentIndex]!)) {
+        break
+      }
+      ;[this.entries[index], this.entries[parentIndex]] = [
+        this.entries[parentIndex]!,
+        this.entries[index]!,
+      ]
+      index = parentIndex
+    }
+  }
+
+  peek(): RankedPortfolioCandidate | undefined {
+    return this.entries[0]
+  }
+
+  pop(): RankedPortfolioCandidate | undefined {
+    const first = this.entries[0]
+    const last = this.entries.pop()
+    if (!first || !last || this.entries.length === 0) return first
+
+    this.entries[0] = last
+    let index = 0
+    while (true) {
+      const leftIndex = index * 2 + 1
+      const rightIndex = leftIndex + 1
+      let bestIndex = index
+      if (
+        leftIndex < this.entries.length &&
+        this.comesBefore(this.entries[leftIndex]!, this.entries[bestIndex]!)
+      ) {
+        bestIndex = leftIndex
+      }
+      if (
+        rightIndex < this.entries.length &&
+        this.comesBefore(this.entries[rightIndex]!, this.entries[bestIndex]!)
+      ) {
+        bestIndex = rightIndex
+      }
+      if (bestIndex === index) break
+      ;[this.entries[index], this.entries[bestIndex]] = [
+        this.entries[bestIndex]!,
+        this.entries[index]!,
+      ]
+      index = bestIndex
+    }
+    return first
+  }
+}
+
+/** Coordinates a fitness-scheduled portfolio of intra-node routing solvers. */
+export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolver<PortfolioSolver> {
   override getSolverName(): string {
     return "PortfolioSingleIntraNodeSolver"
   }
@@ -48,6 +128,9 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
   connMap?: ConnectivityMap
   effort: number
   adaptiveSearchExpanded = false
+  private candidateQueue?: PortfolioCandidatePriorityQueue
+  private candidateOrder = new Map<PortfolioCandidate, number>()
+  private nextCandidateOrder = 0
 
   private getSolvedSegmentCount(solver: unknown): number | null {
     const solvedConnectionsMap = (solver as any).solvedConnectionsMap
@@ -310,19 +393,65 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
     }
     this.stats.dynamicExpansionWorkBudget = this.getDynamicExpansionWorkBudget()
     this.refreshDynamicIterationLimit()
+    this.candidateQueue = undefined
+    this.candidateOrder.clear()
+    this.nextCandidateOrder = 0
+  }
+
+  private initializeCandidateQueue(): void {
+    if (this.candidateQueue) return
+    this.candidateQueue = new PortfolioCandidatePriorityQueue()
+    for (const candidate of this.supervisedSolvers ?? []) {
+      const order = this.nextCandidateOrder++
+      this.candidateOrder.set(candidate, order)
+      if (!candidate.solver.failed) {
+        this.candidateQueue.push({ candidate, order })
+      }
+    }
+  }
+
+  override getSupervisedSolverWithBestFitness(): PortfolioCandidate | null {
+    this.initializeCandidateQueue()
+    while (this.candidateQueue!.peek()?.candidate.solver.failed) {
+      this.candidateQueue!.pop()
+    }
+    return this.candidateQueue!.peek()?.candidate ?? null
+  }
+
+  private popBestCandidate(): PortfolioCandidate | null {
+    this.initializeCandidateQueue()
+    while (this.candidateQueue!.peek()?.candidate.solver.failed) {
+      this.candidateQueue!.pop()
+    }
+    return this.candidateQueue!.pop()?.candidate ?? null
+  }
+
+  private requeueCandidate(candidate: PortfolioCandidate): void {
+    if (candidate.solver.failed || candidate.solver.solved) return
+    const order = this.candidateOrder.get(candidate)
+    if (order === undefined) {
+      throw new Error("Portfolio candidate is missing its stable queue order")
+    }
+    this.candidateQueue!.push({ candidate, order })
   }
 
   private addSupervisedCandidate(hyperParameters: Record<string, any>) {
     const solver = this.generateSolver(hyperParameters)
     this.initializeCandidateBudget(solver)
     const g = this.computeG(solver)
-    this.supervisedSolvers!.push({
+    const candidate: PortfolioCandidate = {
       hyperParameters,
       solver,
       h: 0,
       g,
       f: g,
-    })
+    }
+    this.supervisedSolvers!.push(candidate)
+    if (this.candidateQueue) {
+      const order = this.nextCandidateOrder++
+      this.candidateOrder.set(candidate, order)
+      if (!solver.failed) this.candidateQueue.push({ candidate, order })
+    }
   }
 
   private expandAdaptiveSearch() {
@@ -365,26 +494,56 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
       this.expandAdaptiveSearch()
     }
 
-    super._step()
+    const candidate = this.popBestCandidate()
+    if (!candidate) {
+      this.failed = true
+      this.error = this.getFailureMessage()
+      return
+    }
+
+    for (let substep = 0; substep < this.MIN_SUBSTEPS; substep++) {
+      candidate.solver.step()
+    }
+    this.activeSubSolver = candidate.solver
+    candidate.g = this.computeG(candidate.solver)
+    candidate.h = this.computeH(candidate.solver)
+    candidate.f = this.computeF(candidate.g, candidate.h)
+
+    if (candidate.solver.solved) {
+      this.solved = true
+      this.winningSolver = candidate.solver
+      this.onSolve(candidate)
+    } else {
+      this.requeueCandidate(candidate)
+    }
+
+    this.stats.priorityQueueComparisonCount =
+      this.candidateQueue?.comparisonCount ?? 0
 
     if (!this.solved && !this.failed && this.shouldExpandPortfolio()) {
       this.expandAdaptiveSearch()
     }
   }
 
-  computeG(solver: IntraNodeRouteSolver) {
+  computeG(solver: PortfolioSolver) {
+    const hyperParameters =
+      "hyperParameters" in solver &&
+      solver.hyperParameters &&
+      typeof solver.hyperParameters === "object"
+        ? (solver.hyperParameters as Record<string, number | boolean>)
+        : {}
     if (
-      (solver as any) instanceof HighDensitySolverA01 ||
-      (solver as any) instanceof HighDensityA03Solver
+      solver instanceof HighDensitySolverA01 ||
+      solver instanceof HighDensityA03Solver
     ) {
-      return (solver as any).iterations / 1_000_000
+      return solver.iterations / 1_000_000
     }
-    if (solver?.hyperParameters?.MULTI_HEAD_POLYLINE_SOLVER) {
+    if (hyperParameters.MULTI_HEAD_POLYLINE_SOLVER) {
       return (
         1000 +
-        ((solver.hyperParameters?.ITERATION_PENALTY ?? 0) + solver.iterations) /
+        (Number(hyperParameters.ITERATION_PENALTY ?? 0) + solver.iterations) /
           10_000 +
-        10_000 * (solver.hyperParameters.SEGMENTS_PER_POLYLINE! - 3)
+        10_000 * (Number(hyperParameters.SEGMENTS_PER_POLYLINE) - 3)
       )
     }
     return (
@@ -392,7 +551,7 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
     )
   }
 
-  computeH(solver: IntraNodeRouteSolver) {
+  computeH(solver: PortfolioSolver) {
     if (this.adaptiveSearchExpanded) {
       return 1 - this.getCandidateProgress(solver)
     }
@@ -502,13 +661,13 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
     })
   }
 
-  onSolve(solver: SupervisedSolver<IntraNodeRouteSolver>) {
+  onSolve(solver: PortfolioCandidate) {
     let routes: HighDensityIntraNodeRoute[]
     if (
-      (solver.solver as any) instanceof HighDensitySolverA01 ||
-      (solver.solver as any) instanceof HighDensityA03Solver
+      solver.solver instanceof HighDensitySolverA01 ||
+      solver.solver instanceof HighDensityA03Solver
     ) {
-      routes = (solver.solver as any).getOutput()
+      routes = solver.solver.getOutput()
     } else {
       routes = solver.solver.solvedRoutes
     }

--- a/lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver.ts
+++ b/lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver.ts
@@ -510,6 +510,11 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
     candidate.f = this.computeF(candidate.g, candidate.h)
 
     if (candidate.solver.solved) {
+      const order = this.candidateOrder.get(candidate)
+      if (order === undefined) {
+        throw new Error("Portfolio candidate is missing its stable queue order")
+      }
+      this.candidateQueue!.push({ candidate, order })
       this.solved = true
       this.winningSolver = candidate.solver
       this.onSolve(candidate)

--- a/tests/features/future-connection-point-cache.test.ts
+++ b/tests/features/future-connection-point-cache.test.ts
@@ -1,0 +1,101 @@
+import { expect, test } from "bun:test"
+import { distance } from "@tscircuit/math-utils"
+import type { Node } from "lib/data-structures/SingleRouteCandidatePriorityQueue"
+import { SingleHighDensityRouteSolver6_VertHorzLayer_FutureCost } from "lib/solvers/HighDensitySolver/SingleHighDensityRouteSolver6_VertHorzLayer_FutureCost"
+
+test("the future-cost solver caches the legacy closest point for each grid node", () => {
+  const futurePoints = [
+    { x: 2, y: 8, z: 0 },
+    { x: 8, y: 2, z: 1 },
+    { x: 5, y: 5, z: 0 },
+  ]
+  const solver = new SingleHighDensityRouteSolver6_VertHorzLayer_FutureCost({
+    connectionName: "conn-a",
+    minDistBetweenEnteringPoints: 0.2,
+    bounds: { minX: 0, maxX: 10, minY: 0, maxY: 10 },
+    A: { x: 1, y: 1, z: 0 },
+    B: { x: 9, y: 9, z: 0 },
+    traceThickness: 0.2,
+    obstacleMargin: 0.1,
+    layerCount: 2,
+    obstacleRoutes: [],
+    futureConnections: [
+      { connectionName: "future-conn", points: futurePoints },
+    ],
+  })
+
+  const nodes: Node[] = [
+    { x: 7.9, y: 2.1, z: 1, g: 0, h: 0, f: 0, parent: null },
+    { x: 4.9, y: 5.1, z: 0, g: 0, h: 0, f: 0, parent: null },
+    { x: 2.1, y: 7.9, z: 1, g: 0, h: 0, f: 0, parent: null },
+  ]
+
+  for (const node of nodes) {
+    let expectedPoint = futurePoints[0]!
+    let expectedDistance = Infinity
+    for (const point of futurePoints) {
+      const candidateDistance =
+        distance(node, point) +
+        (node.z !== point.z ? solver.viaPenaltyDistance : 0)
+      if (candidateDistance < expectedDistance) {
+        expectedDistance = candidateDistance
+        expectedPoint = point
+      }
+    }
+
+    expect(solver.getClosestFutureConnectionPoint(node)).toBe(expectedPoint)
+    expect(solver.getClosestFutureConnectionPoint(node)).toBe(expectedPoint)
+  }
+
+  const collisionX = Math.round(5 / solver.cellStep) * solver.cellStep
+  const collisionPointA = { x: collisionX, y: 5, z: 0 }
+  const collisionPointB = {
+    x: collisionX + solver.cellStep * 0.4,
+    y: 5,
+    z: 0,
+  }
+  const collisionSolver =
+    new SingleHighDensityRouteSolver6_VertHorzLayer_FutureCost({
+      connectionName: "conn-a",
+      minDistBetweenEnteringPoints: 0.2,
+      bounds: { minX: 0, maxX: 10, minY: 0, maxY: 10 },
+      A: { x: 1, y: 1, z: 0 },
+      B: { x: 9, y: 9, z: 0 },
+      traceThickness: 0.2,
+      obstacleMargin: 0.1,
+      layerCount: 2,
+      obstacleRoutes: [],
+      futureConnections: [
+        {
+          connectionName: "future-conn",
+          points: [collisionPointA, collisionPointB],
+        },
+      ],
+    })
+  const collisionNodeA: Node = {
+    x: collisionPointA.x,
+    y: 5,
+    z: 0,
+    g: 0,
+    h: 0,
+    f: 0,
+    parent: null,
+  }
+  const collisionNodeB: Node = {
+    ...collisionNodeA,
+    x: collisionPointB.x,
+  }
+
+  expect(collisionSolver.getNodeKey(collisionNodeA)).toBe(
+    collisionSolver.getNodeKey(collisionNodeB),
+  )
+  expect(collisionSolver.getClosestFutureConnectionPoint(collisionNodeA)).toBe(
+    collisionPointA,
+  )
+  expect(collisionSolver.getClosestFutureConnectionPoint(collisionNodeB)).toBe(
+    collisionPointB,
+  )
+  expect(collisionSolver.getClosestFutureConnectionPoint(collisionNodeA)).toBe(
+    collisionPointA,
+  )
+})

--- a/tests/features/portfolio-priority-queue-ordering.test.ts
+++ b/tests/features/portfolio-priority-queue-ordering.test.ts
@@ -39,7 +39,7 @@ test("the portfolio priority queue preserves legacy fitness ordering", () => {
   }
 
   expect(solver.iterations).toBeGreaterThan(10)
-  expect(Number(solver.stats.priorityQueueComparisonCount ?? 0)).toBeGreaterThan(
-    0,
-  )
+  expect(
+    Number(solver.stats.priorityQueueComparisonCount ?? 0),
+  ).toBeGreaterThan(0)
 })

--- a/tests/features/portfolio-priority-queue-ordering.test.ts
+++ b/tests/features/portfolio-priority-queue-ordering.test.ts
@@ -39,9 +39,6 @@ test("the portfolio priority queue preserves legacy fitness ordering", () => {
   }
 
   expect(solver.iterations).toBeGreaterThan(10)
-  expect(
-    Number(solver.stats.priorityQueueComparisonCount ?? 0),
-  ).toBeGreaterThan(0)
 
   const solvableSolver = new PortfolioSingleIntraNodeSolver({
     nodeWithPortPoints: {

--- a/tests/features/portfolio-priority-queue-ordering.test.ts
+++ b/tests/features/portfolio-priority-queue-ordering.test.ts
@@ -42,4 +42,30 @@ test("the portfolio priority queue preserves legacy fitness ordering", () => {
   expect(
     Number(solver.stats.priorityQueueComparisonCount ?? 0),
   ).toBeGreaterThan(0)
+
+  const solvableSolver = new PortfolioSingleIntraNodeSolver({
+    nodeWithPortPoints: {
+      capacityMeshNodeId: "solvable-node",
+      center: { x: 0, y: 0 },
+      width: 4,
+      height: 4,
+      availableZ: [0, 1],
+      portPoints: [
+        { connectionName: "a", x: -2, y: 0, z: 0 },
+        { connectionName: "a", x: 2, y: 0, z: 0 },
+      ],
+    },
+    viaDiameter: 0.3,
+    traceWidth: 0.1,
+    obstacleMargin: 0.15,
+    obstacles: [],
+    layerCount: 2,
+    effort: 1,
+  })
+  solvableSolver.solve()
+
+  expect(solvableSolver.solved).toBe(true)
+  expect(solvableSolver.getSupervisedSolverWithBestFitness()?.solver).toBe(
+    solvableSolver.winningSolver,
+  )
 })

--- a/tests/features/portfolio-priority-queue-ordering.test.ts
+++ b/tests/features/portfolio-priority-queue-ordering.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "bun:test"
+import { PortfolioSingleIntraNodeSolver } from "lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver"
+import type { NodeWithPortPoints } from "lib/types/high-density-types"
+import sample002LargeNode from "../fixtures/srj18-sample002-large-node.json"
+
+test("the portfolio priority queue preserves legacy fitness ordering", () => {
+  const solver = new PortfolioSingleIntraNodeSolver({
+    nodeWithPortPoints: sample002LargeNode as NodeWithPortPoints,
+    viaDiameter: 0.3,
+    traceWidth: 0.1,
+    obstacleMargin: 0.15,
+    obstacles: [],
+    layerCount: 2,
+    effort: 1,
+  })
+  solver.initializeSolvers()
+
+  const getLegacyBestCandidate = () => {
+    let bestFitness = Infinity
+    let bestCandidate:
+      | NonNullable<typeof solver.supervisedSolvers>[number]
+      | null = null
+    for (const candidate of solver.supervisedSolvers ?? []) {
+      if (candidate.solver.solved) return candidate
+      if (candidate.solver.failed) continue
+      if (candidate.f < bestFitness) {
+        bestFitness = candidate.f
+        bestCandidate = candidate
+      }
+    }
+    return bestCandidate
+  }
+
+  for (let step = 0; step < 100 && !solver.solved && !solver.failed; step++) {
+    expect(solver.getSupervisedSolverWithBestFitness()).toBe(
+      getLegacyBestCandidate(),
+    )
+    solver.step()
+  }
+
+  expect(solver.iterations).toBeGreaterThan(10)
+  expect(Number(solver.stats.priorityQueueComparisonCount ?? 0)).toBeGreaterThan(
+    0,
+  )
+})


### PR DESCRIPTION
## Summary

- replace the high-density portfolio's repeated linear best-candidate scan with a stable binary min-heap
- update the selected heap root in place instead of popping, allocating, looking up its order, and reinserting it after every supervisor step
- preserve the legacy selection contract: solved candidates first, then lowest fitness, then original insertion order
- cache repeated future-connection cost queries in a bounded 1,024-slot direct cache
- validate exact node coordinates on cache hits so rounded grid-key collisions cannot change route costs or output
- retain the winning candidate after completion so visualization and post-solve inspection preserve legacy behavior

## Why

The portfolio can supervise dozens of candidates. The heap removes its linear scan, while the in-place root update removes the remaining pop/reinsert overhead.

CPU profiling then showed that queue management was below 0.1% of a representative large-node run. The actual hotspot was repeated future-connection scoring: the helper consumed about 23% total CPU, scanned roughly 30 points per call, and about 64% of requests were reusable with a bounded direct cache. The cache also reuses the already-computed planar distance and evaluates the via penalty once per miss instead of once per cross-layer point.

The cache is intentionally bounded. An earlier unbounded prototype was rejected because it added about 70 MB RSS in a 5,000-step stress run.

## Correctness

- heap ordering remains solved-first, then lowest fitness, then stable insertion order
- failed roots are removed and changed roots are reheapified without changing candidate priority
- cache entries require matching node key and exact `x`, `y`, and `z`
- rounded-key collision coverage alternates between two coordinates sharing one key and verifies the correct point is recomputed each time
- route completion, relaxed DRC, DRC issue count, and via count were unchanged in the local Pipeline9 comparison

## Validation

- `bun run build`
- `bun run format:check`
- 19 focused portfolio, future-cost, large-node, Pipeline9, and grow/shrink tests passed
- representative large-node stress run: 2,094.4 ms to 1,848.7 ms (**11.7% faster**)
- bounded-cache memory in that stress run: RSS 273.4 MB to 277.7 MB; live heap 60.7 MB to 62.3 MB
- local sequential Pipeline9/SRJ18 subset (7 samples):

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Completion | 100.0% | 100.0% | 0.0 pp |
| Relaxed DRC pass | 85.7% | 85.7% | 0.0 pp |
| P50 time | 51.1s | 49.4s | **3.3% faster** |
| P95 time | 90.2s | 88.1s | **2.3% faster** |
| Average vias | 155.14 | 155.14 | 0.0% |

## Exact-head benchmark

[Full same-machine Pipeline9/SRJ18 benchmark](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/33262048382) ran all 16 scenarios sequentially on one 8-vCPU Blacksmith runner, comparing main `85d904d` with PR head `f1f9e1d`:

| Metric | Main | PR | Delta |
| --- | ---: | ---: | ---: |
| Completion | 75.0% | 75.0% | 0.0 pp |
| Relaxed DRC pass | 50.0% | 50.0% | 0.0 pp |
| DRC issues | 74 | 74 | 0 |
| Timeouts | 2 | 2 | 0 |
| P50 time | 102.1s | 104.0s | **1.9% slower** |
| P60 time | 129.1s | 128.2s | 0.8% faster |
| P70 time | 227.0s | 224.9s | 0.9% faster |
| P80 time | 270.5s | 271.0s | 0.2% slower |
| P95 time | 360.0s | 360.0s | 0.0% |
| Average vias | 187.50 | 187.50 | 0.0% |

Outcome changes: 0 improved, 0 regressed.

The stage-level artifact shows that the target high-density route stage did improve in aggregate: 735.9s to 717.4s (**2.5% faster / 18.5s saved**). The total Pipeline9 percentile result remains effectively neutral because unrelated stages and samples that never reach high density dominate the variance.

## Current conclusion

The optimization is measurable inside the target high-density stage and preserves routing outcomes, but the full exact-head benchmark does not show a meaningful end-to-end Pipeline9 speedup. This PR should remain a draft and should not be merged as a general performance improvement without a larger gain.
