### PR TITLE
superseded: available segment-point capacity

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -86,6 +86,12 @@ interface CapacityMeshSolverOptions {
   minNodeArea?: number
   visualizationTraceColorMode?: TraceColorMode
   powerTraceExpansion?: PowerTraceExpanderOptions
+  /**
+   * Selects how topology routes consume shared-edge ports before detailed
+   * high-density routing. Physical-capacity mode preserves the authoritative
+   * legal ports instead of fabricating sub-pitch congestion duplicates.
+   */
+  highDensityRoutingMode?: "legacy" | "physical-capacity"
 }
 export type AutoroutingPipelineSolverOptions = CapacityMeshSolverOptions
 
@@ -474,6 +480,8 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
           segmentPortPoints: sharedEdgeSegments.flatMap(
             (seg) => seg.portPoints,
           ),
+          includePhysicalPortalMetadata:
+            cms.opts.highDensityRoutingMode === "physical-capacity",
           simpleRouteJsonConnections: cms.srjWithPointPairs!.connections,
         })
 
@@ -483,6 +491,8 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
             connections,
             layerCount: cms.srj.layerCount,
             effort: cms.effort,
+            enforcePhysicalPortCapacity:
+              cms.opts.highDensityRoutingMode === "physical-capacity",
             preserveTerminalPcbPortIds: true,
             minViaPadDiameter: cms.viaDiameter,
             flags: {
@@ -527,6 +537,8 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
           minTraceWidth: cms.minTraceWidth,
           obstacles: cms.srj.obstacles,
           layerCount: cms.srj.layerCount,
+          preservePhysicalPortalSlots:
+            cms.opts.highDensityRoutingMode === "physical-capacity",
         },
       ],
     ),

--- a/lib/solvers/PortPointPathingSolver/hgportpointpathingsolver/buildHyperGraph.ts
+++ b/lib/solvers/PortPointPathingSolver/hgportpointpathingsolver/buildHyperGraph.ts
@@ -161,6 +161,7 @@ export function buildHyperGraph(params: {
   layerCount: number
   connectivityMap: ConnectivityMap
   assignableViaObstacles?: Obstacle[]
+  includePhysicalPortalMetadata?: boolean
 }): {
   graph: HyperGraphHg
   connections: ConnectionHgWithSimpleRouteConnection[]
@@ -212,6 +213,12 @@ export function buildHyperGraph(params: {
         )
       const port: RawPort = {
         portId: `${spp.segmentPortPointId}::${z}`,
+        ...(params.includePhysicalPortalMetadata
+          ? {
+              physicalPortalGroupId: spp.edgeId,
+              physicalPortalSlotId: `${spp.segmentPortPointId}::${z}`,
+            }
+          : {}),
         x: spp.x,
         y: spp.y,
         z,

--- a/lib/solvers/PortPointPathingSolver/hgportpointpathingsolver/types.ts
+++ b/lib/solvers/PortPointPathingSolver/hgportpointpathingsolver/types.ts
@@ -17,6 +17,12 @@ import type { PreloadedTracePortAssignment } from "lib/solvers/AvailableSegmentP
 
 export type RawPort = {
   portId: string
+  /** Authoritative capacity-mesh edge that generated this physical portal. */
+  physicalPortalGroupId?: string
+  /** Stable identity for one legal XY/Z slot on the physical portal group. */
+  physicalPortalSlotId?: string
+  /** Source slot from which a legacy congestion duplicate was fabricated. */
+  duplicatedFromPortId?: string
   x: number
   y: number
   z: number
@@ -96,6 +102,11 @@ export interface HgPortPointPathingSolverParams {
   inputSolvedRoutes?: SolvedRoutesHg[]
   layerCount: number
   effort: number
+  /**
+   * Preserve the physical shared-edge ports produced by capacity planning.
+   * When enabled, congestion must reroute instead of creating synthetic ports.
+   */
+  enforcePhysicalPortCapacity?: boolean
   preserveTerminalPcbPortIds?: boolean
   minViaPadDiameter?: number
   flags: {

--- a/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
+++ b/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
@@ -183,6 +183,8 @@ type TinyRegionMetadata = {
 
 type TinyPortMetadata = {
   serializedPortId?: string
+  physicalPortalGroupId?: string
+  physicalPortalSlotId?: string
   x?: number
   y?: number
   z?: number
@@ -414,6 +416,9 @@ const toSerializedPortData = (
   const portMetadata = port.d as typeof port.d & TinyPortMetadata
   return {
     portId: port.d.portId,
+    physicalPortalGroupId: port.d.physicalPortalGroupId,
+    physicalPortalSlotId: port.d.physicalPortalSlotId,
+    duplicatedFromPortId: port.d.duplicatedFromPortId,
     x: port.d.x,
     y: port.d.y,
     z: port.d.z,
@@ -1035,6 +1040,8 @@ export class TinyHypergraphPortPointPathingSolver extends BaseSolver {
   private duplicateCongestedPortReport?: DuplicateCongestedPortSolverReport
   private duplicateCongestedPortError?: string
   private duplicatedPortCount = 0
+  private physicalPortalGroupCount = 0
+  private physicalPortalSlotCount = 0
   private inputNodeWithPortPoints: InputNodeWithPortPoints[]
   private originalRegionById: Map<
     CapacityMeshNodeId,
@@ -1062,6 +1069,31 @@ export class TinyHypergraphPortPointPathingSolver extends BaseSolver {
       ]),
     )
     const serializedGraph = buildSerializedTinyGraph({ ...params, connections })
+    const physicalPortalGroups = new Set<string>()
+    const physicalPortalSlots = new Set<string>()
+    const inputSyntheticPorts: string[] = []
+    for (const port of serializedGraph.ports) {
+      const metadata = asTinyPortMetadata(port.d)
+      if (typeof metadata.physicalPortalGroupId === "string") {
+        physicalPortalGroups.add(metadata.physicalPortalGroupId)
+      }
+      if (typeof metadata.physicalPortalSlotId === "string") {
+        physicalPortalSlots.add(metadata.physicalPortalSlotId)
+      }
+      if (typeof metadata.duplicatedFromPortId === "string") {
+        inputSyntheticPorts.push(port.portId)
+      }
+    }
+    this.physicalPortalGroupCount = physicalPortalGroups.size
+    this.physicalPortalSlotCount = physicalPortalSlots.size
+    if (
+      params.enforcePhysicalPortCapacity === true &&
+      inputSyntheticPorts.length > 0
+    ) {
+      throw new Error(
+        `Physical port capacity mode received ${inputSyntheticPorts.length} fabricated portal(s)`,
+      )
+    }
     this.originalPreloadedSegmentKeysByConnectionId =
       capturePreloadedTraceSegmentBaseline(serializedGraph)
     const preloadedTraceStats =
@@ -1080,6 +1112,7 @@ export class TinyHypergraphPortPointPathingSolver extends BaseSolver {
         )
       : undefined
     const shouldRunDuplicateCongestedPortPrepass =
+      params.enforcePhysicalPortCapacity !== true &&
       connections.length <= MAX_CONNECTIONS_FOR_DUPLICATE_CONGESTED_PORT_PREPASS
     let graphForTiny = serializedGraph
     if (shouldRunDuplicateCongestedPortPrepass) {
@@ -1115,7 +1148,7 @@ export class TinyHypergraphPortPointPathingSolver extends BaseSolver {
           delete metadata._preloadedTracePortAssignments
         }
       }
-    } else {
+    } else if (params.enforcePhysicalPortCapacity !== true) {
       this.duplicateCongestedPortError = `Skipped for ${connections.length} connections`
     }
     this.duplicatedPortCount =
@@ -1492,6 +1525,10 @@ export class TinyHypergraphPortPointPathingSolver extends BaseSolver {
             ? this.tinyPipelineSolver.progress * 0.5
             : this.tinyPipelineSolver.progress
     this.stats = {
+      physicalPortCapacityEnforced:
+        this.params.enforcePhysicalPortCapacity === true,
+      physicalPortalGroupCount: this.physicalPortalGroupCount,
+      physicalPortalSlotCount: this.physicalPortalSlotCount,
       duplicateCongestedPortSourceCount:
         this.duplicateCongestedPortReport?.duplicatedPorts.length ?? 0,
       duplicateCongestedPortCount:
@@ -1586,11 +1623,23 @@ export class TinyHypergraphPortPointPathingSolver extends BaseSolver {
           portMetadata?.portId ??
           `tiny-port-${portId}`,
       ),
+      physicalPortalGroupId:
+        typeof portMetadata?.physicalPortalGroupId === "string"
+          ? portMetadata.physicalPortalGroupId
+          : undefined,
+      physicalPortalSlotId:
+        typeof portMetadata?.physicalPortalSlotId === "string"
+          ? portMetadata.physicalPortalSlotId
+          : undefined,
       x: solvedTinySolver.topology.portX[portId],
       y: solvedTinySolver.topology.portY[portId],
       z: solvedTinySolver.topology.portZ[portId],
       connectionName,
       rootConnectionName,
+      duplicatedFromPortId:
+        typeof portMetadata?.duplicatedFromPortId === "string"
+          ? portMetadata.duplicatedFromPortId
+          : undefined,
       ...(this.params.preserveTerminalPcbPortIds &&
       typeof portMetadata?.pcb_port_id === "string"
         ? { pcb_port_id: portMetadata.pcb_port_id }

--- a/lib/solvers/UniformPortDistributionSolver/UniformPortDistributionSolver.ts
+++ b/lib/solvers/UniformPortDistributionSolver/UniformPortDistributionSolver.ts
@@ -23,6 +23,7 @@ export interface UniformPortDistributionSolverInput {
   nodeWithPortPoints: NodeWithPortPoints[]
   inputNodesWithPortPoints: InputNodeWithPortPoints[]
   obstacles: Obstacle[]
+  preservePhysicalPortalSlots?: boolean
 }
 
 /**
@@ -119,6 +120,10 @@ export class UniformPortDistributionSolver extends BaseSolver {
     const family: PortPointWithOwnerPair[] = []
     for (const portPoint of familyRaw) {
       if (
+        !(
+          this.input.preservePhysicalPortalSlots &&
+          portPoint.physicalPortalSlotId !== undefined
+        ) &&
         !shouldIgnorePortPoint({
           portPoint,
           ownerNodeIds: portPoint.ownerNodeIds,

--- a/lib/types/high-density-types.ts
+++ b/lib/types/high-density-types.ts
@@ -4,6 +4,12 @@ export type PortPoint = {
   connectionName: string
   rootConnectionName?: string
   portPointId?: string
+  /** Capacity-mesh edge that owns this authoritative physical portal. */
+  physicalPortalGroupId?: string
+  /** Stable identity for one legal XY/Z portal slot. */
+  physicalPortalSlotId?: string
+  /** Explicit origin for a congestion-routing duplicate port. */
+  duplicatedFromPortId?: string
   pcb_port_id?: string
   x: number
   y: number

--- a/tests/features/physical-port-capacity-exhaustion.test.ts
+++ b/tests/features/physical-port-capacity-exhaustion.test.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import type { SegmentPortPoint } from "lib/solvers/AvailableSegmentPointSolver/AvailableSegmentPointSolver"
+import { buildHyperGraph } from "lib/solvers/PortPointPathingSolver/hgportpointpathingsolver"
+import { TinyHypergraphPortPointPathingSolver } from "lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver"
+import type { CapacityMeshNode, SimpleRouteConnection } from "lib/types"
+
+test("physical port capacity fails when a saturated cut has no detour", () => {
+  const capacityMeshNodes: CapacityMeshNode[] = [
+    {
+      capacityMeshNodeId: "west",
+      center: { x: -1, y: 0 },
+      width: 2,
+      height: 2,
+      layer: "top",
+      availableZ: [0],
+    },
+    {
+      capacityMeshNodeId: "east",
+      center: { x: 1, y: 0 },
+      width: 2,
+      height: 2,
+      layer: "top",
+      availableZ: [0],
+    },
+  ]
+  const segmentPortPoints: SegmentPortPoint[] = [
+    {
+      segmentPortPointId: "only-slot",
+      edgeId: "edge-west-east",
+      nodeIds: ["west", "east"],
+      x: 0,
+      y: 0,
+      availableZ: [0],
+      connectionName: null,
+      distToCentermostPortOnZ: 0,
+      cramped: false,
+    },
+  ]
+  const simpleRouteJsonConnections: SimpleRouteConnection[] = [
+    "route-a",
+    "route-b",
+  ].map((name, index) => ({
+    name,
+    __rootConnectionNames: [`root-${index}`],
+    pointsToConnect: [
+      { x: -1.5, y: index * 0.2, layer: "top" },
+      { x: 1.5, y: index * 0.2, layer: "top" },
+    ],
+  }))
+  const connectivityMap = new ConnectivityMap({})
+  connectivityMap.addConnections([
+    ["route-a", "root-0"],
+    ["route-b", "root-1"],
+  ])
+  const { graph, connections } = buildHyperGraph({
+    capacityMeshNodes,
+    segmentPortPoints,
+    simpleRouteJsonConnections,
+    layerCount: 1,
+    connectivityMap,
+    includePhysicalPortalMetadata: true,
+  })
+  const solver = new TinyHypergraphPortPointPathingSolver({
+    graph,
+    connections,
+    layerCount: 1,
+    effort: 0.01,
+    enforcePhysicalPortCapacity: true,
+    flags: { FORCE_CENTER_FIRST: true, RIPPING_ENABLED: true },
+    weights: {
+      SHUFFLE_SEED: 0,
+      MEMORY_PF_FACTOR: 4,
+      CENTER_OFFSET_DIST_PENALTY_FACTOR: 0,
+      CENTER_OFFSET_FOCUS_SHIFT: 0,
+      NODE_PF_FACTOR: 0,
+      LAYER_CHANGE_COST: 0,
+      RIPPING_PF_COST: 0,
+      NODE_PF_MAX_PENALTY: 100,
+      BASE_CANDIDATE_COST: 0.6,
+      MAX_ITERATIONS_PER_PATH: 0,
+      RANDOM_WALK_DISTANCE: 0,
+      START_RIPPING_PF_THRESHOLD: 0.3,
+      END_RIPPING_PF_THRESHOLD: 1,
+      MAX_RIPS: 20,
+      RANDOM_RIP_FRACTION: 0.3,
+      STRAIGHT_LINE_DEVIATION_PENALTY_FACTOR: 4,
+      GREEDY_MULTIPLIER: 0.7,
+      MIN_ALLOWED_BOARD_SCORE: -10000,
+    },
+  })
+
+  solver.solve()
+
+  expect(solver.solved).toBeFalse()
+  expect(solver.failed).toBeTrue()
+  expect(solver.stats.physicalPortalSlotCount).toBe(1)
+  expect(solver.stats.duplicateCongestedPortCount).toBe(0)
+})

--- a/tests/features/physical-port-capacity-rejects-fabricated-port.test.ts
+++ b/tests/features/physical-port-capacity-rejects-fabricated-port.test.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import type { SegmentPortPoint } from "lib/solvers/AvailableSegmentPointSolver/AvailableSegmentPointSolver"
+import { buildHyperGraph } from "lib/solvers/PortPointPathingSolver/hgportpointpathingsolver"
+import { TinyHypergraphPortPointPathingSolver } from "lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver"
+import type { CapacityMeshNode, SimpleRouteConnection } from "lib/types"
+
+test("physical port capacity rejects a fabricated portal", () => {
+  const capacityMeshNodes: CapacityMeshNode[] = [
+    {
+      capacityMeshNodeId: "west",
+      center: { x: -1, y: 0 },
+      width: 2,
+      height: 2,
+      layer: "top",
+      availableZ: [0],
+    },
+    {
+      capacityMeshNodeId: "east",
+      center: { x: 1, y: 0 },
+      width: 2,
+      height: 2,
+      layer: "top",
+      availableZ: [0],
+    },
+  ]
+  const segmentPortPoints: SegmentPortPoint[] = [
+    {
+      segmentPortPointId: "portal",
+      edgeId: "edge-west-east",
+      nodeIds: ["west", "east"],
+      x: 0,
+      y: 0,
+      availableZ: [0],
+      connectionName: null,
+      distToCentermostPortOnZ: 0,
+      cramped: false,
+    },
+  ]
+  const simpleRouteJsonConnections: SimpleRouteConnection[] = [
+    {
+      name: "route-a",
+      __rootConnectionNames: ["root-a"],
+      pointsToConnect: [
+        { x: -1.5, y: 0, layer: "top" },
+        { x: 1.5, y: 0, layer: "top" },
+      ],
+    },
+  ]
+  const connectivityMap = new ConnectivityMap({})
+  connectivityMap.addConnections([["route-a", "root-a"]])
+  const { graph, connections } = buildHyperGraph({
+    capacityMeshNodes,
+    segmentPortPoints,
+    simpleRouteJsonConnections,
+    layerCount: 1,
+    connectivityMap,
+    includePhysicalPortalMetadata: true,
+  })
+  graph.ports[0]!.d.duplicatedFromPortId = "source-portal"
+
+  expect(
+    () =>
+      new TinyHypergraphPortPointPathingSolver({
+        graph,
+        connections,
+        layerCount: 1,
+        effort: 0.1,
+        enforcePhysicalPortCapacity: true,
+        flags: { FORCE_CENTER_FIRST: true, RIPPING_ENABLED: true },
+        weights: {
+          SHUFFLE_SEED: 0,
+          MEMORY_PF_FACTOR: 4,
+          CENTER_OFFSET_DIST_PENALTY_FACTOR: 0,
+          CENTER_OFFSET_FOCUS_SHIFT: 0,
+          NODE_PF_FACTOR: 0,
+          LAYER_CHANGE_COST: 0,
+          RIPPING_PF_COST: 0,
+          NODE_PF_MAX_PENALTY: 100,
+          BASE_CANDIDATE_COST: 0.6,
+          MAX_ITERATIONS_PER_PATH: 0,
+          RANDOM_WALK_DISTANCE: 0,
+          START_RIPPING_PF_THRESHOLD: 0.3,
+          END_RIPPING_PF_THRESHOLD: 1,
+          MAX_RIPS: 100,
+          RANDOM_RIP_FRACTION: 0.3,
+          STRAIGHT_LINE_DEVIATION_PENALTY_FACTOR: 4,
+          GREEDY_MULTIPLIER: 0.7,
+          MIN_ALLOWED_BOARD_SCORE: -10000,
+        },
+      }),
+  ).toThrow("Physical port capacity mode received 1 fabricated portal")
+})

--- a/tests/features/physical-port-capacity-routing.test.ts
+++ b/tests/features/physical-port-capacity-routing.test.ts
@@ -1,0 +1,148 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import type { SegmentPortPoint } from "lib/solvers/AvailableSegmentPointSolver/AvailableSegmentPointSolver"
+import { buildHyperGraph } from "lib/solvers/PortPointPathingSolver/hgportpointpathingsolver"
+import { TinyHypergraphPortPointPathingSolver } from "lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver"
+import type { CapacityMeshNode, SimpleRouteConnection } from "lib/types"
+
+test("physical port capacity reroutes overflow through authoritative slots", () => {
+  const capacityMeshNodes: CapacityMeshNode[] = [
+    {
+      capacityMeshNodeId: "west",
+      center: { x: -2, y: 0 },
+      width: 2,
+      height: 4,
+    },
+    {
+      capacityMeshNodeId: "upper",
+      center: { x: 0, y: 1 },
+      width: 2,
+      height: 2,
+    },
+    {
+      capacityMeshNodeId: "lower",
+      center: { x: 0, y: -1 },
+      width: 2,
+      height: 2,
+    },
+    { capacityMeshNodeId: "east", center: { x: 2, y: 0 }, width: 2, height: 4 },
+  ].map((node) => ({ ...node, layer: "top", availableZ: [0] }))
+  const createPortal = (
+    id: string,
+    x: number,
+    y: number,
+    nodeIds: [string, string],
+  ): SegmentPortPoint => ({
+    segmentPortPointId: id,
+    edgeId: `edge-${id}`,
+    nodeIds,
+    x,
+    y,
+    availableZ: [0],
+    connectionName: null,
+    distToCentermostPortOnZ: 0,
+    cramped: false,
+  })
+  const simpleRouteJsonConnections: SimpleRouteConnection[] = [
+    "route-a",
+    "route-b",
+  ].map((name, index) => ({
+    name,
+    __rootConnectionNames: [`root-${index}`],
+    pointsToConnect: [
+      { x: -2.5, y: 0, layer: "top" },
+      { x: 2.5, y: 0, layer: "top" },
+    ],
+  }))
+  const connectivityMap = new ConnectivityMap({})
+  connectivityMap.addConnections([
+    ["route-a", "root-0"],
+    ["route-b", "root-1"],
+  ])
+  const { graph, connections } = buildHyperGraph({
+    capacityMeshNodes,
+    segmentPortPoints: [
+      createPortal("west-upper", -1, 1, ["west", "upper"]),
+      createPortal("upper-east", 1, 1, ["upper", "east"]),
+      createPortal("west-lower", -1, -1, ["west", "lower"]),
+      createPortal("lower-east", 1, -1, ["lower", "east"]),
+    ],
+    layerCount: 1,
+    connectivityMap,
+    includePhysicalPortalMetadata: true,
+    simpleRouteJsonConnections,
+  })
+  const solver = new TinyHypergraphPortPointPathingSolver({
+    graph,
+    connections,
+    layerCount: 1,
+    effort: 0.1,
+    enforcePhysicalPortCapacity: true,
+    flags: { FORCE_CENTER_FIRST: true, RIPPING_ENABLED: true },
+    weights: {
+      SHUFFLE_SEED: 0,
+      MEMORY_PF_FACTOR: 4,
+      CENTER_OFFSET_DIST_PENALTY_FACTOR: 0,
+      CENTER_OFFSET_FOCUS_SHIFT: 0,
+      NODE_PF_FACTOR: 0,
+      LAYER_CHANGE_COST: 0,
+      RIPPING_PF_COST: 0,
+      NODE_PF_MAX_PENALTY: 100,
+      BASE_CANDIDATE_COST: 0.6,
+      MAX_ITERATIONS_PER_PATH: 0,
+      RANDOM_WALK_DISTANCE: 0,
+      START_RIPPING_PF_THRESHOLD: 0.3,
+      END_RIPPING_PF_THRESHOLD: 1,
+      MAX_RIPS: 100,
+      RANDOM_RIP_FRACTION: 0.3,
+      STRAIGHT_LINE_DEVIATION_PENALTY_FACTOR: 4,
+      GREEDY_MULTIPLIER: 0.7,
+      MIN_ALLOWED_BOARD_SCORE: -10000,
+    },
+  })
+
+  solver.solve()
+
+  const assignedPhysicalPorts = solver
+    .getOutput()
+    .nodesWithPortPoints.flatMap((node) => node.portPoints)
+    .filter((portPoint) => portPoint.physicalPortalSlotId !== undefined)
+  const rootsBySlot = new Map<string, Set<string>>()
+  for (const portPoint of assignedPhysicalPorts) {
+    const roots = rootsBySlot.get(portPoint.physicalPortalSlotId!) ?? new Set()
+    roots.add(portPoint.rootConnectionName ?? portPoint.connectionName)
+    rootsBySlot.set(portPoint.physicalPortalSlotId!, roots)
+  }
+
+  expect(solver.solved).toBeTrue()
+  expect(solver.failed).toBeFalse()
+  expect(solver.stats.physicalPortCapacityEnforced).toBeTrue()
+  expect(solver.stats.physicalPortalGroupCount).toBe(4)
+  expect(solver.stats.physicalPortalSlotCount).toBe(4)
+  expect(solver.stats.duplicateCongestedPortCount).toBe(0)
+  expect(
+    new Set(assignedPhysicalPorts.map((point) => point.physicalPortalGroupId)),
+  ).toEqual(
+    new Set([
+      "edge-west-upper",
+      "edge-upper-east",
+      "edge-west-lower",
+      "edge-lower-east",
+    ]),
+  )
+  expect(
+    new Set(
+      assignedPhysicalPorts.map(
+        (point) => point.rootConnectionName ?? point.connectionName,
+      ),
+    ),
+  ).toEqual(new Set(["root-0", "root-1"]))
+  expect(
+    [...rootsBySlot.values()].every((roots) => roots.size === 1),
+  ).toBeTrue()
+  expect(
+    assignedPhysicalPorts.every(
+      (portPoint) => portPoint.duplicatedFromPortId === undefined,
+    ),
+  ).toBeTrue()
+})

--- a/tests/features/uniform-port-distribution-physical-slots.test.ts
+++ b/tests/features/uniform-port-distribution-physical-slots.test.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "bun:test"
+import { UniformPortDistributionSolver } from "lib/solvers/UniformPortDistributionSolver/UniformPortDistributionSolver"
+
+const makeInput = () => {
+  const physicalPoints = [
+    {
+      portPointId: "slot-1",
+      physicalPortalGroupId: "edge-a-b",
+      physicalPortalSlotId: "edge-a-b::slot-1::0",
+      connectionName: "route-a",
+      rootConnectionName: "root-a",
+      x: 4,
+      y: -3,
+      z: 0,
+    },
+    {
+      portPointId: "slot-2",
+      physicalPortalGroupId: "edge-a-b",
+      physicalPortalSlotId: "edge-a-b::slot-2::0",
+      connectionName: "route-b",
+      rootConnectionName: "root-b",
+      x: 4,
+      y: -2,
+      z: 0,
+    },
+  ]
+
+  return {
+    nodeWithPortPoints: [
+      {
+        capacityMeshNodeId: "node-a",
+        center: { x: 0, y: 0 },
+        width: 8,
+        height: 8,
+        availableZ: [0],
+        portPoints: structuredClone(physicalPoints),
+        portPointsInPairs: [
+          structuredClone(physicalPoints) as [
+            (typeof physicalPoints)[number],
+            (typeof physicalPoints)[number],
+          ],
+        ],
+      },
+      {
+        capacityMeshNodeId: "node-b",
+        center: { x: 8, y: 0 },
+        width: 8,
+        height: 8,
+        availableZ: [0],
+        portPoints: structuredClone(physicalPoints),
+        portPointsInPairs: [
+          structuredClone(physicalPoints) as [
+            (typeof physicalPoints)[number],
+            (typeof physicalPoints)[number],
+          ],
+        ],
+      },
+    ],
+    inputNodesWithPortPoints: ["node-a", "node-b"].map((nodeId) => ({
+      capacityMeshNodeId: nodeId,
+      center: { x: nodeId === "node-a" ? 0 : 8, y: 0 },
+      width: 8,
+      height: 8,
+      availableZ: [0],
+      portPoints: physicalPoints.map((point) => ({
+        portPointId: point.portPointId,
+        x: point.x,
+        y: point.y,
+        z: point.z,
+        connectionNodeIds: ["node-a", "node-b"] as [string, string],
+        distToCentermostPortOnZ: 0,
+      })),
+    })),
+    obstacles: [],
+  }
+}
+
+test("physical capacity mode preserves authoritative portal slots", () => {
+  const legacySolver = new UniformPortDistributionSolver(makeInput())
+  legacySolver.solve()
+
+  const capacitySolver = new UniformPortDistributionSolver({
+    ...makeInput(),
+    preservePhysicalPortalSlots: true,
+  })
+  capacitySolver.solve()
+
+  const legacyPoints = legacySolver.getOutput()[0].portPoints
+  const capacityPoints = capacitySolver.getOutput()[0].portPoints
+
+  expect(legacyPoints.map(({ x, y, z }) => ({ x, y, z }))).toEqual([
+    { x: 4, y: -2, z: 0 },
+    { x: 4, y: 2, z: 0 },
+  ])
+  expect(capacityPoints).toEqual(makeInput().nodeWithPortPoints[0].portPoints)
+  expect(capacitySolver.getOutput()[0].portPointsInPairs?.flat()).toEqual(
+    capacityPoints,
+  )
+})


### PR DESCRIPTION
Superseded by #2307 after renaming the branch and simplifying the implementation to use the existing available segment points directly.

The replacement keeps the same narrowly scoped capacity behavior, removes the intermediate metadata model, and adds reviewed SVG snapshots.