### PR TITLE
perf: cache routing geometry evaluations

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/create-pipeline7-autorouting-drc-evaluator.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/create-pipeline7-autorouting-drc-evaluator.ts
@@ -4,7 +4,9 @@ import {
   type SimpleRouteJson as RepairSimpleRouteJson,
   type SimplifiedPcbTraces as RepairSimplifiedPcbTraces,
 } from "high-density-repair03/lib"
+import stableStringify from "fast-json-stable-stringify"
 import type { SimpleRouteJson } from "lib/types"
+import type { HighDensityRoute } from "lib/types/high-density-types"
 import { getViaDimensions } from "lib/utils/getViaDimensions"
 import {
   type ConvertPipeline7HdRoutesOptions,
@@ -13,6 +15,9 @@ import {
 
 const AUTOROUTING_TRACE_CLEARANCE = 0.1
 const AUTOROUTING_VIA_CLEARANCE = 0.1
+
+type RouteGeometryKey = string
+type BoardGeometryKey = string
 
 /**
  * Scores Pipeline7 repair candidates with reusable autorouting-only DRC state.
@@ -50,12 +55,41 @@ export const createPipeline7AutoroutingDrcEvaluator = (
   const convertCandidateRoutes =
     createPipeline7HdRoutesToSimplifiedPcbTracesConverter(conversionOptions)
   const originalTraces = conversionOptions.originalSrj.traces ?? []
+  const routeGeometryIdByKey = new Map<RouteGeometryKey, number>()
+  const resultByBoardGeometryKey = new Map<
+    BoardGeometryKey,
+    ReturnType<DrcEvaluator>
+  >()
+  let nextRouteGeometryId = 0
 
-  return ({ routes, hdRoutes }) => {
+  const getRouteGeometryId = (route: HighDensityRoute): number => {
+    const routeGeometryKey: RouteGeometryKey = stableStringify(route)
+    const existingId = routeGeometryIdByKey.get(routeGeometryKey)
+    if (existingId !== undefined) return existingId
+    const routeGeometryId = nextRouteGeometryId
+    nextRouteGeometryId += 1
+    routeGeometryIdByKey.set(routeGeometryKey, routeGeometryId)
+    return routeGeometryId
+  }
+
+  const getBoardGeometryKey = (
+    routes: HighDensityRoute[],
+  ): BoardGeometryKey => {
+    const routeGeometryIds: number[] = []
+    for (const route of routes) {
+      routeGeometryIds.push(getRouteGeometryId(route))
+    }
+    return routeGeometryIds.join(",")
+  }
+
+  const evaluator: DrcEvaluator = ({ routes, hdRoutes }) => {
     const evaluatedRoutes = routes ?? hdRoutes
     if (!evaluatedRoutes) {
       throw new Error("Pipeline7 autorouting DRC evaluation requires HD routes")
     }
+    const boardGeometryKey = getBoardGeometryKey(evaluatedRoutes)
+    const cachedResult = resultByBoardGeometryKey.get(boardGeometryKey)
+    if (cachedResult !== undefined) return cachedResult
 
     const candidateTraces = convertCandidateRoutes(evaluatedRoutes)
     const tracesToEvaluate = (
@@ -64,6 +98,10 @@ export const createPipeline7AutoroutingDrcEvaluator = (
         : candidateTraces
     ) as RepairSimplifiedPcbTraces
 
-    return engine.evaluate(tracesToEvaluate)
+    const result = engine.evaluate(tracesToEvaluate)
+    resultByBoardGeometryKey.set(boardGeometryKey, result)
+    return result
   }
+  evaluator.consumesHdRoutesDirectly = true
+  return evaluator
 }

--- a/lib/data-structures/HighDensityRouteSpatialIndex.ts
+++ b/lib/data-structures/HighDensityRouteSpatialIndex.ts
@@ -24,6 +24,22 @@ export type HighDensityIntraNodeRoute = {
 }
 export type HighDensityRoute = HighDensityIntraNodeRoute
 
+type SegmentConflictQueryKey = string
+type RouteConnectionName = string
+
+type SegmentConflict = {
+  readonly conflictingRoute: HighDensityRoute
+  readonly distance: number
+}
+
+type SegmentConflictResult = readonly SegmentConflict[]
+
+export interface HighDensityRouteSpatialIndexOptions {
+  cellSize?: number
+  /** Reuse exact segment-conflict queries until addRoute or removeRoute. */
+  memoizeSegmentConflictQueries?: boolean
+}
+
 // --- Utility Functions (Unchanged) ---
 
 const getSegmentBounds = (segment: Segment) => {
@@ -102,12 +118,26 @@ export class HighDensityRouteSpatialIndex {
   private viaBuckets: Map<BucketCoordinate, StoredVia[]> // New: Store vias
   private CELL_SIZE: number
   private maximumCopperRadius = 0
+  private readonly segmentConflictsByQueryKey?: Map<
+    SegmentConflictQueryKey,
+    SegmentConflictResult
+  >
 
-  constructor(routes: HighDensityRoute[], cellSize: number = 1.0) {
+  constructor(
+    routes: HighDensityRoute[],
+    cellSizeOrOptions: number | HighDensityRouteSpatialIndexOptions = {},
+  ) {
     // console.time("HighDensityRouteSpatialIndex Constructor");
+    const options: HighDensityRouteSpatialIndexOptions =
+      typeof cellSizeOrOptions === "number"
+        ? { cellSize: cellSizeOrOptions }
+        : cellSizeOrOptions
     this.segmentBuckets = new Map()
     this.viaBuckets = new Map() // Initialize via buckets
-    this.CELL_SIZE = cellSize
+    this.CELL_SIZE = options.cellSize ?? 1.0
+    this.segmentConflictsByQueryKey = options.memoizeSegmentConflictQueries
+      ? new Map()
+      : undefined
     const epsilon = 1e-9 // For segment boundary checks
 
     for (const route of routes) {
@@ -201,7 +231,14 @@ export class HighDensityRouteSpatialIndex {
     segmentStart: Point, // Keep Point for original Z data if needed elsewhere
     segmentEnd: Point,
     margin: number, // Minimum required clearance
-  ): Array<{ conflictingRoute: HighDensityRoute; distance: number }> {
+  ): SegmentConflictResult {
+    let queryKey: SegmentConflictQueryKey | undefined
+    if (this.segmentConflictsByQueryKey) {
+      queryKey = `${segmentStart.x}:${segmentStart.y}:${segmentStart.z}|${segmentEnd.x}:${segmentEnd.y}:${segmentEnd.z}|${margin}`
+      const cachedConflicts = this.segmentConflictsByQueryKey.get(queryKey)
+      if (cachedConflicts !== undefined) return cachedConflicts
+    }
+
     const querySegment: Segment = [segmentStart, segmentEnd]
     const bounds = getSegmentBounds(querySegment)
 
@@ -223,7 +260,7 @@ export class HighDensityRouteSpatialIndex {
 
     // Use a map to store the minimum squared distance found *per route*
     const conflictingRouteData = new Map<
-      string,
+      RouteConnectionName,
       { route: HighDensityRoute; minDistSq: number }
     >()
     const checkedSegments = new Set<string>() // Store segmentId
@@ -316,10 +353,7 @@ export class HighDensityRouteSpatialIndex {
     }
 
     // --- Convert map to results ---
-    const results: Array<{
-      conflictingRoute: HighDensityRoute
-      distance: number
-    }> = []
+    const results: SegmentConflict[] = []
     for (const data of conflictingRouteData.values()) {
       // Distance reported is centerline-to-centerline (or point)
       results.push({
@@ -328,6 +362,13 @@ export class HighDensityRouteSpatialIndex {
       })
     }
 
+    if (queryKey !== undefined) {
+      const immutableResults: SegmentConflictResult = Object.freeze(
+        results.map((result) => Object.freeze(result)),
+      )
+      this.segmentConflictsByQueryKey?.set(queryKey, immutableResults)
+      return immutableResults
+    }
     return results
   }
 
@@ -336,6 +377,8 @@ export class HighDensityRouteSpatialIndex {
    * @param connectionName The connection name of the route to remove.
    */
   removeRoute(connectionName: string): void {
+    this.segmentConflictsByQueryKey?.clear()
+
     // Remove segments belonging to this route
     for (const [bucketKey, segments] of this.segmentBuckets) {
       const filtered = segments.filter(
@@ -366,6 +409,8 @@ export class HighDensityRouteSpatialIndex {
    * @param route The route to add.
    */
   addRoute(route: HighDensityRoute): void {
+    this.segmentConflictsByQueryKey?.clear()
+
     if (!route || !route.connectionName) {
       console.warn("Skipping route with missing data:", route)
       return
@@ -468,7 +513,7 @@ export class HighDensityRouteSpatialIndex {
     const maxIndexY = Math.floor((searchMaxY + epsilon) / this.CELL_SIZE)
 
     const conflictingRouteData = new Map<
-      string,
+      RouteConnectionName,
       { route: HighDensityRoute; minDistSq: number }
     >()
     const checkedSegments = new Set<string>()

--- a/lib/solvers/UselessViaRemovalSolver/UselessViaRemovalSolver.ts
+++ b/lib/solvers/UselessViaRemovalSolver/UselessViaRemovalSolver.ts
@@ -11,6 +11,8 @@ import { getJumpersGraphics } from "lib/utils/getJumperGraphics"
 import { createObjectsWithZLayers } from "lib/utils/createObjectsWithZLayers"
 import type { ConnectivityMap } from "circuit-json-to-connectivity-map"
 
+type PcbPortId = string
+
 export interface UselessViaRemovalSolverInput {
   unsimplifiedHdRoutes: HighDensityRoute[]
   /** Routed copper that participates in collision checks but is never changed. */
@@ -30,7 +32,10 @@ export interface UselessViaRemovalSolverInput {
    * Physical copper-layer indices on which each PCB-port terminal can directly
    * accept a route endpoint without a via, keyed by PCB port id.
    */
-  terminalLayerIndicesByPcbPortId?: ReadonlyMap<string, ReadonlySet<number>>
+  terminalLayerIndicesByPcbPortId?: ReadonlyMap<
+    PcbPortId,
+    ReadonlySet<number>
+  >
 }
 
 export class UselessViaRemovalSolver extends BaseSolver {
@@ -62,10 +67,13 @@ export class UselessViaRemovalSolver extends BaseSolver {
       "flatbush",
       this.input.obstacles,
     )
-    this.hdRouteSHI = new HighDensityRouteSpatialIndex([
-      ...this.unsimplifiedHdRoutes,
-      ...(input.otherHdRoutes ?? []),
-    ])
+    this.hdRouteSHI = new HighDensityRouteSpatialIndex(
+      [
+        ...this.unsimplifiedHdRoutes,
+        ...(input.otherHdRoutes ?? []),
+      ],
+      { memoizeSegmentConflictQueries: true },
+    )
   }
 
   _step() {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@tscircuit/krt-wasm": "^0.1.0",
     "@tscircuit/length-matching-solver": "git+https://github.com/tscircuit/length-matching-solver.git#0c7f84810aceb70f9517c274116071f2af1ace6b",
     "@tscircuit/math-utils": "^0.0.36",
-    "@tscircuit/power-trace-expander": "git+https://github.com/tscircuit/power-trace-expander.git#69e92efc8c3dec35f9c71ba58b3cdaefffd1c257",
+    "@tscircuit/power-trace-expander": "git+https://github.com/tscircuit/power-trace-expander.git#4ac455fa25f1146e428cbe4d1786e77e3c1a85a6",
     "@tscircuit/rectdiff": "git+https://github.com/tscircuit/rectdiff.git#262f1b7e2c70021785f0ccdbe8e2562f827c7dbf",
     "@tscircuit/solver-utils": "^0.0.16",
     "@types/bun": "^1.2.23",
@@ -97,7 +97,7 @@
     "zdwiel-dataset": "git+https://github.com/dwiel/tscircuit-benchmark.git#be36518b5bf51755dae92c230061ab3cf4e3e063",
     "high-density-repair01": "git+https://github.com/tscircuit/high-density-repair01.git#8eaa775e7c7a2c32c12a82da4edef22477549027",
     "high-density-repair02": "https://codeload.github.com/tscircuit/high-density-repair02/tar.gz/2afc0cbba3bf2f7eb6b9cd33615d21e9ad9352d4",
-    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#a9654302bdfdbc93222f1f66ce5d67ccd6ecd891",
+    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#049c546fe456d813fb901df63906db079f5a4e3f",
     "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d",
     "@tscircuit/high-density-b01": "git+https://github.com/tscircuit/high-density-b01.git#f974f97a77f27bc32b1fe5a8b3bccb7ba023e0b7"
   },

--- a/tests/features/__snapshots__/pipeline7-drc-evaluator-geometry-cache-crossing.snap.svg
+++ b/tests/features/__snapshots__/pipeline7-drc-evaluator-geometry-cache-crossing.snap.svg
@@ -1,0 +1,44 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="-1,0 1,0" data-type="line" data-label="horizontal" points="40,320 600,320" fill="none" stroke="#dc2626" stroke-linejoin="round" stroke-width="28"/></g><g><polyline data-points="0,-1 0,1" data-type="line" data-label="vertical" points="320,600 320,40" fill="none" stroke="#2563eb" stroke-linejoin="round" stroke-width="28"/></g><g><circle data-type="point" data-label="horizontal" data-x="-1" data-y="0" cx="40" cy="320" r="3" fill="#dc2626"/></g><g><circle data-type="point" data-label="horizontal" data-x="1" data-y="0" cx="600" cy="320" r="3" fill="#dc2626"/></g><g><circle data-type="point" data-label="vertical" data-x="0" data-y="-1" cx="320" cy="600" r="3" fill="#2563eb"/></g><g><circle data-type="point" data-label="vertical" data-x="0" data-y="1" cx="320" cy="40" r="3" fill="#2563eb"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":280,"c":0,"e":320,"b":0,"d":-280,"f":320};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/features/__snapshots__/pipeline7-drc-evaluator-geometry-cache-separated.snap.svg
+++ b/tests/features/__snapshots__/pipeline7-drc-evaluator-geometry-cache-separated.snap.svg
@@ -1,0 +1,44 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="-1,0 1,0" data-type="line" data-label="horizontal" points="40,320 488,320" fill="none" stroke="#dc2626" stroke-linejoin="round" stroke-width="22.400000000000002"/></g><g><polyline data-points="1.5,-1 1.5,1" data-type="line" data-label="vertical" points="600,544 600,96" fill="none" stroke="#2563eb" stroke-linejoin="round" stroke-width="22.400000000000002"/></g><g><circle data-type="point" data-label="horizontal" data-x="-1" data-y="0" cx="40" cy="320" r="3" fill="#dc2626"/></g><g><circle data-type="point" data-label="horizontal" data-x="1" data-y="0" cx="488" cy="320" r="3" fill="#dc2626"/></g><g><circle data-type="point" data-label="vertical" data-x="1.5" data-y="-1" cx="600" cy="544" r="3" fill="#2563eb"/></g><g><circle data-type="point" data-label="vertical" data-x="1.5" data-y="1" cx="600" cy="96" r="3" fill="#2563eb"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":224,"c":0,"e":264,"b":0,"d":-224,"f":320};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/features/pipeline7-drc-evaluator-geometry-cache.test.ts
+++ b/tests/features/pipeline7-drc-evaluator-geometry-cache.test.ts
@@ -1,0 +1,116 @@
+import { expect, test } from "bun:test"
+import { getSvgFromGraphicsObject } from "graphics-debug"
+import { createPipeline7AutoroutingDrcEvaluator } from "lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/create-pipeline7-autorouting-drc-evaluator"
+import type { SimpleRouteJson } from "lib/types"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
+
+const getRoutesSvg = (routes: HighDensityRoute[], title: string): string =>
+  getSvgFromGraphicsObject({
+    title,
+    lines: routes.flatMap((route, routeIndex) =>
+      route.route.slice(0, -1).map((point, pointIndex) => ({
+        points: [point, route.route[pointIndex + 1]!],
+        strokeColor: routeIndex === 0 ? "#dc2626" : "#2563eb",
+        strokeWidth: route.traceThickness,
+        label: route.connectionName,
+      })),
+    ),
+    points: routes.flatMap((route, routeIndex) =>
+      route.route.map((point) => ({
+        ...point,
+        color: routeIndex === 0 ? "#dc2626" : "#2563eb",
+        label: route.connectionName,
+      })),
+    ),
+    rects: [],
+    circles: [],
+  })
+
+test("Pipeline7 DRC evaluation reuses equal geometry and invalidates changes", async () => {
+  const srj: SimpleRouteJson = {
+    layerCount: 2,
+    minTraceWidth: 0.1,
+    bounds: { minX: -2, minY: -2, maxX: 2, maxY: 2 },
+    obstacles: [],
+    connections: [
+      {
+        name: "horizontal",
+        pointsToConnect: [
+          { x: -1, y: 0, layer: "top", pointId: "horizontal_start" },
+          { x: 1, y: 0, layer: "top", pointId: "horizontal_end" },
+        ],
+      },
+      {
+        name: "vertical",
+        pointsToConnect: [
+          { x: 0, y: -1, layer: "top", pointId: "vertical_start" },
+          { x: 0, y: 1, layer: "top", pointId: "vertical_end" },
+        ],
+      },
+    ],
+  }
+  const connMap = getConnectivityMapFromSimpleRouteJson(srj)
+  const evaluator = createPipeline7AutoroutingDrcEvaluator({
+    connections: srj.connections,
+    originalConnections: srj.connections,
+    layerCount: srj.layerCount,
+    obstacles: srj.obstacles,
+    defaultViaHoleDiameter: 0.15,
+    connMap,
+    srjWithPointPairs: srj,
+    originalSrj: srj,
+  })
+  const routes: HighDensityRoute[] = [
+    {
+      connectionName: "horizontal",
+      route: [
+        { x: -1, y: 0, z: 0 },
+        { x: 1, y: 0, z: 0 },
+      ],
+      vias: [],
+      traceThickness: 0.1,
+      viaDiameter: 0.3,
+    },
+    {
+      connectionName: "vertical",
+      route: [
+        { x: 0, y: -1, z: 0 },
+        { x: 0, y: 1, z: 0 },
+      ],
+      vias: [],
+      traceThickness: 0.1,
+      viaDiameter: 0.3,
+    },
+  ]
+
+  expect(evaluator.consumesHdRoutesDirectly).toBe(true)
+  const crossingResult = evaluator({ traces: [], routes })
+  const equivalentResult = evaluator({
+    traces: [],
+    routes: structuredClone(routes),
+  })
+  expect(
+    Array.isArray(crossingResult) ? crossingResult : crossingResult.errors,
+  ).toHaveLength(1)
+  expect(equivalentResult).toBe(crossingResult)
+  await expect(getRoutesSvg(routes, "cached crossing geometry")).toMatchSvgSnapshot(
+    import.meta.path,
+    { svgName: "crossing" },
+  )
+
+  routes[1]!.route[0]!.x = 1.5
+  routes[1]!.route[1]!.x = 1.5
+  const separatedResult = evaluator({ traces: [], routes })
+  expect(separatedResult).not.toBe(crossingResult)
+  expect(
+    Array.isArray(separatedResult) ? separatedResult : separatedResult.errors,
+  ).toHaveLength(0)
+  await expect(
+    getRoutesSvg(routes, "changed geometry invalidates cached DRC"),
+  ).toMatchSvgSnapshot(import.meta.path, { svgName: "separated" })
+
+  routes[1]!.route[0]!.x = 0
+  routes[1]!.route[1]!.x = 0
+  expect(evaluator({ traces: [], routes })).toBe(crossingResult)
+})

--- a/tests/solvers/__snapshots__/useless-via-removal-spatial-conflict-query-cache.snap.svg
+++ b/tests/solvers/__snapshots__/useless-via-removal-spatial-conflict-query-cache.snap.svg
@@ -1,0 +1,44 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="0,0 4,0" data-type="line" data-label="indexed route" points="40,320 180,320" fill="none" stroke="#dc2626" stroke-linejoin="round" stroke-width="5.25"/></g><g><polyline data-points="12,0 16,0" data-type="line" data-label="re-added route" points="460,320 600,320" fill="none" stroke="#dc2626" stroke-linejoin="round" stroke-width="5.25"/></g><g><polyline data-points="2,-1 2,1" data-type="line" data-label="repeated query (cache hit)" points="110,355 110,285" fill="none" stroke="#7c3aed" stroke-linejoin="round" stroke-width="2.8000000000000003"/></g><g><polyline data-points="8,-1 8,1" data-type="line" data-label="query after removal (no conflict)" points="320,355 320,285" fill="none" stroke="#64748b" stroke-linejoin="round" stroke-width="2.8000000000000003"/></g><g><polyline data-points="14,-1 14,1" data-type="line" data-label="query after re-add (cache rebuilt)" points="530,355 530,285" fill="none" stroke="#7c3aed" stroke-linejoin="round" stroke-width="2.8000000000000003"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":35,"c":0,"e":40,"b":0,"d":-35,"f":320};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/solvers/useless-via-removal-spatial-conflict-query-cache.test.ts
+++ b/tests/solvers/useless-via-removal-spatial-conflict-query-cache.test.ts
@@ -1,0 +1,161 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { getSvgFromGraphicsObject } from "graphics-debug"
+import { HighDensityRouteSpatialIndex } from "lib/data-structures/HighDensityRouteSpatialIndex"
+import { UselessViaRemovalSolver } from "lib/solvers/UselessViaRemovalSolver/UselessViaRemovalSolver"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+
+test("segment conflict query memoization is opt-in and invalidated by route updates", async () => {
+  const indexedRoute: HighDensityRoute = {
+    connectionName: "indexed_route",
+    traceThickness: 0.15,
+    viaDiameter: 0.3,
+    route: [
+      { x: 0, y: 0, z: 0 },
+      { x: 4, y: 0, z: 0 },
+    ],
+    vias: [],
+  }
+  const queryStart = { x: 2, y: -1, z: 0 }
+  const queryEnd = { x: 2, y: 1, z: 0 }
+  const queryMargin = 0.1
+
+  const defaultIndex = new HighDensityRouteSpatialIndex([indexedRoute])
+  const firstDefaultResult = defaultIndex.getConflictingRoutesForSegment(
+    queryStart,
+    queryEnd,
+    queryMargin,
+  )
+  const secondDefaultResult = defaultIndex.getConflictingRoutesForSegment(
+    queryStart,
+    queryEnd,
+    queryMargin,
+  )
+  expect(secondDefaultResult).not.toBe(firstDefaultResult)
+  expect(secondDefaultResult).toEqual(firstDefaultResult)
+  expect(Object.isFrozen(firstDefaultResult)).toBe(false)
+
+  const memoizedIndex = new HighDensityRouteSpatialIndex([indexedRoute], {
+    memoizeSegmentConflictQueries: true,
+  })
+  const firstMemoizedResult = memoizedIndex.getConflictingRoutesForSegment(
+    queryStart,
+    queryEnd,
+    queryMargin,
+  )
+  const secondMemoizedResult = memoizedIndex.getConflictingRoutesForSegment(
+    queryStart,
+    queryEnd,
+    queryMargin,
+  )
+  expect(firstMemoizedResult).toHaveLength(1)
+  expect(secondMemoizedResult).toBe(firstMemoizedResult)
+  expect(Object.isFrozen(firstMemoizedResult)).toBe(true)
+  expect(Object.isFrozen(firstMemoizedResult[0]!)).toBe(true)
+
+  const distinctQueries: Array<
+    Parameters<HighDensityRouteSpatialIndex["getConflictingRoutesForSegment"]>
+  > = [
+    [{ ...queryStart, x: 2.5 }, queryEnd, queryMargin],
+    [{ ...queryStart, y: -1.5 }, queryEnd, queryMargin],
+    [{ ...queryStart, z: 1 }, queryEnd, queryMargin],
+    [queryStart, { ...queryEnd, x: 2.5 }, queryMargin],
+    [queryStart, { ...queryEnd, y: 1.5 }, queryMargin],
+    [queryStart, { ...queryEnd, z: 1 }, queryMargin],
+    [queryStart, queryEnd, 0.2],
+    [queryEnd, queryStart, queryMargin],
+  ]
+  for (const query of distinctQueries) {
+    const distinctQueryResult =
+      memoizedIndex.getConflictingRoutesForSegment(...query)
+    expect(distinctQueryResult).not.toBe(firstMemoizedResult)
+    expect(memoizedIndex.getConflictingRoutesForSegment(...query)).toBe(
+      distinctQueryResult,
+    )
+  }
+
+  memoizedIndex.removeRoute(indexedRoute.connectionName)
+  const resultAfterRemoval = memoizedIndex.getConflictingRoutesForSegment(
+    queryStart,
+    queryEnd,
+    queryMargin,
+  )
+  expect(resultAfterRemoval).toEqual([])
+  expect(resultAfterRemoval).not.toBe(firstMemoizedResult)
+
+  memoizedIndex.addRoute(indexedRoute)
+  const resultAfterReadd = memoizedIndex.getConflictingRoutesForSegment(
+    queryStart,
+    queryEnd,
+    queryMargin,
+  )
+  expect(resultAfterReadd).toHaveLength(1)
+  expect(resultAfterReadd).not.toBe(resultAfterRemoval)
+  expect(
+    memoizedIndex.getConflictingRoutesForSegment(
+      queryStart,
+      queryEnd,
+      queryMargin,
+    ),
+  ).toBe(resultAfterReadd)
+
+  const viaRemovalSolver = new UselessViaRemovalSolver({
+    unsimplifiedHdRoutes: [indexedRoute],
+    obstacles: [],
+    colorMap: {},
+    layerCount: 2,
+    connMap: new ConnectivityMap({
+      indexed_route: [indexedRoute.connectionName],
+    }),
+  })
+  const viaRemovalIndex = viaRemovalSolver.hdRouteSHI!
+  const firstViaRemovalResult = viaRemovalIndex.getConflictingRoutesForSegment(
+    queryStart,
+    queryEnd,
+    queryMargin,
+  )
+  const secondViaRemovalResult =
+    viaRemovalIndex.getConflictingRoutesForSegment(
+      queryStart,
+      queryEnd,
+      queryMargin,
+    )
+  expect(secondViaRemovalResult).toBe(firstViaRemovalResult)
+
+  const phaseOffsets = [0, 6, 12]
+  await expect(
+    getSvgFromGraphicsObject({
+      title: "Memoized segment conflict queries invalidate with route updates",
+      lines: [
+        ...phaseOffsets
+          .filter((_, phaseIndex) => phaseIndex !== 1)
+          .map((xOffset, phaseIndex) => ({
+            points: indexedRoute.route.map((point) => ({
+              x: point.x + xOffset,
+              y: point.y,
+            })),
+            strokeColor: "#dc2626",
+            strokeWidth: indexedRoute.traceThickness,
+            label: phaseIndex === 0 ? "indexed route" : "re-added route",
+          })),
+        ...phaseOffsets.map((xOffset, phaseIndex) => ({
+          points: [queryStart, queryEnd].map((point) => ({
+            x: point.x + xOffset,
+            y: point.y,
+          })),
+          strokeColor: phaseIndex === 1 ? "#64748b" : "#7c3aed",
+          strokeWidth: 0.08,
+          label:
+            phaseIndex === 0
+              ? "repeated query (cache hit)"
+              : phaseIndex === 1
+                ? "query after removal (no conflict)"
+                : "query after re-add (cache rebuilt)",
+        })),
+      ],
+      points: [],
+      rects: [],
+      circles: [],
+    }),
+  ).toMatchSvgSnapshot(import.meta.path)
+})


### PR DESCRIPTION
## Summary

- Memoize equivalent Pipeline 7 exact-geometry DRC evaluations with semantic route and board geometry key types.
- Add an opt-in `memoizeSegmentConflictQueries` constructor option to `HighDensityRouteSpatialIndex`.
- Enable segment-query memoization for useless-via removal, with cache invalidation on `addRoute` and `removeRoute` and readonly cached results.
- Pin the cache-focused power-expansion and repair03 upstream revisions used by this integration.

This PR contains reusable geometry-cache work only. Tiny-hypergraph step batching is isolated in #2312.

## Visual regression coverage

Three `toMatchSvgSnapshot` baselines cover crossing and separated DRC-cache geometry plus segment-query cache hit/removal/re-add invalidation phases.

## Validation

- All 16 affected tests pass locally.
- TypeScript typecheck and package build pass.
- All nine refreshed CI test shards pass.
- [Same-machine Pipeline 9 benchmark](https://github.com/tscircuit/tscircuit-autorouter/pull/2299#issuecomment-5469945114): 0 improved, 0 regressed; DRC issues, timeouts, and average vias are unchanged; P50-P80 are 0.2%-2.6% faster.

## Stack

- Base: #2298
- Next: #2312
