### PR TITLE
feat: add opt-in GrowShrink original-scale validation

### DIFF
--- a/lib/solvers/HighDensitySolver/HighDensitySolver.ts
+++ b/lib/solvers/HighDensitySolver/HighDensitySolver.ts
@@ -61,6 +61,7 @@ export class HighDensitySolver extends BaseSolver {
   preserveTerminalPcbPortIds: boolean
   growShrinkMaxInnerIterationsPerGrowthAttempt?: number
   growShrinkFallbackToInvalidGeometryOnFailure: boolean
+  growShrinkRequireOriginalScaleValidation: boolean
   growShrinkSolutionValidator?: (routes: HighDensityIntraNodeRoute[]) => boolean
   captureSearchDebug: boolean
 
@@ -96,6 +97,7 @@ export class HighDensitySolver extends BaseSolver {
     preserveTerminalPcbPortIds,
     growShrinkMaxInnerIterationsPerGrowthAttempt,
     growShrinkFallbackToInvalidGeometryOnFailure,
+    growShrinkRequireOriginalScaleValidation,
     growShrinkSolutionValidator,
     captureSearchDebug,
   }: {
@@ -112,6 +114,7 @@ export class HighDensitySolver extends BaseSolver {
     preserveTerminalPcbPortIds?: boolean
     growShrinkMaxInnerIterationsPerGrowthAttempt?: number
     growShrinkFallbackToInvalidGeometryOnFailure?: boolean
+    growShrinkRequireOriginalScaleValidation?: boolean
     growShrinkSolutionValidator?: (
       routes: HighDensityIntraNodeRoute[],
     ) => boolean
@@ -139,6 +142,8 @@ export class HighDensitySolver extends BaseSolver {
       growShrinkMaxInnerIterationsPerGrowthAttempt
     this.growShrinkFallbackToInvalidGeometryOnFailure =
       growShrinkFallbackToInvalidGeometryOnFailure ?? false
+    this.growShrinkRequireOriginalScaleValidation =
+      growShrinkRequireOriginalScaleValidation ?? false
     this.growShrinkSolutionValidator = growShrinkSolutionValidator
     this.captureSearchDebug = captureSearchDebug ?? true
     this.MAX_ITERATIONS =
@@ -385,6 +390,8 @@ export class HighDensitySolver extends BaseSolver {
         this.growShrinkMaxInnerIterationsPerGrowthAttempt,
       fallbackToInvalidGeometryOnFailure:
         this.growShrinkFallbackToInvalidGeometryOnFailure,
+      growShrinkRequireOriginalScaleValidation:
+        this.growShrinkRequireOriginalScaleValidation,
       growShrinkSolutionValidator: this.growShrinkSolutionValidator,
       captureSearchDebug: this.captureSearchDebug,
     }

--- a/lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver/GrowShrinkHighDensityIntraNodeSolver.ts
+++ b/lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver/GrowShrinkHighDensityIntraNodeSolver.ts
@@ -272,7 +272,9 @@ export class GrowShrinkHighDensityIntraNodeSolver extends BaseSolver {
 
   visualize(): GraphicsObject {
     const delegatedVisualization =
-      this.activeSubSolver?.visualize() ?? this.winningSolver?.visualize()
+      this.activeSubSolver?.visualize() ??
+      this.winningSolver?.visualize() ??
+      this.failedSolvers.at(-1)?.visualize()
     if (delegatedVisualization) return delegatedVisualization
 
     if (this.solvedRoutes.length > 0) {
@@ -342,13 +344,55 @@ export class GrowShrinkHighDensityIntraNodeSolver extends BaseSolver {
       }
     }
 
-    return (
-      delegatedVisualization ?? {
-        lines: [],
-        points: [],
-        rects: [],
-        circles: [],
-      }
-    )
+    const portPointsByConnection = new Map<string, PortPoint[]>()
+    for (const portPoint of this.nodeWithPortPoints.portPoints) {
+      const connectionPoints =
+        portPointsByConnection.get(portPoint.connectionName) ?? []
+      connectionPoints.push(portPoint)
+      portPointsByConnection.set(portPoint.connectionName, connectionPoints)
+    }
+
+    return {
+      title: this.error ?? "Grow/shrink high density input",
+      lines: Array.from(portPointsByConnection.entries()).flatMap(
+        ([connectionName, points], connectionIndex) => {
+          if (points.length < 2) return []
+          return [
+            {
+              points: [points[0]!, points[points.length - 1]!],
+              strokeColor:
+                routeColors[connectionIndex % routeColors.length],
+              strokeWidth: this.constructorParams.traceWidth ?? 0.15,
+              label: `${connectionName} required connection`,
+            },
+          ]
+        },
+      ),
+      points: this.nodeWithPortPoints.portPoints.map((point, pointIndex) => ({
+        x: point.x,
+        y: point.y,
+        color: routeColors[pointIndex % routeColors.length],
+        label: connectionLabel(point.connectionName, point.rootConnectionName, [
+          `z${point.z}`,
+        ]),
+      })),
+      rects: [
+        {
+          center: this.nodeWithPortPoints.center,
+          width: this.nodeWithPortPoints.width,
+          height: this.nodeWithPortPoints.height,
+          fill: this.failed
+            ? "rgba(239, 68, 68, 0.10)"
+            : "rgba(14, 165, 233, 0.08)",
+          stroke: this.failed
+            ? "rgba(220, 38, 38, 0.85)"
+            : "rgba(14, 165, 233, 0.55)",
+          label: [this.nodeWithPortPoints.capacityMeshNodeId, this.error]
+            .filter(Boolean)
+            .join("\n"),
+        },
+      ],
+      circles: [],
+    }
   }
 }

--- a/lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver/GrowShrinkHighDensityIntraNodeSolver.ts
+++ b/lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver/GrowShrinkHighDensityIntraNodeSolver.ts
@@ -23,6 +23,8 @@ export type GrowShrinkHighDensityIntraNodeSolverParams =
     maxGrowthAttempts?: number
     maxInnerIterationsPerGrowthAttempt?: number
     fallbackToInvalidGeometryOnFailure?: boolean
+    /** Requires a validator for scaled routes and disables invalid fallbacks. */
+    growShrinkRequireOriginalScaleValidation?: boolean
     growShrinkSolutionValidator?: (
       routes: HighDensityIntraNodeRoute[],
     ) => boolean
@@ -124,7 +126,10 @@ export class GrowShrinkHighDensityIntraNodeSolver extends BaseSolver {
       20_000_000 * (params.effort ?? 1) * (this.maxGrowthAttempts + 1)
 
     if (hasImpossibleSameLayerCrossingGeometry(this.nodeWithPortPoints)) {
-      if (!params.fallbackToInvalidGeometryOnFailure) {
+      if (
+        !params.fallbackToInvalidGeometryOnFailure ||
+        params.growShrinkRequireOriginalScaleValidation
+      ) {
         this.failed = true
         this.progress = 1
         this.error =
@@ -177,6 +182,17 @@ export class GrowShrinkHighDensityIntraNodeSolver extends BaseSolver {
             ),
           )
     if (
+      this.scaleFactor > 1 &&
+      this.constructorParams.growShrinkRequireOriginalScaleValidation &&
+      !this.constructorParams.growShrinkSolutionValidator
+    ) {
+      solver.solved = false
+      solver.failed = true
+      solver.error =
+        "Grow/shrink scaled solutions require validation at the original scale"
+      return false
+    }
+    if (
       this.constructorParams.growShrinkSolutionValidator &&
       !this.constructorParams.growShrinkSolutionValidator(solvedRoutes)
     ) {
@@ -223,7 +239,10 @@ export class GrowShrinkHighDensityIntraNodeSolver extends BaseSolver {
     this.activeSubSolver = null
 
     if (this.growthAttempts >= this.maxGrowthAttempts) {
-      if (this.constructorParams.fallbackToInvalidGeometryOnFailure) {
+      if (
+        this.constructorParams.fallbackToInvalidGeometryOnFailure &&
+        !this.constructorParams.growShrinkRequireOriginalScaleValidation
+      ) {
         this.solvedRoutes = createInvalidDirectConnectionRoutes(
           this.nodeWithPortPoints,
           this.constructorParams.traceWidth ?? 0.15,

--- a/tests/features/never-fail-growth-high-density/__snapshots__/requires-original-scale-validation-impossible-single-layer-crossing.snap.svg
+++ b/tests/features/never-fail-growth-high-density/__snapshots__/requires-original-scale-validation-impossible-single-layer-crossing.snap.svg
@@ -1,0 +1,49 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="-1,0 1,0" data-type="line" data-label="a required connection" points="40,320 600,320" fill="none" stroke="#dc2626" stroke-linejoin="round" stroke-width="42"/></g><g><polyline data-points="0,-1 0,1" data-type="line" data-label="b required connection" points="320,600 320,40" fill="none" stroke="#2563eb" stroke-linejoin="round" stroke-width="42"/></g><g><rect data-type="rect" data-label="cn_crossing
+GrowShrinkHighDensityIntraNodeSolver cannot route an impossible single-layer crossing" data-x="0" data-y="0" x="40" y="40" width="560" height="560" fill="rgba(239, 68, 68, 0.10)" stroke="rgba(220, 38, 38, 0.85)" stroke-width="0.0035714285714285713"/></g><g><circle data-type="point" data-label="a
+z0" data-x="-1" data-y="0" cx="40" cy="320" r="3" fill="#dc2626"/></g><g><circle data-type="point" data-label="a
+z0" data-x="1" data-y="0" cx="600" cy="320" r="3" fill="#2563eb"/></g><g><circle data-type="point" data-label="b
+z0" data-x="0" data-y="-1" cx="320" cy="600" r="3" fill="#16a34a"/></g><g><circle data-type="point" data-label="b
+z0" data-x="0" data-y="1" cx="320" cy="40" r="3" fill="#ca8a04"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":280,"c":0,"e":320,"b":0,"d":-280,"f":320};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/features/never-fail-growth-high-density/__snapshots__/requires-original-scale-validation-rejected-scaled-route.snap.svg
+++ b/tests/features/never-fail-growth-high-density/__snapshots__/requires-original-scale-validation-rejected-scaled-route.snap.svg
@@ -1,0 +1,44 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="9,20 10,22" data-type="line" data-label="a candidate" points="96,488 320,40" fill="none" stroke="#dc2626" stroke-linejoin="round" stroke-width="33.6"/></g><g><polyline data-points="10,22 11,20" data-type="line" data-label="a candidate" points="320,40 544,488" fill="none" stroke="#dc2626" stroke-linejoin="round" stroke-width="33.6"/></g><g><rect data-type="rect" data-label="original physical size" data-x="10" data-y="20" x="208" y="376" width="224" height="224" fill="rgba(239, 68, 68, 0.10)" stroke="#dc2626" stroke-width="0.004464285714285714"/></g><g><circle data-type="point" data-label="a z0" data-x="9.5" data-y="20" cx="208" cy="488" r="3" fill="#2563eb"/></g><g><circle data-type="point" data-label="a z0" data-x="10.5" data-y="20" cx="432" cy="488" r="3" fill="#2563eb"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":224,"c":0,"e":-1920,"b":0,"d":-224,"f":4968};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/features/never-fail-growth-high-density/requires-original-scale-validation.test.ts
+++ b/tests/features/never-fail-growth-high-density/requires-original-scale-validation.test.ts
@@ -1,13 +1,14 @@
 import { expect, test } from "bun:test"
+import { getSvgFromGraphicsObject } from "graphics-debug"
 import { GrowShrinkHighDensityIntraNodeSolver } from "lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver"
 import {
-  emptyVisualization,
   makeCrossingSingleLayerNode,
   makeNode,
   makeScaledRoute,
 } from "./test-helpers"
 
-test("GrowShrinkHighDensityIntraNodeSolver opts into original-scale validation and fail-loud behavior", () => {
+test("GrowShrinkHighDensityIntraNodeSolver opts into original-scale validation and fail-loud behavior", async () => {
+  const attemptedScaledRoute = makeScaledRoute()
   const solver = new GrowShrinkHighDensityIntraNodeSolver({
     nodeWithPortPoints: makeNode(),
     maxGrowthAttempts: 1,
@@ -19,11 +20,38 @@ test("GrowShrinkHighDensityIntraNodeSolver opts into original-scale validation a
     failed: false,
     solved: false,
     error: null,
-    solvedRoutes: [makeScaledRoute()],
+    solvedRoutes: [attemptedScaledRoute],
     step() {
       this.solved = true
     },
-    visualize: emptyVisualization,
+    visualize() {
+      return {
+        title: "Scaled candidate rejected at original size",
+        lines: attemptedScaledRoute.route.slice(0, -1).map((point, index) => ({
+          points: [point, attemptedScaledRoute.route[index + 1]!],
+          strokeColor: "#dc2626",
+          strokeWidth: attemptedScaledRoute.traceThickness,
+          label: `${attemptedScaledRoute.connectionName} candidate`,
+        })),
+        points: makeNode().portPoints.map((point) => ({
+          x: point.x,
+          y: point.y,
+          color: "#2563eb",
+          label: `${point.connectionName} z${point.z}`,
+        })),
+        rects: [
+          {
+            center: makeNode().center,
+            width: makeNode().width,
+            height: makeNode().height,
+            fill: "rgba(239, 68, 68, 0.10)",
+            stroke: "#dc2626",
+            label: "original physical size",
+          },
+        ],
+        circles: [],
+      }
+    },
   } as any
 
   solver.step()
@@ -34,6 +62,9 @@ test("GrowShrinkHighDensityIntraNodeSolver opts into original-scale validation a
   expect(solver.error).toContain(
     "scaled solutions require validation at the original scale",
   )
+  await expect(
+    getSvgFromGraphicsObject(solver.visualize()),
+  ).toMatchSvgSnapshot(import.meta.path, { svgName: "rejected-scaled-route" })
 
   const impossibleSolver = new GrowShrinkHighDensityIntraNodeSolver({
     nodeWithPortPoints: makeCrossingSingleLayerNode(),
@@ -46,4 +77,9 @@ test("GrowShrinkHighDensityIntraNodeSolver opts into original-scale validation a
   expect(impossibleSolver.error).toContain(
     "cannot route an impossible single-layer crossing",
   )
+  await expect(
+    getSvgFromGraphicsObject(impossibleSolver.visualize()),
+  ).toMatchSvgSnapshot(import.meta.path, {
+    svgName: "impossible-single-layer-crossing",
+  })
 })

--- a/tests/features/never-fail-growth-high-density/requires-original-scale-validation.test.ts
+++ b/tests/features/never-fail-growth-high-density/requires-original-scale-validation.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test"
+import { GrowShrinkHighDensityIntraNodeSolver } from "lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver"
+import {
+  emptyVisualization,
+  makeCrossingSingleLayerNode,
+  makeNode,
+  makeScaledRoute,
+} from "./test-helpers"
+
+test("GrowShrinkHighDensityIntraNodeSolver opts into original-scale validation and fail-loud behavior", () => {
+  const solver = new GrowShrinkHighDensityIntraNodeSolver({
+    nodeWithPortPoints: makeNode(),
+    maxGrowthAttempts: 1,
+    growShrinkRequireOriginalScaleValidation: true,
+  })
+  solver.scaleFactor = 2
+  solver.growthAttempts = 1
+  solver.activeSubSolver = {
+    failed: false,
+    solved: false,
+    error: null,
+    solvedRoutes: [makeScaledRoute()],
+    step() {
+      this.solved = true
+    },
+    visualize: emptyVisualization,
+  } as any
+
+  solver.step()
+
+  expect(solver.solved).toBe(false)
+  expect(solver.failed).toBe(true)
+  expect(solver.solvedRoutes).toEqual([])
+  expect(solver.error).toContain(
+    "scaled solutions require validation at the original scale",
+  )
+
+  const impossibleSolver = new GrowShrinkHighDensityIntraNodeSolver({
+    nodeWithPortPoints: makeCrossingSingleLayerNode(),
+    fallbackToInvalidGeometryOnFailure: true,
+    growShrinkRequireOriginalScaleValidation: true,
+  })
+  expect(impossibleSolver.solved).toBe(false)
+  expect(impossibleSolver.failed).toBe(true)
+  expect(impossibleSolver.solvedRoutes).toEqual([])
+  expect(impossibleSolver.error).toContain(
+    "cannot route an impossible single-layer crossing",
+  )
+})


### PR DESCRIPTION
## Summary

- Add growShrinkRequireOriginalScaleValidation to GrowShrinkHighDensityIntraNodeSolver and HighDensitySolver.
- When enabled, require a validator before accepting routes solved on enlarged proxy geometry.
- When enabled, fail loudly instead of returning known-invalid direct or crossing fallback geometry.
- Keep failed candidate visualization available for diagnosis.
- Keep the option disabled by default so existing Pipeline 4, 7, and 9 callers and routing output remain unchanged.

This is independent from the B02 adapter and rollout PRs. No input geometry is rewritten or silently corrected; callers must supply an original-scale validator before opting in for scaled routes.

## Visual regression coverage

Two toMatchSvgSnapshot baselines show:

- a scaled candidate rejected when checked at the original node size;
- an impossible single-layer crossing failing instead of returning invalid fallback geometry.

## Stack

- Base: #2303

## Validation

- 15 focused tests across 10 files pass with 93 assertions.
- Both SVG snapshots pass and were visually inspected.
- bunx tsc --noEmit passes.
- Non-SVG diff checks pass.