### PR TITLE
fix: make single-transition boundary handling tolerance-consistent

### DIFF
--- a/lib/solvers/HighDensitySolver/TwoRouteHighDensitySolver/SingleTransitionCrossingRouteSolver.ts
+++ b/lib/solvers/HighDensitySolver/TwoRouteHighDensitySolver/SingleTransitionCrossingRouteSolver.ts
@@ -18,7 +18,6 @@ import {
 import { findClosestPointToABCWithinBounds } from "lib/utils/findClosestPointToABCWithinBounds"
 import { findPointToGetAroundCircle } from "lib/utils/findPointToGetAroundCircle"
 import { getIntraNodeCrossings } from "lib/utils/getIntraNodeCrossings"
-import { snapToNearestBound } from "lib/utils/snapToNearestBound"
 import {
   calculateTraversalPercentages,
   pointToAngle,
@@ -113,6 +112,12 @@ export class SingleTransitionCrossingRouteSolver extends BaseSolver {
       return
     }
 
+    this.routes = this.routes.map((route) => ({
+      ...route,
+      A: this.snapPortPointToBounds(route.A),
+      B: this.snapPortPointToBounds(route.B),
+    }))
+
     const [routeA, routeB] = this.routes
 
     // Check if one route has a layer transition and the other doesn't
@@ -184,13 +189,38 @@ export class SingleTransitionCrossingRouteSolver extends BaseSolver {
    */
   private getPortPointBoundsPosition(
     point: Point,
-    epsilon = 1e-6,
   ): PortPointBoundsPosition {
     return classifyPointInBounds({
       point,
       bounds: this.bounds,
-      epsilon,
     })
+  }
+
+  private snapPortPointToBounds(point: Point): Point {
+    const clampedX = clamp(point.x, this.bounds.minX, this.bounds.maxX)
+    const clampedY = clamp(point.y, this.bounds.minY, this.bounds.maxY)
+    const candidates = [
+      {
+        distance: Math.abs(point.y - this.bounds.maxY),
+        point: { ...point, x: clampedX, y: this.bounds.maxY },
+      },
+      {
+        distance: Math.abs(point.x - this.bounds.maxX),
+        point: { ...point, x: this.bounds.maxX, y: clampedY },
+      },
+      {
+        distance: Math.abs(point.y - this.bounds.minY),
+        point: { ...point, x: clampedX, y: this.bounds.minY },
+      },
+      {
+        distance: Math.abs(point.x - this.bounds.minX),
+        point: { ...point, x: this.bounds.minX, y: clampedY },
+      },
+    ]
+
+    return candidates.reduce((closest, candidate) =>
+      candidate.distance < closest.distance ? candidate : closest,
+    ).point
   }
 
   /**

--- a/lib/solvers/HighDensitySolver/TwoRouteHighDensitySolver/SingleTransitionCrossingRouteSolver.ts
+++ b/lib/solvers/HighDensitySolver/TwoRouteHighDensitySolver/SingleTransitionCrossingRouteSolver.ts
@@ -187,9 +187,7 @@ export class SingleTransitionCrossingRouteSolver extends BaseSolver {
    * Classifies a point relative to this node's bounds.
    * Uses epsilon to tolerate floating-point noise on boundary coordinates.
    */
-  private getPortPointBoundsPosition(
-    point: Point,
-  ): PortPointBoundsPosition {
+  private getPortPointBoundsPosition(point: Point): PortPointBoundsPosition {
     return classifyPointInBounds({
       point,
       bounds: this.bounds,

--- a/lib/solvers/HighDensitySolver/TwoRouteHighDensitySolver/calculateSideTraversal.ts
+++ b/lib/solvers/HighDensitySolver/TwoRouteHighDensitySolver/calculateSideTraversal.ts
@@ -1,3 +1,5 @@
+import { BOUNDARY_COORDINATE_TOLERANCE_MM } from "lib/utils/classifyPointInBounds"
+
 interface Point {
   x: number
   y: number
@@ -17,8 +19,8 @@ interface SidePercentages {
   bottom: number
 }
 
-// Keep a small epsilon for floating point comparisons
-const EPSILON = 1e-9 // Using a slightly smaller epsilon can sometimes help precision
+// Keep a small epsilon for dimension and angular floating-point comparisons.
+const EPSILON = 1e-9
 
 /**
  * Calculates the percentage of each side traversed when going from point A to point B
@@ -97,34 +99,34 @@ export function pointToAngle(point: Point, bounds: Bounds): number {
 
   // Check sides using epsilon comparisons
   if (
-    Math.abs(point.y - bounds.maxY) < EPSILON &&
-    point.x >= bounds.minX - EPSILON &&
-    point.x <= bounds.maxX + EPSILON
+    Math.abs(point.y - bounds.maxY) <= BOUNDARY_COORDINATE_TOLERANCE_MM &&
+    point.x >= bounds.minX - BOUNDARY_COORDINATE_TOLERANCE_MM &&
+    point.x <= bounds.maxX + BOUNDARY_COORDINATE_TOLERANCE_MM
   ) {
     // Top side (y is maxY)
     // Ensure x is clamped within bounds for distance calculation robustness
     distance = Math.max(0, Math.min(width, point.x - bounds.minX))
   } else if (
-    Math.abs(point.x - bounds.maxX) < EPSILON &&
-    point.y >= bounds.minY - EPSILON &&
-    point.y <= bounds.maxY + EPSILON
+    Math.abs(point.x - bounds.maxX) <= BOUNDARY_COORDINATE_TOLERANCE_MM &&
+    point.y >= bounds.minY - BOUNDARY_COORDINATE_TOLERANCE_MM &&
+    point.y <= bounds.maxY + BOUNDARY_COORDINATE_TOLERANCE_MM
   ) {
     // Right side (x is maxX)
     // Ensure y is clamped within bounds
     distance = width + Math.max(0, Math.min(height, bounds.maxY - point.y))
   } else if (
-    Math.abs(point.y - bounds.minY) < EPSILON &&
-    point.x >= bounds.minX - EPSILON &&
-    point.x <= bounds.maxX + EPSILON
+    Math.abs(point.y - bounds.minY) <= BOUNDARY_COORDINATE_TOLERANCE_MM &&
+    point.x >= bounds.minX - BOUNDARY_COORDINATE_TOLERANCE_MM &&
+    point.x <= bounds.maxX + BOUNDARY_COORDINATE_TOLERANCE_MM
   ) {
     // Bottom side (y is minY)
     // Ensure x is clamped within bounds
     distance =
       width + height + Math.max(0, Math.min(width, bounds.maxX - point.x))
   } else if (
-    Math.abs(point.x - bounds.minX) < EPSILON &&
-    point.y >= bounds.minY - EPSILON &&
-    point.y <= bounds.maxY + EPSILON
+    Math.abs(point.x - bounds.minX) <= BOUNDARY_COORDINATE_TOLERANCE_MM &&
+    point.y >= bounds.minY - BOUNDARY_COORDINATE_TOLERANCE_MM &&
+    point.y <= bounds.maxY + BOUNDARY_COORDINATE_TOLERANCE_MM
   ) {
     // Left side (x is minX)
     // Ensure y is clamped within bounds

--- a/lib/utils/classifyPointInBounds.ts
+++ b/lib/utils/classifyPointInBounds.ts
@@ -1,6 +1,6 @@
-import { pointToBoundsDistance } from "@tscircuit/math-utils"
-
 export type PointBoundsPosition = "on-boundary" | "inside" | "outside"
+
+export const BOUNDARY_COORDINATE_TOLERANCE_MM = 1e-6
 
 const isFiniteNumber = ({ value }: { value: number }): boolean =>
   Number.isFinite(value)
@@ -28,7 +28,7 @@ const isWithinEpsilon = ({
 export const classifyPointInBounds = ({
   point,
   bounds,
-  epsilon = 1e-6,
+  epsilon = BOUNDARY_COORDINATE_TOLERANCE_MM,
 }: {
   point: { x: number; y: number }
   bounds: { minX: number; maxX: number; minY: number; maxY: number }
@@ -47,8 +47,13 @@ export const classifyPointInBounds = ({
     return "outside"
   }
 
-  const distanceToBounds = pointToBoundsDistance(point, bounds)
-  if (distanceToBounds > epsilon) {
+  const isOutsideTolerance =
+    point.x < bounds.minX - epsilon ||
+    point.x > bounds.maxX + epsilon ||
+    point.y < bounds.minY - epsilon ||
+    point.y > bounds.maxY + epsilon
+
+  if (isOutsideTolerance) {
     return "outside"
   }
 

--- a/tests/solvers/__snapshots__/single-transition-crossing-route-boundary-tolerance.snap.svg
+++ b/tests/solvers/__snapshots__/single-transition-crossing-route-boundary-tolerance.snap.svg
@@ -1,0 +1,44 @@
+<svg width="640" height="480" viewBox="0 0 640 480" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="#0d1b2a"/><g><polyline data-points="5,10 5,0" data-type="line" data-label="transition direct" points="320,40 320,440" fill="none" stroke="rgba(255, 0, 0, 0.5)" stroke-linejoin="round" stroke-width="1px"/></g><g><polyline data-points="0,5 10,5" data-type="line" data-label="flat direct" points="120,240 520,240" fill="none" stroke="rgba(255, 0, 0, 0.5)" stroke-linejoin="round" stroke-width="1px"/></g><g><polyline data-points="5,10 5,3.3333333333333335" data-type="line" data-label="transition z=0" points="320,40 320,306.66666666666663" fill="none" stroke="rgba(0, 255, 0, 0.75)" stroke-linejoin="round" stroke-width="6"/></g><g><polyline data-points="5,3.3333333333333335 5,3.3333333333333335" data-type="line" data-label="transition z=0" points="320,306.66666666666663 320,306.66666666666663" fill="none" stroke="rgba(0, 255, 0, 0.75)" stroke-linejoin="round" stroke-width="6"/></g><g><polyline data-points="5,3.3333333333333335 5,0" data-type="line" data-label="transition z=1" points="320,306.66666666666663 320,440" fill="none" stroke="rgba(0, 255, 0, 0.75)" stroke-linejoin="round" stroke-width="6" stroke-dasharray="0.2 0.2"/></g><g><polyline data-points="0,5 4.687243455220801,3.100345471637114" data-type="line" data-label="flat z=0" points="120,240 307.489738208832,315.98618113451545" fill="none" stroke="rgba(255, 0, 255, 0.75)" stroke-linejoin="round" stroke-width="6"/></g><g><polyline data-points="4.687243455220801,3.100345471637114 4.696468584614276,3.0884482993399525" data-type="line" data-label="flat z=0" points="307.489738208832,315.98618113451545 307.8587433845711,316.4620680264019" fill="none" stroke="rgba(255, 0, 255, 0.75)" stroke-linejoin="round" stroke-width="6"/></g><g><polyline data-points="4.696468584614276,3.0884482993399525 4.706146009185167,3.076916032664686" data-type="line" data-label="flat z=0" points="307.8587433845711,316.4620680264019 308.2458403674067,316.9233586934126" fill="none" stroke="rgba(255, 0, 255, 0.75)" stroke-linejoin="round" stroke-width="6"/></g><g><polyline data-points="4.706146009185167,3.076916032664686 5,2.9433333333333334" data-type="line" data-label="flat z=0" points="308.2458403674067,316.9233586934126 320,322.26666666666665" fill="none" stroke="rgba(255, 0, 255, 0.75)" stroke-linejoin="round" stroke-width="6"/></g><g><polyline data-points="5,2.9433333333333334 5.293853990814833,3.076916032664686" data-type="line" data-label="flat z=0" points="320,322.26666666666665 331.7541596325933,316.9233586934126" fill="none" stroke="rgba(255, 0, 255, 0.75)" stroke-linejoin="round" stroke-width="6"/></g><g><polyline data-points="5.293853990814833,3.076916032664686 5.303531415385724,3.0884482993399525" data-type="line" data-label="flat z=0" points="331.7541596325933,316.9233586934126 332.1412566154289,316.4620680264019" fill="none" stroke="rgba(255, 0, 255, 0.75)" stroke-linejoin="round" stroke-width="6"/></g><g><polyline data-points="5.303531415385724,3.0884482993399525 5.312756544779199,3.100345471637114" data-type="line" data-label="flat z=0" points="332.1412566154289,316.4620680264019 332.510261791168,315.98618113451545" fill="none" stroke="rgba(255, 0, 255, 0.75)" stroke-linejoin="round" stroke-width="6"/></g><g><polyline data-points="5.312756544779199,3.100345471637114 10,5" data-type="line" data-label="flat z=0" points="332.510261791168,315.98618113451545 520,240" fill="none" stroke="rgba(255, 0, 255, 0.75)" stroke-linejoin="round" stroke-width="6"/></g><g><rect data-type="rect" data-label="PCB Bounds" data-x="5" data-y="5" x="120" y="40" width="400" height="400" fill="rgba(240, 240, 240, 0.1)" stroke="rgba(0, 0, 0, 0.5)" stroke-width="0.025"/></g><circle data-type="circle" data-label="" data-x="5" data-y="3.3333333333333335" cx="320" cy="306.66666666666663" r="6" fill="rgba(255, 165, 0, 0.7)" stroke="rgba(0, 0, 0, 0.5)" stroke-width="0.025"/><circle data-type="circle" data-label="" data-x="5" data-y="3.3333333333333335" cx="320" cy="306.66666666666663" r="10" fill="rgba(0, 0, 0, 0)" stroke="rgba(255, 165, 0, 0.7)" stroke-width="0.025"/><circle data-type="circle" data-label="" data-x="5" data-y="3.3333333333333335" cx="320" cy="306.66666666666663" r="6" fill="rgba(0, 0, 255, 0.8)" stroke="black" stroke-width="0.025"/><circle data-type="circle" data-label="" data-x="5" data-y="3.3333333333333335" cx="320" cy="306.66666666666663" r="10" fill="rgba(0, 0, 255, 0.3)" stroke="black" stroke-width="0.025"/><g><circle data-type="point" data-label="transition start (z=0)" data-x="5" data-y="10" cx="320" cy="40" r="3" fill="orange"/></g><g><circle data-type="point" data-label="transition end (z=1)" data-x="5" data-y="0" cx="320" cy="440" r="3" fill="orange"/></g><g><circle data-type="point" data-label="flat start (z=0)" data-x="0" data-y="5" cx="120" cy="240" r="3" fill="orange"/></g><g><circle data-type="point" data-label="flat end (z=0)" data-x="10" data-y="5" cx="520" cy="240" r="3" fill="orange"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="480" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '480');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":40,"c":0,"e":120,"b":0,"d":-40,"f":440};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/solvers/single-transition-crossing-route-authoritative-drc.test.ts
+++ b/tests/solvers/single-transition-crossing-route-authoritative-drc.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "bun:test"
+import { getDrcErrors } from "lib/testing/getDrcErrors"
+import {
+  convertToCircuitJson,
+  createPcbBoardElement,
+} from "lib/testing/utils/convertToCircuitJson"
+import type { SimpleRouteJson } from "lib/types"
+import type { HighDensityIntraNodeRoute } from "lib/types/high-density-types"
+
+test("authoritative DRC still rejects real copper violations", () => {
+  const srj: SimpleRouteJson = {
+    layerCount: 2,
+    minTraceWidth: 0.15,
+    obstacles: [],
+    bounds: { minX: 0, maxX: 10, minY: 0, maxY: 10 },
+    connections: [
+      {
+        name: "horizontal",
+        pointsToConnect: [
+          { x: 0, y: 5, layer: "top" },
+          { x: 10, y: 5, layer: "top" },
+        ],
+      },
+      {
+        name: "vertical",
+        pointsToConnect: [
+          { x: 5, y: 0, layer: "top" },
+          { x: 5, y: 10, layer: "top" },
+        ],
+      },
+    ],
+  }
+  const crossingRoutes: HighDensityIntraNodeRoute[] = [
+    {
+      connectionName: "horizontal",
+      traceThickness: 0.15,
+      viaDiameter: 0.3,
+      route: [
+        { x: 0, y: 5, z: 0 },
+        { x: 10, y: 5, z: 0 },
+      ],
+      vias: [],
+    },
+    {
+      connectionName: "vertical",
+      traceThickness: 0.15,
+      viaDiameter: 0.3,
+      route: [
+        { x: 5, y: 0, z: 0 },
+        { x: 5, y: 10, z: 0 },
+      ],
+      vias: [],
+    },
+  ]
+  const circuitJson = [
+    ...convertToCircuitJson(srj, crossingRoutes, {
+      minTraceWidth: srj.minTraceWidth,
+    }),
+    createPcbBoardElement(srj),
+  ]
+  const { errors } = getDrcErrors(circuitJson)
+
+  expect(errors.length).toBeGreaterThan(0)
+  expect(
+    errors.some(
+      (error) =>
+        error.error_type === "pcb_trace_error" &&
+        error.message.includes("accidental contact"),
+    ),
+  ).toBe(true)
+})

--- a/tests/solvers/single-transition-crossing-route-boundary-tolerance.test.ts
+++ b/tests/solvers/single-transition-crossing-route-boundary-tolerance.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test"
+import { getSvgFromGraphicsObject } from "graphics-debug"
 import { SingleTransitionCrossingRouteSolver } from "lib/solvers/HighDensitySolver/TwoRouteHighDensitySolver/SingleTransitionCrossingRouteSolver"
 import { pointToAngle } from "lib/solvers/HighDensitySolver/TwoRouteHighDensitySolver/calculateSideTraversal"
 import type { NodeWithPortPoints } from "lib/types/high-density-types"
@@ -7,7 +8,7 @@ import {
   classifyPointInBounds,
 } from "lib/utils/classifyPointInBounds"
 
-test("single-transition boundary stages share one tolerance on sides and corners", () => {
+test("single-transition boundary stages share one tolerance on sides and corners", async () => {
   const bounds = { minX: 0, maxX: 10, minY: 0, maxY: 10 }
   const acceptedBoundaryOffsetMm = BOUNDARY_COORDINATE_TOLERANCE_MM * 0.5
   const rejectedBoundaryOffsetMm = BOUNDARY_COORDINATE_TOLERANCE_MM * 1.1
@@ -157,6 +158,20 @@ test("single-transition boundary stages share one tolerance on sides and corners
       ),
     ).toBe(true)
   }
+
+  const visualSolver = new SingleTransitionCrossingRouteSolver({
+    nodeWithPortPoints: sideNodeWithPortPoints,
+  })
+  visualSolver.solve()
+
+  await expect(
+    getSvgFromGraphicsObject(visualSolver.visualize(), {
+      backgroundColor: "#0d1b2a",
+      svgWidth: 640,
+      svgHeight: 480,
+      hideInlineLabels: false,
+    }),
+  ).toMatchSvgSnapshot(import.meta.path, { tolerance: 0 })
 
   const outsideToleranceSolver = new SingleTransitionCrossingRouteSolver({
     nodeWithPortPoints: {

--- a/tests/solvers/single-transition-crossing-route-boundary-tolerance.test.ts
+++ b/tests/solvers/single-transition-crossing-route-boundary-tolerance.test.ts
@@ -1,0 +1,176 @@
+import { expect, test } from "bun:test"
+import { SingleTransitionCrossingRouteSolver } from "lib/solvers/HighDensitySolver/TwoRouteHighDensitySolver/SingleTransitionCrossingRouteSolver"
+import { pointToAngle } from "lib/solvers/HighDensitySolver/TwoRouteHighDensitySolver/calculateSideTraversal"
+import type { NodeWithPortPoints } from "lib/types/high-density-types"
+import {
+  BOUNDARY_COORDINATE_TOLERANCE_MM,
+  classifyPointInBounds,
+} from "lib/utils/classifyPointInBounds"
+
+test("single-transition boundary stages share one tolerance on sides and corners", () => {
+  const bounds = { minX: 0, maxX: 10, minY: 0, maxY: 10 }
+  const acceptedBoundaryOffsetMm =
+    BOUNDARY_COORDINATE_TOLERANCE_MM * 0.5
+  const rejectedBoundaryOffsetMm =
+    BOUNDARY_COORDINATE_TOLERANCE_MM * 1.1
+  const acceptedBoundaryPoints = [
+    { x: 5, y: 10 + acceptedBoundaryOffsetMm },
+    { x: 10 + acceptedBoundaryOffsetMm, y: 5 },
+    { x: 5, y: -acceptedBoundaryOffsetMm },
+    { x: -acceptedBoundaryOffsetMm, y: 5 },
+    {
+      x: -acceptedBoundaryOffsetMm,
+      y: 10 + acceptedBoundaryOffsetMm,
+    },
+    {
+      x: 10 + acceptedBoundaryOffsetMm,
+      y: 10 + acceptedBoundaryOffsetMm,
+    },
+    {
+      x: 10 + acceptedBoundaryOffsetMm,
+      y: -acceptedBoundaryOffsetMm,
+    },
+    { x: -acceptedBoundaryOffsetMm, y: -acceptedBoundaryOffsetMm },
+  ]
+  const rejectedBoundaryPoints = [
+    { x: 5, y: 10 + rejectedBoundaryOffsetMm },
+    { x: 10 + rejectedBoundaryOffsetMm, y: 5 },
+    { x: 5, y: -rejectedBoundaryOffsetMm },
+    { x: -rejectedBoundaryOffsetMm, y: 5 },
+    {
+      x: -rejectedBoundaryOffsetMm,
+      y: 10 + rejectedBoundaryOffsetMm,
+    },
+    {
+      x: 10 + rejectedBoundaryOffsetMm,
+      y: 10 + rejectedBoundaryOffsetMm,
+    },
+    {
+      x: 10 + rejectedBoundaryOffsetMm,
+      y: -rejectedBoundaryOffsetMm,
+    },
+    { x: -rejectedBoundaryOffsetMm, y: -rejectedBoundaryOffsetMm },
+  ]
+
+  for (const point of acceptedBoundaryPoints) {
+    expect(classifyPointInBounds({ point, bounds })).toBe("on-boundary")
+    expect(() => pointToAngle(point, bounds)).not.toThrow()
+  }
+
+  for (const point of rejectedBoundaryPoints) {
+    expect(classifyPointInBounds({ point, bounds })).toBe("outside")
+    expect(() => pointToAngle(point, bounds)).toThrow(
+      "does not lie on the boundary",
+    )
+  }
+
+  const sideNodeWithPortPoints: NodeWithPortPoints = {
+    capacityMeshNodeId: "boundary-side-tolerance-node",
+    center: { x: 5, y: 5 },
+    width: 10,
+    height: 10,
+    portPoints: [
+      {
+        connectionName: "transition",
+        x: 5,
+        y: 10 + acceptedBoundaryOffsetMm,
+        z: 0,
+      },
+      {
+        connectionName: "transition",
+        x: 5,
+        y: -acceptedBoundaryOffsetMm,
+        z: 1,
+      },
+      {
+        connectionName: "flat",
+        x: -acceptedBoundaryOffsetMm,
+        y: 5,
+        z: 0,
+      },
+      {
+        connectionName: "flat",
+        x: 10 + acceptedBoundaryOffsetMm,
+        y: 5,
+        z: 0,
+      },
+    ],
+  }
+  const cornerNodeWithPortPoints: NodeWithPortPoints = {
+    capacityMeshNodeId: "boundary-corner-tolerance-node",
+    center: { x: 5, y: 5 },
+    width: 10,
+    height: 10,
+    portPoints: [
+      {
+        connectionName: "transition",
+        x: -acceptedBoundaryOffsetMm,
+        y: 10 + acceptedBoundaryOffsetMm,
+        z: 0,
+      },
+      {
+        connectionName: "transition",
+        x: 10 + acceptedBoundaryOffsetMm,
+        y: -acceptedBoundaryOffsetMm,
+        z: 1,
+      },
+      {
+        connectionName: "flat",
+        x: -acceptedBoundaryOffsetMm,
+        y: -acceptedBoundaryOffsetMm,
+        z: 0,
+      },
+      {
+        connectionName: "flat",
+        x: 10 + acceptedBoundaryOffsetMm,
+        y: 10 + acceptedBoundaryOffsetMm,
+        z: 0,
+      },
+    ],
+  }
+
+  for (const nodeWithPortPoints of [
+    sideNodeWithPortPoints,
+    cornerNodeWithPortPoints,
+  ]) {
+    const firstSolver = new SingleTransitionCrossingRouteSolver({
+      nodeWithPortPoints,
+    })
+    const repeatedSolver = new SingleTransitionCrossingRouteSolver({
+      nodeWithPortPoints,
+    })
+
+    expect(firstSolver.failed).toBe(false)
+    expect(repeatedSolver.failed).toBe(false)
+    expect(() => firstSolver.solve()).not.toThrow()
+    expect(() => repeatedSolver.solve()).not.toThrow()
+    expect(firstSolver.solved).toBe(true)
+    expect(repeatedSolver.solved).toBe(true)
+    expect(repeatedSolver.solvedRoutes).toEqual(firstSolver.solvedRoutes)
+    expect(
+      firstSolver.solvedRoutes.every((route) =>
+        route.route.every(
+          (point) =>
+            point.x >= bounds.minX &&
+            point.x <= bounds.maxX &&
+            point.y >= bounds.minY &&
+            point.y <= bounds.maxY,
+        ),
+      ),
+    ).toBe(true)
+  }
+
+  const outsideToleranceSolver = new SingleTransitionCrossingRouteSolver({
+    nodeWithPortPoints: {
+      ...sideNodeWithPortPoints,
+      portPoints: sideNodeWithPortPoints.portPoints.map((portPoint, index) =>
+        index === 3
+          ? { ...portPoint, x: bounds.maxX + rejectedBoundaryOffsetMm }
+          : portPoint,
+      ),
+    },
+  })
+
+  expect(outsideToleranceSolver.failed).toBe(true)
+  expect(outsideToleranceSolver.error).toContain("outside node bounds")
+})

--- a/tests/solvers/single-transition-crossing-route-boundary-tolerance.test.ts
+++ b/tests/solvers/single-transition-crossing-route-boundary-tolerance.test.ts
@@ -9,10 +9,8 @@ import {
 
 test("single-transition boundary stages share one tolerance on sides and corners", () => {
   const bounds = { minX: 0, maxX: 10, minY: 0, maxY: 10 }
-  const acceptedBoundaryOffsetMm =
-    BOUNDARY_COORDINATE_TOLERANCE_MM * 0.5
-  const rejectedBoundaryOffsetMm =
-    BOUNDARY_COORDINATE_TOLERANCE_MM * 1.1
+  const acceptedBoundaryOffsetMm = BOUNDARY_COORDINATE_TOLERANCE_MM * 0.5
+  const rejectedBoundaryOffsetMm = BOUNDARY_COORDINATE_TOLERANCE_MM * 1.1
   const acceptedBoundaryPoints = [
     { x: 5, y: 10 + acceptedBoundaryOffsetMm },
     { x: 10 + acceptedBoundaryOffsetMm, y: 5 },


### PR DESCRIPTION
## Summary

- establish one shared 1 µm coordinate tolerance for boundary classification and perimeter traversal
- snap accepted near-boundary endpoints onto the exact rectangle before the specialized solver uses them
- handle all four sides and corners consistently while continuing to reject coordinates beyond tolerance
- add deterministic regression coverage plus an authoritative copper-clearance DRC guard

## Root cause

`SingleTransitionCrossingRouteSolver` classified boundary points with a 1e-6 mm tolerance, but `pointToAngle` later required the same geometry to be within 1e-9 mm. The extracted SRJ18 case differed by only 2.1349678824833518e-7 mm, so applicability accepted it and traversal later threw.

## Safety boundary

This does not relax authoritative DRC, board bounds, routing envelopes, trace width, or clearance rules. Only coordinates already accepted as boundary noise are canonicalized. Points beyond 1e-6 mm remain rejected, and a focused test proves real different-net copper contact still produces a DRC error.

## SRJ18 result

The affected extracted pair no longer crashes this solver. Its generated isolated route is still rejected by exact validation for a real copper-clearance violation, and the complete original-size node remains unsolved with the same work count as main. Therefore this PR is a geometry-consistency fix, not an SRJ18 performance or grow/shrink improvement, and no full SRJ18 benchmark is claimed.

Companion package contract coverage: [tscircuit/high-density-a01#91](https://github.com/tscircuit/high-density-a01/pull/91). That PR confirms A01 already solves the same noisy-boundary shape deterministically while preserving exact endpoints.

## Validation

- affected solver and DRC regressions: 3 passed, 0 failed
- broader affected solver suite: 64 passed, 0 failed
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`