### PR TITLE
test: reproduce SRJ18 single-transition boundary mismatch

### DIFF
--- a/tests/bugs/__snapshots__/srj18-cmn70-single-transition-boundary-tolerance.snap.svg
+++ b/tests/bugs/__snapshots__/srj18-cmn70-single-transition-boundary-tolerance.snap.svg
@@ -1,0 +1,44 @@
+<svg width="640" height="480" viewBox="0 0 640 480" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="#0d1b2a"/><g><polyline data-points="-5.191651196625803,3.5071339999999998 -5.3684277865032115,4.0374645000000005" data-type="line" data-label="source_trace_35__source_net_35 direct" points="186.6666553683774,440 120.00008051461782,239.99999999999955" fill="none" stroke="rgba(255, 0, 0, 0.5)" stroke-linejoin="round" stroke-width="1px"/></g><g><polyline data-points="-4.838097589877409,3.5071339999999998 -5.3684277865032115,4.0374645000000005" data-type="line" data-label="source_trace_34__source_net_34 direct" points="319.9999661051329,440 120.00008051461782,239.99999999999955" fill="none" stroke="rgba(255, 0, 0, 0.5)" stroke-linejoin="round" stroke-width="1px"/></g><g><rect data-type="rect" data-label="PCB Bounds" data-x="-4.8380975" data-y="4.0374645" x="119.99999999999977" y="40" width="400" height="400" fill="rgba(240, 240, 240, 0.1)" stroke="rgba(0, 0, 0, 0.5)" stroke-width="0.0026516524999999993"/></g><g><circle data-type="point" data-label="source_trace_35__source_net_35 start (z=0)" data-x="-5.191651196625803" data-y="3.5071339999999998" cx="186.6666553683774" cy="440" r="3" fill="orange"/></g><g><circle data-type="point" data-label="source_trace_35__source_net_35 end (z=3)" data-x="-5.3684277865032115" data-y="4.0374645000000005" cx="120.00008051461782" cy="239.99999999999955" r="3" fill="orange"/></g><g><circle data-type="point" data-label="source_trace_34__source_net_34 start (z=0)" data-x="-4.838097589877409" data-y="3.5071339999999998" cx="319.9999661051329" cy="440" r="3" fill="orange"/></g><g><circle data-type="point" data-label="source_trace_34__source_net_34 end (z=0)" data-x="-5.3684277865032115" data-y="4.0374645000000005" cx="120.00008051461782" cy="239.99999999999955" r="3" fill="orange"/></g><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="480" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '480');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":377.12332215476965,"c":0,"e":2144.5594021086854,"b":0,"d":-377.12332215476965,"f":1762.6220253219458};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script></svg>

--- a/tests/bugs/srj18-cmn70-single-transition-boundary-tolerance.test.ts
+++ b/tests/bugs/srj18-cmn70-single-transition-boundary-tolerance.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test"
+import { getSvgFromGraphicsObject } from "graphics-debug"
+import { SingleTransitionCrossingRouteSolver } from "lib/solvers/HighDensitySolver/TwoRouteHighDensitySolver/SingleTransitionCrossingRouteSolver"
+import type { NodeWithPortPoints } from "lib/types/high-density-types"
+import fixture from "../fixtures/srj18-cmn70-single-transition-boundary-tolerance.json"
+
+const nodeWithPortPoints: NodeWithPortPoints = fixture.nodeWithPortPoints
+
+test("SRJ18 cmn_70 exposes inconsistent single-transition boundary tolerance", async () => {
+  const solver = new SingleTransitionCrossingRouteSolver({
+    nodeWithPortPoints,
+    viaDiameter: fixture.routingRules.viaDiameter,
+    traceThickness: fixture.routingRules.traceWidth,
+    obstacleMargin: fixture.routingRules.obstacleMargin,
+    layerCount: fixture.routingRules.layerCount,
+  })
+
+  expect(solver.failed).toBe(false)
+  expect(() => solver.solve()).toThrow(
+    "does not lie on the boundary defined by",
+  )
+  expect(solver.solved).toBe(false)
+
+  await expect(
+    getSvgFromGraphicsObject(solver.visualize(), {
+      backgroundColor: "#0d1b2a",
+      svgWidth: 640,
+      svgHeight: 480,
+      hideInlineLabels: false,
+    }),
+  ).toMatchSvgSnapshot(import.meta.path, { tolerance: 0 })
+})

--- a/tests/fixtures/srj18-cmn70-single-transition-boundary-tolerance.json
+++ b/tests/fixtures/srj18-cmn70-single-transition-boundary-tolerance.json
@@ -1,0 +1,102 @@
+{
+  "dataset": "srj18",
+  "sampleNumber": 3,
+  "nodeId": "cmn_70",
+  "sourcePairIndices": [2, 3],
+  "routingRules": {
+    "layerCount": 4,
+    "traceWidth": 0.1,
+    "viaDiameter": 0.3,
+    "obstacleMargin": 0.1
+  },
+  "nodeWithPortPoints": {
+    "capacityMeshNodeId": "cmn_70",
+    "center": {
+      "x": -4.8380975,
+      "y": 4.0374645
+    },
+    "width": 1.0606609999999996,
+    "height": 1.0606609999999996,
+    "availableZ": [0, 1, 2, 3],
+    "portPoints": [
+      {
+        "portPointId": "ce1682_pp0_z0::0",
+        "x": -5.191651196625803,
+        "y": 3.5071339999999998,
+        "z": 0,
+        "connectionName": "source_trace_35__source_net_35",
+        "rootConnectionName": "connectivity_net15",
+        "nextPortPointId": "ce26_pp0_z3::3"
+      },
+      {
+        "portPointId": "ce26_pp0_z3::3",
+        "x": -5.3684277865032115,
+        "y": 4.0374645000000005,
+        "z": 3,
+        "connectionName": "source_trace_35__source_net_35",
+        "rootConnectionName": "connectivity_net15",
+        "prevPortPointId": "ce1682_pp0_z0::0"
+      },
+      {
+        "portPointId": "ce1682_pp1_z0::0",
+        "x": -4.838097589877409,
+        "y": 3.5071339999999998,
+        "z": 0,
+        "connectionName": "source_trace_34__source_net_34",
+        "rootConnectionName": "connectivity_net16",
+        "nextPortPointId": "ce26_pp0_z0::0"
+      },
+      {
+        "portPointId": "ce26_pp0_z0::0",
+        "x": -5.3684277865032115,
+        "y": 4.0374645000000005,
+        "z": 0,
+        "connectionName": "source_trace_34__source_net_34",
+        "rootConnectionName": "connectivity_net16",
+        "prevPortPointId": "ce1682_pp1_z0::0"
+      }
+    ],
+    "portPointsInPairs": [
+      [
+        {
+          "portPointId": "ce1682_pp0_z0::0",
+          "x": -5.191651196625803,
+          "y": 3.5071339999999998,
+          "z": 0,
+          "connectionName": "source_trace_35__source_net_35",
+          "rootConnectionName": "connectivity_net15",
+          "nextPortPointId": "ce26_pp0_z3::3"
+        },
+        {
+          "portPointId": "ce26_pp0_z3::3",
+          "x": -5.3684277865032115,
+          "y": 4.0374645000000005,
+          "z": 3,
+          "connectionName": "source_trace_35__source_net_35",
+          "rootConnectionName": "connectivity_net15",
+          "prevPortPointId": "ce1682_pp0_z0::0"
+        }
+      ],
+      [
+        {
+          "portPointId": "ce1682_pp1_z0::0",
+          "x": -4.838097589877409,
+          "y": 3.5071339999999998,
+          "z": 0,
+          "connectionName": "source_trace_34__source_net_34",
+          "rootConnectionName": "connectivity_net16",
+          "nextPortPointId": "ce26_pp0_z0::0"
+        },
+        {
+          "portPointId": "ce26_pp0_z0::0",
+          "x": -5.3684277865032115,
+          "y": 4.0374645000000005,
+          "z": 0,
+          "connectionName": "source_trace_34__source_net_34",
+          "rootConnectionName": "connectivity_net16",
+          "prevPortPointId": "ce1682_pp1_z0::0"
+        }
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- extracts the real `dataset-srj18` sample 3 `cmn_70` single-transition input
- preserves the original connection pair, four-layer routing rules, widths, via diameter, and obstacle margin
- reproduces the inconsistent boundary decision: construction accepts the input, then `pointToAngle` rejects the same point
- adds the solver's native visual snapshot at the failure state

The point is only `0.000000213496788 mm` inside the accepted boundary tolerance. This PR intentionally asserts the current exception; it contains no production fix.

![pre-fix native solver snapshot](https://raw.githubusercontent.com/tscircuit/tscircuit-autorouter/325813244faec37e02ef87a7e7df362cf100c8a9/tests/bugs/__snapshots__/srj18-cmn70-single-transition-boundary-tolerance.snap.svg)

## Validation

- focused reproduction test passes
- typecheck passes
- build passes
- full suite was exercised; unrelated HTTP tests cannot bind ephemeral ports in the sandbox, and the same representative HTTP test passes outside it

The fix is intentionally separated into a stacked PR.
