### PR TITLE
fix: use merged A11 rip-history routing in Pipeline9

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "high-density-repair02": "https://codeload.github.com/tscircuit/high-density-repair02/tar.gz/2afc0cbba3bf2f7eb6b9cd33615d21e9ad9352d4",
     "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#a9654302bdfdbc93222f1f66ce5d67ccd6ecd891",
     "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d",
-    "@tscircuit/high-density-a01-a11": "git+https://github.com/tscircuit/high-density-a01.git#270af942b894b1fd074388947a3a28ad52d44d4b",
+    "@tscircuit/high-density-a01-a11": "git+https://github.com/tscircuit/high-density-a01.git#ac13ef80da71c3998acb5302329b6b704d0470d1",
     "@tscircuit/high-density-b01": "git+https://github.com/tscircuit/high-density-b01.git#e651cab6c314e7aab6df31fd6067277436f67148"
   },
   "dependencies": {

--- a/tests/features/pipeline9-hd30-topology-merge-298-native-size.test.ts
+++ b/tests/features/pipeline9-hd30-topology-merge-298-native-size.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { createPipeline9RegularNodeSolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9HighDensitySolver"
+import { getRouteGeometryViolationError } from "lib/solvers/HighDensitySolver/official-high-density-a11"
+import { areNodePortPointPairsConnectedByRoutes } from "lib/solvers/HyperHighDensitySolver/repairDisconnectedSameRootPortPoints"
+import type { NodeWithPortPoints } from "lib/types/high-density-types"
+import topologyMerge298 from "../fixtures/hd30-sample004-topology-merge-298.json"
+
+test("Pipeline9 routes HD30 topology_merge_298 at native size with A11", () => {
+  const nodeWithPortPoints = topologyMerge298 as NodeWithPortPoints
+  const solver = createPipeline9RegularNodeSolver({
+    nodeWithPortPoints,
+    connMap: new ConnectivityMap({}),
+    colorMap: {},
+    viaDiameter: 0.3,
+    traceWidth: 0.1,
+    obstacleMargin: 0.15,
+    effort: 1,
+    nodePfById: { [nodeWithPortPoints.capacityMeshNodeId]: null },
+    obstacles: [],
+    layerCount: 2,
+  })
+
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(solver.stats.highDensityResizeCount).toBe(0)
+  expect(solver.stats.solverNodeCount.HighDensitySolverA11).toBe(1)
+  expect(solver.nodeSolveMetadataById.get("topology_merge_298")?.solverType).toBe(
+    "HighDensitySolverA11",
+  )
+  expect(solver.routes).toHaveLength(7)
+  expect(getRouteGeometryViolationError(solver.routes)).toBeNull()
+  expect(
+    areNodePortPointPairsConnectedByRoutes(solver.routes, nodeWithPortPoints),
+  ).toBe(true)
+})

--- a/tests/fixtures/hd30-sample004-topology-merge-298.json
+++ b/tests/fixtures/hd30-sample004-topology-merge-298.json
@@ -1,0 +1,283 @@
+{
+  "capacityMeshNodeId": "topology_merge_298",
+  "center": {
+    "x": -9.277980564417435,
+    "y": -1.8425417822087164
+  },
+  "width": 0.35355399999999904,
+  "height": 1.815716435582567,
+  "portPoints": [
+    {
+      "portPointId": "ce1309_pp1_z0::0",
+      "x": -9.454757564417434,
+      "y": -2.20568506932523,
+      "z": 0,
+      "connectionName": "source_trace_2__source_net_2_mst24",
+      "rootConnectionName": "connectivity_net42",
+      "nextPortPointId": "ce1505_pp1_z0::0"
+    },
+    {
+      "portPointId": "ce1505_pp1_z0::0",
+      "x": -9.101203564417435,
+      "y": -2.2020887116565375,
+      "z": 0,
+      "connectionName": "source_trace_2__source_net_2_mst24",
+      "rootConnectionName": "connectivity_net42",
+      "prevPortPointId": "ce1309_pp1_z0::0"
+    },
+    {
+      "portPointId": "ce1309_pp4_z0::0",
+      "x": -9.454757564417434,
+      "y": -1.4793984950922032,
+      "z": 0,
+      "connectionName": "source_trace_3__source_net_3_mst6",
+      "rootConnectionName": "connectivity_net41",
+      "nextPortPointId": "ce1507_pp0_z0::0"
+    },
+    {
+      "portPointId": "ce1507_pp0_z0::0",
+      "x": -9.101203564417435,
+      "y": -1.1114600644174328,
+      "z": 0,
+      "connectionName": "source_trace_3__source_net_3_mst6",
+      "rootConnectionName": "connectivity_net41",
+      "prevPortPointId": "ce1309_pp4_z0::0"
+    },
+    {
+      "portPointId": "ce1507_pp0_z0::0",
+      "x": -9.101203564417435,
+      "y": -1.1114600644174328,
+      "z": 0,
+      "connectionName": "source_trace_3__source_net_3_mst13",
+      "rootConnectionName": "connectivity_net41",
+      "nextPortPointId": "ce1309_pp5_z0::0"
+    },
+    {
+      "portPointId": "ce1309_pp5_z0::0",
+      "x": -9.454757564417434,
+      "y": -1.1162552079756896,
+      "z": 0,
+      "connectionName": "source_trace_3__source_net_3_mst13",
+      "rootConnectionName": "connectivity_net41",
+      "prevPortPointId": "ce1507_pp0_z0::0"
+    },
+    {
+      "portPointId": "ce1309_pp5_z0::0",
+      "x": -9.454757564417434,
+      "y": -1.1162552079756896,
+      "z": 0,
+      "connectionName": "source_trace_3__source_net_3_mst14",
+      "rootConnectionName": "connectivity_net41",
+      "nextPortPointId": "ce1507_pp0_z0::0"
+    },
+    {
+      "portPointId": "ce1507_pp0_z0::0",
+      "x": -9.101203564417435,
+      "y": -1.1114600644174328,
+      "z": 0,
+      "connectionName": "source_trace_3__source_net_3_mst14",
+      "rootConnectionName": "connectivity_net41",
+      "prevPortPointId": "ce1309_pp5_z0::0"
+    },
+    {
+      "portPointId": "ce1309_pp1_z1::1",
+      "x": -9.454757564417434,
+      "y": -1.8425417822087164,
+      "z": 1,
+      "connectionName": "source_trace_16__source_net_16_mst1",
+      "rootConnectionName": "connectivity_net28",
+      "nextPortPointId": "ce1505_pp2_z0::0"
+    },
+    {
+      "portPointId": "ce1505_pp2_z0::0",
+      "x": -9.101203564417435,
+      "y": -1.8365478527608956,
+      "z": 0,
+      "connectionName": "source_trace_16__source_net_16_mst1",
+      "rootConnectionName": "connectivity_net28",
+      "prevPortPointId": "ce1309_pp1_z1::1"
+    },
+    {
+      "portPointId": "ce1505_pp0_z0::0",
+      "x": -9.101203564417435,
+      "y": -2.567629570552179,
+      "z": 0,
+      "connectionName": "source_trace_17__source_net_17",
+      "rootConnectionName": "connectivity_net27",
+      "nextPortPointId": "ce1309_pp0_z0::0"
+    },
+    {
+      "portPointId": "ce1309_pp0_z0::0",
+      "x": -9.454757564417434,
+      "y": -2.568828356441743,
+      "z": 0,
+      "connectionName": "source_trace_17__source_net_17",
+      "rootConnectionName": "connectivity_net27",
+      "prevPortPointId": "ce1505_pp0_z0::0"
+    },
+    {
+      "portPointId": "ce1505_pp3_z0::0",
+      "x": -9.101203564417435,
+      "y": -1.4710069938652541,
+      "z": 0,
+      "connectionName": "source_trace_15__source_net_15",
+      "rootConnectionName": "connectivity_net29",
+      "nextPortPointId": "ce1309_pp2_z0::0"
+    },
+    {
+      "portPointId": "ce1309_pp2_z0::0",
+      "x": -9.454757564417434,
+      "y": -1.8425417822087164,
+      "z": 0,
+      "connectionName": "source_trace_15__source_net_15",
+      "rootConnectionName": "connectivity_net29",
+      "prevPortPointId": "ce1505_pp3_z0::0"
+    }
+  ],
+  "portPointsInPairs": [
+    [
+      {
+        "portPointId": "ce1309_pp1_z0::0",
+        "x": -9.454757564417434,
+        "y": -2.20568506932523,
+        "z": 0,
+        "connectionName": "source_trace_2__source_net_2_mst24",
+        "rootConnectionName": "connectivity_net42",
+        "nextPortPointId": "ce1505_pp1_z0::0"
+      },
+      {
+        "portPointId": "ce1505_pp1_z0::0",
+        "x": -9.101203564417435,
+        "y": -2.2020887116565375,
+        "z": 0,
+        "connectionName": "source_trace_2__source_net_2_mst24",
+        "rootConnectionName": "connectivity_net42",
+        "prevPortPointId": "ce1309_pp1_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce1309_pp4_z0::0",
+        "x": -9.454757564417434,
+        "y": -1.4793984950922032,
+        "z": 0,
+        "connectionName": "source_trace_3__source_net_3_mst6",
+        "rootConnectionName": "connectivity_net41",
+        "nextPortPointId": "ce1507_pp0_z0::0"
+      },
+      {
+        "portPointId": "ce1507_pp0_z0::0",
+        "x": -9.101203564417435,
+        "y": -1.1114600644174328,
+        "z": 0,
+        "connectionName": "source_trace_3__source_net_3_mst6",
+        "rootConnectionName": "connectivity_net41",
+        "prevPortPointId": "ce1309_pp4_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce1507_pp0_z0::0",
+        "x": -9.101203564417435,
+        "y": -1.1114600644174328,
+        "z": 0,
+        "connectionName": "source_trace_3__source_net_3_mst13",
+        "rootConnectionName": "connectivity_net41",
+        "nextPortPointId": "ce1309_pp5_z0::0"
+      },
+      {
+        "portPointId": "ce1309_pp5_z0::0",
+        "x": -9.454757564417434,
+        "y": -1.1162552079756896,
+        "z": 0,
+        "connectionName": "source_trace_3__source_net_3_mst13",
+        "rootConnectionName": "connectivity_net41",
+        "prevPortPointId": "ce1507_pp0_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce1309_pp5_z0::0",
+        "x": -9.454757564417434,
+        "y": -1.1162552079756896,
+        "z": 0,
+        "connectionName": "source_trace_3__source_net_3_mst14",
+        "rootConnectionName": "connectivity_net41",
+        "nextPortPointId": "ce1507_pp0_z0::0"
+      },
+      {
+        "portPointId": "ce1507_pp0_z0::0",
+        "x": -9.101203564417435,
+        "y": -1.1114600644174328,
+        "z": 0,
+        "connectionName": "source_trace_3__source_net_3_mst14",
+        "rootConnectionName": "connectivity_net41",
+        "prevPortPointId": "ce1309_pp5_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce1309_pp1_z1::1",
+        "x": -9.454757564417434,
+        "y": -1.8425417822087164,
+        "z": 1,
+        "connectionName": "source_trace_16__source_net_16_mst1",
+        "rootConnectionName": "connectivity_net28",
+        "nextPortPointId": "ce1505_pp2_z0::0"
+      },
+      {
+        "portPointId": "ce1505_pp2_z0::0",
+        "x": -9.101203564417435,
+        "y": -1.8365478527608956,
+        "z": 0,
+        "connectionName": "source_trace_16__source_net_16_mst1",
+        "rootConnectionName": "connectivity_net28",
+        "prevPortPointId": "ce1309_pp1_z1::1"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce1505_pp0_z0::0",
+        "x": -9.101203564417435,
+        "y": -2.567629570552179,
+        "z": 0,
+        "connectionName": "source_trace_17__source_net_17",
+        "rootConnectionName": "connectivity_net27",
+        "nextPortPointId": "ce1309_pp0_z0::0"
+      },
+      {
+        "portPointId": "ce1309_pp0_z0::0",
+        "x": -9.454757564417434,
+        "y": -2.568828356441743,
+        "z": 0,
+        "connectionName": "source_trace_17__source_net_17",
+        "rootConnectionName": "connectivity_net27",
+        "prevPortPointId": "ce1505_pp0_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce1505_pp3_z0::0",
+        "x": -9.101203564417435,
+        "y": -1.4710069938652541,
+        "z": 0,
+        "connectionName": "source_trace_15__source_net_15",
+        "rootConnectionName": "connectivity_net29",
+        "nextPortPointId": "ce1309_pp2_z0::0"
+      },
+      {
+        "portPointId": "ce1309_pp2_z0::0",
+        "x": -9.454757564417434,
+        "y": -1.8425417822087164,
+        "z": 0,
+        "connectionName": "source_trace_15__source_net_15",
+        "rootConnectionName": "connectivity_net29",
+        "prevPortPointId": "ce1505_pp3_z0::0"
+      }
+    ]
+  ],
+  "availableZ": [
+    0,
+    1
+  ]
+}


### PR DESCRIPTION
## Summary

- update the Pipeline9 A11 dependency to the merged history-aware routing implementation
- add a production-path regression for the HD30 `sample004-topology_merge_298` node
- keep the established A01/A03 candidates on their known-good revision

## Root cause

The native-size A11 attempt could revisit ripped routes without accounting for their prior displacement. History-aware routing costs let this topology converge at its original size instead of requiring growth.

## Results

| HD30 (27 nodes) | Before | After |
| --- | ---: | ---: |
| Solved | 27 | 27 |
| Native-size solves | 6 | 7 |
| Growth attempts | 22 | 21 |
| Exact-valid outputs | 17 | 18 |
| Same-machine local runtime | 68.35 s | 66.05 s |

Only `sample004-topology_merge_298` changes outcome. It previously grew once and fell through to A01 with a geometry-invalid result; it now finishes exact-valid at native size with A11. The other 26 outcomes are unchanged.

The SRJ18 same-machine comparison found no completion, DRC, timeout, or route-outcome regressions. P50 was effectively neutral (+0.4%), while P80 and P90 were 3.6% and 1.5% faster.

## Validation

- red/green production regression against the previous A11 dependency
- focused Pipeline9/A11 suite: 4 files, 28 assertions
- TypeScript check
- production build
- all 9 CI test shards
