### PR TITLE
feat: add bounded A11 and A12 native routing to Pipeline9

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9HighDensitySolver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9HighDensitySolver.ts
@@ -362,6 +362,7 @@ export const createPipeline9RegularNodeSolver = ({
     layerCount,
     useGrowShrinkHighDensityIntraNodeSolver: true,
     useHighDensitySolverA11: true,
+    useHighDensitySolverA12: true,
     preserveTerminalPcbPortIds: false,
     growShrinkFallbackToInvalidGeometryOnFailure: false,
     captureSearchDebug: false,

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9HighDensitySolver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9HighDensitySolver.ts
@@ -361,6 +361,7 @@ export const createPipeline9RegularNodeSolver = ({
     obstacles,
     layerCount,
     useGrowShrinkHighDensityIntraNodeSolver: true,
+    useHighDensitySolverA11: true,
     preserveTerminalPcbPortIds: false,
     growShrinkFallbackToInvalidGeometryOnFailure: false,
     captureSearchDebug: false,

--- a/lib/solvers/HighDensitySolver/HighDensitySolver.ts
+++ b/lib/solvers/HighDensitySolver/HighDensitySolver.ts
@@ -58,6 +58,7 @@ export class HighDensitySolver extends BaseSolver {
   obstacles: Obstacle[]
   layerCount: number
   useGrowShrinkHighDensityIntraNodeSolver: boolean
+  useHighDensitySolverA11: boolean
   preserveTerminalPcbPortIds: boolean
   growShrinkMaxInnerIterationsPerGrowthAttempt?: number
   growShrinkFallbackToInvalidGeometryOnFailure: boolean
@@ -93,6 +94,7 @@ export class HighDensitySolver extends BaseSolver {
     obstacles,
     layerCount,
     useGrowShrinkHighDensityIntraNodeSolver,
+    useHighDensitySolverA11,
     preserveTerminalPcbPortIds,
     growShrinkMaxInnerIterationsPerGrowthAttempt,
     growShrinkFallbackToInvalidGeometryOnFailure,
@@ -109,6 +111,7 @@ export class HighDensitySolver extends BaseSolver {
     obstacles?: Obstacle[]
     layerCount?: number
     useGrowShrinkHighDensityIntraNodeSolver?: boolean
+    useHighDensitySolverA11?: boolean
     preserveTerminalPcbPortIds?: boolean
     growShrinkMaxInnerIterationsPerGrowthAttempt?: number
     growShrinkFallbackToInvalidGeometryOnFailure?: boolean
@@ -134,6 +137,7 @@ export class HighDensitySolver extends BaseSolver {
     this.layerCount = layerCount ?? 2
     this.useGrowShrinkHighDensityIntraNodeSolver =
       useGrowShrinkHighDensityIntraNodeSolver ?? false
+    this.useHighDensitySolverA11 = useHighDensitySolverA11 ?? false
     this.preserveTerminalPcbPortIds = preserveTerminalPcbPortIds ?? false
     this.growShrinkMaxInnerIterationsPerGrowthAttempt =
       growShrinkMaxInnerIterationsPerGrowthAttempt
@@ -387,6 +391,7 @@ export class HighDensitySolver extends BaseSolver {
         this.growShrinkFallbackToInvalidGeometryOnFailure,
       growShrinkSolutionValidator: this.growShrinkSolutionValidator,
       captureSearchDebug: this.captureSearchDebug,
+      useHighDensitySolverA11: this.useHighDensitySolverA11,
     }
     this.activeSubSolver = this.useGrowShrinkHighDensityIntraNodeSolver
       ? new GrowShrinkHighDensityIntraNodeSolver(intraNodeSolverParams)

--- a/lib/solvers/HighDensitySolver/HighDensitySolver.ts
+++ b/lib/solvers/HighDensitySolver/HighDensitySolver.ts
@@ -59,6 +59,7 @@ export class HighDensitySolver extends BaseSolver {
   layerCount: number
   useGrowShrinkHighDensityIntraNodeSolver: boolean
   useHighDensitySolverA11: boolean
+  useHighDensitySolverA12: boolean
   preserveTerminalPcbPortIds: boolean
   growShrinkMaxInnerIterationsPerGrowthAttempt?: number
   growShrinkFallbackToInvalidGeometryOnFailure: boolean
@@ -95,6 +96,7 @@ export class HighDensitySolver extends BaseSolver {
     layerCount,
     useGrowShrinkHighDensityIntraNodeSolver,
     useHighDensitySolverA11,
+    useHighDensitySolverA12,
     preserveTerminalPcbPortIds,
     growShrinkMaxInnerIterationsPerGrowthAttempt,
     growShrinkFallbackToInvalidGeometryOnFailure,
@@ -112,6 +114,7 @@ export class HighDensitySolver extends BaseSolver {
     layerCount?: number
     useGrowShrinkHighDensityIntraNodeSolver?: boolean
     useHighDensitySolverA11?: boolean
+    useHighDensitySolverA12?: boolean
     preserveTerminalPcbPortIds?: boolean
     growShrinkMaxInnerIterationsPerGrowthAttempt?: number
     growShrinkFallbackToInvalidGeometryOnFailure?: boolean
@@ -138,6 +141,7 @@ export class HighDensitySolver extends BaseSolver {
     this.useGrowShrinkHighDensityIntraNodeSolver =
       useGrowShrinkHighDensityIntraNodeSolver ?? false
     this.useHighDensitySolverA11 = useHighDensitySolverA11 ?? false
+    this.useHighDensitySolverA12 = useHighDensitySolverA12 ?? false
     this.preserveTerminalPcbPortIds = preserveTerminalPcbPortIds ?? false
     this.growShrinkMaxInnerIterationsPerGrowthAttempt =
       growShrinkMaxInnerIterationsPerGrowthAttempt
@@ -392,6 +396,7 @@ export class HighDensitySolver extends BaseSolver {
       growShrinkSolutionValidator: this.growShrinkSolutionValidator,
       captureSearchDebug: this.captureSearchDebug,
       useHighDensitySolverA11: this.useHighDensitySolverA11,
+      useHighDensitySolverA12: this.useHighDensitySolverA12,
     }
     this.activeSubSolver = this.useGrowShrinkHighDensityIntraNodeSolver
       ? new GrowShrinkHighDensityIntraNodeSolver(intraNodeSolverParams)

--- a/lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver/GrowShrinkHighDensityIntraNodeSolver.ts
+++ b/lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver/GrowShrinkHighDensityIntraNodeSolver.ts
@@ -154,6 +154,8 @@ export class GrowShrinkHighDensityIntraNodeSolver extends BaseSolver {
       this.constructorParams
     this.activeSubSolver = new PortfolioSingleIntraNodeSolver({
       ...portfolioParams,
+      useHighDensitySolverA11:
+        this.scaleFactor === 1 && portfolioParams.useHighDensitySolverA11,
       nodeWithPortPoints: scaleNodeWithPortPoints(
         this.nodeWithPortPoints,
         this.scaleFactor,

--- a/lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver/GrowShrinkHighDensityIntraNodeSolver.ts
+++ b/lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver/GrowShrinkHighDensityIntraNodeSolver.ts
@@ -156,6 +156,8 @@ export class GrowShrinkHighDensityIntraNodeSolver extends BaseSolver {
       ...portfolioParams,
       useHighDensitySolverA11:
         this.scaleFactor === 1 && portfolioParams.useHighDensitySolverA11,
+      useHighDensitySolverA12:
+        this.scaleFactor === 1 && portfolioParams.useHighDensitySolverA12,
       nodeWithPortPoints: scaleNodeWithPortPoints(
         this.nodeWithPortPoints,
         this.scaleFactor,

--- a/lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver.ts
+++ b/lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver.ts
@@ -1,6 +1,8 @@
 import {
+  getRouteGeometryViolationError,
   HighDensitySolverA03 as HighDensityA03Solver,
   HighDensitySolverA01,
+  HighDensitySolverA11,
 } from "@tscircuit/high-density-a01"
 import { ConnectivityMap } from "circuit-json-to-connectivity-map"
 import {
@@ -20,41 +22,72 @@ import {
   HyperParameterSupervisorSolver,
   SupervisedSolver,
 } from "../HyperParameterSupervisorSolver"
-import { repairDisconnectedSameRootPortPoints } from "./repairDisconnectedSameRootPortPoints"
+import {
+  areNodePortPointPairsConnectedByRoutes,
+  repairDisconnectedSameRootPortPoints,
+} from "./repairDisconnectedSameRootPortPoints"
 
 // Match the existing six-ordering portfolio used by the other intra-node
 // solver. The first ordering remains in the normal portfolio; the remaining
 // orderings are introduced only after that portfolio spends its dynamically
 // derived exploration budget or exhausts all of its candidates.
 const ORDERING_SHUFFLE_SEEDS = Array.from({ length: 6 }, (_, seed) => seed)
+const HIGH_DENSITY_A11_MAX_ITERATIONS = 5_000
 
-/** Coordinates a fitness-scheduled portfolio of intra-node routing solvers. */
-export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolver<
+type ExternalGridSolver =
+  | HighDensitySolverA01
+  | HighDensityA03Solver
+  | HighDensitySolverA11
+
+type PortfolioCandidateSolver =
   | IntraNodeRouteSolver
   | TwoCrossingRoutesHighDensitySolver
   | SingleTransitionCrossingRouteSolver
   | SingleTransitionIntraNodeSolver
   | SingleTransitionThroughObstacleIntraNodeSolver
   | SingleLayerNoDifferentRootIntersectionsIntraNodeSolver
-  | HighDensityA03Solver
+  | MultiHeadPolyLineIntraNodeSolver3
+  | ExternalGridSolver
+
+function isExternalGridSolver(
+  solver: PortfolioCandidateSolver,
+): solver is ExternalGridSolver {
+  return (
+    solver instanceof HighDensitySolverA01 ||
+    solver instanceof HighDensityA03Solver
+  )
+}
+
+export type PortfolioSingleIntraNodeSolverParams = ConstructorParameters<
+  typeof CachedIntraNodeRouteSolver
+>[0] & {
+  effort?: number
+  useHighDensitySolverA11?: boolean
+}
+
+/** Coordinates a fitness-scheduled portfolio of intra-node routing solvers. */
+export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolver<
+  PortfolioCandidateSolver
 > {
   override getSolverName(): string {
     return "PortfolioSingleIntraNodeSolver"
   }
 
-  constructorParams: ConstructorParameters<typeof CachedIntraNodeRouteSolver>[0]
+  constructorParams: PortfolioSingleIntraNodeSolverParams
   solvedRoutes: HighDensityIntraNodeRoute[] = []
   nodeWithPortPoints: NodeWithPortPoints
   connMap?: ConnectivityMap
   effort: number
   adaptiveSearchExpanded = false
 
-  private getSolvedSegmentCount(solver: unknown): number | null {
-    const solvedConnectionsMap = (solver as any).solvedConnectionsMap
-    if (!(solvedConnectionsMap instanceof Map)) return null
+  private getSolvedSegmentCount(
+    solver: PortfolioCandidateSolver,
+  ): number | null {
+    if (!isExternalGridSolver(solver)) return null
+    if (!solver._setupDone) return null
 
     let solvedSegmentCount = 0
-    for (const routes of solvedConnectionsMap.values()) {
+    for (const routes of solver.solvedConnectionsMap.values()) {
       if (Array.isArray(routes)) solvedSegmentCount += routes.length
     }
     return solvedSegmentCount
@@ -72,7 +105,7 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
     )
   }
 
-  private getCandidateProgress(solver: { progress: number }): number {
+  private getCandidateProgress(solver: PortfolioCandidateSolver): number {
     const solvedSegmentCount = this.getSolvedSegmentCount(solver)
     if (solvedSegmentCount !== null) {
       return Math.min(1, solvedSegmentCount / this.getNodeSegmentCount())
@@ -100,11 +133,7 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
     )
   }
 
-  constructor(
-    opts: ConstructorParameters<typeof CachedIntraNodeRouteSolver>[0] & {
-      effort?: number
-    },
-  ) {
+  constructor(opts: PortfolioSingleIntraNodeSolverParams) {
     super()
     this.nodeWithPortPoints = opts.nodeWithPortPoints
     this.connMap = opts.connMap
@@ -116,7 +145,7 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
   }
 
   getCombinationDefs() {
-    return [
+    const combinations = [
       ["throughObstacle"],
       ["singleLayerNoDifferentRootIntersections"],
       ["multiHeadPolyLine"],
@@ -129,6 +158,10 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
       ["highDensityA01"],
       ["highDensityA03"],
     ]
+    if (this.constructorParams.useHighDensitySolverA11) {
+      combinations.push(["highDensityA11"])
+    }
+    return combinations
   }
 
   getHyperParameterDefs() {
@@ -266,6 +299,15 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
           },
         ],
       },
+      {
+        name: "highDensityA11",
+        possibleValues: [
+          {
+            HIGH_DENSITY_A11: true,
+            SHUFFLE_SEED: ORDERING_SHUFFLE_SEEDS[0],
+          },
+        ],
+      },
     ]
   }
 
@@ -274,9 +316,10 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
    * their natural iteration budget from the problem. Running setup here does
    * not advance the solver or give it preference in the portfolio.
    */
-  private initializeCandidateBudget(solver: unknown) {
-    const setup = (solver as any).setup
-    if (typeof setup === "function") setup.call(solver)
+  private initializeCandidateBudget(solver: PortfolioCandidateSolver) {
+    // Keep A11's fine grid lazy so easy nodes do not pay its setup cost.
+    if (solver instanceof HighDensitySolverA11) return
+    if (isExternalGridSolver(solver)) solver.setup()
   }
 
   private refreshDynamicIterationLimit() {
@@ -372,17 +415,21 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
     }
   }
 
-  computeG(solver: IntraNodeRouteSolver) {
-    if (
-      (solver as any) instanceof HighDensitySolverA01 ||
-      (solver as any) instanceof HighDensityA03Solver
-    ) {
-      return (solver as any).iterations / 1_000_000
+  computeG(solver: PortfolioCandidateSolver) {
+    if (solver instanceof HighDensitySolverA11) {
+      // Preserve established solutions before A11 explores the native grid.
+      return this.GREEDY_MULTIPLIER + 1 + solver.iterations / 1_000_000
     }
-    if (solver?.hyperParameters?.MULTI_HEAD_POLYLINE_SOLVER) {
+    if (
+      solver instanceof HighDensitySolverA01 ||
+      solver instanceof HighDensityA03Solver
+    ) {
+      return solver.iterations / 1_000_000
+    }
+    if (solver instanceof MultiHeadPolyLineIntraNodeSolver2) {
       return (
         1000 +
-        ((solver.hyperParameters?.ITERATION_PENALTY ?? 0) + solver.iterations) /
+        ((solver.hyperParameters.ITERATION_PENALTY ?? 0) + solver.iterations) /
           10_000 +
         10_000 * (solver.hyperParameters.SEGMENTS_PER_POLYLINE! - 3)
       )
@@ -392,14 +439,14 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
     )
   }
 
-  computeH(solver: IntraNodeRouteSolver) {
+  computeH(solver: PortfolioCandidateSolver) {
     if (this.adaptiveSearchExpanded) {
       return 1 - this.getCandidateProgress(solver)
     }
     return 1 - (solver.progress || 0)
   }
 
-  generateSolver(hyperParameters: any): IntraNodeRouteSolver {
+  generateSolver(hyperParameters: any): PortfolioCandidateSolver {
     if (hyperParameters.SINGLE_LAYER_NO_DIFFERENT_ROOT_INTERSECTIONS) {
       if (
         !SingleLayerNoDifferentRootIntersectionsIntraNodeSolver.isApplicable(
@@ -416,14 +463,14 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
         ineligibleSolver.failed = true
         ineligibleSolver.error =
           "Single-layer no-different-root-intersection solver not applicable"
-        return ineligibleSolver as any
+        return ineligibleSolver
       }
 
       return new SingleLayerNoDifferentRootIntersectionsIntraNodeSolver({
         nodeWithPortPoints: this.nodeWithPortPoints,
         traceWidth: this.constructorParams.traceWidth,
         viaDiameter: this.constructorParams.viaDiameter,
-      }) as any
+      })
     }
 
     if (hyperParameters.HIGH_DENSITY_A01) {
@@ -439,7 +486,7 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
           shuffleSeed: hyperParameters.SHUFFLE_SEED ?? 0,
         },
       })
-      return solver as any
+      return solver
     }
     if (hyperParameters.HIGH_DENSITY_A03) {
       const solver = new HighDensityA03Solver({
@@ -458,25 +505,40 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
         effort: this.effort,
         hyperParameters,
       })
-      return solver as any
+      return solver
+    }
+    if (hyperParameters.HIGH_DENSITY_A11) {
+      const solver = new HighDensitySolverA11({
+        nodeWithPortPoints: this.nodeWithPortPoints,
+        viaDiameter: this.constructorParams.viaDiameter ?? 0.3,
+        viaMinDistFromBorder: (this.constructorParams.viaDiameter ?? 0.3) / 2,
+        traceMargin: 0.1,
+        traceThickness: this.constructorParams.traceWidth ?? 0.15,
+        effort: this.effort,
+        hyperParameters: {
+          shuffleSeed: hyperParameters.SHUFFLE_SEED ?? 0,
+        },
+      })
+      solver.MAX_ITERATIONS = HIGH_DENSITY_A11_MAX_ITERATIONS
+      return solver
     }
     if (hyperParameters.CLOSED_FORM_TWO_TRACE_SAME_LAYER) {
       return new TwoCrossingRoutesHighDensitySolver({
         nodeWithPortPoints: this.nodeWithPortPoints,
         viaDiameter: this.constructorParams.viaDiameter,
-      }) as any
+      })
     }
     if (hyperParameters.CLOSED_FORM_TWO_TRACE_TRANSITION_CROSSING) {
       return new SingleTransitionCrossingRouteSolver({
         nodeWithPortPoints: this.nodeWithPortPoints,
         viaDiameter: this.constructorParams.viaDiameter,
-      }) as any
+      })
     }
     if (hyperParameters.CLOSED_FORM_SINGLE_TRANSITION) {
       return new SingleTransitionIntraNodeSolver({
         nodeWithPortPoints: this.nodeWithPortPoints,
         viaDiameter: this.constructorParams.viaDiameter,
-      }) as any
+      })
     }
     if (hyperParameters.THROUGH_OBSTACLE) {
       return new SingleTransitionThroughObstacleIntraNodeSolver({
@@ -486,7 +548,7 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
         layerCount: this.constructorParams.layerCount,
         viaDiameter: this.constructorParams.viaDiameter,
         traceThickness: this.constructorParams.traceWidth,
-      }) as any
+      })
     }
     if (hyperParameters.MULTI_HEAD_POLYLINE_SOLVER) {
       return new MultiHeadPolyLineIntraNodeSolver3({
@@ -494,7 +556,7 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
         connMap: this.connMap,
         hyperParameters: hyperParameters,
         viaDiameter: this.constructorParams.viaDiameter,
-      }) as any
+      })
     }
     return new CachedIntraNodeRouteSolver({
       ...this.constructorParams,
@@ -502,13 +564,10 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
     })
   }
 
-  onSolve(solver: SupervisedSolver<IntraNodeRouteSolver>) {
+  onSolve(solver: SupervisedSolver<PortfolioCandidateSolver>) {
     let routes: HighDensityIntraNodeRoute[]
-    if (
-      (solver.solver as any) instanceof HighDensitySolverA01 ||
-      (solver.solver as any) instanceof HighDensityA03Solver
-    ) {
-      routes = (solver.solver as any).getOutput()
+    if (isExternalGridSolver(solver.solver)) {
+      routes = solver.solver.getOutput()
     } else {
       routes = solver.solver.solvedRoutes
     }
@@ -525,9 +584,32 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
       return route
     })
 
-    this.solvedRoutes = repairDisconnectedSameRootPortPoints(
+    const repairedRoutes = repairDisconnectedSameRootPortPoints(
       routesWithRootConnectionNames,
       this.nodeWithPortPoints,
     )
+    if (solver.hyperParameters.HIGH_DENSITY_A11) {
+      const geometryError = getRouteGeometryViolationError(repairedRoutes)
+      const pairConnectivityIsValid = areNodePortPointPairsConnectedByRoutes(
+        repairedRoutes,
+        this.nodeWithPortPoints,
+      )
+      if (geometryError || !pairConnectivityIsValid) {
+        solver.solver.solved = false
+        solver.solver.failed = true
+        solver.solver.error = `HighDensitySolverA11 output rejected: ${geometryError ?? "not all port-point pairs are connected"}`
+        this.solved = false
+        this.failed = false
+        this.error = null
+        this.winningSolver = undefined
+        this.activeSubSolver = null
+        this.solvedRoutes = []
+        this.stats.rejectedHighDensityA11CandidateCount =
+          Number(this.stats.rejectedHighDensityA11CandidateCount ?? 0) + 1
+        this.refreshDynamicIterationLimit()
+        return
+      }
+    }
+    this.solvedRoutes = repairedRoutes
   }
 }

--- a/lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver.ts
+++ b/lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver.ts
@@ -3,6 +3,7 @@ import {
   HighDensitySolverA03 as HighDensityA03Solver,
   HighDensitySolverA01,
   HighDensitySolverA11,
+  HighDensitySolverA12,
 } from "@tscircuit/high-density-a01"
 import { ConnectivityMap } from "circuit-json-to-connectivity-map"
 import {
@@ -33,11 +34,13 @@ import {
 // derived exploration budget or exhausts all of its candidates.
 const ORDERING_SHUFFLE_SEEDS = Array.from({ length: 6 }, (_, seed) => seed)
 const HIGH_DENSITY_A11_MAX_ITERATIONS = 5_000
+const HIGH_DENSITY_A12_MAX_ITERATIONS = 15_000
 
 type ExternalGridSolver =
   | HighDensitySolverA01
   | HighDensityA03Solver
   | HighDensitySolverA11
+  | HighDensitySolverA12
 
 type PortfolioCandidateSolver =
   | IntraNodeRouteSolver
@@ -63,6 +66,7 @@ export type PortfolioSingleIntraNodeSolverParams = ConstructorParameters<
 >[0] & {
   effort?: number
   useHighDensitySolverA11?: boolean
+  useHighDensitySolverA12?: boolean
 }
 
 /** Coordinates a fitness-scheduled portfolio of intra-node routing solvers. */
@@ -158,6 +162,9 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
     ]
     if (this.constructorParams.useHighDensitySolverA11) {
       combinations.push(["highDensityA11"])
+    }
+    if (this.constructorParams.useHighDensitySolverA12) {
+      combinations.push(["highDensityA12"])
     }
     return combinations
   }
@@ -306,6 +313,15 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
           },
         ],
       },
+      {
+        name: "highDensityA12",
+        possibleValues: [
+          {
+            HIGH_DENSITY_A12: true,
+            SHUFFLE_SEED: ORDERING_SHUFFLE_SEEDS[0],
+          },
+        ],
+      },
     ]
   }
 
@@ -315,8 +331,13 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
    * not advance the solver or give it preference in the portfolio.
    */
   private initializeCandidateBudget(solver: PortfolioCandidateSolver) {
-    // Keep A11's fine grid lazy so easy nodes do not pay its setup cost.
-    if (solver instanceof HighDensitySolverA11) return
+    // Keep the fine-grid solvers lazy so easy nodes do not pay their setup cost.
+    if (
+      solver instanceof HighDensitySolverA11 ||
+      solver instanceof HighDensitySolverA12
+    ) {
+      return
+    }
     if (isExternalGridSolver(solver)) solver.setup()
   }
 
@@ -417,6 +438,10 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
     if (solver instanceof HighDensitySolverA11) {
       // Preserve established solutions before A11 explores the native grid.
       return this.GREEDY_MULTIPLIER + 1 + solver.iterations / 1_000_000
+    }
+    if (solver instanceof HighDensitySolverA12) {
+      // A12 is complementary but more expensive, so run it after A11.
+      return this.GREEDY_MULTIPLIER + 2 + solver.iterations / 1_000_000
     }
     if (
       solver instanceof HighDensitySolverA01 ||
@@ -520,6 +545,21 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
       solver.MAX_ITERATIONS = HIGH_DENSITY_A11_MAX_ITERATIONS
       return solver
     }
+    if (hyperParameters.HIGH_DENSITY_A12) {
+      const solver = new HighDensitySolverA12({
+        nodeWithPortPoints: this.nodeWithPortPoints,
+        viaDiameter: this.constructorParams.viaDiameter ?? 0.3,
+        viaMinDistFromBorder: (this.constructorParams.viaDiameter ?? 0.3) / 2,
+        traceMargin: 0.1,
+        traceThickness: this.constructorParams.traceWidth ?? 0.15,
+        effort: this.effort,
+        hyperParameters: {
+          shuffleSeed: hyperParameters.SHUFFLE_SEED ?? 0,
+        },
+      })
+      solver.MAX_ITERATIONS = HIGH_DENSITY_A12_MAX_ITERATIONS
+      return solver
+    }
     if (hyperParameters.CLOSED_FORM_TWO_TRACE_SAME_LAYER) {
       return new TwoCrossingRoutesHighDensitySolver({
         nodeWithPortPoints: this.nodeWithPortPoints,
@@ -586,7 +626,12 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
       routesWithRootConnectionNames,
       this.nodeWithPortPoints,
     )
-    if (solver.hyperParameters.HIGH_DENSITY_A11) {
+    const exactGridSolverName =
+      solver.solver instanceof HighDensitySolverA11 ||
+      solver.solver instanceof HighDensitySolverA12
+        ? solver.solver.getSolverName()
+        : null
+    if (exactGridSolverName) {
       const geometryError = getRouteGeometryViolationError(repairedRoutes)
       const pairConnectivityIsValid = areNodePortPointPairsConnectedByRoutes(
         repairedRoutes,
@@ -595,15 +640,15 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
       if (geometryError || !pairConnectivityIsValid) {
         solver.solver.solved = false
         solver.solver.failed = true
-        solver.solver.error = `HighDensitySolverA11 output rejected: ${geometryError ?? "not all port-point pairs are connected"}`
+        solver.solver.error = `${exactGridSolverName} output rejected: ${geometryError ?? "not all port-point pairs are connected"}`
         this.solved = false
         this.failed = false
         this.error = null
         this.winningSolver = undefined
         this.activeSubSolver = null
         this.solvedRoutes = []
-        this.stats.rejectedHighDensityA11CandidateCount =
-          Number(this.stats.rejectedHighDensityA11CandidateCount ?? 0) + 1
+        this.stats.rejectedExactGridCandidateCount =
+          Number(this.stats.rejectedExactGridCandidateCount ?? 0) + 1
         this.refreshDynamicIterationLimit()
         return
       }

--- a/lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver.ts
+++ b/lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver.ts
@@ -66,9 +66,7 @@ export type PortfolioSingleIntraNodeSolverParams = ConstructorParameters<
 }
 
 /** Coordinates a fitness-scheduled portfolio of intra-node routing solvers. */
-export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolver<
-  PortfolioCandidateSolver
-> {
+export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolver<PortfolioCandidateSolver> {
   override getSolverName(): string {
     return "PortfolioSingleIntraNodeSolver"
   }

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "high-density-repair01": "git+https://github.com/tscircuit/high-density-repair01.git#8eaa775e7c7a2c32c12a82da4edef22477549027",
     "high-density-repair02": "https://codeload.github.com/tscircuit/high-density-repair02/tar.gz/2afc0cbba3bf2f7eb6b9cd33615d21e9ad9352d4",
     "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#a9654302bdfdbc93222f1f66ce5d67ccd6ecd891",
-    "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d",
+    "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#57dc394852dcce99d38509fb7f5b5c8c0b680e0c",
     "@tscircuit/high-density-b01": "git+https://github.com/tscircuit/high-density-b01.git#e651cab6c314e7aab6df31fd6067277436f67148"
   },
   "dependencies": {

--- a/tests/features/high-density-a11-native-coarse-grid.test.ts
+++ b/tests/features/high-density-a11-native-coarse-grid.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "bun:test"
+import { HighDensitySolverA11 } from "@tscircuit/high-density-a01"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { GrowShrinkHighDensityIntraNodeSolver } from "lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver"
+import { PortfolioSingleIntraNodeSolver } from "lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver"
+import type { NodeWithPortPoints } from "lib/types/high-density-types"
+import sample002Cmn279 from "../fixtures/srj18-sample002-cmn279.json"
+
+test("native portfolios include A11 while grown portfolios stay coarse", () => {
+  const nodeWithPortPoints = sample002Cmn279 as NodeWithPortPoints
+  const solverParams = {
+    nodeWithPortPoints,
+    connMap: new ConnectivityMap({}),
+    viaDiameter: 0.3,
+    traceWidth: 0.1,
+    obstacleMargin: 0.15,
+    effort: 1,
+    obstacles: [],
+    layerCount: 2,
+    useHighDensitySolverA11: true,
+  }
+  const nativePortfolio = new PortfolioSingleIntraNodeSolver(solverParams)
+  nativePortfolio.initializeSolvers()
+  const a11Candidate = nativePortfolio.supervisedSolvers?.find(
+    ({ solver: candidateSolver }) =>
+      candidateSolver instanceof HighDensitySolverA11,
+  )?.solver
+
+  expect(a11Candidate).toBeInstanceOf(HighDensitySolverA11)
+  if (!(a11Candidate instanceof HighDensitySolverA11)) {
+    throw new Error("Native portfolio did not create an A11 candidate")
+  }
+  expect(a11Candidate.MAX_ITERATIONS).toBe(5_000)
+  expect(a11Candidate.rows).toBeUndefined()
+  a11Candidate.step()
+  expect(a11Candidate.rows).toBeDefined()
+  expect(a11Candidate.MAX_ITERATIONS).toBe(5_000)
+
+  const standardPortfolio = new PortfolioSingleIntraNodeSolver({
+    ...solverParams,
+    useHighDensitySolverA11: false,
+  })
+  standardPortfolio.initializeSolvers()
+  expect(
+    standardPortfolio.supervisedSolvers?.some(
+      ({ solver: candidateSolver }) =>
+        candidateSolver instanceof HighDensitySolverA11,
+    ),
+  ).toBe(false)
+
+  const grownSolver = new GrowShrinkHighDensityIntraNodeSolver(solverParams)
+  grownSolver.scaleFactor = 2
+  grownSolver.step()
+
+  expect(grownSolver.activeSubSolver).toBeInstanceOf(
+    PortfolioSingleIntraNodeSolver,
+  )
+  expect(
+    grownSolver.activeSubSolver?.supervisedSolvers?.some(
+      ({ solver: candidateSolver }) =>
+        candidateSolver.getSolverName() === "HighDensitySolverA11",
+    ),
+  ).toBe(false)
+})

--- a/tests/features/high-density-a11-native-coarse-grid.test.ts
+++ b/tests/features/high-density-a11-native-coarse-grid.test.ts
@@ -1,12 +1,15 @@
 import { expect, test } from "bun:test"
-import { HighDensitySolverA11 } from "@tscircuit/high-density-a01"
+import {
+  HighDensitySolverA11,
+  HighDensitySolverA12,
+} from "@tscircuit/high-density-a01"
 import { ConnectivityMap } from "circuit-json-to-connectivity-map"
 import { GrowShrinkHighDensityIntraNodeSolver } from "lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver"
 import { PortfolioSingleIntraNodeSolver } from "lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver"
 import type { NodeWithPortPoints } from "lib/types/high-density-types"
 import sample002Cmn279 from "../fixtures/srj18-sample002-cmn279.json"
 
-test("native portfolios include A11 while grown portfolios stay coarse", () => {
+test("native portfolios include A11 and A12 while grown portfolios stay coarse", () => {
   const nodeWithPortPoints = sample002Cmn279 as NodeWithPortPoints
   const solverParams = {
     nodeWithPortPoints,
@@ -18,12 +21,17 @@ test("native portfolios include A11 while grown portfolios stay coarse", () => {
     obstacles: [],
     layerCount: 2,
     useHighDensitySolverA11: true,
+    useHighDensitySolverA12: true,
   }
   const nativePortfolio = new PortfolioSingleIntraNodeSolver(solverParams)
   nativePortfolio.initializeSolvers()
   const a11Candidate = nativePortfolio.supervisedSolvers?.find(
     ({ solver: candidateSolver }) =>
       candidateSolver instanceof HighDensitySolverA11,
+  )?.solver
+  const a12Candidate = nativePortfolio.supervisedSolvers?.find(
+    ({ solver: candidateSolver }) =>
+      candidateSolver instanceof HighDensitySolverA12,
   )?.solver
 
   expect(a11Candidate).toBeInstanceOf(HighDensitySolverA11)
@@ -35,16 +43,27 @@ test("native portfolios include A11 while grown portfolios stay coarse", () => {
   a11Candidate.step()
   expect(a11Candidate.rows).toBeDefined()
   expect(a11Candidate.MAX_ITERATIONS).toBe(5_000)
+  expect(a12Candidate).toBeInstanceOf(HighDensitySolverA12)
+  if (!(a12Candidate instanceof HighDensitySolverA12)) {
+    throw new Error("Native portfolio did not create an A12 candidate")
+  }
+  expect(a12Candidate.MAX_ITERATIONS).toBe(15_000)
+  expect(a12Candidate._setupDone).toBe(false)
+  a12Candidate.step()
+  expect(a12Candidate._setupDone).toBe(true)
+  expect(a12Candidate.MAX_ITERATIONS).toBe(15_000)
 
   const standardPortfolio = new PortfolioSingleIntraNodeSolver({
     ...solverParams,
     useHighDensitySolverA11: false,
+    useHighDensitySolverA12: false,
   })
   standardPortfolio.initializeSolvers()
   expect(
     standardPortfolio.supervisedSolvers?.some(
       ({ solver: candidateSolver }) =>
-        candidateSolver instanceof HighDensitySolverA11,
+        candidateSolver instanceof HighDensitySolverA11 ||
+        candidateSolver instanceof HighDensitySolverA12,
     ),
   ).toBe(false)
 
@@ -58,7 +77,8 @@ test("native portfolios include A11 while grown portfolios stay coarse", () => {
   expect(
     grownSolver.activeSubSolver?.supervisedSolvers?.some(
       ({ solver: candidateSolver }) =>
-        candidateSolver.getSolverName() === "HighDensitySolverA11",
+        candidateSolver.getSolverName() === "HighDensitySolverA11" ||
+        candidateSolver.getSolverName() === "HighDensitySolverA12",
     ),
   ).toBe(false)
 })

--- a/tests/features/high-density-a11-portfolio-priority.test.ts
+++ b/tests/features/high-density-a11-portfolio-priority.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test"
+import { PortfolioSingleIntraNodeSolver } from "lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver"
+import { makeNode } from "./never-fail-growth-high-density/test-helpers"
+
+test("native portfolio gives established candidates priority over A11", () => {
+  const solver = new PortfolioSingleIntraNodeSolver({
+    nodeWithPortPoints: makeNode(),
+    viaDiameter: 0.3,
+    traceWidth: 0.15,
+    obstacleMargin: 0.15,
+    effort: 1,
+    obstacles: [],
+    layerCount: 2,
+    useHighDensitySolverA11: true,
+  })
+
+  solver.initializeSolvers()
+
+  const a11Candidate = solver.supervisedSolvers?.find(
+    ({ solver: candidate }) =>
+      candidate.getSolverName() === "HighDensitySolverA11",
+  )
+  const a01Candidate = solver.supervisedSolvers?.find(
+    ({ hyperParameters }) => hyperParameters.HIGH_DENSITY_A01,
+  )
+  expect(a11Candidate?.g).toBe(solver.GREEDY_MULTIPLIER + 1)
+  expect(a11Candidate?.f).toBe(solver.GREEDY_MULTIPLIER + 1)
+  expect(a01Candidate?.g).toBe(0)
+  expect(a01Candidate?.f).toBe(0)
+
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.winningSolver?.getSolverName()).not.toBe("HighDensitySolverA11")
+  expect(a11Candidate?.solver.iterations).toBe(0)
+})

--- a/tests/features/high-density-a11-portfolio-priority.test.ts
+++ b/tests/features/high-density-a11-portfolio-priority.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test"
 import { PortfolioSingleIntraNodeSolver } from "lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver"
 import { makeNode } from "./never-fail-growth-high-density/test-helpers"
 
-test("native portfolio gives established candidates priority over A11", () => {
+test("native portfolio orders A11 and A12 after established candidates", () => {
   const solver = new PortfolioSingleIntraNodeSolver({
     nodeWithPortPoints: makeNode(),
     viaDiameter: 0.3,
@@ -12,6 +12,7 @@ test("native portfolio gives established candidates priority over A11", () => {
     obstacles: [],
     layerCount: 2,
     useHighDensitySolverA11: true,
+    useHighDensitySolverA12: true,
   })
 
   solver.initializeSolvers()
@@ -23,8 +24,14 @@ test("native portfolio gives established candidates priority over A11", () => {
   const a01Candidate = solver.supervisedSolvers?.find(
     ({ hyperParameters }) => hyperParameters.HIGH_DENSITY_A01,
   )
+  const a12Candidate = solver.supervisedSolvers?.find(
+    ({ solver: candidate }) =>
+      candidate.getSolverName() === "HighDensitySolverA12",
+  )
   expect(a11Candidate?.g).toBe(solver.GREEDY_MULTIPLIER + 1)
   expect(a11Candidate?.f).toBe(solver.GREEDY_MULTIPLIER + 1)
+  expect(a12Candidate?.g).toBe(solver.GREEDY_MULTIPLIER + 2)
+  expect(a12Candidate?.f).toBe(solver.GREEDY_MULTIPLIER + 2)
   expect(a01Candidate?.g).toBe(0)
   expect(a01Candidate?.f).toBe(0)
 
@@ -33,4 +40,5 @@ test("native portfolio gives established candidates priority over A11", () => {
   expect(solver.solved).toBe(true)
   expect(solver.winningSolver?.getSolverName()).not.toBe("HighDensitySolverA11")
   expect(a11Candidate?.solver.iterations).toBe(0)
+  expect(a12Candidate?.solver.iterations).toBe(0)
 })

--- a/tests/features/pipeline9-hd30-topology-merge-298-native-size.test.ts
+++ b/tests/features/pipeline9-hd30-topology-merge-298-native-size.test.ts
@@ -27,9 +27,9 @@ test("Pipeline9 routes HD30 topology_merge_298 at native size with A11", () => {
   expect(solver.failed).toBe(false)
   expect(solver.stats.highDensityResizeCount).toBe(0)
   expect(solver.stats.solverNodeCount.HighDensitySolverA11).toBe(1)
-  expect(solver.nodeSolveMetadataById.get("topology_merge_298")?.solverType).toBe(
-    "HighDensitySolverA11",
-  )
+  expect(
+    solver.nodeSolveMetadataById.get("topology_merge_298")?.solverType,
+  ).toBe("HighDensitySolverA11")
   expect(solver.routes).toHaveLength(7)
   expect(getRouteGeometryViolationError(solver.routes)).toBeNull()
   expect(

--- a/tests/features/pipeline9-hd30-topology-merge-298-native-size.test.ts
+++ b/tests/features/pipeline9-hd30-topology-merge-298-native-size.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { createPipeline9RegularNodeSolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9HighDensitySolver"
+import { getRouteGeometryViolationError } from "@tscircuit/high-density-a01"
+import { areNodePortPointPairsConnectedByRoutes } from "lib/solvers/HyperHighDensitySolver/repairDisconnectedSameRootPortPoints"
+import type { NodeWithPortPoints } from "lib/types/high-density-types"
+import topologyMerge298 from "../fixtures/hd30-sample004-topology-merge-298.json"
+
+test("Pipeline9 routes HD30 topology_merge_298 at native size with A11", () => {
+  const nodeWithPortPoints = topologyMerge298 as NodeWithPortPoints
+  const solver = createPipeline9RegularNodeSolver({
+    nodeWithPortPoints,
+    connMap: new ConnectivityMap({}),
+    colorMap: {},
+    viaDiameter: 0.3,
+    traceWidth: 0.1,
+    obstacleMargin: 0.15,
+    effort: 1,
+    nodePfById: { [nodeWithPortPoints.capacityMeshNodeId]: null },
+    obstacles: [],
+    layerCount: 2,
+  })
+
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(solver.stats.highDensityResizeCount).toBe(0)
+  expect(solver.stats.solverNodeCount.HighDensitySolverA11).toBe(1)
+  expect(solver.nodeSolveMetadataById.get("topology_merge_298")?.solverType).toBe(
+    "HighDensitySolverA11",
+  )
+  expect(solver.routes).toHaveLength(7)
+  expect(getRouteGeometryViolationError(solver.routes)).toBeNull()
+  expect(
+    areNodePortPointPairsConnectedByRoutes(solver.routes, nodeWithPortPoints),
+  ).toBe(true)
+})

--- a/tests/features/pipeline9-high-density-a11-native.test.ts
+++ b/tests/features/pipeline9-high-density-a11-native.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test"
+import { getRouteGeometryViolationError } from "@tscircuit/high-density-a01"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { createPipeline9RegularNodeSolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9HighDensitySolver"
+import { areNodePortPointPairsConnectedByRoutes } from "lib/solvers/HyperHighDensitySolver/repairDisconnectedSameRootPortPoints"
+import type { NodeWithPortPoints } from "lib/types/high-density-types"
+import sample002Cmn279 from "../fixtures/srj18-sample002-cmn279.json"
+
+test("Pipeline9 A11 solves a difficult node at native size only", () => {
+  const nodeWithPortPoints = sample002Cmn279 as NodeWithPortPoints
+  const solver = createPipeline9RegularNodeSolver({
+    nodeWithPortPoints,
+    connMap: new ConnectivityMap({}),
+    colorMap: {},
+    viaDiameter: 0.3,
+    traceWidth: 0.1,
+    obstacleMargin: 0.15,
+    effort: 1,
+    nodePfById: { cmn_279: 0 },
+    obstacles: [],
+    layerCount: 2,
+  })
+
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(solver.stats.highDensityResizeCount).toBe(0)
+  expect(solver.stats.solverNodeCount.HighDensitySolverA11).toBe(1)
+  expect(solver.nodeSolveMetadataById.get("cmn_279")?.solverType).toBe(
+    "HighDensitySolverA11",
+  )
+  expect(solver.routes).toHaveLength(4)
+  expect(getRouteGeometryViolationError(solver.routes)).toBeNull()
+  expect(
+    areNodePortPointPairsConnectedByRoutes(solver.routes, nodeWithPortPoints),
+  ).toBe(true)
+})

--- a/tests/features/pipeline9-high-density-a12-native.test.ts
+++ b/tests/features/pipeline9-high-density-a12-native.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test"
+import { getRouteGeometryViolationError } from "@tscircuit/high-density-a01"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { createPipeline9RegularNodeSolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9HighDensitySolver"
+import { areNodePortPointPairsConnectedByRoutes } from "lib/solvers/HyperHighDensitySolver/repairDisconnectedSameRootPortPoints"
+import type { NodeWithPortPoints } from "lib/types/high-density-types"
+import sample003Cmn70 from "../fixtures/hd30-sample003-cmn70.json"
+
+test("Pipeline9 A12 solves its HD30 node without growth", () => {
+  const nodeWithPortPoints = sample003Cmn70 as NodeWithPortPoints
+  const solver = createPipeline9RegularNodeSolver({
+    nodeWithPortPoints,
+    connMap: new ConnectivityMap({}),
+    colorMap: {},
+    viaDiameter: 0.3,
+    traceWidth: 0.1,
+    obstacleMargin: 0.15,
+    effort: 1,
+    nodePfById: { cmn_70: 0 },
+    obstacles: [],
+    layerCount: 4,
+  })
+
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(solver.stats.highDensityResizeCount).toBe(0)
+  expect(solver.stats.solverNodeCount.HighDensitySolverA12).toBe(1)
+  expect(solver.nodeSolveMetadataById.get("cmn_70")?.solverType).toBe(
+    "HighDensitySolverA12",
+  )
+  expect(solver.routes).toHaveLength(5)
+  expect(getRouteGeometryViolationError(solver.routes)).toBeNull()
+  expect(
+    areNodePortPointPairsConnectedByRoutes(solver.routes, nodeWithPortPoints),
+  ).toBe(true)
+})

--- a/tests/fixtures/hd30-sample003-cmn70.json
+++ b/tests/fixtures/hd30-sample003-cmn70.json
@@ -1,0 +1,204 @@
+{
+  "capacityMeshNodeId": "cmn_70",
+  "center": {
+    "x": -4.8380975,
+    "y": 4.0374645
+  },
+  "width": 1.0606609999999996,
+  "height": 1.0606609999999996,
+  "portPoints": [
+    {
+      "portPointId": "ce1693_pp1_z0::0",
+      "x": -4.307767,
+      "y": 4.3910181966258035,
+      "z": 0,
+      "connectionName": "source_trace_0__source_net_0_mst12",
+      "rootConnectionName": "connectivity_net48",
+      "nextPortPointId": "ce1691_pp0_z1::1"
+    },
+    {
+      "portPointId": "ce1691_pp0_z1::1",
+      "x": -4.307767,
+      "y": 4.2672745,
+      "z": 1,
+      "connectionName": "source_trace_0__source_net_0_mst12",
+      "rootConnectionName": "connectivity_net48",
+      "prevPortPointId": "ce1693_pp1_z0::0"
+    },
+    {
+      "portPointId": "ce1692_pp0_z3::3",
+      "x": -4.307767,
+      "y": 4.2672745,
+      "z": 3,
+      "connectionName": "source_trace_0__source_net_0_mst14",
+      "rootConnectionName": "connectivity_net48",
+      "nextPortPointId": "ce1693_pp1_z0::0"
+    },
+    {
+      "portPointId": "ce1693_pp1_z0::0",
+      "x": -4.307767,
+      "y": 4.3910181966258035,
+      "z": 0,
+      "connectionName": "source_trace_0__source_net_0_mst14",
+      "rootConnectionName": "connectivity_net48",
+      "prevPortPointId": "ce1692_pp0_z3::3"
+    },
+    {
+      "portPointId": "ce1682_pp0_z0::0",
+      "x": -5.191651196625803,
+      "y": 3.5071339999999998,
+      "z": 0,
+      "connectionName": "source_trace_35__source_net_35",
+      "rootConnectionName": "connectivity_net15",
+      "nextPortPointId": "ce26_pp0_z3::3"
+    },
+    {
+      "portPointId": "ce26_pp0_z3::3",
+      "x": -5.3684277865032115,
+      "y": 4.0374645000000005,
+      "z": 3,
+      "connectionName": "source_trace_35__source_net_35",
+      "rootConnectionName": "connectivity_net15",
+      "prevPortPointId": "ce1682_pp0_z0::0"
+    },
+    {
+      "portPointId": "ce1682_pp1_z0::0",
+      "x": -4.838097589877409,
+      "y": 3.5071339999999998,
+      "z": 0,
+      "connectionName": "source_trace_34__source_net_34",
+      "rootConnectionName": "connectivity_net16",
+      "nextPortPointId": "ce26_pp0_z0::0"
+    },
+    {
+      "portPointId": "ce26_pp0_z0::0",
+      "x": -5.3684277865032115,
+      "y": 4.0374645000000005,
+      "z": 0,
+      "connectionName": "source_trace_34__source_net_34",
+      "rootConnectionName": "connectivity_net16",
+      "prevPortPointId": "ce1682_pp1_z0::0"
+    },
+    {
+      "portPointId": "ce1693_pp0_z0::0",
+      "x": -4.307767,
+      "y": 4.037464589877409,
+      "z": 0,
+      "connectionName": "source_trace_33__source_net_33",
+      "rootConnectionName": "connectivity_net17",
+      "nextPortPointId": "ce719_pp2_z0::0"
+    },
+    {
+      "portPointId": "ce719_pp2_z0::0",
+      "x": -4.8380975,
+      "y": 4.567794786503212,
+      "z": 0,
+      "connectionName": "source_trace_33__source_net_33",
+      "rootConnectionName": "connectivity_net17",
+      "prevPortPointId": "ce1693_pp0_z0::0"
+    }
+  ],
+  "portPointsInPairs": [
+    [
+      {
+        "portPointId": "ce1693_pp1_z0::0",
+        "x": -4.307767,
+        "y": 4.3910181966258035,
+        "z": 0,
+        "connectionName": "source_trace_0__source_net_0_mst12",
+        "rootConnectionName": "connectivity_net48",
+        "nextPortPointId": "ce1691_pp0_z1::1"
+      },
+      {
+        "portPointId": "ce1691_pp0_z1::1",
+        "x": -4.307767,
+        "y": 4.2672745,
+        "z": 1,
+        "connectionName": "source_trace_0__source_net_0_mst12",
+        "rootConnectionName": "connectivity_net48",
+        "prevPortPointId": "ce1693_pp1_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce1692_pp0_z3::3",
+        "x": -4.307767,
+        "y": 4.2672745,
+        "z": 3,
+        "connectionName": "source_trace_0__source_net_0_mst14",
+        "rootConnectionName": "connectivity_net48",
+        "nextPortPointId": "ce1693_pp1_z0::0"
+      },
+      {
+        "portPointId": "ce1693_pp1_z0::0",
+        "x": -4.307767,
+        "y": 4.3910181966258035,
+        "z": 0,
+        "connectionName": "source_trace_0__source_net_0_mst14",
+        "rootConnectionName": "connectivity_net48",
+        "prevPortPointId": "ce1692_pp0_z3::3"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce1682_pp0_z0::0",
+        "x": -5.191651196625803,
+        "y": 3.5071339999999998,
+        "z": 0,
+        "connectionName": "source_trace_35__source_net_35",
+        "rootConnectionName": "connectivity_net15",
+        "nextPortPointId": "ce26_pp0_z3::3"
+      },
+      {
+        "portPointId": "ce26_pp0_z3::3",
+        "x": -5.3684277865032115,
+        "y": 4.0374645000000005,
+        "z": 3,
+        "connectionName": "source_trace_35__source_net_35",
+        "rootConnectionName": "connectivity_net15",
+        "prevPortPointId": "ce1682_pp0_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce1682_pp1_z0::0",
+        "x": -4.838097589877409,
+        "y": 3.5071339999999998,
+        "z": 0,
+        "connectionName": "source_trace_34__source_net_34",
+        "rootConnectionName": "connectivity_net16",
+        "nextPortPointId": "ce26_pp0_z0::0"
+      },
+      {
+        "portPointId": "ce26_pp0_z0::0",
+        "x": -5.3684277865032115,
+        "y": 4.0374645000000005,
+        "z": 0,
+        "connectionName": "source_trace_34__source_net_34",
+        "rootConnectionName": "connectivity_net16",
+        "prevPortPointId": "ce1682_pp1_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce1693_pp0_z0::0",
+        "x": -4.307767,
+        "y": 4.037464589877409,
+        "z": 0,
+        "connectionName": "source_trace_33__source_net_33",
+        "rootConnectionName": "connectivity_net17",
+        "nextPortPointId": "ce719_pp2_z0::0"
+      },
+      {
+        "portPointId": "ce719_pp2_z0::0",
+        "x": -4.8380975,
+        "y": 4.567794786503212,
+        "z": 0,
+        "connectionName": "source_trace_33__source_net_33",
+        "rootConnectionName": "connectivity_net17",
+        "prevPortPointId": "ce1693_pp0_z0::0"
+      }
+    ]
+  ],
+  "availableZ": [0, 1, 2, 3]
+}

--- a/tests/fixtures/hd30-sample004-topology-merge-298.json
+++ b/tests/fixtures/hd30-sample004-topology-merge-298.json
@@ -1,0 +1,283 @@
+{
+  "capacityMeshNodeId": "topology_merge_298",
+  "center": {
+    "x": -9.277980564417435,
+    "y": -1.8425417822087164
+  },
+  "width": 0.35355399999999904,
+  "height": 1.815716435582567,
+  "portPoints": [
+    {
+      "portPointId": "ce1309_pp1_z0::0",
+      "x": -9.454757564417434,
+      "y": -2.20568506932523,
+      "z": 0,
+      "connectionName": "source_trace_2__source_net_2_mst24",
+      "rootConnectionName": "connectivity_net42",
+      "nextPortPointId": "ce1505_pp1_z0::0"
+    },
+    {
+      "portPointId": "ce1505_pp1_z0::0",
+      "x": -9.101203564417435,
+      "y": -2.2020887116565375,
+      "z": 0,
+      "connectionName": "source_trace_2__source_net_2_mst24",
+      "rootConnectionName": "connectivity_net42",
+      "prevPortPointId": "ce1309_pp1_z0::0"
+    },
+    {
+      "portPointId": "ce1309_pp4_z0::0",
+      "x": -9.454757564417434,
+      "y": -1.4793984950922032,
+      "z": 0,
+      "connectionName": "source_trace_3__source_net_3_mst6",
+      "rootConnectionName": "connectivity_net41",
+      "nextPortPointId": "ce1507_pp0_z0::0"
+    },
+    {
+      "portPointId": "ce1507_pp0_z0::0",
+      "x": -9.101203564417435,
+      "y": -1.1114600644174328,
+      "z": 0,
+      "connectionName": "source_trace_3__source_net_3_mst6",
+      "rootConnectionName": "connectivity_net41",
+      "prevPortPointId": "ce1309_pp4_z0::0"
+    },
+    {
+      "portPointId": "ce1507_pp0_z0::0",
+      "x": -9.101203564417435,
+      "y": -1.1114600644174328,
+      "z": 0,
+      "connectionName": "source_trace_3__source_net_3_mst13",
+      "rootConnectionName": "connectivity_net41",
+      "nextPortPointId": "ce1309_pp5_z0::0"
+    },
+    {
+      "portPointId": "ce1309_pp5_z0::0",
+      "x": -9.454757564417434,
+      "y": -1.1162552079756896,
+      "z": 0,
+      "connectionName": "source_trace_3__source_net_3_mst13",
+      "rootConnectionName": "connectivity_net41",
+      "prevPortPointId": "ce1507_pp0_z0::0"
+    },
+    {
+      "portPointId": "ce1309_pp5_z0::0",
+      "x": -9.454757564417434,
+      "y": -1.1162552079756896,
+      "z": 0,
+      "connectionName": "source_trace_3__source_net_3_mst14",
+      "rootConnectionName": "connectivity_net41",
+      "nextPortPointId": "ce1507_pp0_z0::0"
+    },
+    {
+      "portPointId": "ce1507_pp0_z0::0",
+      "x": -9.101203564417435,
+      "y": -1.1114600644174328,
+      "z": 0,
+      "connectionName": "source_trace_3__source_net_3_mst14",
+      "rootConnectionName": "connectivity_net41",
+      "prevPortPointId": "ce1309_pp5_z0::0"
+    },
+    {
+      "portPointId": "ce1309_pp1_z1::1",
+      "x": -9.454757564417434,
+      "y": -1.8425417822087164,
+      "z": 1,
+      "connectionName": "source_trace_16__source_net_16_mst1",
+      "rootConnectionName": "connectivity_net28",
+      "nextPortPointId": "ce1505_pp2_z0::0"
+    },
+    {
+      "portPointId": "ce1505_pp2_z0::0",
+      "x": -9.101203564417435,
+      "y": -1.8365478527608956,
+      "z": 0,
+      "connectionName": "source_trace_16__source_net_16_mst1",
+      "rootConnectionName": "connectivity_net28",
+      "prevPortPointId": "ce1309_pp1_z1::1"
+    },
+    {
+      "portPointId": "ce1505_pp0_z0::0",
+      "x": -9.101203564417435,
+      "y": -2.567629570552179,
+      "z": 0,
+      "connectionName": "source_trace_17__source_net_17",
+      "rootConnectionName": "connectivity_net27",
+      "nextPortPointId": "ce1309_pp0_z0::0"
+    },
+    {
+      "portPointId": "ce1309_pp0_z0::0",
+      "x": -9.454757564417434,
+      "y": -2.568828356441743,
+      "z": 0,
+      "connectionName": "source_trace_17__source_net_17",
+      "rootConnectionName": "connectivity_net27",
+      "prevPortPointId": "ce1505_pp0_z0::0"
+    },
+    {
+      "portPointId": "ce1505_pp3_z0::0",
+      "x": -9.101203564417435,
+      "y": -1.4710069938652541,
+      "z": 0,
+      "connectionName": "source_trace_15__source_net_15",
+      "rootConnectionName": "connectivity_net29",
+      "nextPortPointId": "ce1309_pp2_z0::0"
+    },
+    {
+      "portPointId": "ce1309_pp2_z0::0",
+      "x": -9.454757564417434,
+      "y": -1.8425417822087164,
+      "z": 0,
+      "connectionName": "source_trace_15__source_net_15",
+      "rootConnectionName": "connectivity_net29",
+      "prevPortPointId": "ce1505_pp3_z0::0"
+    }
+  ],
+  "portPointsInPairs": [
+    [
+      {
+        "portPointId": "ce1309_pp1_z0::0",
+        "x": -9.454757564417434,
+        "y": -2.20568506932523,
+        "z": 0,
+        "connectionName": "source_trace_2__source_net_2_mst24",
+        "rootConnectionName": "connectivity_net42",
+        "nextPortPointId": "ce1505_pp1_z0::0"
+      },
+      {
+        "portPointId": "ce1505_pp1_z0::0",
+        "x": -9.101203564417435,
+        "y": -2.2020887116565375,
+        "z": 0,
+        "connectionName": "source_trace_2__source_net_2_mst24",
+        "rootConnectionName": "connectivity_net42",
+        "prevPortPointId": "ce1309_pp1_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce1309_pp4_z0::0",
+        "x": -9.454757564417434,
+        "y": -1.4793984950922032,
+        "z": 0,
+        "connectionName": "source_trace_3__source_net_3_mst6",
+        "rootConnectionName": "connectivity_net41",
+        "nextPortPointId": "ce1507_pp0_z0::0"
+      },
+      {
+        "portPointId": "ce1507_pp0_z0::0",
+        "x": -9.101203564417435,
+        "y": -1.1114600644174328,
+        "z": 0,
+        "connectionName": "source_trace_3__source_net_3_mst6",
+        "rootConnectionName": "connectivity_net41",
+        "prevPortPointId": "ce1309_pp4_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce1507_pp0_z0::0",
+        "x": -9.101203564417435,
+        "y": -1.1114600644174328,
+        "z": 0,
+        "connectionName": "source_trace_3__source_net_3_mst13",
+        "rootConnectionName": "connectivity_net41",
+        "nextPortPointId": "ce1309_pp5_z0::0"
+      },
+      {
+        "portPointId": "ce1309_pp5_z0::0",
+        "x": -9.454757564417434,
+        "y": -1.1162552079756896,
+        "z": 0,
+        "connectionName": "source_trace_3__source_net_3_mst13",
+        "rootConnectionName": "connectivity_net41",
+        "prevPortPointId": "ce1507_pp0_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce1309_pp5_z0::0",
+        "x": -9.454757564417434,
+        "y": -1.1162552079756896,
+        "z": 0,
+        "connectionName": "source_trace_3__source_net_3_mst14",
+        "rootConnectionName": "connectivity_net41",
+        "nextPortPointId": "ce1507_pp0_z0::0"
+      },
+      {
+        "portPointId": "ce1507_pp0_z0::0",
+        "x": -9.101203564417435,
+        "y": -1.1114600644174328,
+        "z": 0,
+        "connectionName": "source_trace_3__source_net_3_mst14",
+        "rootConnectionName": "connectivity_net41",
+        "prevPortPointId": "ce1309_pp5_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce1309_pp1_z1::1",
+        "x": -9.454757564417434,
+        "y": -1.8425417822087164,
+        "z": 1,
+        "connectionName": "source_trace_16__source_net_16_mst1",
+        "rootConnectionName": "connectivity_net28",
+        "nextPortPointId": "ce1505_pp2_z0::0"
+      },
+      {
+        "portPointId": "ce1505_pp2_z0::0",
+        "x": -9.101203564417435,
+        "y": -1.8365478527608956,
+        "z": 0,
+        "connectionName": "source_trace_16__source_net_16_mst1",
+        "rootConnectionName": "connectivity_net28",
+        "prevPortPointId": "ce1309_pp1_z1::1"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce1505_pp0_z0::0",
+        "x": -9.101203564417435,
+        "y": -2.567629570552179,
+        "z": 0,
+        "connectionName": "source_trace_17__source_net_17",
+        "rootConnectionName": "connectivity_net27",
+        "nextPortPointId": "ce1309_pp0_z0::0"
+      },
+      {
+        "portPointId": "ce1309_pp0_z0::0",
+        "x": -9.454757564417434,
+        "y": -2.568828356441743,
+        "z": 0,
+        "connectionName": "source_trace_17__source_net_17",
+        "rootConnectionName": "connectivity_net27",
+        "prevPortPointId": "ce1505_pp0_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce1505_pp3_z0::0",
+        "x": -9.101203564417435,
+        "y": -1.4710069938652541,
+        "z": 0,
+        "connectionName": "source_trace_15__source_net_15",
+        "rootConnectionName": "connectivity_net29",
+        "nextPortPointId": "ce1309_pp2_z0::0"
+      },
+      {
+        "portPointId": "ce1309_pp2_z0::0",
+        "x": -9.454757564417434,
+        "y": -1.8425417822087164,
+        "z": 0,
+        "connectionName": "source_trace_15__source_net_15",
+        "rootConnectionName": "connectivity_net29",
+        "prevPortPointId": "ce1505_pp3_z0::0"
+      }
+    ]
+  ],
+  "availableZ": [
+    0,
+    1
+  ]
+}

--- a/tests/fixtures/srj18-sample002-cmn279.json
+++ b/tests/fixtures/srj18-sample002-cmn279.json
@@ -1,0 +1,169 @@
+{
+  "capacityMeshNodeId": "cmn_279",
+  "center": {
+    "x": 7.6880999999999995,
+    "y": -4.8483
+  },
+  "width": 1.4749999999999996,
+  "height": 0.7749999999999995,
+  "portPoints": [
+    {
+      "portPointId": "ce4968_pp2_z1::1",
+      "x": 8.179766666666666,
+      "y": -5.235799999999999,
+      "z": 1,
+      "connectionName": "source_trace_85__source_net_85_mst0",
+      "rootConnectionName": "connectivity_net43",
+      "nextPortPointId": "ce4976_pp4_z1::1"
+    },
+    {
+      "portPointId": "ce4976_pp4_z1::1",
+      "x": 8.2381,
+      "y": -4.460800000000001,
+      "z": 1,
+      "connectionName": "source_trace_85__source_net_85_mst0",
+      "rootConnectionName": "connectivity_net43",
+      "prevPortPointId": "ce4968_pp2_z1::1"
+    },
+    {
+      "portPointId": "ce4456_pp1_z1::1",
+      "x": 6.9506,
+      "y": -4.8483,
+      "z": 1,
+      "connectionName": "source_trace_84__source_net_84_mst0",
+      "rootConnectionName": "connectivity_net44",
+      "nextPortPointId": "ce4976_pp1_z1::1"
+    },
+    {
+      "portPointId": "ce4976_pp1_z1::1",
+      "x": 7.4131,
+      "y": -4.460800000000001,
+      "z": 1,
+      "connectionName": "source_trace_84__source_net_84_mst0",
+      "rootConnectionName": "connectivity_net44",
+      "prevPortPointId": "ce4456_pp1_z1::1"
+    },
+    {
+      "portPointId": "ce4976_pp2_z1::1",
+      "x": 7.6880999999999995,
+      "y": -4.460800000000001,
+      "z": 1,
+      "connectionName": "source_trace_95__source_net_95",
+      "rootConnectionName": "connectivity_net33",
+      "nextPortPointId": "ce4968_pp1_z1::1"
+    },
+    {
+      "portPointId": "ce4968_pp1_z1::1",
+      "x": 7.6880999999999995,
+      "y": -5.235799999999999,
+      "z": 1,
+      "connectionName": "source_trace_95__source_net_95",
+      "rootConnectionName": "connectivity_net33",
+      "prevPortPointId": "ce4976_pp2_z1::1"
+    },
+    {
+      "portPointId": "ce4976_pp0_z1::1",
+      "x": 7.1381,
+      "y": -4.460800000000001,
+      "z": 1,
+      "connectionName": "source_trace_94__source_net_94",
+      "rootConnectionName": "connectivity_net34",
+      "nextPortPointId": "ce4968_pp0_z1::1"
+    },
+    {
+      "portPointId": "ce4968_pp0_z1::1",
+      "x": 7.196433333333333,
+      "y": -5.235799999999999,
+      "z": 1,
+      "connectionName": "source_trace_94__source_net_94",
+      "rootConnectionName": "connectivity_net34",
+      "prevPortPointId": "ce4976_pp0_z1::1"
+    }
+  ],
+  "portPointsInPairs": [
+    [
+      {
+        "portPointId": "ce4968_pp2_z1::1",
+        "x": 8.179766666666666,
+        "y": -5.235799999999999,
+        "z": 1,
+        "connectionName": "source_trace_85__source_net_85_mst0",
+        "rootConnectionName": "connectivity_net43",
+        "nextPortPointId": "ce4976_pp4_z1::1"
+      },
+      {
+        "portPointId": "ce4976_pp4_z1::1",
+        "x": 8.2381,
+        "y": -4.460800000000001,
+        "z": 1,
+        "connectionName": "source_trace_85__source_net_85_mst0",
+        "rootConnectionName": "connectivity_net43",
+        "prevPortPointId": "ce4968_pp2_z1::1"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce4456_pp1_z1::1",
+        "x": 6.9506,
+        "y": -4.8483,
+        "z": 1,
+        "connectionName": "source_trace_84__source_net_84_mst0",
+        "rootConnectionName": "connectivity_net44",
+        "nextPortPointId": "ce4976_pp1_z1::1"
+      },
+      {
+        "portPointId": "ce4976_pp1_z1::1",
+        "x": 7.4131,
+        "y": -4.460800000000001,
+        "z": 1,
+        "connectionName": "source_trace_84__source_net_84_mst0",
+        "rootConnectionName": "connectivity_net44",
+        "prevPortPointId": "ce4456_pp1_z1::1"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce4976_pp2_z1::1",
+        "x": 7.6880999999999995,
+        "y": -4.460800000000001,
+        "z": 1,
+        "connectionName": "source_trace_95__source_net_95",
+        "rootConnectionName": "connectivity_net33",
+        "nextPortPointId": "ce4968_pp1_z1::1"
+      },
+      {
+        "portPointId": "ce4968_pp1_z1::1",
+        "x": 7.6880999999999995,
+        "y": -5.235799999999999,
+        "z": 1,
+        "connectionName": "source_trace_95__source_net_95",
+        "rootConnectionName": "connectivity_net33",
+        "prevPortPointId": "ce4976_pp2_z1::1"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce4976_pp0_z1::1",
+        "x": 7.1381,
+        "y": -4.460800000000001,
+        "z": 1,
+        "connectionName": "source_trace_94__source_net_94",
+        "rootConnectionName": "connectivity_net34",
+        "nextPortPointId": "ce4968_pp0_z1::1"
+      },
+      {
+        "portPointId": "ce4968_pp0_z1::1",
+        "x": 7.196433333333333,
+        "y": -5.235799999999999,
+        "z": 1,
+        "connectionName": "source_trace_94__source_net_94",
+        "rootConnectionName": "connectivity_net34",
+        "prevPortPointId": "ce4976_pp0_z1::1"
+      }
+    ]
+  ],
+  "availableZ": [
+    0,
+    1
+  ]
+}


### PR DESCRIPTION
## Summary
- enable upstream A11 and A12 as Pipeline9 candidates only at native node size
- preserve established solver results, then try A11, then the more expensive A12
- keep both fine-grid candidates lazy and bound them to 5,000 and 15,000 iterations respectively
- preserve the existing grown-node portfolio and reject invalid geometry or disconnected port pairs
- use the single canonical high-density dependency

## Root cause
Some difficult high-density nodes only converged after grow/shrink because the production Pipeline9 portfolio did not include the specialized native-grid solvers. A11 covers fine-grid history-aware searches, while A12 adds a mixed-resolution search for cases where a uniform fine grid is unnecessarily large.

A12 previously caused a timeout when it could run too early and search for too long. Here it starts after established candidates and A11, is limited to the native-size attempt, and stops after 15,000 iterations. The exact SRJ18 sample 12 regression now completes DRC-clean without increasing any timeout.

## Validation
- package build, TypeScript typecheck, formatting, and diff checks
- focused A11 and A12 integration, priority, lazy setup, iteration-bound, native-only, geometry, and connectivity tests
- exact Pipeline9 SRJ18 sample 12 replay: solved with zero relaxed-DRC errors
- full Game Boy Advance routing regression with the original SVG snapshot
- historical bugreport87 and bugreport88 routing checks
- grow/shrink and invalid-output regression coverage