### PR TITLE
Make Pipeline 9 the default benchmark solver

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       solver_name:
-        description: 'Solver name to benchmark (optional, default: AutoroutingPipelineSolver7_MultiGraph; use "all" for all solvers)'
+        description: 'Solver name to benchmark (optional, default: AutoroutingPipelineSolver9_PreloadedTraceGraph; use "all" for all solvers)'
         required: false
         type: string
       scenario_limit:

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -8,7 +8,7 @@ SAMPLE_TIMEOUT=""
 SAMPLE_NUMBERS=""
 INCLUDE_ASSIGNABLE=false
 DATASET="dataset01"
-DEFAULT_SOLVER_NAME="AutoroutingPipelineSolver7_MultiGraph"
+DEFAULT_SOLVER_NAME="AutoroutingPipelineSolver9_PreloadedTraceGraph"
 PIPELINE_ID=""
 NETWORKED_COLD_HOT=false
 
@@ -97,20 +97,20 @@ Options:
   -h, --help           Show this help
 
 Defaults:
-  Running ./benchmark.sh with no parameters benchmarks only AutoroutingPipelineSolver7_MultiGraph.
+  Running ./benchmark.sh with no parameters benchmarks only AutoroutingPipelineSolver9_PreloadedTraceGraph.
   Use "all" to benchmark every available solver.
 
 Examples:
   ./benchmark.sh
-  ./benchmark.sh AutoroutingPipelineSolver7_MultiGraph
+  ./benchmark.sh AutoroutingPipelineSolver9_PreloadedTraceGraph
   ./benchmark.sh all 20 --concurrency auto
-  ./benchmark.sh --solver AutoroutingPipelineSolver7_MultiGraph --effort 2
-  ./benchmark.sh --solver AutoroutingPipelineSolver7_MultiGraph --sample-timeout 90s
+  ./benchmark.sh --solver AutoroutingPipelineSolver9_PreloadedTraceGraph --effort 2
+  ./benchmark.sh --solver AutoroutingPipelineSolver9_PreloadedTraceGraph --sample-timeout 90s
   ./benchmark.sh --pipeline 10 --dataset 29 --sample 1
   ./benchmark.sh --pipeline 10 --dataset 29 --limit 5
   ./benchmark.sh --sample-numbers 120,139,148 --concurrency 8 --sample-timeout 120s
-  ./benchmark.sh --solver AutoroutingPipelineSolver7_MultiGraph --scenario-limit 20
-  ./benchmark.sh --solver AutoroutingPipelineSolver7_MultiGraph --dataset zdwiel --scenario-limit 20
+  ./benchmark.sh --solver AutoroutingPipelineSolver9_PreloadedTraceGraph --scenario-limit 20
+  ./benchmark.sh --solver AutoroutingPipelineSolver9_PreloadedTraceGraph --dataset zdwiel --scenario-limit 20
   ./benchmark.sh --pipeline 4
   ./benchmark.sh --pipeline 5
   ./benchmark.sh --pipeline 6
@@ -119,7 +119,7 @@ Examples:
   ./benchmark.sh --pipeline 9net --dataset 18
   ./benchmark.sh --pipeline 10 --dataset 29
   ./benchmark.sh --pipeline krt
-  ./benchmark.sh --solver AutoroutingPipelineSolver7_MultiGraph --dataset srj05 --scenario-limit 20
+  ./benchmark.sh --solver AutoroutingPipelineSolver9_PreloadedTraceGraph --dataset srj05 --scenario-limit 20
   ./benchmark.sh --dataset 11 --scenario-limit 20
   ./benchmark.sh --dataset 12 --scenario-limit 10
   ./benchmark.sh --dataset 13

--- a/scripts/benchmark/index.ts
+++ b/scripts/benchmark/index.ts
@@ -72,7 +72,8 @@ const DEFAULT_TASK_TIMEOUT_BASE_MS = 300 * 1000
 const DEFAULT_TASK_TIMEOUT_PER_EFFORT_MS = 60 * 1000
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 30 * 1000
 const DEFAULT_TERMINATE_TIMEOUT_MS = 5 * 1000
-const DEFAULT_BENCHMARK_SOLVER_NAME = "AutoroutingPipelineSolver7_MultiGraph"
+const DEFAULT_BENCHMARK_SOLVER_NAME =
+  "AutoroutingPipelineSolver9_PreloadedTraceGraph"
 const NETWORKED_PIPELINE9_SOLVER_NAME = "AutoroutingPipelineSolver9_Networked"
 const NETWORKED_PIPELINE9_COLD_NAME = "Pipeline9_Networked Cold"
 const NETWORKED_PIPELINE9_HOT_NAME = "Pipeline9_Networked Hot"

--- a/tests/benchmark-default-solver.test.ts
+++ b/tests/benchmark-default-solver.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+
+const pipeline9SolverName = "AutoroutingPipelineSolver9_PreloadedTraceGraph"
+
+test("benchmark entrypoints default to Pipeline 9", () => {
+  const benchmarkScript = readFileSync(
+    new URL("../benchmark.sh", import.meta.url),
+    "utf8",
+  )
+  const benchmarkRunner = readFileSync(
+    new URL("../scripts/benchmark/index.ts", import.meta.url),
+    "utf8",
+  )
+  const benchmarkWorkflow = readFileSync(
+    new URL("../.github/workflows/benchmark.yml", import.meta.url),
+    "utf8",
+  )
+
+  expect(benchmarkScript).toContain(
+    `DEFAULT_SOLVER_NAME="${pipeline9SolverName}"`,
+  )
+  expect(benchmarkScript).toContain(
+    `Running ./benchmark.sh with no parameters benchmarks only ${pipeline9SolverName}.`,
+  )
+  expect(benchmarkRunner).toMatch(
+    new RegExp(
+      `const DEFAULT_BENCHMARK_SOLVER_NAME\\s*=\\s*"${pipeline9SolverName}"`,
+    ),
+  )
+  expect(benchmarkWorkflow).toContain(
+    `default: ${pipeline9SolverName}; use "all" for all solvers`,
+  )
+})


### PR DESCRIPTION
## Summary
- make `AutoroutingPipelineSolver9_PreloadedTraceGraph` the default benchmark solver
- align the benchmark script help and workflow input description
- add regression coverage that keeps all benchmark entrypoints on Pipeline 9

## Validation
- `bun test tests/benchmark-default-solver.test.ts tests/pr-benchmark-command.test.ts --timeout 9999999`
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`
- `./benchmark.sh --help`