### PR TITLE
Run /benchmark-all on datasets 01 and 18

### DIFF
--- a/.github/workflows/benchmark-dispatch.yml
+++ b/.github/workflows/benchmark-dispatch.yml
@@ -43,7 +43,7 @@ jobs:
             const command = parsePrBenchmarkCommand(context.payload.comment.body)
             const isProfile = command.kind === 'profile'
             const datasets = command.kind === 'benchmark-all'
-              ? ['dataset01', 'srj18', 'srj19', 'srj20', 'srj21', 'srj23']
+              ? ['dataset01', 'srj18']
               : [command.datasetName]
             const pr = await github.rest.pulls.get({
               owner: context.repo.owner,

--- a/.github/workflows/benchmark-instructions.yml
+++ b/.github/workflows/benchmark-instructions.yml
@@ -35,7 +35,7 @@ jobs:
               "",
               "Comment `/benchmark` to run the default dataset, or append any arguments accepted by `./benchmark.sh`.",
               "Comment `/benchmark-long` for an 8-vCPU run that defaults to 8 workers and has an eight-hour timeout.",
-              "Comment `/benchmark-all` to start separate workflow runs and result comments for the default dataset plus srj18, srj19, srj20, srj21, and srj23. You may append benchmark arguments such as `--pipeline 9`; `--dataset` is not accepted because the command selects every configured dataset.",
+              "Comment `/benchmark-all` to start separate workflow runs and result comments for dataset01 and dataset18. You may append benchmark arguments such as `--pipeline 9`; `--dataset` is not accepted because the command selects both datasets.",
               "Append `--same-machine` to `/benchmark` or `/benchmark-all` to compare current main and the PR head sequentially on the same 8-vCPU Blacksmith runner.",
               "Comment `/profile --dataset 18` to compare direct Pipeline 7 stage-time percentages between current main and the PR head sequentially on one Blacksmith runner.",
               "",

--- a/tests/pr-benchmark-command.test.ts
+++ b/tests/pr-benchmark-command.test.ts
@@ -185,7 +185,7 @@ test("PR benchmark commands preserve arguments and fan-out behavior", () => {
     "parsePrBenchmarkCommand(context.payload.comment.body)",
   )
   expect(dispatchWorkflow).toContain(
-    "['dataset01', 'srj18', 'srj19', 'srj20', 'srj21', 'srj23']",
+    "['dataset01', 'srj18']",
   )
   expect(dispatchWorkflow).toContain(
     "? [...command.benchmarkArgs, '--dataset', dataset]",

--- a/tests/pr-benchmark-command.test.ts
+++ b/tests/pr-benchmark-command.test.ts
@@ -184,9 +184,7 @@ test("PR benchmark commands preserve arguments and fan-out behavior", () => {
   expect(dispatchWorkflow).toContain(
     "parsePrBenchmarkCommand(context.payload.comment.body)",
   )
-  expect(dispatchWorkflow).toContain(
-    "['dataset01', 'srj18']",
-  )
+  expect(dispatchWorkflow).toContain("['dataset01', 'srj18']")
   expect(dispatchWorkflow).toContain(
     "? [...command.benchmarkArgs, '--dataset', dataset]",
   )


### PR DESCRIPTION
## Summary
- limit `/benchmark-all` fan-out to dataset01 and dataset18 (canonical workflow name `srj18`)
- update the benchmark instructions comment to describe the two datasets
- update the workflow assertion in the benchmark command test

## Testing
- `bun test tests/pr-benchmark-command.test.ts --timeout 9999999`