### PR TITLE
Fix same-machine comparisons across default solver changes

### DIFF
--- a/scripts/benchmark/same-machine-results.ts
+++ b/scripts/benchmark/same-machine-results.ts
@@ -1,5 +1,9 @@
 import { readFile, writeFile } from "node:fs/promises"
-import type { BenchmarkReport, WorkerResult } from "./benchmark-types"
+import type {
+  BenchmarkReport,
+  SolverRunSummary,
+  WorkerResult,
+} from "./benchmark-types"
 
 type SameMachineBenchmarkInput = {
   mainReport: BenchmarkReport
@@ -8,6 +12,25 @@ type SameMachineBenchmarkInput = {
   prSha: string
   repository: string
   runnerName: string
+}
+
+type SolverComparison = {
+  mainSummary: SolverRunSummary
+  prSummary: SolverRunSummary
+}
+
+type ChangedOutcome = {
+  solverComparison: SolverComparison
+  sampleNumber: number
+  mainTest: WorkerResult
+  prTest: WorkerResult
+  delta: "Improved" | "Regressed"
+}
+
+type ChangedOutcomeInput = {
+  mainReport: BenchmarkReport
+  prReport: BenchmarkReport
+  solverComparisons: SolverComparison[]
 }
 
 const formatTime = (timeMs: number | null): string => {
@@ -118,30 +141,69 @@ const outcomeLabel = (test: WorkerResult): string => {
   return test.relaxedDrcPassed ? "DRC passed" : "Solved (DRC failed)"
 }
 
-const testKey = (test: WorkerResult): string =>
-  `${test.solverName}::${test.scenarioName}::${test.sampleNumber}`
+const testKey = (test: WorkerResult, solverName = test.solverName): string =>
+  `${solverName}::${test.scenarioName}::${test.sampleNumber}`
 
 const formatSolverName = (solverName: string): string =>
   solverName.replace(/^AutoroutingPipelineSolver(\d+).*$/, "Pipeline$1")
+
+const formatSolverComparison = ({
+  mainSummary,
+  prSummary,
+}: SolverComparison): string => {
+  const mainSolver = formatSolverName(mainSummary.solverName)
+  const prSolver = formatSolverName(prSummary.solverName)
+  const solverNamesMatch = mainSolver === prSolver
+  if (solverNamesMatch) return mainSolver
+  return `${mainSolver} → ${prSolver}`
+}
 
 const escapeTableCell = (value: unknown): string =>
   String(value ?? "")
     .replace(/\|/g, "\\|")
     .replace(/\r?\n/g, " ")
 
-const getChangedOutcomes = (
+const getSolverComparisons = (
   mainReport: BenchmarkReport,
   prReport: BenchmarkReport,
-) => {
-  const mainTests = new Map(
+): SolverComparison[] => {
+  const comparesSingleDefaults =
+    mainReport.summary.length === 1 &&
+    prReport.summary.length === 1
+  return prReport.summary.map((prSummary) => {
+    const mainSummary = comparesSingleDefaults
+      ? mainReport.summary[0]
+      : mainReport.summary.find(
+          (summary) => summary.solverName === prSummary.solverName,
+        )
+    if (!mainSummary) {
+      throw new Error(`Main report is missing solver ${prSummary.solverName}`)
+    }
+    return { mainSummary, prSummary }
+  })
+}
+
+const getChangedOutcomes = ({
+  mainReport,
+  prReport,
+  solverComparisons,
+}: ChangedOutcomeInput): ChangedOutcome[] => {
+  const mainTests = Object.fromEntries(
     mainReport.tests.map((test) => [testKey(test), test]),
   )
   return prReport.tests.flatMap((prTest) => {
-    const mainTest = mainTests.get(testKey(prTest))
+    const solverComparison = solverComparisons.find(
+      (comparison) =>
+        comparison.prSummary.solverName === prTest.solverName,
+    )
+    if (!solverComparison) return []
+    const mainTest = mainTests[
+      testKey(prTest, solverComparison.mainSummary.solverName)
+    ]
     if (!mainTest || outcomeScore(mainTest) === outcomeScore(prTest)) return []
     return [
       {
-        solverName: prTest.solverName,
+        solverComparison,
         sampleNumber: prTest.sampleNumber,
         mainTest,
         prTest,
@@ -168,10 +230,12 @@ export const renderSameMachineBenchmarkResults = ({
     )
   }
 
-  const mainSummaries = new Map(
-    mainReport.summary.map((summary) => [summary.solverName, summary]),
-  )
-  const changedOutcomes = getChangedOutcomes(mainReport, prReport)
+  const solverComparisons = getSolverComparisons(mainReport, prReport)
+  const changedOutcomes = getChangedOutcomes({
+    mainReport,
+    prReport,
+    solverComparisons,
+  })
   const lines = [
     "## Same Machine Benchmark Results",
     "",
@@ -184,24 +248,21 @@ export const renderSameMachineBenchmarkResults = ({
     "| --- | --- | ---: | ---: | ---: |",
   ]
 
-  for (const prSummary of prReport.summary) {
-    const mainSummary = mainSummaries.get(prSummary.solverName)
-    if (!mainSummary) {
-      throw new Error(`Main report is missing solver ${prSummary.solverName}`)
-    }
-    const solver = formatSolverName(prSummary.solverName)
+  for (const comparison of solverComparisons) {
+    const { mainSummary, prSummary } = comparison
+    const solver = formatSolverComparison(comparison)
     const mainTimeouts = mainReport.tests.filter(
-      (test) => test.solverName === prSummary.solverName && test.didTimeout,
+      (test) => test.solverName === mainSummary.solverName && test.didTimeout,
     ).length
     const prTimeouts = prReport.tests.filter(
       (test) => test.solverName === prSummary.solverName && test.didTimeout,
     ).length
-    const mainDrcIssues = getDrcIssueCount(mainReport, prSummary.solverName)
+    const mainDrcIssues = getDrcIssueCount(mainReport, mainSummary.solverName)
     const prDrcIssues = getDrcIssueCount(prReport, prSummary.solverName)
     const timePercentiles = [50, 60, 70, 80, 90, 95].map((percentile) => {
       const mainTime = getTimePercentile(
         mainReport,
-        prSummary.solverName,
+        mainSummary.solverName,
         percentile / 100,
       )
       const prTime = getTimePercentile(
@@ -239,10 +300,12 @@ export const renderSameMachineBenchmarkResults = ({
       "",
       "| Solver | Sample | Main | PR | Main time | PR time | Delta |",
       "| --- | ---: | --- | --- | ---: | ---: | --- |",
-      ...changedOutcomes.map(
-        ({ solverName, sampleNumber, mainTest, prTest, delta }) =>
-          `| ${escapeTableCell(formatSolverName(solverName))} | ${sampleNumber} | ${escapeTableCell(outcomeLabel(mainTest))} | ${escapeTableCell(outcomeLabel(prTest))} | ${formatTime(mainTest.elapsedTimeMs)} | ${formatTime(prTest.elapsedTimeMs)} | ${delta} |`,
-      ),
+      ...changedOutcomes.map((outcome) => {
+        const { solverComparison, sampleNumber, mainTest, prTest, delta } =
+          outcome
+        const solver = formatSolverComparison(solverComparison)
+        return `| ${escapeTableCell(solver)} | ${sampleNumber} | ${escapeTableCell(outcomeLabel(mainTest))} | ${escapeTableCell(outcomeLabel(prTest))} | ${formatTime(mainTest.elapsedTimeMs)} | ${formatTime(prTest.elapsedTimeMs)} | ${delta} |`
+      }),
       "",
       "</details>",
     )

--- a/tests/same-machine-benchmark-default-solver-change.test.ts
+++ b/tests/same-machine-benchmark-default-solver-change.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "bun:test"
+import type {
+  BenchmarkReport,
+  SolverRunSummary,
+  WorkerResult,
+} from "../scripts/benchmark/benchmark-types"
+import { renderSameMachineBenchmarkResults } from "../scripts/benchmark/same-machine-results"
+
+test("same-machine benchmark compares different single default solvers", () => {
+  const mainSolverName = "AutoroutingPipelineSolver9"
+  const prSolverName = "AutoroutingPipelineSolver7_MultiGraph"
+  const makeSummary = (
+    solverName: string,
+    completedRateLabel: string,
+  ): SolverRunSummary => ({
+    solverName,
+    completedRateLabel,
+    relaxedDrcRateLabel: completedRateLabel,
+    timedOutLabel: completedRateLabel.startsWith("0.0%") ? "1/1" : "0/1",
+    p50TimeMs: 1_000,
+    p95TimeMs: 1_000,
+    avgVia: completedRateLabel.startsWith("0.0%") ? null : 2,
+  })
+  const makeTest = (
+    solverName: string,
+    didSolve: boolean,
+  ): WorkerResult => ({
+    solverName,
+    scenarioName: "sample1",
+    sampleNumber: 1,
+    elapsedTimeMs: didSolve ? 1_000 : 2_000,
+    didSolve,
+    didTimeout: !didSolve,
+    relaxedDrcPassed: didSolve,
+    drcErrorCount: didSolve ? 0 : undefined,
+  })
+  const makeReport = (
+    summary: SolverRunSummary,
+    workerResult: WorkerResult,
+  ): BenchmarkReport => ({
+    version: 1,
+    datasetName: "srj18",
+    scenarioCount: 1,
+    effortLabel: "1x effort",
+    summary: [summary],
+    solverFailureSummary: [],
+    timeoutSummary: [],
+    failureSummary: [],
+    snapshots: [],
+    tests: [workerResult],
+  })
+  const mainReport = makeReport(
+    makeSummary(mainSolverName, "0.0% (🕒100.0%)"),
+    makeTest(mainSolverName, false),
+  )
+  const prReport = makeReport(
+    makeSummary(prSolverName, "100.0% (🕒0.0%)"),
+    makeTest(prSolverName, true),
+  )
+
+  const markdown = renderSameMachineBenchmarkResults({
+    mainReport,
+    prReport,
+    mainSha: "a".repeat(40),
+    prSha: "b".repeat(40),
+    repository: "tscircuit/tscircuit-autorouter",
+    runnerName: "blacksmith-test-runner",
+  })
+
+  expect(markdown).toContain(
+    "| Pipeline9 → Pipeline7 | Completion | 0.0% (🕒100.0%) | 100.0% (🕒0.0%) | +100.0 pp |",
+  )
+  expect(markdown).toContain(
+    "| Pipeline9 → Pipeline7 | P50 time | 2.0s | 1.0s | -50.0% |",
+  )
+  expect(markdown).toContain("Outcome changes: **1 improved**, **0 regressed**")
+  expect(markdown).toContain(
+    "| Pipeline9 → Pipeline7 | 1 | Timeout | DRC passed |",
+  )
+})


### PR DESCRIPTION
## Summary

- compare each revision’s single default solver even when the solver names differ
- label changed solver rows in main-to-branch order
- preserve exact solver-name matching for multi-solver reports

## Testing

- bun test tests/same-machine-benchmark-results.test.ts tests/same-machine-benchmark-default-solver-change.test.ts
- bunx tsc --noEmit
- bun run build