### PR TITLE
Reuse static connectivity during Pipeline9 DRC repair

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver.ts
@@ -23,7 +23,7 @@ import type { HighDensityRoute } from "lib/types/high-density-types"
 import { convertHdRouteToSimplifiedRoute } from "lib/utils/convertHdRouteToSimplifiedRoute"
 import { mapZToLayerName } from "lib/utils/mapZToLayerName"
 import { Pipeline7AdaptiveDrcBranchPortfolioSolver } from "../AutoroutingPipeline7_MultiGraph/Pipeline7AdaptiveDrcBranchPortfolioSolver"
-import { convertPipeline7HdRoutesToSimplifiedPcbTraces } from "../AutoroutingPipeline7_MultiGraph/convertPipeline7HdRoutesToSimplifiedPcbTraces"
+import { createPipeline7HdRoutesToSimplifiedPcbTracesConverter } from "../AutoroutingPipeline7_MultiGraph/convertPipeline7HdRoutesToSimplifiedPcbTraces"
 import { applyPipeline9RegionalB01Repairs } from "./applyPipeline9RegionalB01Repairs"
 import { applyPipeline9TerminalEscapeRelocations } from "./applyPipeline9TerminalEscapeRelocations"
 import { assignUniquePcbTraceIdsToNewTraces } from "./assignUniquePcbTraceIdsToNewTraces"
@@ -660,15 +660,18 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
     const currentMutatedPreloadedTraces = params.updatedPreloadedTraces.filter(
       (trace) => params.mutatedPreloadedTraceIds.has(trace.pcb_trace_id),
     )
-    const currentNewTraces = convertPipeline7HdRoutesToSimplifiedPcbTraces({
-      connections: params.newConnections,
-      originalConnections: params.originalSrj.connections,
-      hdRoutes: params.newHdRoutes,
-      layerCount: params.layerCount,
-      obstacles: params.obstacles,
-      defaultViaHoleDiameter: params.defaultViaHoleDiameter,
-      connMap: params.connMap,
-    })
+    // Repair candidates change copper geometry, but their connection metadata
+    // and obstacle connectivity remain fixed throughout this solver's lifetime.
+    const convertNewRoutes =
+      createPipeline7HdRoutesToSimplifiedPcbTracesConverter({
+        connections: params.newConnections,
+        originalConnections: params.originalSrj.connections,
+        layerCount: params.layerCount,
+        obstacles: params.obstacles,
+        defaultViaHoleDiameter: params.defaultViaHoleDiameter,
+        connMap: params.connMap,
+      })
+    const currentNewTraces = convertNewRoutes(params.newHdRoutes)
     const currentNewTraceIds = new Set(
       currentNewTraces.map((trace) => trace.pcb_trace_id),
     )
@@ -1015,15 +1018,7 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
       const evaluatedNewRoutes = evaluatedRoutes.filter(
         (route) => !this.syntheticConnectionNames.has(route.connectionName),
       )
-      const evaluatedNewTraces = convertPipeline7HdRoutesToSimplifiedPcbTraces({
-        connections: params.newConnections,
-        originalConnections: params.originalSrj.connections,
-        hdRoutes: evaluatedNewRoutes,
-        layerCount: params.layerCount,
-        obstacles: params.obstacles,
-        defaultViaHoleDiameter: params.defaultViaHoleDiameter,
-        connMap: params.connMap,
-      })
+      const evaluatedNewTraces = convertNewRoutes(evaluatedNewRoutes)
       const uniquelyNamedNewTraces = assignUniquePcbTraceIdsToNewTraces(
         evaluatedNewTraces,
         params.originalSrj.traces ?? [],

--- a/tests/features/pipeline9-joint-drc-reuses-static-connectivity.test.ts
+++ b/tests/features/pipeline9-joint-drc-reuses-static-connectivity.test.ts
@@ -89,7 +89,9 @@ test("Pipeline9 reuses obstacle connectivity while evaluating changed repair geo
     throw new Error("Expected DRC errors with centers")
   }
   expect(initial.errorsWithCenters).toMatchObject([{ center: { x: 0, y: 0 } }])
-  expect(changed.errorsWithCenters).toMatchObject([{ center: { x: 0.5, y: 0 } }])
+  expect(changed.errorsWithCenters).toMatchObject([
+    { center: { x: 0.5, y: 0 } },
+  ])
   expect(warmedConnectivityChecks).toBeGreaterThan(0)
   expect(connectivityChecks).toBe(warmedConnectivityChecks)
 })

--- a/tests/features/pipeline9-joint-drc-reuses-static-connectivity.test.ts
+++ b/tests/features/pipeline9-joint-drc-reuses-static-connectivity.test.ts
@@ -1,0 +1,95 @@
+import { expect, test } from "bun:test"
+import { Pipeline9JointDrcRepairSolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver"
+import type { SimpleRouteJson } from "lib/types"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
+
+test("Pipeline9 reuses obstacle connectivity while evaluating changed repair geometry", () => {
+  const routes: HighDensityRoute[] = [
+    {
+      connectionName: "horizontal",
+      traceThickness: 0.1,
+      viaDiameter: 0.3,
+      route: [
+        { x: -1, y: 0, z: 0 },
+        { x: 1, y: 0, z: 0 },
+      ],
+      vias: [],
+    },
+    {
+      connectionName: "vertical",
+      traceThickness: 0.1,
+      viaDiameter: 0.3,
+      route: [
+        { x: 0, y: -1, z: 0 },
+        { x: 0, y: 1, z: 0 },
+      ],
+      vias: [],
+    },
+  ]
+  const srj: SimpleRouteJson = {
+    layerCount: 2,
+    minTraceWidth: 0.1,
+    bounds: { minX: -5, minY: -5, maxX: 5, maxY: 5 },
+    connections: routes.map((route) => ({
+      name: route.connectionName,
+      pointsToConnect: route.route.map((point, index) => ({
+        x: point.x,
+        y: point.y,
+        layer: "top",
+        pointId: `${route.connectionName}_${index}`,
+      })),
+    })),
+    obstacles: [
+      {
+        type: "rect",
+        center: { x: 4, y: 4 },
+        width: 0.5,
+        height: 0.5,
+        layers: ["top", "bottom"],
+        connectedTo: ["distant_pad"],
+      },
+    ],
+  }
+  const connMap = getConnectivityMapFromSimpleRouteJson(srj)
+  let connectivityChecks = 0
+  const areIdsConnected = connMap.areIdsConnected.bind(connMap)
+  connMap.areIdsConnected = (left: string, right: string): boolean => {
+    if (right === "distant_pad") connectivityChecks += 1
+    return areIdsConnected(left, right)
+  }
+  const solver = new Pipeline9JointDrcRepairSolver({
+    srj,
+    srjWithPointPairs: srj,
+    originalSrj: srj,
+    newConnections: srj.connections,
+    newHdRoutes: routes,
+    updatedPreloadedTraces: [],
+    mutatedPreloadedTraceIds: new Set(),
+    connMap,
+    obstacles: srj.obstacles,
+    layerCount: 2,
+    defaultViaDiameter: 0.3,
+    defaultViaHoleDiameter: 0.15,
+    effort: 1,
+    colorMap: {},
+  })
+  const evaluate = solver.exactRepairSolver!.params.drcEvaluator!
+  const initial = evaluate({ traces: [], routes })
+  const warmedConnectivityChecks = connectivityChecks
+  const candidate = structuredClone(routes)
+  expect(evaluate({ traces: [], routes: candidate })).toEqual(initial)
+
+  // Reusing static lookup data must not reuse the candidate's copper geometry.
+  for (const point of candidate[1]!.route) point.x = 0.5
+  const changed = evaluate({ traces: [], routes: candidate })
+  expect(Array.isArray(initial)).toBeFalse()
+  expect(Array.isArray(changed)).toBeFalse()
+  if (Array.isArray(initial) || Array.isArray(changed)) {
+    throw new Error("Expected DRC errors with centers")
+  }
+  expect(initial.errorsWithCenters).toMatchObject([{ center: { x: 0, y: 0 } }])
+  expect(changed.errorsWithCenters).toMatchObject([{ center: { x: 0.5, y: 0 } }])
+  expect(warmedConnectivityChecks).toBeGreaterThan(0)
+  expect(connectivityChecks).toBe(warmedConnectivityChecks)
+})


### PR DESCRIPTION
Pipeline9 repeatedly rebuilt connection metadata and scanned multilayer obstacle connectivity for every DRC repair candidate. Pipeline7 already retains that prepared converter. Reuse it throughout Pipeline9's joint repair stage, while converting each candidate's geometry afresh.

The reported SRJ18 runs completed 13/16 boards with Pipeline7 versus 11/16 with Pipeline9. Both additional Pipeline9 timeouts, samples 2 and 12, were in joint DRC repair after high-density routing had finished. [Original Pipeline7 run](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/33661933114) · [Original Pipeline9 run](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/33661945494).

## Same-machine SRJ18 results

[Benchmark run and raw reports](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/33668815739): main `0f0fd848` and PR `e1542c99`, run sequentially on one 8-vCPU Blacksmith machine, 16 samples, effort 1, concurrency 4, 360s per-sample timeout. The subsequent commit only wraps a test assertion; production code is identical.

| Metric | Main | PR |
| --- | ---: | ---: |
| Completed | 12/16 (75.0%) | **13/16 (81.3%)** |
| Timeouts | 2 | **1** |
| P50 | 94.9s | **85.8s (-9.6%)** |
| P95 | 360.0s | **339.4s (-5.7%)** |
| Relaxed DRC passes | 8/16 | 8/16 |
| DRC issues, 12 boards completed by both | 74 | 74 |
| Vias, 12 boards completed by both | 2,250 | 2,250 |

Sample 2 now completes in **328.2s**. Sample 12 already finishes on main in this controlled run, but falls from **343.2s to 253.3s**; its joint repair stage falls from **113.7s to 54.8s (-51.8%)**. Sample 8's repair stage falls from 95.5s to 53.0s. Total time on the 12 boards completed by both falls from 1,367.3s to 1,190.2s (-13.0%). There are no outcome regressions, and every common completed board retains its individual DRC and via counts.

The aggregate DRC total rises from 74 to 86 and average vias from 187.50 to 211.23 because the newly completed sample 2 contributes 12 DRC issues and 496 vias. It remains DRC-failing; relaxed DRC passes stay at 8/16. The remaining sample 6 timeout occurs in high-density routing, and samples 14/15 fail upstream pathing in both revisions.

## Validation

- New regression fails on main and passes with the fix: cloned candidates reuse obstacle connectivity, and an in-place route change updates the reported DRC collision location.
- Eleven focused tests pass, including reference DRC, preloaded-trace ownership, SRJ18 sample 9, and SRJ23 samples 52/53.
- A separate sample 12 CPU profile attributes 65.7s to repeated connected-obstacle lookups. Replaying its captured repair input performs the same 313 evaluations and emits byte-identical HD routes before/after (SHA-256 `6c30d3b86d626843fed903037a8d566897b97fbb0d7a07a6a5f5cd706878091c`).
- Local type check and production build pass.
- Final CI: all nine test shards, build, type check, format check, added-code check, and Vercel checks pass.
