### PR TITLE
Avoid scoring unused high-density nodes

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -536,6 +536,9 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
         cms.portPointPathingSolver?.getOutput().nodesWithPortPoints ?? []
       const nodePortPointsSource =
         uniformNodes.length > 0 ? uniformNodes : fallbackNodes
+      const highDensityNodeIds = new Set(
+        nodePortPointsSource.map((node) => node.capacityMeshNodeId),
+      )
 
       cms.highDensityNodePortPoints = structuredClone(nodePortPointsSource)
 
@@ -546,10 +549,14 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
             (
               cms.portPointPathingSolver?.getOutput().inputNodeWithPortPoints ??
               []
-            ).map((node) => [
-              node.capacityMeshNodeId,
-              cms.portPointPathingSolver?.computeNodePf(node) ?? null,
-            ]),
+            )
+              .filter((node) =>
+                highDensityNodeIds.has(node.capacityMeshNodeId),
+              )
+              .map((node) => [
+                node.capacityMeshNodeId,
+                cms.portPointPathingSolver?.computeNodePf(node) ?? null,
+              ]),
           ),
           colorMap: cms.colorMap,
           connMap: cms.connMap,

--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -550,9 +550,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
               cms.portPointPathingSolver?.getOutput().inputNodeWithPortPoints ??
               []
             )
-              .filter((node) =>
-                highDensityNodeIds.has(node.capacityMeshNodeId),
-              )
+              .filter((node) => highDensityNodeIds.has(node.capacityMeshNodeId))
               .map((node) => [
                 node.capacityMeshNodeId,
                 cms.portPointPathingSolver?.computeNodePf(node) ?? null,

--- a/tests/repro/am625sip-analog-1v8-link-17.test.ts
+++ b/tests/repro/am625sip-analog-1v8-link-17.test.ts
@@ -4,9 +4,7 @@ import type { SimpleRouteJson } from "lib/types"
 import realBoardPhase from "../../fixtures/repro/am625sip-analog-1v8-link-17.srj.json"
 import { getLastStepSvg } from "../fixtures/getLastStepSvg"
 
-// The unchanged production phase takes about one minute because the
-// high-density and exact-geometry stages currently run synchronously.
-test.skip("routes the faithful AM625SIP analog 1.8 V link 17 phase", () => {
+test("routes the faithful AM625SIP analog 1.8 V link 17 phase", () => {
   const solver = new AutoroutingPipelineSolver7_MultiGraph(
     structuredClone(realBoardPhase) as SimpleRouteJson,
     { cacheProvider: null },

--- a/tests/repro/am625sip-analog-1v8-link-17.test.ts
+++ b/tests/repro/am625sip-analog-1v8-link-17.test.ts
@@ -16,6 +16,10 @@ test("routes the faithful AM625SIP analog 1.8 V link 17 phase", () => {
 
   expect(solver.failed).toBe(false)
   expect(solver.solved).toBe(true)
+  expect(solver.highDensityNodePortPoints).toHaveLength(22)
+  expect(solver.highDensityRouteSolver?.nodePfById.size).toBe(
+    solver.highDensityNodePortPoints?.length,
+  )
   expect(getLastStepSvg(solver.visualize())).toMatchSvgSnapshot(
     import.meta.path,
   )


### PR DESCRIPTION
## Summary

- restrict path-quality scoring to nodes passed into high-density routing
- avoid recomputing scores for unrelated pre-routing capacity-mesh nodes
- enable the faithful AM625SIP regression test from the parent PR
- assert that the high-density score map contains exactly the nodes routed by that phase

`HighDensitySolver` only reads scores by the IDs in `nodePortPoints`, so scores for every other input node were computed and discarded. The real board has 21,658 input nodes but only 22 nodes entering this phase.

The regression assertion deterministically fails on the parent branch because the score map has 21,658 entries while only 22 nodes enter high-density routing. It passes after the fix with 22 entries. The SVG remains unchanged, proving the optimization preserves the routed result.

## Result

- synchronous high-density transition: ~25.2 s → effectively 0 ms
- complete faithful-board SVG snapshot test: ~63 s → 36.5 s
- routing result still solves without failure

## Testing

- `bun test tests/repro/am625sip-analog-1v8-link-17.test.ts --timeout 9999999`
- `bun run build`

Stacked on tscircuit/tscircuit-autorouter#2351.
