### PR TITLE
Speed up Pipeline9 global repair via lookup

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "zdwiel-dataset": "git+https://github.com/dwiel/tscircuit-benchmark.git#be36518b5bf51755dae92c230061ab3cf4e3e063",
     "high-density-repair01": "git+https://github.com/tscircuit/high-density-repair01.git#01f9fe901ac6f691c325bb25d993f52d916a98a1",
     "high-density-repair02": "https://codeload.github.com/tscircuit/high-density-repair02/tar.gz/2afc0cbba3bf2f7eb6b9cd33615d21e9ad9352d4",
-    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#a9654302bdfdbc93222f1f66ce5d67ccd6ecd891",
+    "high-density-repair03": "git+https://github.com/Abse2001/high-density-repair03.git#421e5dc657c3a7e525f01a3cc3974f5f6fc20b99",
     "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d",
     "@tscircuit/high-density-b01": "git+https://github.com/tscircuit/high-density-b01.git#e651cab6c314e7aab6df31fd6067277436f67148"
   },


### PR DESCRIPTION
## Summary

Pin the general same-root via-site lookup optimization from https://github.com/tscircuit/high-density-repair03/pull/89 for Pipeline9 validation.

The repair solver previously rebuilt every via on the board each time it looked for copies of a single root's via site. The dependency change collects only that root's routes, retaining board indexes, traversal order, and current geometry. It adds no flags, adaptive tuning, changed budgets, or sample-specific behavior.

This draft includes current main `3dbbad3a` and is independent of the post-repair simplification draft #2324. It includes main's recently merged repair01 crossing fix and #2349's static-connectivity reuse. The fork dependency pin is temporary pending upstream review/merge of the dependency PR.

## Evidence and validation

- Profile of a saved SRJ20 sample7 global-repair input identified whole-board via reconstruction as a major cost.
- Sequential focused local replays: baseline 183.1 seconds, candidate 55.8 seconds. Every route/coordinate and repair statistic matched exactly (379 initial / 39 final indexed DRC issues; 41 candidate attempts).
- These timings are diagnostic, not a full-benchmark speed or completion claim.
- Dependency typecheck and all 85 tests pass (581 assertions).
- Autorouter build passes.
- Five focused Pipeline9 tests pass (75 assertions): stage contracts, via preservation, DRC identity ownership, and SRJ23 samples37/70.
- Main advanced during initial benchmark dispatch. The first six jobs comparing `3dbbad3a` against the older `8a6fec0a` candidate were cancelled; they are not acceptance results. The updated candidate retains only the dependency-pin difference from current main.
- No snapshots were updated.

## Acceptance still pending

Run all six Pipeline9 datasets (`dataset01`, `srj18`, `srj19`, `srj20`, `srj21`, `srj23`), main then this exact PR head sequentially on the same Blacksmith runner per dataset. Report completion, DRC-clean cases, common-solved DRC/via changes, and every regression; do not infer routing quality from timing alone.

### Five completed datasets at exact head `3b521341`

Main `3dbbad3a` and candidate ran sequentially on one Blacksmith runner per dataset. Raw reports were audited sample by sample.

| Dataset | Completion main -> PR | Clean main -> PR | Common-solved DRC change |
| --- | --- | --- | --- |
| dataset01 | 85 -> 85 | 85 -> 85 | 0 |
| SRJ18 | 13 -> 13 | 8 -> 8 | 0 |
| SRJ19 | 182 -> 188 | 79 -> 79 | 0 |
| SRJ20 | Pending | Pending | Pending |
| SRJ21 | 10 -> 10 | 9 -> 9 | 0 |
| SRJ23 | 76 -> 76 | 64 -> 64 | 0 |

[SRJ19 same-machine result](https://github.com/tscircuit/tscircuit-autorouter/pull/2356#issuecomment-5518396991): six timeouts become solved, with no lost completion. Samples77/117/133/163/167/193 have19/12/3/30/23/9 DRCs respectively. These new outputs account for the entire total DRC increase718 ->814; DRCs and vias are unchanged for every common-solved sample. No additional clean board yet. SRJ19 P50 is6.9% faster and P90 is20.9% faster; other datasets have mixed timing, including SRJ23 P50 +9.4% and SRJ21 P95 +1.1%.

SRJ20 remains running. This is a completion improvement, not evidence of fewer DRCs, simpler geometry, a clean RP2350 board, or full-suite acceptance. RP2350 producer fixes and their known regressions are tracked separately in draft #2357.
