### PR TITLE
Preserve Pipeline9 fixed terminals and distinct same-net routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "zdwiel-dataset": "git+https://github.com/dwiel/tscircuit-benchmark.git#be36518b5bf51755dae92c230061ab3cf4e3e063",
     "high-density-repair01": "git+https://github.com/tscircuit/high-density-repair01.git#01f9fe901ac6f691c325bb25d993f52d916a98a1",
     "high-density-repair02": "https://codeload.github.com/tscircuit/high-density-repair02/tar.gz/2afc0cbba3bf2f7eb6b9cd33615d21e9ad9352d4",
-    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#a9654302bdfdbc93222f1f66ce5d67ccd6ecd891",
+    "high-density-repair03": "git+https://github.com/Abse2001/high-density-repair03.git#421e5dc657c3a7e525f01a3cc3974f5f6fc20b99",
     "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d",
     "@tscircuit/high-density-b01": "git+https://github.com/tscircuit/high-density-b01.git#e651cab6c314e7aab6df31fd6067277436f67148"
   },

--- a/package.json
+++ b/package.json
@@ -95,10 +95,10 @@
     "vite": "^6.0.11",
     "vite-tsconfig-paths": "^5.1.4",
     "zdwiel-dataset": "git+https://github.com/dwiel/tscircuit-benchmark.git#be36518b5bf51755dae92c230061ab3cf4e3e063",
-    "high-density-repair01": "git+https://github.com/tscircuit/high-density-repair01.git#01f9fe901ac6f691c325bb25d993f52d916a98a1",
+    "high-density-repair01": "git+https://github.com/Abse2001/high-density-repair01.git#7ea99ed6ef60a163cf19607c34a4cacded48c9d7",
     "high-density-repair02": "https://codeload.github.com/tscircuit/high-density-repair02/tar.gz/2afc0cbba3bf2f7eb6b9cd33615d21e9ad9352d4",
     "high-density-repair03": "git+https://github.com/Abse2001/high-density-repair03.git#421e5dc657c3a7e525f01a3cc3974f5f6fc20b99",
-    "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d",
+    "@tscircuit/high-density-a01": "git+https://github.com/Abse2001/high-density-a01.git#adc2062454990bd476711bcba0c2aad6f1663c04",
     "@tscircuit/high-density-b01": "git+https://github.com/tscircuit/high-density-b01.git#e651cab6c314e7aab6df31fd6067277436f67148"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

Integrate two general producer fixes into Pipeline9, together with the independently benchmarked via-lookup optimization in #2356:

- https://github.com/tscircuit/high-density-a01/pull/100: preserve distinct named same-net terminal pairs even when their endpoint grid cells coincide. This fixes silent route omission in A01/A03.
- https://github.com/tscircuit/high-density-repair01/pull/18: preserve exact fixed-node coordinates when materializing force-improved routes and derive vias at their actual route coordinates. Fixed terminals must not be rounded into different or coincident positions.
- https://github.com/tscircuit/high-density-repair03/pull/89: collect only same-root vias during repair lookup, preserving geometry and traversal order. Included from #2356; not a separate quality claim.

Only three dependency pins differ from main `3dbbad3a`. Fork pins are temporary pending upstream dependency review. There are no feature flags, sample-specific thresholds, adaptive calibration changes, extra repair passes, or new solver variants. Existing draft #2324 is untouched.

Read AGENTS.md and the additions in #2321. Cross-checked the exact current dependency pins and merged Pipeline9 changes #2328 and #2349. Repair01's newer main has identical runtime source to the current pin before the precision fix; its additional changes are regression-test coverage.

## Local evidence

- Both producer bugs have focused numeric regressions that fail before their respective changes and pass afterward.
- Repair01: all 16 tests / 72 assertions and typecheck pass.
- A01/A03: regression passes with 16 assertions; build passes.
- Repair03: all 85 tests / 581 assertions and typecheck pass. Saved-input replay outputs are exactly equal before/after the lookup optimization.
- Autorouter integration: build passes; seven focused Pipeline9 tests / 72 assertions pass (fixed preloads, regional boundaries, via materialization/preservation, joint-repair metadata/static connectivity, and immutable boundary vias). No snapshots changed.
- RP2350 normal-core phase with both producer fixes reaches all 175/175 high-density nodes and finishes, emitting 131 traces in 1363.7 seconds. The earlier current-source baseline stopped at 165/175 with an immutable fixed-route conflict. The baseline preceded #2349, which changes only the later repair conversion stage; this is not a same-machine benchmark comparison.
- Independent final evaluation finds 50 reports: 18 geometric DRCs plus 32 disconnected outer breakout endpoints already reported in the input. This fixture is the MCU-core phase; parent-board routing is not included. Do not describe this as a clean complete board.
- A fresh local run using the exact published Git dependency pins also completed: all 175/175 high-density nodes, 131 traces, 591.0 seconds, the same 50 DRC reports. Deep equality confirms the entire routed output matches the preceding local-checkout producer run. Local timings are diagnostic, not benchmark evidence.

## Acceptance pending

**Known regression: this candidate does not meet acceptance.** SRJ18's exact-head same-machine run reports 13/16 completed on both revisions, but clean cases8 ->6 and DRC issues87 ->97. Samples1,9,12 become dirty; sample8 becomes clean. Sample9 includes two missing-connection reports. Full-suite results are still pending; the two producer changes are being isolated locally. [SRJ18 result](https://github.com/tscircuit/tscircuit-autorouter/pull/2357#issuecomment-5518719342).

Run all six datasets (`dataset01`, `srj18`, `srj19`, `srj20`, `srj21`, `srj23`) on Blacksmith, main then this exact head sequentially on the same runner per dataset. Report each dataset, all new/lost completions, newly clean/dirty cases, common-solved DRC and via changes, failures/timeouts, and timing regressions.

The in-flight #2356 benchmark suite covers only the performance fix, not these producer fixes. Do not reuse those results as validation of this combined candidate. No full-suite quality improvement or zero-regression claim is established yet.
