### PR TITLE
Skip resolved trace errors in Pipeline9 regional repair

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/applyPipeline9RegionalB01Repairs.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/applyPipeline9RegionalB01Repairs.ts
@@ -598,8 +598,19 @@ export const applyPipeline9RegionalB01Repairs = ({
           error.type === "pcb_via_clearance_error") &&
         typeof error.pcb_trace_id === "string",
     )
-    for (const error of repairableErrors) {
+    for (const scheduledError of repairableErrors) {
       if (candidateSearchBudgetExhausted) break
+      // An accepted regional repair can clear several queued collisions or
+      // move a remaining collision. Use its current finding before searching.
+      const error: Pipeline9DrcError | undefined =
+        typeof scheduledError.pcb_trace_error_id === "string"
+          ? currentErrors.find(
+              (currentError): boolean =>
+                currentError.pcb_trace_error_id ===
+                scheduledError.pcb_trace_error_id,
+            )
+          : scheduledError
+      if (!error) continue
       const center = getRepairCenter(error, srj)
       const traceIds = getPipeline9RegionalRepairTraceIds({
         error,

--- a/tests/features/pipeline9-regional-repair-skips-resolved-errors.test.ts
+++ b/tests/features/pipeline9-regional-repair-skips-resolved-errors.test.ts
@@ -1,0 +1,82 @@
+import { expect, test } from "bun:test"
+import type { DrcEvaluator } from "high-density-repair03/lib"
+import { applyPipeline9RegionalB01Repairs } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/applyPipeline9RegionalB01Repairs"
+import type { Pipeline9DrcError } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9JointDrcRepairUtils"
+import type { SimpleRouteJson } from "lib/types"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
+
+type DrcFeedback = {
+  errors: Pipeline9DrcError[]
+  errorsWithCenters: Pipeline9DrcError[]
+}
+
+test("Pipeline9 does not search collisions already cleared by an accepted regional repair", (): void => {
+  const srj: SimpleRouteJson = {
+    layerCount: 2,
+    minTraceWidth: 0.1,
+    bounds: { minX: -2, minY: -2, maxX: 2, maxY: 2 },
+    obstacles: [],
+    connections: [{
+      name: "signal",
+      pointsToConnect: [
+        { x: -1, y: 0, layer: "top" },
+        { x: 1, y: 0, layer: "top" },
+      ],
+    }],
+  }
+  const routes: HighDensityRoute[] = [{
+    connectionName: "signal",
+    rootConnectionName: "signal",
+    traceThickness: 0.1,
+    viaDiameter: 0.3,
+    route: [{ x: -1, y: 0, z: 0 }, { x: 0, y: 1, z: 0 }, { x: 1, y: 0, z: 0 }],
+    vias: [],
+  }]
+  const unresolvedError: Pipeline9DrcError = {
+    type: "pcb_trace_error",
+    pcb_trace_id: "signal_0",
+    pcb_trace_error_id: "overlap_signal_0_unresolved",
+    center: { x: 1_000, y: 1_000 },
+  }
+  const errors: Pipeline9DrcError[] = [0, 1].map((index): Pipeline9DrcError => ({
+    type: "pcb_trace_error",
+    pcb_trace_id: "signal_0",
+    pcb_trace_error_id: `overlap_signal_0_fixed_${index}`,
+    center: { x: 0, y: 0 },
+  }))
+  errors.push(unresolvedError)
+  // Model two findings on the same detour: replacing that detour resolves both.
+  // The evaluator is deterministic in route geometry, not call count.
+  const drcEvaluator: DrcEvaluator = ({ routes, hdRoutes }): DrcFeedback => {
+    const candidateRoutes: HighDensityRoute[] | undefined = routes ?? hdRoutes
+    if (!candidateRoutes) throw new Error("Missing regional candidate geometry")
+    const remainingErrors: Pipeline9DrcError[] = candidateRoutes[0]!.route.some(
+      (point): boolean => point.y > 0.25,
+    ) ? errors : [unresolvedError]
+    return {
+      errors: remainingErrors,
+      errorsWithCenters: remainingErrors,
+    }
+  }
+  const result: ReturnType<typeof applyPipeline9RegionalB01Repairs> = applyPipeline9RegionalB01Repairs({
+    srj,
+    routes,
+    fixedObstacleRoutes: [],
+    newConnections: srj.connections,
+    syntheticConnectionNames: new Set(),
+    drcEvaluator,
+    preloadRepairTraceIds: new Set(["signal_0"]),
+    connMap: getConnectivityMapFromSimpleRouteJson(srj),
+    colorMap: { signal: "red" },
+    viaDiameter: 0.3,
+    traceWidth: 0.1,
+    obstacleMargin: 0.15,
+    effort: 1,
+  })
+  expect(result.remainingDrcIssueCount).toBe(1)
+  expect(result.acceptedCandidateCount).toBe(1)
+  expect(result.candidateSearchCount).toBe(17)
+  expect(result.routes[0]!.route[0]).toMatchObject({ x: -1, y: 0, z: 0 })
+  expect(result.routes[0]!.route.at(-1)).toMatchObject({ x: 1, y: 0, z: 0 })
+})

--- a/tests/features/pipeline9-regional-repair-skips-resolved-errors.test.ts
+++ b/tests/features/pipeline9-regional-repair-skips-resolved-errors.test.ts
@@ -17,34 +17,44 @@ test("Pipeline9 does not search collisions already cleared by an accepted region
     minTraceWidth: 0.1,
     bounds: { minX: -2, minY: -2, maxX: 2, maxY: 2 },
     obstacles: [],
-    connections: [{
-      name: "signal",
-      pointsToConnect: [
-        { x: -1, y: 0, layer: "top" },
-        { x: 1, y: 0, layer: "top" },
-      ],
-    }],
+    connections: [
+      {
+        name: "signal",
+        pointsToConnect: [
+          { x: -1, y: 0, layer: "top" },
+          { x: 1, y: 0, layer: "top" },
+        ],
+      },
+    ],
   }
-  const routes: HighDensityRoute[] = [{
-    connectionName: "signal",
-    rootConnectionName: "signal",
-    traceThickness: 0.1,
-    viaDiameter: 0.3,
-    route: [{ x: -1, y: 0, z: 0 }, { x: 0, y: 1, z: 0 }, { x: 1, y: 0, z: 0 }],
-    vias: [],
-  }]
+  const routes: HighDensityRoute[] = [
+    {
+      connectionName: "signal",
+      rootConnectionName: "signal",
+      traceThickness: 0.1,
+      viaDiameter: 0.3,
+      route: [
+        { x: -1, y: 0, z: 0 },
+        { x: 0, y: 1, z: 0 },
+        { x: 1, y: 0, z: 0 },
+      ],
+      vias: [],
+    },
+  ]
   const unresolvedError: Pipeline9DrcError = {
     type: "pcb_trace_error",
     pcb_trace_id: "signal_0",
     pcb_trace_error_id: "overlap_signal_0_unresolved",
     center: { x: 1_000, y: 1_000 },
   }
-  const errors: Pipeline9DrcError[] = [0, 1].map((index): Pipeline9DrcError => ({
-    type: "pcb_trace_error",
-    pcb_trace_id: "signal_0",
-    pcb_trace_error_id: `overlap_signal_0_fixed_${index}`,
-    center: { x: 0, y: 0 },
-  }))
+  const errors: Pipeline9DrcError[] = [0, 1].map(
+    (index): Pipeline9DrcError => ({
+      type: "pcb_trace_error",
+      pcb_trace_id: "signal_0",
+      pcb_trace_error_id: `overlap_signal_0_fixed_${index}`,
+      center: { x: 0, y: 0 },
+    }),
+  )
   errors.push(unresolvedError)
   // Model two findings on the same detour: replacing that detour resolves both.
   // The evaluator is deterministic in route geometry, not call count.
@@ -53,27 +63,30 @@ test("Pipeline9 does not search collisions already cleared by an accepted region
     if (!candidateRoutes) throw new Error("Missing regional candidate geometry")
     const remainingErrors: Pipeline9DrcError[] = candidateRoutes[0]!.route.some(
       (point): boolean => point.y > 0.25,
-    ) ? errors : [unresolvedError]
+    )
+      ? errors
+      : [unresolvedError]
     return {
       errors: remainingErrors,
       errorsWithCenters: remainingErrors,
     }
   }
-  const result: ReturnType<typeof applyPipeline9RegionalB01Repairs> = applyPipeline9RegionalB01Repairs({
-    srj,
-    routes,
-    fixedObstacleRoutes: [],
-    newConnections: srj.connections,
-    syntheticConnectionNames: new Set(),
-    drcEvaluator,
-    preloadRepairTraceIds: new Set(["signal_0"]),
-    connMap: getConnectivityMapFromSimpleRouteJson(srj),
-    colorMap: { signal: "red" },
-    viaDiameter: 0.3,
-    traceWidth: 0.1,
-    obstacleMargin: 0.15,
-    effort: 1,
-  })
+  const result: ReturnType<typeof applyPipeline9RegionalB01Repairs> =
+    applyPipeline9RegionalB01Repairs({
+      srj,
+      routes,
+      fixedObstacleRoutes: [],
+      newConnections: srj.connections,
+      syntheticConnectionNames: new Set(),
+      drcEvaluator,
+      preloadRepairTraceIds: new Set(["signal_0"]),
+      connMap: getConnectivityMapFromSimpleRouteJson(srj),
+      colorMap: { signal: "red" },
+      viaDiameter: 0.3,
+      traceWidth: 0.1,
+      obstacleMargin: 0.15,
+      effort: 1,
+    })
   expect(result.remainingDrcIssueCount).toBe(1)
   expect(result.acceptedCandidateCount).toBe(1)
   expect(result.candidateSearchCount).toBe(17)


### PR DESCRIPTION
## Summary

Refresh queued trace-collision findings after each accepted Pipeline9 regional repair. A repair can clear more than one collision or move a remaining collision's center. The loop previously kept searching the original findings, spending its existing candidate budget on errors that no longer existed.

Before searching a queued finding with `pcb_trace_error_id`, resolve it against the current DRC results. Skip removed findings and use the current center for remaining ones. Findings without that identity keep their existing behavior. No new flags, fallback branches, budget changes, sample thresholds, adaptive calibration, or repair phases.

This is an independent source-only fix against main `3dbbad3a`, with unchanged dependencies. Drafts #2324, #2356, and #2357 are untouched. Read AGENTS.md and #2321; checked current merged Pipeline9 conventions and that #2324 does not change this helper.

## Verification

- New numeric regression uses deterministic geometry-based DRC feedback: one repaired detour clears two findings while a separate finding remains. Unmodified main performs 23 searches; fixed code performs 17, preserving the accepted route's exact endpoints and the unresolved finding. The test fails before the change and passes after it.
- Seven focused Pipeline9 tests pass (86 assertions), including SRJ23 samples21/52/53, identity ownership, metadata, and existing search-budget behavior. The strengthened new regression and existing budget test were rerun afterward: both pass (9 assertions).
- Build passes. No snapshots changed; no formatting or linting performed.
- CI found line-layout issues only in the new test. Follow-up `d95280d7` corrects them manually, without running a formatter/linter or changing assertions. The test still passes5assertions. Production `lib` and package.json remain byte-for-byte identical to benchmark source `2b969f2`; the in-flight all-six suite retains that source revision in its provenance.
- Residual RP2350 experiment: replaying the existing joint solver on an already completed producer-fixed output leaves 8 geometric DRCs without this fix and 7 with it; regional accepted candidates4 ->5, attempted candidates29 ->26. This extra-pass experiment is not a new published pipeline phase.
- Stronger validation on the captured first joint-stage input from the full RP2350 run: baseline replay exactly matches the complete output, and this patch leaves that output unchanged (18 geometric DRCs plus32 inherited outer-boundary endpoint reports). Therefore this change does NOT yet establish a full-pipeline RP2350 DRC reduction.

## Acceptance pending

Run all six Pipeline9 datasets on Blacksmith, main then this exact PR head sequentially on the same runner per dataset. Report each dataset and every completion, DRC, via, failure/timeout, and timing regression. Prior benchmark suites on other PR heads do not validate this change. Keep draft until the exact-head results are reviewed.
