### PR TITLE
Keep Pipeline9 terminal relocations inside original pads

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver.ts
@@ -1400,6 +1400,7 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
     const terminalEscapeResult = shouldRunPostExactPrecisionPass
       ? applyPipeline9TerminalEscapeRelocations({
           srj: this.params.srj,
+          originalObstacles: this.params.originalSrj.obstacles,
           routes: exactOutput,
           newConnections: this.params.newConnections,
           syntheticConnectionNames: this.syntheticConnectionNames,

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/applyPipeline9TerminalEscapeRelocations.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/applyPipeline9TerminalEscapeRelocations.ts
@@ -224,22 +224,27 @@ const createTerminalCandidate = ({
  */
 export const applyPipeline9TerminalEscapeRelocations = ({
   srj,
+  originalObstacles,
   routes,
   newConnections,
   syntheticConnectionNames,
   drcEvaluator,
 }: {
   srj: SimpleRouteJson
+  originalObstacles: Obstacle[]
   routes: HighDensityRoute[]
   newConnections: SimpleRouteConnection[]
   syntheticConnectionNames: ReadonlySet<string>
   drcEvaluator: DrcEvaluator
 }): TerminalEscapeRelocationResult => {
+  // Routing approximations can extend beyond rotated pads. Terminal candidates
+  // must stay inside the original copper, not its axis-aligned routing cover.
+  const terminalSrj: SimpleRouteJson = { ...srj, obstacles: originalObstacles }
   let currentRoutes = routes
   let currentErrors = getPipeline9DrcErrors(drcEvaluator, currentRoutes)
   let attemptedCandidateCount = 0
   let acceptedCandidateCount = 0
-  const portPositionMap = getPcbPortPositionMap(srj)
+  const portPositionMap = getPcbPortPositionMap(terminalSrj)
 
   for (let pass = 0; pass < 2; pass++) {
     let acceptedOnPass = false
@@ -252,7 +257,7 @@ export const applyPipeline9TerminalEscapeRelocations = ({
       if (typeof error.pcb_trace_id !== "string") continue
       const routeIndex = routeIndexByTraceId.get(error.pcb_trace_id)
       const conflictingObstacle = getObstacleById(
-        srj,
+        terminalSrj,
         getErrorObstacleId(error),
       )
       if (routeIndex === undefined || !conflictingObstacle) continue
@@ -265,7 +270,7 @@ export const applyPipeline9TerminalEscapeRelocations = ({
           endpointIndex === 0 ? route.route[0] : route.route.at(-1)
         if (!endpoint || typeof endpoint.pcb_port_id !== "string") continue
         const terminalObstacle = getTerminalObstacle({
-          srj,
+          srj: terminalSrj,
           pcbPortId: endpoint.pcb_port_id,
           z: endpoint.z,
           portPositionMap,

--- a/tests/features/pipeline9-terminal-escape-original-rotated-pads.test.ts
+++ b/tests/features/pipeline9-terminal-escape-original-rotated-pads.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test"
-import type { DrcEvaluator } from "high-density-repair03/lib"
+import type { DrcError, DrcEvaluator } from "high-density-repair03/lib"
 import { convertPipeline7HdRoutesToSimplifiedPcbTraces } from "lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/convertPipeline7HdRoutesToSimplifiedPcbTraces"
 import { applyPipeline9TerminalEscapeRelocations } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/applyPipeline9TerminalEscapeRelocations"
 import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
@@ -8,6 +8,11 @@ import type { Obstacle, SimpleRouteJson } from "lib/types"
 import type { HighDensityRoute } from "lib/types/high-density-types"
 import { addApproximatingRectsToSrj } from "lib/utils/addApproximatingRectsToSrj"
 import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
+
+type DrcFeedback = {
+  errors: DrcError[]
+  errorsWithCenters: DrcError[]
+}
 
 test("Pipeline9 terminal relocation stays inside original rotated copper, not its routing cover", (): void => {
   const terminalPad: Obstacle = {
@@ -27,38 +32,46 @@ test("Pipeline9 terminal relocation stays inside original rotated copper, not it
     layerCount: 2,
     minTraceWidth: 0.15,
     bounds: { minX: -1, minY: -1, maxX: 3, maxY: 1 },
-    obstacles: [terminalPad, {
-      ...terminalPad,
-      center: { x: 0.35, y: 0.35 },
-      connectedTo: ["pcb_smtpad_1", "foreign_net"],
-      circuitJsonMetadata: { pcb_smtpad_id: "pcb_smtpad_1" },
-    }],
-    connections: [{
-      name: "signal",
-      pointsToConnect: [
-        { x: 0, y: 0, layer: "top", pcb_port_id: "pcb_port_start" },
-        { x: 2, y: 0, layer: "top" },
-      ],
-    }],
+    obstacles: [
+      terminalPad,
+      {
+        ...terminalPad,
+        center: { x: 0.35, y: 0.35 },
+        connectedTo: ["pcb_smtpad_1", "foreign_net"],
+        circuitJsonMetadata: { pcb_smtpad_id: "pcb_smtpad_1" },
+      },
+    ],
+    connections: [
+      {
+        name: "signal",
+        pointsToConnect: [
+          { x: 0, y: 0, layer: "top", pcb_port_id: "pcb_port_start" },
+          { x: 2, y: 0, layer: "top" },
+        ],
+      },
+    ],
   }
   const routingSrj: SimpleRouteJson = addApproximatingRectsToSrj(originalSrj)
-  const routes: HighDensityRoute[] = [{
-    connectionName: "signal",
-    traceThickness: 0.15,
-    viaDiameter: 0.3,
-    route: [
-      { x: 0, y: 0, z: 0, pcb_port_id: "pcb_port_start" },
-      { x: 2, y: 0, z: 0 },
-    ],
-    vias: [],
-  }]
+  const routes: HighDensityRoute[] = [
+    {
+      connectionName: "signal",
+      traceThickness: 0.15,
+      viaDiameter: 0.3,
+      route: [
+        { x: 0, y: 0, z: 0, pcb_port_id: "pcb_port_start" },
+        { x: 2, y: 0, z: 0 },
+      ],
+      vias: [],
+    },
+  ]
   const evaluatedTerminals: HighDensityRoute["route"] = []
-  const connMap: ReturnType<typeof getConnectivityMapFromSimpleRouteJson> = getConnectivityMapFromSimpleRouteJson(originalSrj)
-  const drcEvaluator: DrcEvaluator = ({ routes, hdRoutes }): EvaluateRelaxedDrcResult => {
+  const connMap: ReturnType<typeof getConnectivityMapFromSimpleRouteJson> =
+    getConnectivityMapFromSimpleRouteJson(originalSrj)
+  const drcEvaluator: DrcEvaluator = ({ routes, hdRoutes }): DrcFeedback => {
     const candidateRoutes: HighDensityRoute[] | undefined = routes ?? hdRoutes
     if (!candidateRoutes) throw new Error("Missing terminal candidate geometry")
     evaluatedTerminals.push({ ...candidateRoutes[0]!.route[0]! })
-    return evaluateRelaxedDrc({
+    const result: EvaluateRelaxedDrcResult = evaluateRelaxedDrc({
       inputSrj: originalSrj,
       srjWithPointPairs: originalSrj,
       routedTraces: convertPipeline7HdRoutesToSimplifiedPcbTraces({
@@ -71,23 +84,36 @@ test("Pipeline9 terminal relocation stays inside original rotated copper, not it
         connMap,
       }),
     })
+    return {
+      errors: result.errors.map((error): DrcError => ({ ...error })),
+      errorsWithCenters: result.errorsWithCenters.map(
+        (error): DrcError => ({ ...error }),
+      ),
+    }
   }
-  const result: ReturnType<typeof applyPipeline9TerminalEscapeRelocations> = applyPipeline9TerminalEscapeRelocations({
-    srj: routingSrj,
-    originalObstacles: originalSrj.obstacles,
-    routes,
-    newConnections: routingSrj.connections,
-    syntheticConnectionNames: new Set(),
-    drcEvaluator,
-  })
+  const result: ReturnType<typeof applyPipeline9TerminalEscapeRelocations> =
+    applyPipeline9TerminalEscapeRelocations({
+      srj: routingSrj,
+      originalObstacles: originalSrj.obstacles,
+      routes,
+      newConnections: routingSrj.connections,
+      syntheticConnectionNames: new Set(),
+      drcEvaluator,
+    })
 
-  expect(routingSrj.obstacles.length).toBeGreaterThan(originalSrj.obstacles.length)
+  expect(routingSrj.obstacles.length).toBeGreaterThan(
+    originalSrj.obstacles.length,
+  )
   expect(result.attemptedCandidateCount).toBeGreaterThan(0)
-  expect(evaluatedTerminals.some((point): boolean => point.x !== 0 || point.y !== 0)).toBeTrue()
+  expect(
+    evaluatedTerminals.some((point): boolean => point.x !== 0 || point.y !== 0),
+  ).toBeTrue()
   const radians: number = (225 * Math.PI) / 180
   for (const point of evaluatedTerminals) {
-    const localX: number = point.x * Math.cos(radians) + point.y * Math.sin(radians)
-    const localY: number = -point.x * Math.sin(radians) + point.y * Math.cos(radians)
+    const localX: number =
+      point.x * Math.cos(radians) + point.y * Math.sin(radians)
+    const localY: number =
+      -point.x * Math.sin(radians) + point.y * Math.cos(radians)
     expect(Math.abs(localX) + 0.075).toBeLessThanOrEqual(terminalPad.width / 2)
     expect(Math.abs(localY) + 0.075).toBeLessThanOrEqual(terminalPad.height / 2)
     expect(point.pcb_port_id).toBe("pcb_port_start")

--- a/tests/features/pipeline9-terminal-escape-original-rotated-pads.test.ts
+++ b/tests/features/pipeline9-terminal-escape-original-rotated-pads.test.ts
@@ -1,0 +1,97 @@
+import { expect, test } from "bun:test"
+import type { DrcEvaluator } from "high-density-repair03/lib"
+import { convertPipeline7HdRoutesToSimplifiedPcbTraces } from "lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/convertPipeline7HdRoutesToSimplifiedPcbTraces"
+import { applyPipeline9TerminalEscapeRelocations } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/applyPipeline9TerminalEscapeRelocations"
+import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
+import type { EvaluateRelaxedDrcResult } from "lib/testing/evaluate-relaxed-drc"
+import type { Obstacle, SimpleRouteJson } from "lib/types"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+import { addApproximatingRectsToSrj } from "lib/utils/addApproximatingRectsToSrj"
+import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
+
+test("Pipeline9 terminal relocation stays inside original rotated copper, not its routing cover", (): void => {
+  const terminalPad: Obstacle = {
+    type: "rect",
+    center: { x: 0, y: 0 },
+    width: 0.254,
+    height: 0.8128,
+    ccwRotationDegrees: 225,
+    layers: ["top"],
+    connectedTo: ["pcb_smtpad_0", "pcb_port_start"],
+    circuitJsonMetadata: {
+      pcb_smtpad_id: "pcb_smtpad_0",
+      pcb_port_id: "pcb_port_start",
+    },
+  }
+  const originalSrj: SimpleRouteJson = {
+    layerCount: 2,
+    minTraceWidth: 0.15,
+    bounds: { minX: -1, minY: -1, maxX: 3, maxY: 1 },
+    obstacles: [terminalPad, {
+      ...terminalPad,
+      center: { x: 0.35, y: 0.35 },
+      connectedTo: ["pcb_smtpad_1", "foreign_net"],
+      circuitJsonMetadata: { pcb_smtpad_id: "pcb_smtpad_1" },
+    }],
+    connections: [{
+      name: "signal",
+      pointsToConnect: [
+        { x: 0, y: 0, layer: "top", pcb_port_id: "pcb_port_start" },
+        { x: 2, y: 0, layer: "top" },
+      ],
+    }],
+  }
+  const routingSrj: SimpleRouteJson = addApproximatingRectsToSrj(originalSrj)
+  const routes: HighDensityRoute[] = [{
+    connectionName: "signal",
+    traceThickness: 0.15,
+    viaDiameter: 0.3,
+    route: [
+      { x: 0, y: 0, z: 0, pcb_port_id: "pcb_port_start" },
+      { x: 2, y: 0, z: 0 },
+    ],
+    vias: [],
+  }]
+  const evaluatedTerminals: HighDensityRoute["route"] = []
+  const connMap: ReturnType<typeof getConnectivityMapFromSimpleRouteJson> = getConnectivityMapFromSimpleRouteJson(originalSrj)
+  const drcEvaluator: DrcEvaluator = ({ routes, hdRoutes }): EvaluateRelaxedDrcResult => {
+    const candidateRoutes: HighDensityRoute[] | undefined = routes ?? hdRoutes
+    if (!candidateRoutes) throw new Error("Missing terminal candidate geometry")
+    evaluatedTerminals.push({ ...candidateRoutes[0]!.route[0]! })
+    return evaluateRelaxedDrc({
+      inputSrj: originalSrj,
+      srjWithPointPairs: originalSrj,
+      routedTraces: convertPipeline7HdRoutesToSimplifiedPcbTraces({
+        connections: originalSrj.connections,
+        originalConnections: originalSrj.connections,
+        hdRoutes: candidateRoutes,
+        layerCount: 2,
+        obstacles: originalSrj.obstacles,
+        defaultViaHoleDiameter: 0.15,
+        connMap,
+      }),
+    })
+  }
+  const result: ReturnType<typeof applyPipeline9TerminalEscapeRelocations> = applyPipeline9TerminalEscapeRelocations({
+    srj: routingSrj,
+    originalObstacles: originalSrj.obstacles,
+    routes,
+    newConnections: routingSrj.connections,
+    syntheticConnectionNames: new Set(),
+    drcEvaluator,
+  })
+
+  expect(routingSrj.obstacles.length).toBeGreaterThan(originalSrj.obstacles.length)
+  expect(result.attemptedCandidateCount).toBeGreaterThan(0)
+  expect(evaluatedTerminals.some((point): boolean => point.x !== 0 || point.y !== 0)).toBeTrue()
+  const radians: number = (225 * Math.PI) / 180
+  for (const point of evaluatedTerminals) {
+    const localX: number = point.x * Math.cos(radians) + point.y * Math.sin(radians)
+    const localY: number = -point.x * Math.sin(radians) + point.y * Math.cos(radians)
+    expect(Math.abs(localX) + 0.075).toBeLessThanOrEqual(terminalPad.width / 2)
+    expect(Math.abs(localY) + 0.075).toBeLessThanOrEqual(terminalPad.height / 2)
+    expect(point.pcb_port_id).toBe("pcb_port_start")
+  }
+  expect(result.routes[0]!.route.at(-1)).toEqual(routes[0]!.route.at(-1))
+  expect(result.acceptedCandidateCount).toBeGreaterThan(0)
+})


### PR DESCRIPTION
## Summary

Keep Pipeline9 terminal relocation candidates inside the original pad copper. The joint stage now passes original obstacles explicitly to the existing terminal-escape helper, while retaining its routing connections and bounds.

Pipeline9 preprocessing replaces rotated pads with axis-aligned routing rectangles. Those rectangles can extend outside the real pad. Previously the terminal pass used one such rectangle as if it were the pad itself, and could relocate a trace endpoint off its original copper.

This is a standalone source-only fix on main `3dbbad3a`; dependencies are unchanged. No feature flags, new phase, adaptive tuning, thresholds, search-budget changes, or fallbacks. AGENTS.md, the additional guidance in #2321, and recent merged Pipeline9 changes were checked. Existing drafts #2324/#2356/#2357/#2358 are not modified by this branch.

## Validation

- New numerical regression uses two rotated pads, real preprocessing, and the reference DRC evaluator. It checks every proposed terminal against the original rotated pad dimensions including trace radius, preserves port identity and the opposite endpoint, and verifies that a relocation is accepted.
- With the old routing-obstacle input, the test fails: a proposed terminal extends0.285745mm along a pad half-width of0.127mm. With original obstacles it passes.
- Five focused tests pass (140 assertions), including the existing SRJ23sample50 terminal-escape case, SRJ18sample9 reference-clean-output guard, preload identity ownership, and static connectivity reuse.
- `bun run build` passes. No snapshots, formatter, or linter changes.
- CI identified an interface/index-signature mismatch in the test-only DRC adapter. The test now copies each reference error into the repair evaluator's record type. Full `bunx tsc --noEmit` passes, and the numerical regression still passes104assertions. Manual line wrapping follows the CI-reported style without running a formatter/linter.
- The all-six benchmark suite targets source commit `4bd873b3`. Successor `6e4d5eda` changes only this test; `lib` and package.json are byte-for-byte unchanged. Keep benchmark provenance on `4bd873b3` rather than relabeling it as a different revision.

## Diagnostic evidence and limits

This bug was isolated while investigating the **known regressions** in producer draft #2357. On SRJ18sample9 with only its repair01 precision change installed, the existing pipeline produces5DRCs, including two missing connections introduced after joint repair. Using original pads removes both missing connections, leaving3geometricDRCs. A01-only isolation is clean. This is focused diagnostic evidence with different dependency pins, **not the benchmark outcome of this standalone branch**; it does not make #2357 acceptable or resolve its other regressions.

Run all six datasets (`dataset01`, `srj18`, `srj19`, `srj20`, `srj21`, `srj23`) main then this exact head sequentially on the same Blacksmith runner per dataset. Report every completion/DRC regression and per-sample changes. No whole-suite, clean-RP2350, or visual-simplification improvement is claimed pending evidence.
