### PR TITLE
fix: accept same-net copper at Pipeline 9 handoffs

### DIFF
--- a/lib/testing/filterDisconnectedEndpointsOnSameNetCopper.ts
+++ b/lib/testing/filterDisconnectedEndpointsOnSameNetCopper.ts
@@ -1,0 +1,133 @@
+import { pointToSegmentDistance } from "@tscircuit/math-utils"
+import type { AnyCircuitElement, PcbTrace, PcbTraceError } from "circuit-json"
+import type { ConnectivityMap } from "circuit-json-to-connectivity-map"
+
+type WireRoutePoint = Extract<PcbTrace["route"][number], { route_type: "wire" }>
+
+type TraceSegment = {
+  trace: PcbTrace
+  start: WireRoutePoint
+  end: WireRoutePoint
+}
+
+const GEOMETRY_EPSILON = 1e-9
+
+const getEndpointCopperWidth = (
+  trace: PcbTrace,
+  endpoint: "start" | "end",
+): number | undefined => {
+  if (trace.route_thickness_mode === "interpolated") return undefined
+
+  let segmentStartIndex = endpoint === "start" ? 0 : trace.route.length - 2
+  const indexStep = endpoint === "start" ? 1 : -1
+  while (segmentStartIndex >= 0 && segmentStartIndex < trace.route.length - 1) {
+    const start = trace.route[segmentStartIndex]
+    const end = trace.route[segmentStartIndex + 1]
+    if (
+      start?.route_type !== "wire" ||
+      end?.route_type !== "wire" ||
+      start.layer !== end.layer
+    ) {
+      return undefined
+    }
+    if (Math.hypot(start.x - end.x, start.y - end.y) > GEOMETRY_EPSILON) {
+      return start.width
+    }
+    segmentStartIndex += indexStep
+  }
+
+  return undefined
+}
+
+const getTraceSegmentsByNetAndLayer = (
+  traces: PcbTrace[],
+  connMap: ConnectivityMap,
+) => {
+  const segmentsByNetAndLayer = new Map<string, Map<string, TraceSegment[]>>()
+
+  for (const trace of traces) {
+    if (trace.route_thickness_mode === "interpolated") continue
+    const netId = connMap.getNetConnectedToId(trace.pcb_trace_id)
+    if (!netId) continue
+
+    for (let index = 0; index < trace.route.length - 1; index += 1) {
+      const start = trace.route[index]
+      const end = trace.route[index + 1]
+      if (
+        start?.route_type !== "wire" ||
+        end?.route_type !== "wire" ||
+        start.layer !== end.layer ||
+        Math.hypot(start.x - end.x, start.y - end.y) <= GEOMETRY_EPSILON
+      ) {
+        continue
+      }
+
+      const segmentsByLayer =
+        segmentsByNetAndLayer.get(netId) ?? new Map<string, TraceSegment[]>()
+      const segments = segmentsByLayer.get(start.layer) ?? []
+      segments.push({ trace, start, end })
+      segmentsByLayer.set(start.layer, segments)
+      segmentsByNetAndLayer.set(netId, segmentsByLayer)
+    }
+  }
+
+  return segmentsByNetAndLayer
+}
+
+export const filterDisconnectedEndpointsOnSameNetCopper = ({
+  circuitJson,
+  connMap,
+  errors,
+}: {
+  circuitJson: AnyCircuitElement[]
+  connMap: ConnectivityMap
+  errors: PcbTraceError[]
+}): PcbTraceError[] => {
+  const traces = circuitJson.filter(
+    (element): element is PcbTrace => element.type === "pcb_trace",
+  )
+  const traceById = new Map(traces.map((trace) => [trace.pcb_trace_id, trace]))
+  const segmentsByNetAndLayer = getTraceSegmentsByNetAndLayer(traces, connMap)
+
+  return errors.filter((error) => {
+    const trace = traceById.get(error.pcb_trace_id)
+    if (!trace) return true
+
+    const endpoint = error.pcb_trace_error_id.endsWith("_start")
+      ? "start"
+      : error.pcb_trace_error_id.endsWith("_end")
+        ? "end"
+        : undefined
+    if (
+      !endpoint ||
+      error.pcb_trace_error_id !==
+        `disconnected_endpoint_${trace.pcb_trace_id}_${endpoint}`
+    ) {
+      return true
+    }
+
+    const point =
+      endpoint === "start"
+        ? trace.route[0]
+        : trace.route[trace.route.length - 1]
+    if (point?.route_type !== "wire") return true
+
+    const endpointCopperWidth = getEndpointCopperWidth(trace, endpoint)
+    const netId = connMap.getNetConnectedToId(trace.pcb_trace_id)
+    if (endpointCopperWidth === undefined || !netId) return true
+
+    const candidateSegments =
+      segmentsByNetAndLayer.get(netId)?.get(point.layer) ?? []
+    const touchesSameNetCopper = candidateSegments.some((segment) => {
+      if (segment.trace.pcb_trace_id === trace.pcb_trace_id) return false
+      const maximumContactDistance =
+        endpointCopperWidth / 2 + segment.start.width / 2 + GEOMETRY_EPSILON
+      return (
+        pointToSegmentDistance(point, segment.start, segment.end) <=
+        maximumContactDistance
+      )
+    })
+
+    return !touchesSameNetCopper
+  })
+}

--- a/lib/testing/getDrcErrors.ts
+++ b/lib/testing/getDrcErrors.ts
@@ -19,6 +19,7 @@ import {
   getFullConnectivityMapFromCircuitJson,
 } from "circuit-json-to-connectivity-map"
 import { Point } from "graphics-debug"
+import { filterDisconnectedEndpointsOnSameNetCopper } from "./filterDisconnectedEndpointsOnSameNetCopper"
 
 type CircuitJson = AnyCircuitElement[]
 type CircuitJsonElement = CircuitJson[number]
@@ -112,7 +113,11 @@ export const getDrcErrors = (
     ...checkPcbTracesOutOfBoard(circuitJson),
     ...(options.includeTraceContinuity === false
       ? []
-      : checkTracesAreContiguous(circuitJson)),
+      : filterDisconnectedEndpointsOnSameNetCopper({
+          circuitJson,
+          connMap,
+          errors: checkTracesAreContiguous(circuitJson),
+        })),
     ...viaTraceErrors,
     ...padTraceErrors,
     ...viaErrors,

--- a/tests/evaluate-relaxed-drc-preloaded-trace-handoffs.test.ts
+++ b/tests/evaluate-relaxed-drc-preloaded-trace-handoffs.test.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "bun:test"
+import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
+import type { SimpleRouteJson, SimplifiedPcbTrace } from "lib/types"
+
+test("relaxed DRC accepts net-level endpoints on same-net preloaded copper", () => {
+  const preloadedTraces: SimplifiedPcbTrace[] = [
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "left_fanout",
+      connection_name: "breakout:left_handoff",
+      connectsTo: ["left_handoff"],
+      route: [
+        { route_type: "wire", x: 0, y: 0, width: 0.1, layer: "top" },
+        { route_type: "wire", x: 1, y: 0, width: 0.1, layer: "top" },
+      ],
+    },
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "right_fanout",
+      connection_name: "breakout:right_handoff",
+      connectsTo: ["right_handoff"],
+      route: [
+        { route_type: "wire", x: 3, y: 0, width: 0.1, layer: "top" },
+        { route_type: "wire", x: 2, y: 0, width: 0.1, layer: "top" },
+      ],
+    },
+  ]
+  const inputSrj: SimpleRouteJson = {
+    layerCount: 2,
+    minTraceWidth: 0.1,
+    bounds: { minX: -1, minY: -1, maxX: 4, maxY: 1 },
+    obstacles: [],
+    connections: [
+      {
+        name: "dq",
+        pointsToConnect: [
+          { x: 1, y: 0, layer: "top", pointId: "left_handoff" },
+          { x: 2, y: 0, layer: "top", pointId: "right_handoff" },
+        ],
+      },
+    ],
+    traces: preloadedTraces,
+  }
+  const globalTrace: SimplifiedPcbTrace = {
+    type: "pcb_trace",
+    pcb_trace_id: "global_trace",
+    connection_name: "dq",
+    connectsTo: ["left_handoff", "right_handoff"],
+    route: [
+      { route_type: "wire", x: 1, y: 0, width: 0.1, layer: "top" },
+      { route_type: "wire", x: 2, y: 0, width: 0.1, layer: "top" },
+    ],
+  }
+
+  const { errors } = evaluateRelaxedDrc({
+    inputSrj,
+    srjWithPointPairs: inputSrj,
+    routedTraces: [globalTrace],
+  })
+  const globalTraceErrors = errors.filter(
+    (error) => "pcb_trace_id" in error && error.pcb_trace_id === "global_trace",
+  )
+
+  expect(globalTraceErrors).toEqual([])
+})


### PR DESCRIPTION
## Summary

- make autorouter's relaxed DRC accept a trace endpoint only when it geometrically touches same-net copper on the same PCB layer
- keep every real disconnected endpoint and every non-continuity DRC error unchanged
- add focused coverage for a global net-level trace joining two preloaded fanout traces

## Why

Pipeline 9 receives valid phase-boundary routes whose endpoints touch preloaded fanout copper and share the same logical source trace. The pinned checks implementation only recognizes pad-connected net-level endpoints, so joint DRC repair sees four false disconnected endpoints and mutates clean parallel DDR routes into a real overlap.

The adapter now verifies the trace net through the existing connectivity map, indexes non-degenerate wire segments by net and layer, and removes only an exact `disconnected_endpoint_<trace>_<side>` result whose endpoint is within the two traces' combined copper radii. This is geometry-backed connectivity, not an error-message allowlist or repair fallback.

I evaluated upgrading `@tscircuit/checks` first. The first release with equivalent endpoint semantics also enables stricter terminal-layer validation and exposes two unrelated existing router defects (`bugreport88` and Pipeline 7 sample169), so this PR keeps the repository's established dependency instead of hiding those real errors or expanding scope.

Full two-component processed-SVG E2E: tscircuit/core#3609

## Validation

- `bun test --timeout 9999999 tests/evaluate-relaxed-drc-preloaded-trace-handoffs.test.ts tests/evaluate-relaxed-drc-preloaded-trace-connects-to.test.ts tests/evaluate-relaxed-drc-original-connectivity.test.ts`
- `bun test --timeout 9999999 tests/features/pipeline7-srj20-sample169-multi-crossing-drc.test.ts`
- `bun test --timeout 9999999 tests/bugs/bugreport88-9a86ed.test.ts`
- `bun run build`
- injected the built package into core #3609: all 101 non-snapshot assertions pass and the processed SVG changes by 0.01%, above the E2E's 0.001% threshold
- confirmed the new regression fails before this change with both `disconnected_endpoint_global_trace_start` and `disconnected_endpoint_global_trace_end`
