### PR TITLE
check via-pad clearance in Pipeline9 DRC

### DIFF
--- a/lib/testing/getDrcErrors.ts
+++ b/lib/testing/getDrcErrors.ts
@@ -5,10 +5,12 @@ import {
   checkPcbTracesOutOfBoard,
   checkSameNetViaSpacing,
   checkTracesAreContiguous,
+  checkViaPadClearance,
   checkViaTraceClearance,
 } from "@tscircuit/checks"
 import type {
   AnyCircuitElement,
+  PcbPadPadClearanceError,
   PcbPadTraceClearanceError,
   PcbTraceError,
   PcbViaClearanceError,
@@ -31,6 +33,7 @@ type PcbViaWithTraceId = CircuitJsonElement & {
 type DrcError =
   | PcbTraceError
   | PcbViaTraceClearanceError
+  | PcbPadPadClearanceError
   | PcbPadTraceClearanceError
   | PcbViaClearanceError
 
@@ -90,6 +93,10 @@ export const getDrcErrors = (
         minClearance: options.traceClearance,
       })
     : []
+  const viaPadErrors = checkViaPadClearance(circuitJson, {
+    connMap,
+    minClearance: options.traceClearance,
+  })
   const padTraceErrors = includeTypedTraceClearance
     ? checkPadTraceClearance(circuitJson, {
         connMap,
@@ -114,6 +121,7 @@ export const getDrcErrors = (
       ? []
       : checkTracesAreContiguous(circuitJson)),
     ...viaTraceErrors,
+    ...viaPadErrors,
     ...padTraceErrors,
     ...viaErrors,
   ]

--- a/tests/repro/rv1106g2-pipeline9-via-pad-overlap.test.ts
+++ b/tests/repro/rv1106g2-pipeline9-via-pad-overlap.test.ts
@@ -1,6 +1,4 @@
-import { checkViaPadClearance } from "@tscircuit/checks"
 import { expect, test } from "bun:test"
-import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import { getSvgFromGraphicsObject } from "graphics-debug"
 import {
   combinePreloadedAndRoutedTraces,
@@ -15,7 +13,7 @@ import srjJson from "../../fixtures/repro/rv1106g2-pipeline9-final-drc/phase-2.i
   type: "json",
 }
 
-test("Pipeline9 places an RV1106G2 via beside an unrelated pad", () => {
+test("Pipeline9 DRC reports the RV1106G2 via beside an unrelated pad", () => {
   const input = srjJson as SimpleRouteJson
   const routedTraces = routedTracesJson as SimplifiedPcbTrace[]
   const drc = evaluateRelaxedDrc({
@@ -24,20 +22,8 @@ test("Pipeline9 places an RV1106G2 via beside an unrelated pad", () => {
     routedTraces,
     drcOptions: { traceClearance: 0.1 },
   })
-  const connMap = getFullConnectivityMapFromCircuitJson(drc.circuitJson)
-  connMap.addConnections(
-    drc.circuitJson.flatMap((element) =>
-      element.type === "pcb_via" && element.pcb_trace_id
-        ? [[element.pcb_via_id, element.pcb_trace_id]]
-        : [],
-    ),
-  )
-  const viaPadErrors = checkViaPadClearance(drc.circuitJson, {
-    connMap,
-    minClearance: 0.1,
-  })
 
-  expect(viaPadErrors).toContainEqual(
+  expect(drc.errors).toContainEqual(
     expect.objectContaining({
       pcb_pad_ids: expect.arrayContaining(["pcb_smtpad_53"]),
     }),


### PR DESCRIPTION
### Motivation
- prevent Pipeline9 from treating RV1106G2 routes with foreign-pad via collisions as clean

### Before
- reference DRC omitted via-to-pad clearance errors

### After
- reference DRC includes and reports the reproduced foreign-pad collision