### PR TITLE
preserve via-pad route owner

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver.ts
@@ -145,6 +145,12 @@ export const addAutoroutingViaTraceIds = ({
             (viaId): viaId is string => typeof viaId === "string",
           )
         : []),
+      ...(Array.isArray(error.pcb_pad_ids)
+        ? error.pcb_pad_ids.filter(
+            (padId): padId is string =>
+              typeof padId === "string" && traceIdByViaId.has(padId),
+          )
+        : []),
     ]
     const primaryTraceId =
       typeof error.pcb_trace_id === "string" ? error.pcb_trace_id : undefined

--- a/tests/repro/rv1106g2-pipeline9-via-owner-metadata.test.ts
+++ b/tests/repro/rv1106g2-pipeline9-via-owner-metadata.test.ts
@@ -14,7 +14,7 @@ import srjJson from "../../fixtures/repro/rv1106g2-pipeline9-final-drc/phase-2.i
   type: "json",
 }
 
-test("Pipeline9 loses the owner of an RV1106G2 via-pad error", () => {
+test("Pipeline9 preserves the owner of an RV1106G2 via-pad error", () => {
   const input = srjJson as SimpleRouteJson
   const routedTraces = routedTracesJson as SimplifiedPcbTrace[]
   const drc = evaluateRelaxedDrc({
@@ -35,7 +35,7 @@ test("Pipeline9 loses the owner of an RV1106G2 via-pad error", () => {
     ),
   })
 
-  expect(mappedError.pcb_trace_ids).toBeUndefined()
+  expect(mappedError.pcb_trace_ids).toEqual(["source_net_31_mst6_0"])
 
   const fullBoard = {
     ...input,


### PR DESCRIPTION
### Motivation
- let Pipeline9 target real-board via-pad errors during repair

### Before
- via ids stored in pcb_pad_ids lost their routed trace owner

### After
- evaluated via ids are mapped back to their routed trace owner