### PR TITLE
Avoid scoring unused high-density nodes

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -536,6 +536,9 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
         cms.portPointPathingSolver?.getOutput().nodesWithPortPoints ?? []
       const nodePortPointsSource =
         uniformNodes.length > 0 ? uniformNodes : fallbackNodes
+      const highDensityNodeIds = new Set(
+        nodePortPointsSource.map((node) => node.capacityMeshNodeId),
+      )
 
       cms.highDensityNodePortPoints = structuredClone(nodePortPointsSource)
 
@@ -546,10 +549,12 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
             (
               cms.portPointPathingSolver?.getOutput().inputNodeWithPortPoints ??
               []
-            ).map((node) => [
-              node.capacityMeshNodeId,
-              cms.portPointPathingSolver?.computeNodePf(node) ?? null,
-            ]),
+            )
+              .filter((node) => highDensityNodeIds.has(node.capacityMeshNodeId))
+              .map((node) => [
+                node.capacityMeshNodeId,
+                cms.portPointPathingSolver?.computeNodePf(node) ?? null,
+              ]),
           ),
           colorMap: cms.colorMap,
           connMap: cms.connMap,

--- a/tests/repro/am625sip-analog-1v8-link-12.test.ts
+++ b/tests/repro/am625sip-analog-1v8-link-12.test.ts
@@ -3,10 +3,7 @@ import { AutoroutingPipelineSolver7_MultiGraph } from "lib/autorouter-pipelines/
 import type { SimpleRouteJson } from "lib/types"
 import realBoardPhase from "../../fixtures/repro/am625sip-analog-1v8-link-12.srj.json"
 
-// This is the unchanged routing-phase input emitted by the production board.
-// It currently stops emitting progress while synchronously scoring high-density
-// nodes, so the regression is skipped until the stacked fix makes it terminate.
-test.skip("routes the faithful AM625SIP analog 1.8 V link 12 phase", () => {
+test("routes the faithful AM625SIP analog 1.8 V link 12 phase", () => {
   const solver = new AutoroutingPipelineSolver7_MultiGraph(
     structuredClone(realBoardPhase) as SimpleRouteJson,
     { cacheProvider: null },
@@ -18,4 +15,8 @@ test.skip("routes the faithful AM625SIP analog 1.8 V link 12 phase", () => {
 
   expect(solver.failed).toBe(false)
   expect(solver.solved).toBe(true)
+  expect(solver.highDensityNodePortPoints).toHaveLength(4)
+  expect(solver.highDensityRouteSolver?.nodePfById.size).toBe(
+    solver.highDensityNodePortPoints?.length,
+  )
 })


### PR DESCRIPTION
Stacked on #2368.\n\nPipeline 7 was computing an expensive pathfinding score for every input node from port-point pathing, even though HighDensitySolver only receives the much smaller post-distribution node set. This filters scoring to the exact node IDs passed into HighDensitySolver.\n\nOn the unchanged AM625SIP ANALOG_1V8_LINK_12 production phase:\n- before: 60.0 s\n- after: 39.6 s\n- improvement: ~34%\n- high-density nodes consumed/scored: 4/4\n\nThe route still solves successfully. The remaining ~28 s is spent in the separate GlobalDrcBranchPortfolioSolver and is not hidden by this change.\n\nValidation:\n- bun test tests/repro/am625sip-analog-1v8-link-12.test.ts --timeout 9999999\n- bun run build\n- git diff --check