### PR TITLE
Reduce Pipeline9 joint DRC candidate allocation churn

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver.ts
@@ -26,16 +26,22 @@ import { Pipeline7AdaptiveDrcBranchPortfolioSolver } from "../AutoroutingPipelin
 import { createPipeline7HdRoutesToSimplifiedPcbTracesConverter } from "../AutoroutingPipeline7_MultiGraph/convertPipeline7HdRoutesToSimplifiedPcbTraces"
 import { applyPipeline9RegionalB01Repairs } from "./applyPipeline9RegionalB01Repairs"
 import { applyPipeline9TerminalEscapeRelocations } from "./applyPipeline9TerminalEscapeRelocations"
-import { assignUniquePcbTraceIdsToNewTraces } from "./assignUniquePcbTraceIdsToNewTraces"
 import {
   type PreloadedHighDensityRoute,
   convertPreloadedTraceToHdRoutes,
 } from "./convertPreloadedTraceToHdRoutes"
-import { filterPipeline9DrcErrorsAgainstBaseline } from "./filterPipeline9DrcErrorsAgainstBaseline"
+import { createPipeline9JointDrcCandidateIdentityPlanner } from "./createPipeline9JointDrcCandidateIdentityPlanner"
+import {
+  createPipeline9DrcBaselineFilter,
+  filterPipeline9DrcErrorsAgainstBaseline,
+} from "./filterPipeline9DrcErrorsAgainstBaseline"
 import { getPipeline9PreloadedTraceIdsInInitialDrcRegions } from "./getPipeline9PreloadedTraceIdsInInitialDrcRegions"
 import { getPipeline9PreloadedViaPairTraceGroups } from "./getPipeline9PreloadedViaPairTraceGroups"
 import { mergePipeline9MovablePreloadedVias } from "./mergePipeline9MovablePreloadedVias"
-import { normalizePipeline9DrcErrorsForRepair } from "./normalizePipeline9DrcErrorsForRepair"
+import {
+  getPipeline9TraceIdByViaId,
+  normalizePipeline9DrcErrorsForRepair,
+} from "./normalizePipeline9DrcErrorsForRepair"
 import {
   getPipeline9DrcErrors,
   getPipeline9RouteIndexByTraceId,
@@ -123,20 +129,13 @@ export const addAutoroutingViaTraceIds = ({
   errors,
   circuitJson,
   evaluatedTraceIds,
+  traceIdByViaId = getPipeline9TraceIdByViaId(circuitJson),
 }: {
   errors: Array<Record<string, unknown>>
   circuitJson: AnyCircuitElement[]
   evaluatedTraceIds: ReadonlySet<string>
+  traceIdByViaId?: ReadonlyMap<string, string>
 }): Array<Record<string, unknown>> => {
-  const traceIdByViaId = new Map(
-    circuitJson.flatMap((element) =>
-      element.type === "pcb_via" &&
-      typeof element.pcb_via_id === "string" &&
-      typeof element.pcb_trace_id === "string"
-        ? [[element.pcb_via_id, element.pcb_trace_id] as const]
-        : [],
-    ),
-  )
   return errors.map((error) => {
     const explicitViaIds = [
       ...(typeof error.pcb_via_id === "string" ? [error.pcb_via_id] : []),
@@ -1005,51 +1004,94 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
         evaluatedTraceIds: baselineEvaluatedTraceIds,
       }),
     }
+    const filterReferenceErrorsAgainstBaseline =
+      createPipeline9DrcBaselineFilter({ baselineErrors })
+    const filterReferenceErrorsWithCentersAgainstBaseline =
+      createPipeline9DrcBaselineFilter({
+        baselineErrors: baselineErrorsWithCenters,
+      })
+    const filterIndexedErrorsAgainstBaseline = createPipeline9DrcBaselineFilter(
+      {
+        baselineErrors: autoroutingBaselineDrc.errors,
+      },
+    )
+    const filterIndexedErrorsWithCentersAgainstBaseline =
+      createPipeline9DrcBaselineFilter({
+        baselineErrors: autoroutingBaselineDrc.errorsWithCenters,
+      })
     let referenceDrcCandidateCache:
       | {
           candidateKey: string
           result: ReturnType<DrcEvaluator>
         }
       | undefined
+    const getCandidateIdentityPlan =
+      createPipeline9JointDrcCandidateIdentityPlanner({
+        originalPreloadedTraces: params.originalSrj.traces ?? [],
+        movablePreloadedSections: this.movablePreloadedSections,
+      })
+    const replacedOriginalTraceIds = new Set(
+      nonMovableMutatedPreloadedTraces.flatMap((trace) =>
+        trace.__replaces_pcb_trace_id ? [trace.__replaces_pcb_trace_id] : [],
+      ),
+    )
+    const evaluatedMovablePreloadedTraceTemplates =
+      this.movablePreloadedSections.map((movableSection) => {
+        const originalTraceId = movableSection.originalTrace.pcb_trace_id
+        const replacesOriginalTrace =
+          !replacedOriginalTraceIds.has(originalTraceId)
+        replacedOriginalTraceIds.add(originalTraceId)
+        return {
+          ...movableSection.originalTrace,
+          pcb_trace_id: movableSection.evaluationTraceId,
+          __replaces_pcb_trace_id: replacesOriginalTrace
+            ? originalTraceId
+            : undefined,
+        }
+      })
+    const retainedOriginalPreloadedTraces = (
+      params.originalSrj.traces ?? []
+    ).filter((trace) => !replacedOriginalTraceIds.has(trace.pcb_trace_id))
 
     const prepareCandidateDrcInput = (
       evaluatedRoutes: HighDensityRoute[],
     ): PreparedCandidateDrcInput => {
-      const evaluatedNewRoutes = evaluatedRoutes.filter(
-        (route) => !this.syntheticConnectionNames.has(route.connectionName),
-      )
+      const evaluatedNewRoutes: HighDensityRoute[] = []
+      const evaluatedMovableRouteByConnectionName = new Map<
+        string,
+        HighDensityRoute
+      >()
+      for (const route of evaluatedRoutes) {
+        if (!this.syntheticConnectionNames.has(route.connectionName)) {
+          evaluatedNewRoutes.push(route)
+        } else if (
+          !evaluatedMovableRouteByConnectionName.has(route.connectionName)
+        ) {
+          evaluatedMovableRouteByConnectionName.set(route.connectionName, route)
+        }
+      }
       const evaluatedNewTraces = convertNewRoutes(evaluatedNewRoutes)
-      const uniquelyNamedNewTraces = assignUniquePcbTraceIdsToNewTraces(
-        evaluatedNewTraces,
-        params.originalSrj.traces ?? [],
+      const candidateIdentityPlan = getCandidateIdentityPlan(evaluatedNewTraces)
+      const uniquelyNamedNewTraces = evaluatedNewTraces.map(
+        (trace, traceIndex) => {
+          const pcbTraceId = candidateIdentityPlan.solverTraceIds[traceIndex]!
+          return trace.pcb_trace_id === pcbTraceId
+            ? trace
+            : { ...trace, pcb_trace_id: pcbTraceId }
+        },
       )
-      const replacedOriginalTraceIds = new Set<string>()
-      const originalTraceIdByEvaluationTraceId = new Map<string, string>()
       const evaluatedMovablePreloadedTraces = this.movablePreloadedSections.map(
-        (movableSection) => {
-          const evaluatedRoute = evaluatedRoutes.find(
-            (route) =>
-              route.connectionName === movableSection.syntheticConnectionName,
+        (movableSection, movableSectionIndex) => {
+          const evaluatedRoute = evaluatedMovableRouteByConnectionName.get(
+            movableSection.syntheticConnectionName,
           )
           if (!evaluatedRoute) {
             throw new Error(
               `Pipeline9 joint DRC repair lost preloaded section "${movableSection.syntheticConnectionName}"`,
             )
           }
-          const originalTraceId = movableSection.originalTrace.pcb_trace_id
-          originalTraceIdByEvaluationTraceId.set(
-            movableSection.evaluationTraceId,
-            originalTraceId,
-          )
-          const replacesOriginalTrace =
-            !replacedOriginalTraceIds.has(originalTraceId)
-          replacedOriginalTraceIds.add(originalTraceId)
           return {
-            ...movableSection.originalTrace,
-            pcb_trace_id: movableSection.evaluationTraceId,
-            ...(replacesOriginalTrace
-              ? { __replaces_pcb_trace_id: originalTraceId }
-              : { __replaces_pcb_trace_id: undefined }),
+            ...evaluatedMovablePreloadedTraceTemplates[movableSectionIndex]!,
             route: convertHdRouteToSimplifiedRoute(
               evaluatedRoute,
               params.layerCount,
@@ -1062,39 +1104,23 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
           }
         },
       )
-      const solverTraceIdByEvaluationTraceId = new Map<string, string>()
-      for (
-        let traceIndex = 0;
-        traceIndex < evaluatedNewTraces.length;
-        traceIndex++
-      ) {
-        solverTraceIdByEvaluationTraceId.set(
-          uniquelyNamedNewTraces[traceIndex]!.pcb_trace_id,
-          evaluatedNewTraces[traceIndex]!.pcb_trace_id,
-        )
-      }
-      for (const movableSection of this.movablePreloadedSections) {
-        solverTraceIdByEvaluationTraceId.set(
-          movableSection.evaluationTraceId,
-          `${movableSection.syntheticConnectionName}_0`,
-        )
-      }
-      const movableTraceIds = new Set(solverTraceIdByEvaluationTraceId.values())
       const routedTraces = [
         ...nonMovableMutatedPreloadedTraces,
         ...evaluatedMovablePreloadedTraces,
         ...uniquelyNamedNewTraces,
       ]
-      const evaluatedTraces = combinePreloadedAndRoutedTraces(
-        params.originalSrj.traces ?? [],
-        routedTraces,
-      )
+      const evaluatedTraces = [
+        ...retainedOriginalPreloadedTraces,
+        ...routedTraces,
+      ]
       return {
         evaluatedTraces,
-        movableTraceIds,
-        originalTraceIdByEvaluationTraceId,
+        movableTraceIds: candidateIdentityPlan.movableTraceIds,
+        originalTraceIdByEvaluationTraceId:
+          candidateIdentityPlan.originalTraceIdByEvaluationTraceId,
         routedTraces,
-        solverTraceIdByEvaluationTraceId,
+        solverTraceIdByEvaluationTraceId:
+          candidateIdentityPlan.solverTraceIdByEvaluationTraceId,
       }
     }
     const normalizeCandidateDrcResult = ({
@@ -1103,30 +1129,28 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
       circuitJson,
       movableTraceIds,
       solverTraceIdByEvaluationTraceId,
+      traceIdByViaId = getPipeline9TraceIdByViaId(circuitJson),
     }: {
       errors: Array<Record<string, unknown>>
       errorsWithCenters: Array<Record<string, unknown>>
       circuitJson: AnyCircuitElement[]
       movableTraceIds: ReadonlySet<string>
       solverTraceIdByEvaluationTraceId: ReadonlyMap<string, string>
+      traceIdByViaId?: ReadonlyMap<string, string>
     }): NormalizedCandidateDrcResult => {
-      const remappedCircuitJson = circuitJson.map((element) => {
-        if (
-          !("pcb_trace_id" in element) ||
-          typeof element.pcb_trace_id !== "string"
+      const remappedTraceIdByViaId = new Map<string, string>()
+      for (const [viaId, evaluationTraceId] of traceIdByViaId) {
+        remappedTraceIdByViaId.set(
+          viaId,
+          solverTraceIdByEvaluationTraceId.get(evaluationTraceId) ??
+            evaluationTraceId,
         )
-          return element
-        const solverTraceId = solverTraceIdByEvaluationTraceId.get(
-          element.pcb_trace_id,
-        )
-        return solverTraceId
-          ? { ...element, pcb_trace_id: solverTraceId }
-          : element
-      })
+      }
       return {
         errors: normalizePipeline9DrcErrorsForRepair({
           errors: remapDrcTraceIds(errors, solverTraceIdByEvaluationTraceId),
-          circuitJson: remappedCircuitJson,
+          circuitJson,
+          traceIdByViaId: remappedTraceIdByViaId,
           newTraceIds: movableTraceIds,
         }),
         errorsWithCenters: normalizePipeline9DrcErrorsForRepair({
@@ -1134,7 +1158,8 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
             errorsWithCenters,
             solverTraceIdByEvaluationTraceId,
           ),
-          circuitJson: remappedCircuitJson,
+          circuitJson,
+          traceIdByViaId: remappedTraceIdByViaId,
           newTraceIds: movableTraceIds,
         }),
       }
@@ -1155,12 +1180,16 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
       const evaluatedTraceIds = new Set(
         candidateDrcInput.evaluatedTraces.map((trace) => trace.pcb_trace_id),
       )
+      const traceIdByViaId = getPipeline9TraceIdByViaId(
+        evaluatedDrc.circuitJson,
+      )
       const evaluatedErrors = addAutoroutingViaTraceIds({
         errors: evaluatedDrc.errors as unknown as Array<
           Record<string, unknown>
         >,
         circuitJson: evaluatedDrc.circuitJson,
         evaluatedTraceIds,
+        traceIdByViaId,
       })
       const evaluatedErrorsWithCenters = addAutoroutingViaTraceIds({
         errors: evaluatedDrc.errorsWithCenters as unknown as Array<
@@ -1168,17 +1197,16 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
         >,
         circuitJson: evaluatedDrc.circuitJson,
         evaluatedTraceIds,
+        traceIdByViaId,
       })
-      const evaluatedNewErrors = filterPipeline9DrcErrorsAgainstBaseline({
+      const evaluatedNewErrors = filterReferenceErrorsAgainstBaseline({
         errors: evaluatedErrors,
-        baselineErrors,
         originalTraceIdByPreparedTraceId:
           candidateDrcInput.originalTraceIdByEvaluationTraceId,
       })
       const evaluatedNewErrorsWithCenters =
-        filterPipeline9DrcErrorsAgainstBaseline({
+        filterReferenceErrorsWithCentersAgainstBaseline({
           errors: evaluatedErrorsWithCenters,
-          baselineErrors: baselineErrorsWithCenters,
           originalTraceIdByPreparedTraceId:
             candidateDrcInput.originalTraceIdByEvaluationTraceId,
         })
@@ -1189,6 +1217,7 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
         movableTraceIds: candidateDrcInput.movableTraceIds,
         solverTraceIdByEvaluationTraceId:
           candidateDrcInput.solverTraceIdByEvaluationTraceId,
+        traceIdByViaId,
       })
     }
     const cachedReferenceDrcEvaluator: DrcEvaluator = ({
@@ -1229,12 +1258,14 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
       const evaluatedTraceIds = new Set(
         candidateDrcInput.evaluatedTraces.map((trace) => trace.pcb_trace_id),
       )
+      const traceIdByViaId = getPipeline9TraceIdByViaId(viaCircuitJson)
       const evaluatedErrors = addAutoroutingViaTraceIds({
         errors: evaluatedDrc.errors as unknown as Array<
           Record<string, unknown>
         >,
         circuitJson: viaCircuitJson,
         evaluatedTraceIds,
+        traceIdByViaId,
       })
       const evaluatedErrorsWithCenters = addAutoroutingViaTraceIds({
         errors: evaluatedDrc.errorsWithCenters as unknown as Array<
@@ -1242,22 +1273,16 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
         >,
         circuitJson: viaCircuitJson,
         evaluatedTraceIds,
+        traceIdByViaId,
       })
-      const evaluatedNewErrors = filterPipeline9DrcErrorsAgainstBaseline({
+      const evaluatedNewErrors = filterIndexedErrorsAgainstBaseline({
         errors: evaluatedErrors,
-        baselineErrors: autoroutingBaselineDrc.errors as unknown as Array<
-          Record<string, unknown>
-        >,
         originalTraceIdByPreparedTraceId:
           candidateDrcInput.originalTraceIdByEvaluationTraceId,
       })
       const evaluatedNewErrorsWithCenters =
-        filterPipeline9DrcErrorsAgainstBaseline({
+        filterIndexedErrorsWithCentersAgainstBaseline({
           errors: evaluatedErrorsWithCenters,
-          baselineErrors:
-            autoroutingBaselineDrc.errorsWithCenters as unknown as Array<
-              Record<string, unknown>
-            >,
           originalTraceIdByPreparedTraceId:
             candidateDrcInput.originalTraceIdByEvaluationTraceId,
         })
@@ -1286,6 +1311,7 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
         movableTraceIds: candidateDrcInput.movableTraceIds,
         solverTraceIdByEvaluationTraceId:
           candidateDrcInput.solverTraceIdByEvaluationTraceId,
+        traceIdByViaId,
       })
     }
     this.drcEvaluator = drcEvaluator

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/createPipeline9JointDrcCandidateIdentityPlanner.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/createPipeline9JointDrcCandidateIdentityPlanner.ts
@@ -1,0 +1,82 @@
+import type { SimplifiedPcbTrace } from "lib/types"
+import { assignUniquePcbTraceIdsToNewTraces } from "./assignUniquePcbTraceIdsToNewTraces"
+
+type MovablePreloadedSectionIdentity = {
+  originalTrace: SimplifiedPcbTrace
+  syntheticConnectionName: string
+  evaluationTraceId: string
+}
+
+export type Pipeline9JointDrcCandidateIdentityPlan = {
+  movableTraceIds: ReadonlySet<string>
+  originalTraceIdByEvaluationTraceId: ReadonlyMap<string, string>
+  solverTraceIdByEvaluationTraceId: ReadonlyMap<string, string>
+  solverTraceIds: readonly string[]
+}
+
+/**
+ * Trace ownership and collision-safe IDs depend on candidate topology, not
+ * copper coordinates. Cache that plan while repair strategies move geometry.
+ */
+export const createPipeline9JointDrcCandidateIdentityPlanner = ({
+  originalPreloadedTraces,
+  movablePreloadedSections,
+}: {
+  originalPreloadedTraces: readonly SimplifiedPcbTrace[]
+  movablePreloadedSections: readonly MovablePreloadedSectionIdentity[]
+}): ((
+  evaluatedNewTraces: readonly SimplifiedPcbTrace[],
+) => Pipeline9JointDrcCandidateIdentityPlan) => {
+  const originalTraceIdByEvaluationTraceId = new Map(
+    movablePreloadedSections.map((section) => [
+      section.evaluationTraceId,
+      section.originalTrace.pcb_trace_id,
+    ]),
+  )
+  let cachedEvaluationTraceIds: readonly string[] | undefined
+  let cachedPlan: Pipeline9JointDrcCandidateIdentityPlan | undefined
+
+  return (
+    evaluatedNewTraces: readonly SimplifiedPcbTrace[],
+  ): Pipeline9JointDrcCandidateIdentityPlan => {
+    const topologyMatches =
+      cachedEvaluationTraceIds?.length === evaluatedNewTraces.length &&
+      evaluatedNewTraces.every(
+        (trace, traceIndex) =>
+          trace.pcb_trace_id === cachedEvaluationTraceIds?.[traceIndex],
+      )
+    if (topologyMatches) return cachedPlan!
+
+    const uniquelyNamedNewTraces = assignUniquePcbTraceIdsToNewTraces(
+      [...evaluatedNewTraces],
+      originalPreloadedTraces,
+    )
+    const solverTraceIdByEvaluationTraceId = new Map<string, string>()
+    for (
+      let traceIndex = 0;
+      traceIndex < evaluatedNewTraces.length;
+      traceIndex++
+    ) {
+      solverTraceIdByEvaluationTraceId.set(
+        uniquelyNamedNewTraces[traceIndex]!.pcb_trace_id,
+        evaluatedNewTraces[traceIndex]!.pcb_trace_id,
+      )
+    }
+    for (const movableSection of movablePreloadedSections) {
+      solverTraceIdByEvaluationTraceId.set(
+        movableSection.evaluationTraceId,
+        `${movableSection.syntheticConnectionName}_0`,
+      )
+    }
+    cachedEvaluationTraceIds = evaluatedNewTraces.map(
+      (trace) => trace.pcb_trace_id,
+    )
+    cachedPlan = {
+      movableTraceIds: new Set(solverTraceIdByEvaluationTraceId.values()),
+      originalTraceIdByEvaluationTraceId,
+      solverTraceIdByEvaluationTraceId,
+      solverTraceIds: uniquelyNamedNewTraces.map((trace) => trace.pcb_trace_id),
+    }
+    return cachedPlan
+  }
+}

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/filterPipeline9DrcErrorsAgainstBaseline.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/filterPipeline9DrcErrorsAgainstBaseline.ts
@@ -7,6 +7,12 @@ const DRC_ERROR_ID_KEYS = [
   "pcb_pad_trace_clearance_error_id",
 ] as const
 
+type PreparedTraceAlias = readonly [string, string]
+const preparedTraceAliasesByMap = new WeakMap<
+  ReadonlyMap<string, string>,
+  readonly PreparedTraceAlias[]
+>()
+
 const isMissingConnectionError = (error: DrcError): boolean =>
   typeof error.pcb_trace_error_id === "string" &&
   error.pcb_trace_error_id.startsWith("missing_connection_")
@@ -16,9 +22,13 @@ const normalizePreparedTraceIds = (
   originalTraceIdByPreparedTraceId: ReadonlyMap<string, string>,
 ): string => {
   let normalized = value
-  const aliases = [...originalTraceIdByPreparedTraceId].sort(
-    ([left], [right]) => right.length - left.length,
-  )
+  let aliases = preparedTraceAliasesByMap.get(originalTraceIdByPreparedTraceId)
+  if (!aliases) {
+    aliases = [...originalTraceIdByPreparedTraceId].sort(
+      ([left], [right]) => right.length - left.length,
+    )
+    preparedTraceAliasesByMap.set(originalTraceIdByPreparedTraceId, aliases)
+  }
   for (const [preparedTraceId, originalTraceId] of aliases) {
     normalized = normalized.replaceAll(preparedTraceId, originalTraceId)
   }
@@ -113,6 +123,22 @@ export const filterPipeline9DrcErrorsAgainstBaseline = <
   baselineErrors: DrcError[]
   originalTraceIdByPreparedTraceId?: ReadonlyMap<string, string>
 }): TError[] => {
+  const filterErrors = createPipeline9DrcBaselineFilter({ baselineErrors })
+  return filterErrors({ errors, originalTraceIdByPreparedTraceId })
+}
+
+/** Compiles inherited error identities once for repeated candidate checks. */
+export const createPipeline9DrcBaselineFilter = ({
+  baselineErrors,
+}: {
+  baselineErrors: DrcError[]
+}): (<TError extends DrcError>({
+  errors,
+  originalTraceIdByPreparedTraceId,
+}: {
+  errors: TError[]
+  originalTraceIdByPreparedTraceId?: ReadonlyMap<string, string>
+}) => TError[]) => {
   const baselineErrorIdentities = new Set(
     baselineErrors
       // A missing connection describes unfinished routing, not an inherited
@@ -122,11 +148,18 @@ export const filterPipeline9DrcErrorsAgainstBaseline = <
       .map((error) => getDrcErrorIdentity(error, new Map())),
   )
   baselineErrorIdentities.delete(undefined)
-  return errors.filter((error) => {
-    const identity = getDrcErrorIdentity(
-      error,
-      originalTraceIdByPreparedTraceId,
-    )
-    return identity === undefined || !baselineErrorIdentities.has(identity)
-  })
+  return <TError extends DrcError>({
+    errors,
+    originalTraceIdByPreparedTraceId = new Map(),
+  }: {
+    errors: TError[]
+    originalTraceIdByPreparedTraceId?: ReadonlyMap<string, string>
+  }): TError[] =>
+    errors.filter((error) => {
+      const identity = getDrcErrorIdentity(
+        error,
+        originalTraceIdByPreparedTraceId,
+      )
+      return identity === undefined || !baselineErrorIdentities.has(identity)
+    })
 }

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/normalizePipeline9DrcErrorsForRepair.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/normalizePipeline9DrcErrorsForRepair.ts
@@ -2,26 +2,34 @@ import type { AnyCircuitElement } from "circuit-json"
 
 type DrcError = Record<string, unknown>
 
+export const getPipeline9TraceIdByViaId = (
+  circuitJson: AnyCircuitElement[],
+): ReadonlyMap<string, string> => {
+  const traceIdByViaId = new Map<string, string>()
+  for (const element of circuitJson) {
+    if (
+      element.type === "pcb_via" &&
+      typeof element.pcb_via_id === "string" &&
+      typeof element.pcb_trace_id === "string"
+    ) {
+      traceIdByViaId.set(element.pcb_via_id, element.pcb_trace_id)
+    }
+  }
+  return traceIdByViaId
+}
+
 /** Makes the movable new route the primary identity in joint DRC errors. */
 export const normalizePipeline9DrcErrorsForRepair = ({
   errors,
   circuitJson,
+  traceIdByViaId = getPipeline9TraceIdByViaId(circuitJson),
   newTraceIds,
 }: {
   errors: DrcError[]
   circuitJson: AnyCircuitElement[]
+  traceIdByViaId?: ReadonlyMap<string, string>
   newTraceIds: ReadonlySet<string>
 }): DrcError[] => {
-  const traceIdByViaId = new Map(
-    circuitJson.flatMap((element) =>
-      element.type === "pcb_via" &&
-      typeof element.pcb_via_id === "string" &&
-      typeof element.pcb_trace_id === "string"
-        ? [[element.pcb_via_id, element.pcb_trace_id] as const]
-        : [],
-    ),
-  )
-
   return errors.map((error) => {
     const primaryTraceId =
       typeof error.pcb_trace_id === "string" ? error.pcb_trace_id : undefined

--- a/tests/features/pipeline9-joint-drc-candidate-identity-plan.test.ts
+++ b/tests/features/pipeline9-joint-drc-candidate-identity-plan.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test"
+import { createPipeline9JointDrcCandidateIdentityPlanner } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/createPipeline9JointDrcCandidateIdentityPlanner"
+import type { SimplifiedPcbTrace } from "lib/types"
+
+const createTrace = (pcbTraceId: string, y: number): SimplifiedPcbTrace => ({
+  type: "pcb_trace",
+  pcb_trace_id: pcbTraceId,
+  connection_name: pcbTraceId,
+  route: [
+    { route_type: "wire", x: -1, y, width: 0.1, layer: "top" },
+    { route_type: "wire", x: 1, y, width: 0.1, layer: "top" },
+  ],
+})
+
+test("Pipeline9 reuses trace identity plans while candidate geometry changes", () => {
+  const preloadedTrace = createTrace("route_0", 2)
+  const getIdentityPlan = createPipeline9JointDrcCandidateIdentityPlanner({
+    originalPreloadedTraces: [preloadedTrace],
+    movablePreloadedSections: [
+      {
+        originalTrace: preloadedTrace,
+        syntheticConnectionName: "pipeline9_preloaded_drc_0",
+        evaluationTraceId: "route_0__pipeline9_section_0",
+      },
+    ],
+  })
+  const firstPlan = getIdentityPlan([createTrace("route_0", 0)])
+  const movedGeometryPlan = getIdentityPlan([createTrace("route_0", 1)])
+
+  expect(movedGeometryPlan).toBe(firstPlan)
+  expect(firstPlan.solverTraceIds).toEqual(["route_0_routed"])
+  expect(firstPlan.solverTraceIdByEvaluationTraceId).toEqual(
+    new Map([
+      ["route_0_routed", "route_0"],
+      ["route_0__pipeline9_section_0", "pipeline9_preloaded_drc_0_0"],
+    ]),
+  )
+
+  const changedTopologyPlan = getIdentityPlan([
+    createTrace("route_0", 1),
+    createTrace("route_1", 1),
+  ])
+  expect(changedTopologyPlan).not.toBe(firstPlan)
+  expect(changedTopologyPlan.solverTraceIds).toEqual([
+    "route_0_routed",
+    "route_1",
+  ])
+})


### PR DESCRIPTION
## Problem

Pipeline9's joint DRC repair evaluates many candidate geometries. The copper coordinates can change on every attempt, but trace identity, preload replacement relationships, inherited baseline error identities, and via ownership rules usually do not.

The evaluator rebuilt that static metadata for every candidate. It also copied the complete Circuit JSON just to remap via owners before normalizing DRC errors. Those repeated allocations add avoidable processing and garbage-collection overhead during browser routing. This change removes that redundant work; it does not change the debugger's synchronous solve scheduling or establish that a retained-memory leak exists.

## Fix

Use one joint DRC evaluation path for every board, with or without preloaded traces:

- compile collision-safe trace identities and preload ownership once per candidate topology
- invalidate and rebuild the identity plan if a repair strategy changes trace count or ordering
- precompute the retained preloaded copper and movable preload templates
- index synthetic repair routes in one pass instead of repeatedly scanning candidates
- compile inherited baseline error identities and prepared-trace aliases once
- build one via-owner index per DRC result and reuse it for both error collections
- remap the small via-owner index instead of cloning the complete Circuit JSON

Candidate geometry is still converted and evaluated on every attempt, so the cache cannot return stale copper coordinates.

## Validation

- `bun run build`
- `bunx tsc --noEmit`
- eight focused joint-DRC, preload ownership, reference fallback, clearance, and candidate-identity regression tests
- large Pipeline9 browser-routing regression
- bounded post-exact and regional repair regressions
- Biome formatting check for changed files
- `git diff --check`