### PR TITLE
perf: reduce duplicate Pipeline9 DRC evaluations

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver.ts
@@ -5,6 +5,7 @@ import {
   AutoroutingDrcEngine,
   type DrcEvaluator,
   GlobalDrcBranchPortfolioSolver,
+  type GlobalDrcBranchPortfolioSolverParams,
   type SimpleRouteJson as RepairSimpleRouteJson,
   type SimplifiedPcbTraces as RepairSimplifiedPcbTraces,
 } from "high-density-repair03/lib"
@@ -51,9 +52,15 @@ const EXACT_REPAIR_BROAD_MAX_ITERATIONS = 12
 // residual sets. Keep that exhaustive search for compact residues while
 // bounding terminal relocation's repeated whole-board indexed DRC scans.
 const MAX_POST_EXACT_PRECISION_PASS_INDEXED_ISSUE_COUNT = 16
+const MAX_INITIAL_DRC_ISSUE_COUNT_FOR_FAST_PROBE = 16
 const INDEXED_DRC_CANDIDATE_CACHE_SIZE = 64
 
 type DrcCandidateKey = string & { readonly __brand: "DrcCandidateKey" }
+
+type Pipeline9ExactRepairSolver = BaseSolver & {
+  readonly params: GlobalDrcBranchPortfolioSolverParams
+  getOutput(): HighDensityRoute[]
+}
 
 type Pipeline9JointDrcRepairSolverParams = {
   srj: SimpleRouteJson
@@ -648,9 +655,7 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
   readonly movablePreloadedSections: MovablePreloadedSection[]
   readonly fixedPreloadedObstacleRoutes: PreloadedHighDensityRoute[]
   readonly syntheticConnectionNames: ReadonlySet<string>
-  readonly exactRepairSolver?:
-    | Pipeline7AdaptiveDrcBranchPortfolioSolver
-    | GlobalDrcBranchPortfolioSolver
+  readonly exactRepairSolver?: Pipeline9ExactRepairSolver
   private drcEvaluator?: DrcEvaluator
   private cachedReferenceDrcEvaluator?: DrcEvaluator
   private referenceDrcValidationCount = 0
@@ -1336,8 +1341,8 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
     }
     this.drcEvaluator = drcEvaluator
 
-    const exactRepairParams = {
-      srj: extendedSrjWithPointPairs as any,
+    const exactRepairParams: GlobalDrcBranchPortfolioSolverParams = {
+      srj: extendedSrjWithPointPairs as RepairSimpleRouteJson,
       hdRoutes: [
         ...params.newHdRoutes,
         ...this.movablePreloadedSections.map(
@@ -1362,14 +1367,13 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
       broadPassMultiplier: 3,
     }
     const shouldAttemptFastProbe =
-      currentDrc.errors.length <=
-      MAX_POST_EXACT_PRECISION_PASS_INDEXED_ISSUE_COUNT
+      currentDrc.errors.length <= MAX_INITIAL_DRC_ISSUE_COUNT_FOR_FAST_PROBE
     this.exactRepairSolver = shouldAttemptFastProbe
       ? new Pipeline7AdaptiveDrcBranchPortfolioSolver(exactRepairParams)
       : new GlobalDrcBranchPortfolioSolver(exactRepairParams)
-    if (!shouldAttemptFastProbe) {
-      this.stats.pipeline7AdaptiveExactDrcFastProbeAttempted = false
-    }
+    this.stats.exactRepairFastProbeAttempted = shouldAttemptFastProbe
+    this.stats.exactRepairFastProbeMaxInitialDrcIssueCount =
+      MAX_INITIAL_DRC_ISSUE_COUNT_FOR_FAST_PROBE
     this.activeSubSolver = this.exactRepairSolver
     this.MAX_ITERATIONS = this.exactRepairSolver.MAX_ITERATIONS + 1
   }

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver.ts
@@ -4,6 +4,7 @@ import type { GraphicsObject } from "graphics-debug"
 import {
   AutoroutingDrcEngine,
   type DrcEvaluator,
+  GlobalDrcBranchPortfolioSolver,
   type SimpleRouteJson as RepairSimpleRouteJson,
   type SimplifiedPcbTraces as RepairSimplifiedPcbTraces,
 } from "high-density-repair03/lib"
@@ -50,6 +51,9 @@ const EXACT_REPAIR_BROAD_MAX_ITERATIONS = 12
 // residual sets. Keep that exhaustive search for compact residues while
 // bounding terminal relocation's repeated whole-board indexed DRC scans.
 const MAX_POST_EXACT_PRECISION_PASS_INDEXED_ISSUE_COUNT = 16
+const INDEXED_DRC_CANDIDATE_CACHE_SIZE = 64
+
+type DrcCandidateKey = string & { readonly __brand: "DrcCandidateKey" }
 
 type Pipeline9JointDrcRepairSolverParams = {
   srj: SimpleRouteJson
@@ -644,12 +648,38 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
   readonly movablePreloadedSections: MovablePreloadedSection[]
   readonly fixedPreloadedObstacleRoutes: PreloadedHighDensityRoute[]
   readonly syntheticConnectionNames: ReadonlySet<string>
-  readonly exactRepairSolver?: Pipeline7AdaptiveDrcBranchPortfolioSolver
+  readonly exactRepairSolver?:
+    | Pipeline7AdaptiveDrcBranchPortfolioSolver
+    | GlobalDrcBranchPortfolioSolver
   private drcEvaluator?: DrcEvaluator
   private cachedReferenceDrcEvaluator?: DrcEvaluator
   private referenceDrcValidationCount = 0
   private referenceDrcFalseNegativeCount = 0
+  private indexedDrcEvaluationCount = 0
+  private indexedDrcCacheHitCount = 0
+  private indexedDrcEvaluationTimeMs = 0
+  private readonly indexedDrcCandidateCache = new Map<
+    DrcCandidateKey,
+    ReturnType<DrcEvaluator>
+  >()
   private combinedOutput?: HighDensityRoute[]
+
+  private cacheIndexedDrcResult(
+    candidateKey: DrcCandidateKey,
+    result: ReturnType<DrcEvaluator>,
+  ): void {
+    if (
+      this.indexedDrcCandidateCache.size >= INDEXED_DRC_CANDIDATE_CACHE_SIZE
+    ) {
+      const oldestCandidateKey = this.indexedDrcCandidateCache
+        .keys()
+        .next().value
+      if (oldestCandidateKey !== undefined) {
+        this.indexedDrcCandidateCache.delete(oldestCandidateKey)
+      }
+    }
+    this.indexedDrcCandidateCache.set(candidateKey, result)
+  }
 
   constructor(params: Pipeline9JointDrcRepairSolverParams) {
     super()
@@ -983,7 +1013,8 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
           Math.max(
             params.defaultViaDiameter,
             params.originalSrj.minTraceWidth,
-          ) + Math.max(traceClearance, viaClearance),
+          ) +
+          2 * Math.max(traceClearance, viaClearance),
       },
     )
     const autoroutingBaselineDrcResult = autoroutingDrcEngine.evaluate(
@@ -1219,6 +1250,14 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
       if (!evaluatedRoutes) {
         throw new Error("Pipeline9 joint DRC repair requires HD routes")
       }
+      const candidateKey = JSON.stringify(evaluatedRoutes) as DrcCandidateKey
+      const cachedResult = this.indexedDrcCandidateCache.get(candidateKey)
+      if (cachedResult !== undefined) {
+        this.indexedDrcCacheHitCount += 1
+        return cachedResult
+      }
+      const evaluationStartedAtMs = performance.now()
+      this.indexedDrcEvaluationCount += 1
       const candidateDrcInput = prepareCandidateDrcInput(evaluatedRoutes)
       const evaluatedDrc = autoroutingDrcEngine.evaluate(
         candidateDrcInput.evaluatedTraces as RepairSimplifiedPcbTraces,
@@ -1277,9 +1316,12 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
         ) {
           this.referenceDrcFalseNegativeCount += 1
         }
+        this.indexedDrcEvaluationTimeMs +=
+          performance.now() - evaluationStartedAtMs
+        this.cacheIndexedDrcResult(candidateKey, referenceResult)
         return referenceResult
       }
-      return normalizeCandidateDrcResult({
+      const normalizedResult = normalizeCandidateDrcResult({
         errors: evaluatedNewErrors,
         errorsWithCenters: evaluatedNewErrorsWithCenters,
         circuitJson: viaCircuitJson,
@@ -1287,10 +1329,14 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
         solverTraceIdByEvaluationTraceId:
           candidateDrcInput.solverTraceIdByEvaluationTraceId,
       })
+      this.indexedDrcEvaluationTimeMs +=
+        performance.now() - evaluationStartedAtMs
+      this.cacheIndexedDrcResult(candidateKey, normalizedResult)
+      return normalizedResult
     }
     this.drcEvaluator = drcEvaluator
 
-    this.exactRepairSolver = new Pipeline7AdaptiveDrcBranchPortfolioSolver({
+    const exactRepairParams = {
       srj: extendedSrjWithPointPairs as any,
       hdRoutes: [
         ...params.newHdRoutes,
@@ -1314,7 +1360,16 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
       viaInPadMaxIterations: EXACT_REPAIR_MAX_ITERATIONS,
       broadMaxIterations: EXACT_REPAIR_BROAD_MAX_ITERATIONS,
       broadPassMultiplier: 3,
-    })
+    }
+    const shouldAttemptFastProbe =
+      currentDrc.errors.length <=
+      MAX_POST_EXACT_PRECISION_PASS_INDEXED_ISSUE_COUNT
+    this.exactRepairSolver = shouldAttemptFastProbe
+      ? new Pipeline7AdaptiveDrcBranchPortfolioSolver(exactRepairParams)
+      : new GlobalDrcBranchPortfolioSolver(exactRepairParams)
+    if (!shouldAttemptFastProbe) {
+      this.stats.pipeline7AdaptiveExactDrcFastProbeAttempted = false
+    }
     this.activeSubSolver = this.exactRepairSolver
     this.MAX_ITERATIONS = this.exactRepairSolver.MAX_ITERATIONS + 1
   }
@@ -1392,6 +1447,11 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
           terminalEscapeAcceptedCount: 0,
           referenceDrcValidationCount: this.referenceDrcValidationCount,
           referenceDrcFalseNegativeCount: this.referenceDrcFalseNegativeCount,
+          indexedDrcEvaluationCount: this.indexedDrcEvaluationCount,
+          indexedDrcCacheHitCount: this.indexedDrcCacheHitCount,
+          indexedDrcEvaluationTimeMs: this.indexedDrcEvaluationTimeMs,
+          indexedDrcCandidateCacheSize: this.indexedDrcCandidateCache.size,
+          indexedDrcCandidateCacheCapacity: INDEXED_DRC_CANDIDATE_CACHE_SIZE,
         }
         this.solved = true
         return
@@ -1483,6 +1543,11 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
       terminalEscapeAcceptedCount: terminalEscapeResult.acceptedCandidateCount,
       referenceDrcValidationCount: this.referenceDrcValidationCount,
       referenceDrcFalseNegativeCount: this.referenceDrcFalseNegativeCount,
+      indexedDrcEvaluationCount: this.indexedDrcEvaluationCount,
+      indexedDrcCacheHitCount: this.indexedDrcCacheHitCount,
+      indexedDrcEvaluationTimeMs: this.indexedDrcEvaluationTimeMs,
+      indexedDrcCandidateCacheSize: this.indexedDrcCandidateCache.size,
+      indexedDrcCandidateCacheCapacity: INDEXED_DRC_CANDIDATE_CACHE_SIZE,
     }
     this.solved = true
   }

--- a/tests/features/pipeline9-joint-drc-reuses-static-connectivity.test.ts
+++ b/tests/features/pipeline9-joint-drc-reuses-static-connectivity.test.ts
@@ -78,9 +78,10 @@ test("Pipeline9 reuses obstacle connectivity while evaluating changed repair geo
   const initial = evaluate({ traces: [], routes })
   const warmedConnectivityChecks = connectivityChecks
   const candidate = structuredClone(routes)
-  expect(evaluate({ traces: [], routes: candidate })).toEqual(initial)
+  const repeated = evaluate({ traces: [], routes: candidate })
+  expect(repeated).toBe(initial)
 
-  // Reusing static lookup data must not reuse the candidate's copper geometry.
+  // Exact cache hits must not reuse results after copper geometry changes.
   for (const point of candidate[1]!.route) point.x = 0.5
   const changed = evaluate({ traces: [], routes: candidate })
   expect(Array.isArray(initial)).toBeFalse()

--- a/tests/features/pipeline9-joint-drc-skips-high-residue-probe.test.ts
+++ b/tests/features/pipeline9-joint-drc-skips-high-residue-probe.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "bun:test"
+import { GlobalDrcBranchPortfolioSolver } from "high-density-repair03/lib"
+import { Pipeline9JointDrcRepairSolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver"
+import type { SimpleRouteConnection, SimpleRouteJson } from "lib/types"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
+
+test("Pipeline9 skips the fast probe for a high initial DRC residue", () => {
+  const connections: SimpleRouteConnection[] = []
+  const routes: HighDensityRoute[] = []
+  for (let routeIndex = 0; routeIndex < 7; routeIndex++) {
+    const connectionName = `route_${routeIndex}`
+    const angleRadians = (routeIndex * Math.PI) / 7
+    const x = Math.cos(angleRadians)
+    const y = Math.sin(angleRadians)
+    connections.push({
+      name: connectionName,
+      pointsToConnect: [
+        {
+          x: -x,
+          y: -y,
+          layer: "top",
+          pointId: `${connectionName}_start`,
+        },
+        {
+          x,
+          y,
+          layer: "top",
+          pointId: `${connectionName}_end`,
+        },
+      ],
+    })
+    routes.push({
+      connectionName,
+      traceThickness: 0.1,
+      viaDiameter: 0.3,
+      route: [
+        { x: -x, y: -y, z: 0 },
+        { x, y, z: 0 },
+      ],
+      vias: [],
+    })
+  }
+  const srj: SimpleRouteJson = {
+    layerCount: 2,
+    minTraceWidth: 0.1,
+    bounds: { minX: -2, minY: -2, maxX: 2, maxY: 2 },
+    connections,
+    obstacles: [],
+  }
+  const solver = new Pipeline9JointDrcRepairSolver({
+    srj,
+    srjWithPointPairs: srj,
+    originalSrj: srj,
+    newConnections: connections,
+    newHdRoutes: routes,
+    updatedPreloadedTraces: [],
+    mutatedPreloadedTraceIds: new Set(),
+    connMap: getConnectivityMapFromSimpleRouteJson(srj),
+    obstacles: [],
+    layerCount: 2,
+    defaultViaDiameter: 0.3,
+    defaultViaHoleDiameter: 0.15,
+    effort: 1,
+    colorMap: {},
+  })
+
+  expect(Number(solver.stats.initialJointDrcIssueCount)).toBeGreaterThan(16)
+  expect(solver.exactRepairSolver).toBeInstanceOf(
+    GlobalDrcBranchPortfolioSolver,
+  )
+  expect(solver.stats.pipeline7AdaptiveExactDrcFastProbeAttempted).toBeFalse()
+})

--- a/tests/features/pipeline9-joint-drc-skips-high-residue-probe.test.ts
+++ b/tests/features/pipeline9-joint-drc-skips-high-residue-probe.test.ts
@@ -1,5 +1,4 @@
 import { expect, test } from "bun:test"
-import { GlobalDrcBranchPortfolioSolver } from "high-density-repair03/lib"
 import { Pipeline9JointDrcRepairSolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver"
 import type { SimpleRouteConnection, SimpleRouteJson } from "lib/types"
 import type { HighDensityRoute } from "lib/types/high-density-types"
@@ -66,8 +65,5 @@ test("Pipeline9 skips the fast probe for a high initial DRC residue", () => {
   })
 
   expect(Number(solver.stats.initialJointDrcIssueCount)).toBeGreaterThan(16)
-  expect(solver.exactRepairSolver).toBeInstanceOf(
-    GlobalDrcBranchPortfolioSolver,
-  )
-  expect(solver.stats.pipeline7AdaptiveExactDrcFastProbeAttempted).toBeFalse()
+  expect(solver.stats.exactRepairFastProbeAttempted).toBeFalse()
 })


### PR DESCRIPTION
## Summary

- reuse exact candidate DRC evaluations through a bounded 64-entry cache
- start the full repair portfolio directly for high-residue candidates
- size spatial-index cells to cover clearance on both sides of routed copper
- add focused coverage for cache reuse and high-residue solver selection

## Safety

- exact geometry is part of every cache key
- DRC acceptance rules and repair iteration limits are unchanged
- cache memory is explicitly bounded

## Validation

- repository formatter completed successfully
- performance benchmark will be reported separately

