### PR TITLE
Add bugreport103 pedometer reproduction

### DIFF
--- a/fixtures/bug-reports/bugreport103-pedometer/bugreport103-pedometer.fixture.tsx
+++ b/fixtures/bug-reports/bugreport103-pedometer/bugreport103-pedometer.fixture.tsx
@@ -1,0 +1,25 @@
+import { AutoroutingPipelineDebugger } from "lib/testing/AutoroutingPipelineDebugger"
+import type { SimpleRouteJson } from "lib/types"
+import { useEffect, useState } from "react"
+
+const srjUrl = `${import.meta.env.BASE_URL}fixtures/bugreport103-pedometer.srj.json`
+
+export default () => {
+  const [srj, setSrj] = useState<SimpleRouteJson | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetch(srjUrl)
+      .then((response) => {
+        if (!response.ok) throw new Error(`HTTP ${response.status}`)
+        return response.json()
+      })
+      .then((inputSrj: SimpleRouteJson) => setSrj(inputSrj))
+      .catch((loadError: unknown) => setError(String(loadError)))
+  }, [])
+
+  if (error) return <div>Failed to load pedometer fixture: {error}</div>
+  if (!srj) return <div>Loading pedometer fixture...</div>
+
+  return <AutoroutingPipelineDebugger srj={srj} />
+}


### PR DESCRIPTION
## Summary

- add the pedometer Simple Route JSON as `bugreport103-pedometer`
- load the large reproduction from `public/fixtures` in the autorouting debugger

## Validation

- verified the JSON parses and has the expected autorouter shape
- confirmed the committed reproduction matches the supplied board byte-for-byte
- tests not run, per request (fixture-only change)

<img width="1499" height="1023" alt="Screenshot 2026-09-04 at 5 30 34 PM" src="https://github.com/user-attachments/assets/1d8b5e39-b40f-4a0f-aa19-7643d0555213" />
