### PR TITLE
perf: skip Pipeline 9 fast probe for high DRC residue

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver.ts
@@ -4,6 +4,8 @@ import type { GraphicsObject } from "graphics-debug"
 import {
   AutoroutingDrcEngine,
   type DrcEvaluator,
+  GlobalDrcBranchPortfolioSolver,
+  type GlobalDrcBranchPortfolioSolverParams,
   type SimpleRouteJson as RepairSimpleRouteJson,
   type SimplifiedPcbTraces as RepairSimplifiedPcbTraces,
 } from "high-density-repair03/lib"
@@ -50,9 +52,15 @@ const EXACT_REPAIR_BROAD_MAX_ITERATIONS = 12
 // residual sets. Keep that exhaustive search for compact residues while
 // bounding terminal relocation's repeated whole-board indexed DRC scans.
 const MAX_POST_EXACT_PRECISION_PASS_INDEXED_ISSUE_COUNT = 16
+const MAX_INITIAL_DRC_ISSUE_COUNT_FOR_FAST_PROBE = 16
 const INDEXED_DRC_CANDIDATE_CACHE_SIZE = 64
 
 type DrcCandidateKey = string & { readonly __brand: "DrcCandidateKey" }
+
+type Pipeline9ExactRepairSolver = BaseSolver & {
+  readonly params: GlobalDrcBranchPortfolioSolverParams
+  getOutput(): HighDensityRoute[]
+}
 
 type Pipeline9JointDrcRepairSolverParams = {
   srj: SimpleRouteJson
@@ -647,7 +655,7 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
   readonly movablePreloadedSections: MovablePreloadedSection[]
   readonly fixedPreloadedObstacleRoutes: PreloadedHighDensityRoute[]
   readonly syntheticConnectionNames: ReadonlySet<string>
-  readonly exactRepairSolver?: Pipeline7AdaptiveDrcBranchPortfolioSolver
+  readonly exactRepairSolver?: Pipeline9ExactRepairSolver
   private drcEvaluator?: DrcEvaluator
   private cachedReferenceDrcEvaluator?: DrcEvaluator
   private referenceDrcValidationCount = 0
@@ -1332,8 +1340,8 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
     }
     this.drcEvaluator = drcEvaluator
 
-    this.exactRepairSolver = new Pipeline7AdaptiveDrcBranchPortfolioSolver({
-      srj: extendedSrjWithPointPairs as any,
+    const exactRepairParams: GlobalDrcBranchPortfolioSolverParams = {
+      srj: extendedSrjWithPointPairs as RepairSimpleRouteJson,
       hdRoutes: [
         ...params.newHdRoutes,
         ...this.movablePreloadedSections.map(
@@ -1356,7 +1364,15 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
       viaInPadMaxIterations: EXACT_REPAIR_MAX_ITERATIONS,
       broadMaxIterations: EXACT_REPAIR_BROAD_MAX_ITERATIONS,
       broadPassMultiplier: 3,
-    })
+    }
+    const shouldAttemptFastProbe =
+      currentDrc.errors.length <= MAX_INITIAL_DRC_ISSUE_COUNT_FOR_FAST_PROBE
+    this.exactRepairSolver = shouldAttemptFastProbe
+      ? new Pipeline7AdaptiveDrcBranchPortfolioSolver(exactRepairParams)
+      : new GlobalDrcBranchPortfolioSolver(exactRepairParams)
+    this.stats.exactRepairFastProbeAttempted = shouldAttemptFastProbe
+    this.stats.exactRepairFastProbeMaxInitialDrcIssueCount =
+      MAX_INITIAL_DRC_ISSUE_COUNT_FOR_FAST_PROBE
     this.activeSubSolver = this.exactRepairSolver
     this.MAX_ITERATIONS = this.exactRepairSolver.MAX_ITERATIONS + 1
   }

--- a/tests/features/pipeline9-joint-drc-skips-high-residue-probe.test.ts
+++ b/tests/features/pipeline9-joint-drc-skips-high-residue-probe.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "bun:test"
+import { Pipeline9JointDrcRepairSolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver"
+import type { SimpleRouteConnection, SimpleRouteJson } from "lib/types"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
+
+test("Pipeline9 skips the fast probe for a high initial DRC residue", () => {
+  const connections: SimpleRouteConnection[] = []
+  const routes: HighDensityRoute[] = []
+  for (let routeIndex = 0; routeIndex < 7; routeIndex++) {
+    const connectionName = `route_${routeIndex}`
+    const angleRadians = (routeIndex * Math.PI) / 7
+    const x = Math.cos(angleRadians)
+    const y = Math.sin(angleRadians)
+    connections.push({
+      name: connectionName,
+      pointsToConnect: [
+        {
+          x: -x,
+          y: -y,
+          layer: "top",
+          pointId: `${connectionName}_start`,
+        },
+        {
+          x,
+          y,
+          layer: "top",
+          pointId: `${connectionName}_end`,
+        },
+      ],
+    })
+    routes.push({
+      connectionName,
+      traceThickness: 0.1,
+      viaDiameter: 0.3,
+      route: [
+        { x: -x, y: -y, z: 0 },
+        { x, y, z: 0 },
+      ],
+      vias: [],
+    })
+  }
+  const srj: SimpleRouteJson = {
+    layerCount: 2,
+    minTraceWidth: 0.1,
+    bounds: { minX: -2, minY: -2, maxX: 2, maxY: 2 },
+    connections,
+    obstacles: [],
+  }
+  const solver = new Pipeline9JointDrcRepairSolver({
+    srj,
+    srjWithPointPairs: srj,
+    originalSrj: srj,
+    newConnections: connections,
+    newHdRoutes: routes,
+    updatedPreloadedTraces: [],
+    mutatedPreloadedTraceIds: new Set(),
+    connMap: getConnectivityMapFromSimpleRouteJson(srj),
+    obstacles: [],
+    layerCount: 2,
+    defaultViaDiameter: 0.3,
+    defaultViaHoleDiameter: 0.15,
+    effort: 1,
+    colorMap: {},
+  })
+
+  expect(Number(solver.stats.initialJointDrcIssueCount)).toBeGreaterThan(
+    Number(solver.stats.exactRepairFastProbeMaxInitialDrcIssueCount),
+  )
+  expect(solver.stats.exactRepairFastProbeAttempted).toBeFalse()
+})


### PR DESCRIPTION
## Summary

- skip the short exact-repair probe when the initial joint DRC residue exceeds 16 issues
- start the existing full repair portfolio directly for high-residue cases
- preserve the existing low-residue path and DRC evaluation rules
- add focused coverage for the high-residue selection policy

## Validation

- targeted Biome formatting only