### PR TITLE
Add RP2040 motor controller Pipeline11 bug report fixture

### DIFF
--- a/fixtures/bug-reports/bugreport105-rp2040-motor-controller-pipeline11-simplification/bugreport105-rp2040-motor-controller-pipeline11-simplification.fixture.tsx
+++ b/fixtures/bug-reports/bugreport105-rp2040-motor-controller-pipeline11-simplification/bugreport105-rp2040-motor-controller-pipeline11-simplification.fixture.tsx
@@ -1,0 +1,19 @@
+import { AutoroutingPipelineSolver11_Simplification } from "lib"
+import { AutoroutingPipelineDebugger } from "lib/testing/AutoroutingPipelineDebugger"
+import type { SimpleRouteJson } from "lib/types"
+import rp2040MotorControllerSrj from "../../real-boards/rp2040-motor-controller-board.srj.json" with {
+  type: "json",
+}
+
+// Captured from https://tscircuit.com/imrishabh18/rp2040-motor-controller
+// at tscircuit/rp2040-motor-controller commit b4560e5.
+const inputSrj = rp2040MotorControllerSrj as SimpleRouteJson
+
+export default () => (
+  <AutoroutingPipelineDebugger
+    srj={inputSrj}
+    createSolver={(srj) =>
+      new AutoroutingPipelineSolver11_Simplification(srj)
+    }
+  />
+)

--- a/fixtures/bug-reports/bugreport105-rp2040-motor-controller-pipeline11-simplification/bugreport105-rp2040-motor-controller-pipeline11-simplification.fixture.tsx
+++ b/fixtures/bug-reports/bugreport105-rp2040-motor-controller-pipeline11-simplification/bugreport105-rp2040-motor-controller-pipeline11-simplification.fixture.tsx
@@ -12,8 +12,6 @@ const inputSrj = rp2040MotorControllerSrj as SimpleRouteJson
 export default () => (
   <AutoroutingPipelineDebugger
     srj={inputSrj}
-    createSolver={(srj) =>
-      new AutoroutingPipelineSolver11_Simplification(srj)
-    }
+    createSolver={(srj) => new AutoroutingPipelineSolver11_Simplification(srj)}
   />
 )


### PR DESCRIPTION
Adds bugreport105 for the RP2040 motor controller using the existing SRJ capture from https://tscircuit.com/imrishabh18/rp2040-motor-controller (source commit `b4560e5`). The fixture explicitly creates Pipeline11's simplification solver in the autorouting debugger.

Validated with `bunx tsc --noEmit`, `bun run build`, fixture module loading, and the existing RP2040 Pipeline11 visual regression test (185 assertions). The solver preserves all 148 traces and reduces 150 vias to 73.
