### PR TITLE
perf: avoid unused repair02 sample setup and distant-pad lookups

### DIFF
--- a/lib/solvers/HighDensityRepairSolver/Pipeline4HighDensityRepairSolver.ts
+++ b/lib/solvers/HighDensityRepairSolver/Pipeline4HighDensityRepairSolver.ts
@@ -249,8 +249,13 @@ export class Pipeline4HighDensityRepairSolver extends BaseSolver {
       routeIndexesByNode.set(nodeIndex, routeIndexes)
     }
 
+    // Do not construct pad/obstacle inputs for samples the limit will discard.
+    const skipSamples =
+      params.maxSampleEntries !== undefined &&
+      routeIndexesByNode.size > params.maxSampleEntries
+    const nodesToRepair = skipSamples ? [] : routeIndexesByNode.entries()
     const layeredObstacles = createObjectsWithZLayers(
-      params.obstacles,
+      skipSamples ? [] : params.obstacles,
       Math.max(
         2,
         ...params.nodeWithPortPoints.flatMap(
@@ -258,7 +263,7 @@ export class Pipeline4HighDensityRepairSolver extends BaseSolver {
         ),
       ),
     )
-    const sampleEntries = Array.from(routeIndexesByNode.entries()).map(
+    const sampleEntries = Array.from(nodesToRepair).map(
       ([nodeIndex, routeIndexes]) => {
         const node = params.nodeWithPortPoints[nodeIndex]
         return {
@@ -304,19 +309,12 @@ export class Pipeline4HighDensityRepairSolver extends BaseSolver {
         }
       },
     )
-    this.sampleEntries =
-      params.maxSampleEntries !== undefined &&
-      sampleEntries.length > params.maxSampleEntries
-        ? []
-        : sampleEntries
+    this.sampleEntries = sampleEntries
 
     this.MAX_ITERATIONS = Math.max(this.sampleEntries.length * 1_000, 100_000)
     this.stats = {
       sampleCount: this.sampleEntries.length,
-      skippedSampleCount:
-        sampleEntries.length > this.sampleEntries.length
-          ? sampleEntries.length
-          : 0,
+      skippedSampleCount: skipSamples ? routeIndexesByNode.size : 0,
       repairedNodeCount: 0,
       repairedRouteCount: 0,
     }

--- a/lib/solvers/HighDensityRepairSolver/getConnectedPadSides.ts
+++ b/lib/solvers/HighDensityRepairSolver/getConnectedPadSides.ts
@@ -22,11 +22,11 @@ export const getConnectedPadSides = (
     const entersConnectedPad = obstacles.some(
       (obstacle) =>
         obstacle.__zLayers.includes(point.z) &&
-        isObstacleConnectedToRoute(obstacle, route, connMap) &&
         Math.abs(point.x - obstacle.center.x) <=
           obstacle.width / 2 + tolerance &&
         Math.abs(point.y - obstacle.center.y) <=
-          obstacle.height / 2 + tolerance,
+          obstacle.height / 2 + tolerance &&
+        isObstacleConnectedToRoute(obstacle, route, connMap),
     )
     if (!entersConnectedPad) continue
     if (Math.abs(point.x - (node.center.x - node.width / 2)) <= tolerance) {

--- a/tests/solvers/repair02-connected-pad-sides.test.ts
+++ b/tests/solvers/repair02-connected-pad-sides.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test"
+import { expect, spyOn, test } from "bun:test"
 import { ConnectivityMap } from "circuit-json-to-connectivity-map"
 import { getConnectedPadSides } from "lib/solvers/HighDensityRepairSolver/getConnectedPadSides"
 import type {
@@ -49,6 +49,7 @@ test("repair02 pad sides require a same-layer connected terminal on the boundary
   expect(
     getConnectedPadSides(node, route, [{ ...pad, __zLayers: [1] }], connMap),
   ).toEqual([])
+  const connectivityCheck = spyOn(connMap, "areIdsConnected")
   expect(
     getConnectedPadSides(
       node,
@@ -57,6 +58,8 @@ test("repair02 pad sides require a same-layer connected terminal on the boundary
       connMap,
     ),
   ).toEqual([])
+  expect(connectivityCheck).not.toHaveBeenCalled()
+  connectivityCheck.mockRestore()
   expect(
     getConnectedPadSides({ ...node, height: 6 }, route, [pad], connMap),
   ).toEqual([])

--- a/tests/solvers/repair02-skipped-sample-construction.test.ts
+++ b/tests/solvers/repair02-skipped-sample-construction.test.ts
@@ -1,0 +1,70 @@
+import { expect, spyOn, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { Pipeline4HighDensityRepairSolver } from "lib/solvers/HighDensityRepairSolver/Pipeline4HighDensityRepairSolver"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+import type { Obstacle } from "lib/types/srj-types"
+
+test("repair02 does not construct samples that exceed its existing limit", () => {
+  const nodes = [0, 4].map((x, index) => ({
+    capacityMeshNodeId: `cell${index}`,
+    center: { x, y: 0 },
+    width: 2,
+    height: 2,
+    availableZ: [0],
+    portPoints: [],
+  }))
+  const routes: HighDensityRoute[] = nodes.map((node) => ({
+    regionId: node.capacityMeshNodeId,
+    connectionName: "route",
+    traceThickness: 0.1,
+    viaDiameter: 0.3,
+    vias: [],
+    route: [
+      { x: node.center.x - 1, y: 0, z: 0 },
+      { x: node.center.x + 1, y: 0, z: 0 },
+    ],
+  }))
+  const obstacles: Obstacle[] = nodes.map((node) => ({
+    type: "rect",
+    center: { x: node.center.x - 1, y: 0 },
+    width: 0.5,
+    height: 0.5,
+    layers: ["top"],
+    connectedTo: ["pad"],
+  }))
+  const connMap = new ConnectivityMap({ net: ["route", "pad"] })
+  const connectivityCheck = spyOn(connMap, "areIdsConnected")
+  const params = {
+    nodeWithPortPoints: nodes,
+    hdRoutes: routes,
+    obstacles,
+    connMap,
+  }
+
+  for (const maxSampleEntries of [0, 1]) {
+    const solver = new Pipeline4HighDensityRepairSolver({
+      ...params,
+      maxSampleEntries,
+    })
+    expect(solver.sampleEntries).toEqual([])
+    expect(solver.stats.skippedSampleCount).toBe(2)
+    solver.solve()
+    expect(solver.solved).toBe(true)
+    expect(solver.getOutput()).toEqual(routes)
+    expect(connectivityCheck).not.toHaveBeenCalled()
+  }
+
+  for (const maxSampleEntries of [2, undefined]) {
+    const solver = new Pipeline4HighDensityRepairSolver({
+      ...params,
+      maxSampleEntries,
+    })
+    expect(solver.sampleEntries).toHaveLength(2)
+    expect(solver.stats.skippedSampleCount).toBe(0)
+    for (const entry of solver.sampleEntries) {
+      const [route] = entry.sample.nodeHdRoutes!
+      expect(route!.connectedPadSides).toEqual(["left"])
+    }
+  }
+  connectivityCheck.mockRestore()
+})


### PR DESCRIPTION
## Summary

Recover repair02 setup time after the connected-pad fix in #2399, without changing routing behavior.

- Check Pipeline9's existing sample limit before constructing repair inputs. SRJ18 sample 12 was constructing 1,477 samples before discarding all of them under its 80-sample limit.
- For active samples, check pad geometry before querying `connMap`.
- Add work-count regressions for skipped samples and spatial rejection, plus exact-limit/unlimited pad-metadata coverage.

No repair budget, margin, dependency, or snapshot changes.

## Measurements

Local SRJ18 sample-12 profiling against the merged pad fix:

| Measurement | Before | After |
| --- | ---: | ---: |
| Captured-input repair constructor, limit 80 | 13.13s | 1.13s |
| Captured-input repair constructor, unlimited | 13.15s | 1.20s |
| Full solve | 98.36s | 89.31s |

Generated repair inputs have identical SHA-256 hashes before/after in both constructor replays. The full routed output is byte-for-byte identical with zero relaxed-DRC errors in both runs. These are local measurements; same-machine dataset01/SRJ18 benchmarks will validate the full-dataset impact.

The existing per-stage benchmark timer starts after construction, which explains why the slow repair setup was missing from its stage breakdown.

## Validation

- 15 focused tests pass, including the connected-pad approach, sample limit, Game Boy, NRF, regional identity, and representative SRJ23 snapshots, without updating snapshots.
- Build and typecheck pass.
