### PR TITLE
Integrate SRJ33 DRC failure dataset into benchmark tools

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -31,7 +31,7 @@ on:
         default: false
         type: boolean
       dataset_name:
-        description: "Dataset to benchmark (optional: dataset01, zdwiel, srj05, srj11, srj12, srj13, srj14, srj15, srj16, srj18, srj19, srj20, srj21, srj23, srj24, srj27, srj28, or srj29)"
+        description: "Dataset to benchmark (optional: dataset01, zdwiel, srj05, srj11, srj12, srj13, srj14, srj15, srj16, srj18, srj19, srj20, srj21, srj23, srj24, srj27, srj28, srj29, or srj33)"
         required: false
         type: string
       profile_solvers:

--- a/README.md
+++ b/README.md
@@ -203,3 +203,19 @@ bun run build
 ## Maintainer resources
 
 Track routing performance and benchmark results in the [Autorouter Benchmark Dashboard](https://autorouter-benchmark-dashboard.vercel.app/).
+
+### DRC failure dataset (SRJ33)
+
+[dataset-srj33-drc-failures](https://github.com/tscircuit/dataset-srj33-drc-failures)
+contains 31 bug-report inputs (28 distinct SRJs) that completed Pipeline 7 routing
+but failed the dataset's pinned relaxed DRC checks. The integration loads the
+original inputs so current solvers can be compared against that baseline.
+
+```sh
+bun scripts/run-sample.ts --pipeline 7 --dataset srj33 --sample 1
+```
+
+Use `srj33` in the benchmark workflow's dataset input, or open
+`benchmarks/dataset-srj33` in the Cosmos playground to browse samples 001–031.
+The dataset repository records source issues, duplicate inputs, routed baseline
+outputs, and DRC evidence.

--- a/fixtures/benchmarks/dataset-srj33.fixture.tsx
+++ b/fixtures/benchmarks/dataset-srj33.fixture.tsx
@@ -1,0 +1,27 @@
+import * as datasetSrj33 from "@tscircuit/dataset-srj33-drc-failures"
+import {
+  DatasetBenchmarkFixture,
+  type DatasetCircuit,
+} from "./DatasetBenchmarkFixture"
+
+const circuitKeyPattern = /^sample(\d{3})$/
+
+const circuits = Object.entries(datasetSrj33)
+  .map(([key, srj]) => {
+    const circuitMatch = key.match(circuitKeyPattern)
+    if (!circuitMatch) return null
+
+    return {
+      id: circuitMatch[1],
+      srj: srj as DatasetCircuit["srj"],
+    }
+  })
+  .filter((circuit): circuit is DatasetCircuit => circuit !== null)
+  .sort((a, b) => Number(a.id) - Number(b.id))
+
+export default () => (
+  <DatasetBenchmarkFixture
+    datasetLabel="dataset-srj33-drc-failures"
+    circuits={circuits}
+  />
+)

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@tscircuit/dataset-srj27-power-traces": "git+https://github.com/tscircuit/dataset-srj27-power-traces.git#eb24d36",
     "@tscircuit/dataset-srj28-partially-prerouted": "git+https://github.com/tscircuit/dataset-srj28-partially-prerouted.git#5b1673544b6ade4480612539ba6574ad414fddc0",
     "@tscircuit/dataset-srj29-ddr3-bga-pairs": "git+https://github.com/ShiboSoftwareDev/dataset-srj29-ddr3-bga-pairs.git#585c3abd4c6ce4be52bbc430b1d5e6dcc9b4ea30",
+    "@tscircuit/dataset-srj33-drc-failures": "git+https://github.com/tscircuit/dataset-srj33-drc-failures.git#c55b028f537c91c8f99f06ae10db26cc2d2aaac6",
     "@tscircuit/fanout-solver": "^0.0.29",
     "@tscircuit/fixed-via-hypergraph-solver": "https://codeload.github.com/tscircuit/fixed-via-hypergraph-solver/tar.gz/bed37a6201b5dd07c9cc68b828917ecc20d6d049",
     "@tscircuit/hypergraph": "^0.0.71",

--- a/scripts/benchmark/scenarios.ts
+++ b/scripts/benchmark/scenarios.ts
@@ -20,6 +20,7 @@ export const DATASET_NAMES = [
   "srj27",
   "srj28",
   "srj29",
+  "srj33",
 ] as const
 
 export type DatasetName = (typeof DATASET_NAMES)[number]
@@ -27,7 +28,7 @@ export type DatasetName = (typeof DATASET_NAMES)[number]
 type DatasetModule = Record<string, unknown>
 
 export const DATASET_OPTIONS_LABEL =
-  "1/dataset01, zdwiel, 5/srj05, 11/srj11, 12/srj12, 13/srj13, 14/srj14, 15/srj15, 16/srj16, 18/srj18, 19/srj19, 20/srj20, 21/srj21, 23/srj23, 24/srj24, 27/srj27, 28/srj28, 29/srj29"
+  "1/dataset01, zdwiel, 5/srj05, 11/srj11, 12/srj12, 13/srj13, 14/srj14, 15/srj15, 16/srj16, 18/srj18, 19/srj19, 20/srj20, 21/srj21, 23/srj23, 24/srj24, 27/srj27, 28/srj28, 29/srj29, 33/srj33"
 
 const datasetAliases: Record<string, DatasetName> = {
   "1": "dataset01",
@@ -115,6 +116,11 @@ const datasetAliases: Record<string, DatasetName> = {
   srj29: "srj29",
   "dataset-srj29-ddr3-bga-pairs": "srj29",
   "@tscircuit/dataset-srj29-ddr3-bga-pairs": "srj29",
+  "33": "srj33",
+  dataset33: "srj33",
+  srj33: "srj33",
+  "dataset-srj33-drc-failures": "srj33",
+  "@tscircuit/dataset-srj33-drc-failures": "srj33",
   zdwiel: "zdwiel",
 }
 
@@ -260,6 +266,8 @@ const datasetLoaders: Record<DatasetName, () => Promise<DatasetModule>> = {
       ? (dataset as DatasetModule)
       : module
   },
+  srj33: async () =>
+    (await import("@tscircuit/dataset-srj33-drc-failures")) as DatasetModule,
 }
 
 const datasetScenarioKeyPatterns: Record<DatasetName, RegExp> = {
@@ -281,6 +289,7 @@ const datasetScenarioKeyPatterns: Record<DatasetName, RegExp> = {
   srj27: /^sample\d{3}$/,
   srj28: /^circuit\d{3}$/,
   srj29: /^sample\d{3}$/,
+  srj33: /^sample\d{3}$/,
 }
 
 export const toSimpleRouteJson = (value: unknown): SimpleRouteJson | null => {

--- a/tests/benchmark-dataset-aliases.test.ts
+++ b/tests/benchmark-dataset-aliases.test.ts
@@ -37,4 +37,13 @@ test("benchmark dataset aliases resolve to canonical dataset names", () => {
   expect(parseDatasetName("29")).toBe("srj29")
   expect(parseDatasetName("dataset29")).toBe("srj29")
   expect(parseDatasetName("dataset-srj29-ddr3-bga-pairs")).toBe("srj29")
+  for (const alias of [
+    "33",
+    "srj33",
+    "dataset33",
+    "dataset-srj33-drc-failures",
+    "@tscircuit/dataset-srj33-drc-failures",
+  ]) {
+    expect(parseDatasetName(alias)).toBe("srj33")
+  }
 })

--- a/tests/benchmark-dataset-srj33.test.ts
+++ b/tests/benchmark-dataset-srj33.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test"
+import { sample001 } from "@tscircuit/dataset-srj33-drc-failures"
+import {
+  loadScenarioBySampleNumber,
+  loadScenarios,
+} from "../scripts/benchmark/scenarios"
+
+test("SRJ33 exposes all 31 original routing inputs in report order", async () => {
+  const scenarios = await loadScenarios("srj33")
+  expect(scenarios.map(([name]) => name)).toEqual(
+    Array.from({ length: 31 }, (_, i) => `sample${String(i + 1).padStart(3, "0")}`),
+  )
+  for (const [, srj] of scenarios) {
+    expect(srj.connections.length).toBeGreaterThan(0)
+    expect(srj.obstacles.length).toBeGreaterThan(0)
+  }
+  expect(scenarios[0][1].bounds).toEqual(sample001.bounds)
+  expect<unknown>(scenarios[0][1].connections).toEqual(sample001.connections)
+  expect<unknown>(scenarios[0][1].traces).toEqual(sample001.traces)
+
+  const last = await loadScenarioBySampleNumber("srj33", 31, 0.5)
+  expect(last.scenarioName).toBe("sample031")
+  expect(last.totalSamples).toBe(31)
+  expect(last.sourceLabel).toBe("srj33#31:sample031")
+  expect(last.scenario).toHaveProperty("effort", 0.5)
+  expect(await loadScenarios("srj33", { scenarioLimit: 2 })).toHaveLength(2)
+  await expect(loadScenarioBySampleNumber("srj33", 32)).rejects.toThrow(
+    "Sample 32 is out of range for dataset srj33 (31 samples)",
+  )
+})

--- a/tests/benchmark-dataset-srj33.test.ts
+++ b/tests/benchmark-dataset-srj33.test.ts
@@ -8,7 +8,10 @@ import {
 test("SRJ33 exposes all 31 original routing inputs in report order", async () => {
   const scenarios = await loadScenarios("srj33")
   expect(scenarios.map(([name]) => name)).toEqual(
-    Array.from({ length: 31 }, (_, i) => `sample${String(i + 1).padStart(3, "0")}`),
+    Array.from(
+      { length: 31 },
+      (_, i) => `sample${String(i + 1).padStart(3, "0")}`,
+    ),
   )
   for (const [, srj] of scenarios) {
     expect(srj.connections.length).toBeGreaterThan(0)


### PR DESCRIPTION
Add `--dataset srj33` to the benchmark and run-sample loaders, and a Cosmos benchmark fixture for all 31 original bug-report inputs from [dataset-srj33-drc-failures](https://github.com/tscircuit/dataset-srj33-drc-failures). The GitHub dependency is pinned to `c55b028f537c91c8f99f06ae10db26cc2d2aaac6`.

The corpus contains 28 distinct SRJs across 31 reports. It was selected for completed Pipeline 7 routing with relaxed DRC failures; the integration loads original inputs rather than stored routed outputs. Adds numeric/package aliases, workflow help, usage documentation, and coverage for ordering, sample limits, effort overrides, and out-of-range selection.

Validation:
- Three focused dataset tests passed (183 assertions).
- `bunx tsc --noEmit` passed.
- `bun scripts/run-sample.ts --pipeline 7 --dataset srj33 --sample 1 --out-dir ../srj33-cli-smoke` completed routing and reproduced the expected three DRC errors.
