### PR TITLE
Filter and expand SRJ33 to 37 Pipeline 9 DRC failure inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,15 +207,17 @@ Track routing performance and benchmark results in the [Autorouter Benchmark Das
 ### DRC failure dataset (SRJ33)
 
 [dataset-srj33-drc-failures](https://github.com/tscircuit/dataset-srj33-drc-failures)
-contains 31 bug-report inputs (28 distinct SRJs) that completed Pipeline 7 routing
-but failed the dataset's pinned relaxed DRC checks. The integration loads the
-original inputs so current solvers can be compared against that baseline.
+contains 12 distinct inputs with at least one relaxed DRC issue in the
+[Pipeline 9 benchmark](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/33978041068).
+The 19 passing samples have been removed. Original IDs are preserved:
+001–006, 010–013, 020, and 025.
 
 ```sh
-bun scripts/run-sample.ts --pipeline 7 --dataset srj33 --sample 1
+bun scripts/run-sample.ts --pipeline 9 --dataset srj33 --sample 1
 ```
 
 Use `srj33` in the benchmark workflow's dataset input, or open
-`benchmarks/dataset-srj33` in the Cosmos playground to browse samples 001–031.
-The dataset repository records source issues, duplicate inputs, routed baseline
-outputs, and DRC evidence.
+`benchmarks/dataset-srj33` in Cosmos. CLI `--sample` selects by position in the
+filtered list: `--sample 12` loads `sample025`. Cosmos uses the original IDs.
+The dataset records source issues and Pipeline 9 filtering evidence; its saved
+routed outputs remain the historical Pipeline 7 baseline.

--- a/README.md
+++ b/README.md
@@ -207,17 +207,22 @@ Track routing performance and benchmark results in the [Autorouter Benchmark Das
 ### DRC failure dataset (SRJ33)
 
 [dataset-srj33-drc-failures](https://github.com/tscircuit/dataset-srj33-drc-failures)
-contains 12 distinct inputs with at least one relaxed DRC issue in the
-[Pipeline 9 benchmark](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/33978041068).
-The 19 passing samples have been removed. Original IDs are preserved:
-001–006, 010–013, 020, and 025.
+contains 37 distinct inputs with at least one measured Pipeline 9 relaxed DRC
+issue. The [original benchmark](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/33978041068)
+retained 12 samples and excluded 19 DRC passes. An
+[additional audit](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/33980539076)
+added 25 bug-report inputs that completed routing with DRC issues after the
+recent DRC fix. Original IDs remain 001–006, 010–013, 020, and 025; additions use
+032–056.
 
 ```sh
 bun scripts/run-sample.ts --pipeline 9 --dataset srj33 --sample 1
 ```
 
 Use `srj33` in the benchmark workflow's dataset input, or open
-`benchmarks/dataset-srj33` in Cosmos. CLI `--sample` selects by position in the
-filtered list: `--sample 12` loads `sample025`. Cosmos uses the original IDs.
-The dataset records source issues and Pipeline 9 filtering evidence; its saved
-routed outputs remain the historical Pipeline 7 baseline.
+`benchmarks/dataset-srj33` in Cosmos. CLI `--sample` selects by position:
+`--sample 12` loads `sample025`, and `--sample 37` loads `sample056`.
+Cosmos uses the sample IDs. The dataset records source links, pinned revisions,
+and Pipeline 9 selection evidence. Saved outputs for the original 12 are their
+historical Pipeline 7 baseline; additions include Pipeline 9 outputs and exact
+DRC errors.

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@tscircuit/dataset-srj27-power-traces": "git+https://github.com/tscircuit/dataset-srj27-power-traces.git#eb24d36",
     "@tscircuit/dataset-srj28-partially-prerouted": "git+https://github.com/tscircuit/dataset-srj28-partially-prerouted.git#5b1673544b6ade4480612539ba6574ad414fddc0",
     "@tscircuit/dataset-srj29-ddr3-bga-pairs": "git+https://github.com/ShiboSoftwareDev/dataset-srj29-ddr3-bga-pairs.git#585c3abd4c6ce4be52bbc430b1d5e6dcc9b4ea30",
-    "@tscircuit/dataset-srj33-drc-failures": "git+https://github.com/tscircuit/dataset-srj33-drc-failures.git#c55b028f537c91c8f99f06ae10db26cc2d2aaac6",
+    "@tscircuit/dataset-srj33-drc-failures": "git+https://github.com/tscircuit/dataset-srj33-drc-failures.git#130e693aee9d2a92cfc826e243051b9ac994783b",
     "@tscircuit/fanout-solver": "^0.0.29",
     "@tscircuit/fixed-via-hypergraph-solver": "https://codeload.github.com/tscircuit/fixed-via-hypergraph-solver/tar.gz/bed37a6201b5dd07c9cc68b828917ecc20d6d049",
     "@tscircuit/hypergraph": "^0.0.71",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@tscircuit/dataset-srj27-power-traces": "git+https://github.com/tscircuit/dataset-srj27-power-traces.git#eb24d36",
     "@tscircuit/dataset-srj28-partially-prerouted": "git+https://github.com/tscircuit/dataset-srj28-partially-prerouted.git#5b1673544b6ade4480612539ba6574ad414fddc0",
     "@tscircuit/dataset-srj29-ddr3-bga-pairs": "git+https://github.com/ShiboSoftwareDev/dataset-srj29-ddr3-bga-pairs.git#585c3abd4c6ce4be52bbc430b1d5e6dcc9b4ea30",
-    "@tscircuit/dataset-srj33-drc-failures": "git+https://github.com/tscircuit/dataset-srj33-drc-failures.git#4543b348f9e3716711666714249cf4b6bc763b84",
+    "@tscircuit/dataset-srj33-drc-failures": "git+https://github.com/tscircuit/dataset-srj33-drc-failures.git#f566b62be0f83395d9ab63ddc068f9d645b68b16",
     "@tscircuit/fanout-solver": "^0.0.29",
     "@tscircuit/fixed-via-hypergraph-solver": "https://codeload.github.com/tscircuit/fixed-via-hypergraph-solver/tar.gz/bed37a6201b5dd07c9cc68b828917ecc20d6d049",
     "@tscircuit/hypergraph": "^0.0.71",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@tscircuit/dataset-srj27-power-traces": "git+https://github.com/tscircuit/dataset-srj27-power-traces.git#eb24d36",
     "@tscircuit/dataset-srj28-partially-prerouted": "git+https://github.com/tscircuit/dataset-srj28-partially-prerouted.git#5b1673544b6ade4480612539ba6574ad414fddc0",
     "@tscircuit/dataset-srj29-ddr3-bga-pairs": "git+https://github.com/ShiboSoftwareDev/dataset-srj29-ddr3-bga-pairs.git#585c3abd4c6ce4be52bbc430b1d5e6dcc9b4ea30",
-    "@tscircuit/dataset-srj33-drc-failures": "git+https://github.com/tscircuit/dataset-srj33-drc-failures.git#130e693aee9d2a92cfc826e243051b9ac994783b",
+    "@tscircuit/dataset-srj33-drc-failures": "git+https://github.com/tscircuit/dataset-srj33-drc-failures.git#4543b348f9e3716711666714249cf4b6bc763b84",
     "@tscircuit/fanout-solver": "^0.0.29",
     "@tscircuit/fixed-via-hypergraph-solver": "https://codeload.github.com/tscircuit/fixed-via-hypergraph-solver/tar.gz/bed37a6201b5dd07c9cc68b828917ecc20d6d049",
     "@tscircuit/hypergraph": "^0.0.71",

--- a/tests/benchmark-dataset-srj33.test.ts
+++ b/tests/benchmark-dataset-srj33.test.ts
@@ -5,12 +5,13 @@ import {
   loadScenarios,
 } from "../scripts/benchmark/scenarios"
 
-test("SRJ33 exposes the 12 Pipeline 9 DRC failure inputs in report order", async () => {
+test("SRJ33 exposes the 37 Pipeline 9 DRC failure inputs in dataset order", async () => {
   const scenarios = await loadScenarios("srj33")
   expect(scenarios.map(([name]) => name)).toEqual(
-    [1, 2, 3, 4, 5, 6, 10, 11, 12, 13, 20, 25].map(
-      (id) => `sample${String(id).padStart(3, "0")}`,
-    ),
+    [
+      1, 2, 3, 4, 5, 6, 10, 11, 12, 13, 20, 25, 32, 33, 34, 35, 36, 37, 38, 39,
+      40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56,
+    ].map((id) => `sample${String(id).padStart(3, "0")}`),
   )
   for (const [, srj] of scenarios) {
     expect(srj.connections.length).toBeGreaterThan(0)
@@ -20,13 +21,13 @@ test("SRJ33 exposes the 12 Pipeline 9 DRC failure inputs in report order", async
   expect<unknown>(scenarios[0][1].connections).toEqual(sample001.connections)
   expect<unknown>(scenarios[0][1].traces).toEqual(sample001.traces)
 
-  const last = await loadScenarioBySampleNumber("srj33", 12, 0.5)
-  expect(last.scenarioName).toBe("sample025")
-  expect(last.totalSamples).toBe(12)
-  expect(last.sourceLabel).toBe("srj33#12:sample025")
+  const last = await loadScenarioBySampleNumber("srj33", 37, 0.5)
+  expect(last.scenarioName).toBe("sample056")
+  expect(last.totalSamples).toBe(37)
+  expect(last.sourceLabel).toBe("srj33#37:sample056")
   expect(last.scenario).toHaveProperty("effort", 0.5)
   expect(await loadScenarios("srj33", { scenarioLimit: 2 })).toHaveLength(2)
-  await expect(loadScenarioBySampleNumber("srj33", 13)).rejects.toThrow(
-    "Sample 13 is out of range for dataset srj33 (12 samples)",
+  await expect(loadScenarioBySampleNumber("srj33", 38)).rejects.toThrow(
+    "Sample 38 is out of range for dataset srj33 (37 samples)",
   )
 })

--- a/tests/benchmark-dataset-srj33.test.ts
+++ b/tests/benchmark-dataset-srj33.test.ts
@@ -5,12 +5,11 @@ import {
   loadScenarios,
 } from "../scripts/benchmark/scenarios"
 
-test("SRJ33 exposes all 31 original routing inputs in report order", async () => {
+test("SRJ33 exposes the 12 Pipeline 9 DRC failure inputs in report order", async () => {
   const scenarios = await loadScenarios("srj33")
   expect(scenarios.map(([name]) => name)).toEqual(
-    Array.from(
-      { length: 31 },
-      (_, i) => `sample${String(i + 1).padStart(3, "0")}`,
+    [1, 2, 3, 4, 5, 6, 10, 11, 12, 13, 20, 25].map(
+      (id) => `sample${String(id).padStart(3, "0")}`,
     ),
   )
   for (const [, srj] of scenarios) {
@@ -21,13 +20,13 @@ test("SRJ33 exposes all 31 original routing inputs in report order", async () =>
   expect<unknown>(scenarios[0][1].connections).toEqual(sample001.connections)
   expect<unknown>(scenarios[0][1].traces).toEqual(sample001.traces)
 
-  const last = await loadScenarioBySampleNumber("srj33", 31, 0.5)
-  expect(last.scenarioName).toBe("sample031")
-  expect(last.totalSamples).toBe(31)
-  expect(last.sourceLabel).toBe("srj33#31:sample031")
+  const last = await loadScenarioBySampleNumber("srj33", 12, 0.5)
+  expect(last.scenarioName).toBe("sample025")
+  expect(last.totalSamples).toBe(12)
+  expect(last.sourceLabel).toBe("srj33#12:sample025")
   expect(last.scenario).toHaveProperty("effort", 0.5)
   expect(await loadScenarios("srj33", { scenarioLimit: 2 })).toHaveLength(2)
-  await expect(loadScenarioBySampleNumber("srj33", 32)).rejects.toThrow(
-    "Sample 32 is out of range for dataset srj33 (31 samples)",
+  await expect(loadScenarioBySampleNumber("srj33", 13)).rejects.toThrow(
+    "Sample 13 is out of range for dataset srj33 (12 samples)",
   )
 })


### PR DESCRIPTION
SRJ33 now contains 37 distinct inputs with measured Pipeline 9 DRC issues: the 12 failures from the supplied benchmark plus 25 additional bug-report SRJs. This updates the dataset dependency to `f566b62be0f83395d9ab63ddc068f9d645b68b16`, excludes the 19 original DRC passes, and updates the loader regression test and documentation for the sparse sample IDs (001–006, 010–013, 020, 025, and 032–056).

The [additional discovery run](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/33978900493) screened 136 deduplicated inputs. All 25 qualifiers were [rerouted and rechecked on Blacksmith](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/33980539076) at `0f18c99a09d19d8e690bb1767eef0c86ba80473e`, after the recent DRC fix. Each completed routing and retained at least one relaxed DRC issue (301 issues across additions). The dataset includes original SRJs, Pipeline 9 routed outputs, exact error objects, source links, and frozen runtime dependencies. The original 12 retain their historical Pipeline 7 output/evidence, explicitly labeled separately from their Pipeline 9 selection results.

Validation: all 37 dataset entries validated; every stored DRC error reproduced with its pinned runtime; 3 focused dataset/alias/scenario tests passed (195 assertions); TypeScript passed; scoped formatting and `git diff --check` passed.
