### PR TITLE
Compare paired benchmark routes using the same DRC checks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1545,7 +1545,7 @@ jobs:
                 '',
                 `Queued \`${dataset}\` on current main \`${mainSha.slice(0, 7)}\` and PR head \`${prSha.slice(0, 7)}\`.`,
                 '',
-                'Both revisions will run sequentially in one Blacksmith job.',
+                'Both solvers will run sequentially in one Blacksmith job, using the PR benchmark harness and DRC for both outputs.',
                 '',
                 `Workflow: [View run](${runUrl})`,
               ].join('\n'),
@@ -1559,7 +1559,7 @@ jobs:
       - name: Checkout benchmark controller
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ steps.refs.outputs.pr_sha }}
           path: same-machine-controller
           persist-credentials: false
 
@@ -1590,14 +1590,22 @@ jobs:
         working-directory: same-machine-pr
         run: bun install
 
+      - name: Install common harness dependencies
+        working-directory: same-machine-controller
+        run: bun install
+
       - name: Prepare comparison artifacts
         run: mkdir -p same-machine-results/main same-machine-results/pr
 
       - name: Benchmark current main
-        working-directory: same-machine-main
+        working-directory: same-machine-controller
         env:
           BENCHMARK_ARGS_JSON: ${{ inputs.benchmark_args_json }}
           BENCHMARK_DATASET: ${{ steps.refs.outputs.dataset }}
+          BENCHMARK_SOLVER_ROOT: ${{ github.workspace }}/same-machine-main
+          BENCHMARK_SOLVER_REVISION: ${{ steps.refs.outputs.main_sha }}
+          BENCHMARK_DRC_REVISION: ${{ steps.refs.outputs.pr_sha }}
+          BENCHMARK_ROUTED_OUTPUT_DIR: ${{ github.workspace }}/same-machine-results/main/routed-outputs
         run: |
           chmod +x ./benchmark.sh
           node <<'NODE'
@@ -1618,10 +1626,14 @@ jobs:
           cp benchmark-snapshots.html ../same-machine-results/main/benchmark-snapshots.html
 
       - name: Benchmark PR head
-        working-directory: same-machine-pr
+        working-directory: same-machine-controller
         env:
           BENCHMARK_ARGS_JSON: ${{ inputs.benchmark_args_json }}
           BENCHMARK_DATASET: ${{ steps.refs.outputs.dataset }}
+          BENCHMARK_SOLVER_ROOT: ${{ github.workspace }}/same-machine-pr
+          BENCHMARK_SOLVER_REVISION: ${{ steps.refs.outputs.pr_sha }}
+          BENCHMARK_DRC_REVISION: ${{ steps.refs.outputs.pr_sha }}
+          BENCHMARK_ROUTED_OUTPUT_DIR: ${{ github.workspace }}/same-machine-results/pr/routed-outputs
         run: |
           chmod +x ./benchmark.sh
           node <<'NODE'
@@ -1715,7 +1727,7 @@ jobs:
       - name: Checkout benchmarked code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ steps.refs.outputs.pr_sha }}
           persist-credentials: false
 
       - name: Setup bun

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1556,13 +1556,6 @@ jobs:
             core.setOutput('pr_sha', prSha)
             core.setOutput('status_comment_id', String(statusComment.data.id))
 
-      - name: Checkout benchmark controller
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ steps.refs.outputs.pr_sha }}
-          path: same-machine-controller
-          persist-credentials: false
-
       - name: Checkout current main
         uses: actions/checkout@v4
         with:
@@ -1590,15 +1583,11 @@ jobs:
         working-directory: same-machine-pr
         run: bun install
 
-      - name: Install common harness dependencies
-        working-directory: same-machine-controller
-        run: bun install
-
       - name: Prepare comparison artifacts
         run: mkdir -p same-machine-results/main same-machine-results/pr
 
       - name: Benchmark current main
-        working-directory: same-machine-controller
+        working-directory: same-machine-pr
         env:
           BENCHMARK_ARGS_JSON: ${{ inputs.benchmark_args_json }}
           BENCHMARK_DATASET: ${{ steps.refs.outputs.dataset }}
@@ -1626,7 +1615,7 @@ jobs:
           cp benchmark-snapshots.html ../same-machine-results/main/benchmark-snapshots.html
 
       - name: Benchmark PR head
-        working-directory: same-machine-controller
+        working-directory: same-machine-pr
         env:
           BENCHMARK_ARGS_JSON: ${{ inputs.benchmark_args_json }}
           BENCHMARK_DATASET: ${{ steps.refs.outputs.dataset }}
@@ -1654,7 +1643,7 @@ jobs:
           cp benchmark-snapshots.html ../same-machine-results/pr/benchmark-snapshots.html
 
       - name: Render same-machine comparison
-        working-directory: same-machine-controller
+        working-directory: same-machine-pr
         env:
           MAIN_SHA: ${{ steps.refs.outputs.main_sha }}
           PR_SHA: ${{ steps.refs.outputs.pr_sha }}

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -50,7 +50,7 @@ get_solvers() {
     import { join } from "node:path"
 
     // Use autorouter-pipelines/index.ts as the source of truth for benchmarkable solvers
-    const pipelinesIndex = readFileSync(join(process.cwd(), "lib", "autorouter-pipelines", "index.ts"), "utf8")
+    const pipelinesIndex = readFileSync(join(process.env.BENCHMARK_SOLVER_ROOT ?? process.cwd(), "lib", "autorouter-pipelines", "index.ts"), "utf8")
     const pipelineNames = new Set()
     for (const match of pipelinesIndex.matchAll(/export\s*\{([\s\S]*?)\}\s*from/g)) {
       const exportEntries = match[1].split(",").map((entry) => entry.trim()).filter(Boolean)
@@ -61,7 +61,7 @@ get_solvers() {
     }
 
     // Resolve aliases from lib/index.ts
-    const libIndex = readFileSync(join(process.cwd(), "lib", "index.ts"), "utf8")
+    const libIndex = readFileSync(join(process.env.BENCHMARK_SOLVER_ROOT ?? process.cwd(), "lib", "index.ts"), "utf8")
     const solvers = [...pipelineNames].flatMap(name => {
       const aliasMatches = [...libIndex.matchAll(new RegExp(name + "\\s+as\\s+(\\w+)", "g"))].map(match => match[1])
       return [name, ...aliasMatches]

--- a/scripts/benchmark/README.md
+++ b/scripts/benchmark/README.md
@@ -1,0 +1,28 @@
+# Same-machine comparisons
+
+Comment `/benchmark-all --same-machine` on a PR to compare dataset01 and SRJ18.
+Both revisions run sequentially on the same Blacksmith machine. The PR's
+benchmark harness loads each checkout's solver and its dependencies separately.
+Both outputs use the PR's DRC converter, rules, checks dependency, and dataset.
+Solver timing ends before DRC, output export, and snapshot rendering.
+
+The report records the solver and checker commits. Comparison fails if checker
+revisions differ, solver revisions do not match the requested refs, the case
+sets differ, or a solved case has no DRC result. Alongside pass/fail changes,
+it lists per-board DRC count changes even when both revisions fail that board.
+
+The workflow supplies these variables to the common harness:
+
+- `BENCHMARK_SOLVER_ROOT`: checkout containing the solver's `lib/index.ts`.
+- `BENCHMARK_SOLVER_REVISION`: commit of that checkout.
+- `BENCHMARK_DRC_REVISION`: commit of the common harness and checker.
+- `BENCHMARK_ROUTED_OUTPUT_DIR`: directory for solved-board JSON inputs.
+
+The artifact includes `main/routed-outputs` and `pr/routed-outputs`, keyed by
+solver and sample number. Each JSON file contains `inputSrj`,
+`srjWithPointPairs`, and `routedTraces`, ready to pass to `evaluateRelaxedDrc`
+or `getBugReportSnapshotSvg` for investigation without rerouting.
+
+Standalone benchmark runs use the current checkout unless a solver root is
+provided. Old reports without checker provenance cannot be used for this
+normalized comparison; rerun them with the common harness.

--- a/scripts/benchmark/benchmark-run-task.ts
+++ b/scripts/benchmark/benchmark-run-task.ts
@@ -1,8 +1,8 @@
 import { getSvgFromGraphicsObject } from "graphics-debug"
-import * as autorouterModule from "../../lib"
-import { convertSrjToGraphicsObject } from "../../lib"
-import { KrtAutoroutingPipelineSolver } from "../../lib/testing/KrtAutoroutingPipelineSolver"
+import { resolve } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
 import { evaluateRelaxedDrc } from "../../lib/testing/evaluate-relaxed-drc"
+import { convertSrjToGraphicsObject } from "../../lib/utils/convertSrjToGraphicsObject"
 import type {
   SimpleRouteJson,
   SimplifiedPcbTrace,
@@ -70,6 +70,8 @@ type SolverConstructor = new (
 ) => SolverInstance
 
 type RunTaskOptions = {
+  solverRoot?: string
+  routedOutputDirectory?: string
   onProgress?: (progress: WorkerProgress) => void
   progressIntervalMs?: number
 }
@@ -117,21 +119,34 @@ export const getBenchmarkSolverOptions = (
   }
 }
 
-const getSolverConstructor = (solverName: string): SolverConstructor => {
-  if (solverName === "KrtAutoroutingPipelineSolver") {
-    return KrtAutoroutingPipelineSolver
-  }
-
-  const ctor = (autorouterModule as Record<string, unknown>)[solverName]
+const getSolverConstructor = async (
+  solverName: string,
+  solverRoot: string,
+): Promise<SolverConstructor> => {
+  const modulePath =
+    solverName === "KrtAutoroutingPipelineSolver"
+      ? "lib/testing/KrtAutoroutingPipelineSolver.ts"
+      : "lib/index.ts"
+  const module = await import(
+    pathToFileURL(resolve(solverRoot, modulePath)).href
+  )
+  const ctor = module[solverName]
   if (typeof ctor !== "function") {
-    throw new Error(`Solver "${solverName}" was not found`)
+    throw new Error(`Solver "${solverName}" was not found in ${solverRoot}`)
   }
   return ctor as SolverConstructor
 }
 
-export const createSolverForTask = (task: BenchmarkTask): SolverInstance => {
+export const createSolverForTask = async (
+  task: BenchmarkTask,
+  solverRoot: string = process.env.BENCHMARK_SOLVER_ROOT ??
+    fileURLToPath(new URL("../../", import.meta.url)),
+): Promise<SolverInstance> => {
   const constructorName = task.solverConstructorName ?? task.solverName
-  const SolverConstructor = getSolverConstructor(constructorName)
+  const SolverConstructor = await getSolverConstructor(
+    constructorName,
+    solverRoot,
+  )
   const scenarioOptions = getBenchmarkSolverOptions(task.scenario)
   if (!task.networkedCachePass) {
     return new SolverConstructor(task.scenario, scenarioOptions)
@@ -471,7 +486,7 @@ export const runTask = async (
   task: BenchmarkTask,
   options: RunTaskOptions = {},
 ): Promise<WorkerResultWithImage> => {
-  const solver = createSolverForTask(task)
+  const solver = await createSolverForTask(task, options.solverRoot)
   const start = performance.now()
   let solveError: string | undefined
 
@@ -526,11 +541,23 @@ export const runTask = async (
       ? []
       : (solver.getOutputSimplifiedPcbTraces?.() ?? [])
     const viaCount = countTraceVias(traces)
-    const { errors } = evaluateRelaxedDrc({
+    const drcInput = {
       inputSrj: task.scenario,
       srjWithPointPairs: solver.srjWithPointPairs ?? task.scenario,
       routedTraces: traces,
-    })
+    }
+    const outputDirectory =
+      options.routedOutputDirectory ?? process.env.BENCHMARK_ROUTED_OUTPUT_DIR
+    if (outputDirectory) {
+      await Bun.write(
+        resolve(
+          outputDirectory,
+          `${encodeURIComponent(task.solverName)}-${task.sampleNumber}.json`,
+        ),
+        JSON.stringify(drcInput),
+      )
+    }
+    const { errors } = evaluateRelaxedDrc(drcInput)
     const relaxedDrcPassed = errors.length === 0
     const drcSummary = summarizeDrcErrors(errors as object[])
     let benchmarkSnapshot: BenchmarkSnapshotWithImage | undefined

--- a/scripts/benchmark/benchmark-types.ts
+++ b/scripts/benchmark/benchmark-types.ts
@@ -206,6 +206,9 @@ export type BenchmarkBestViaCellsReport = {
 }
 
 export type BenchmarkReport = {
+  /** Exact revisions used by a paired run; absent in standalone reports. */
+  solverRevision?: string
+  drcRevision?: string
   version: 1
   datasetName: string
   scenarioCount: number

--- a/scripts/benchmark/index.ts
+++ b/scripts/benchmark/index.ts
@@ -810,7 +810,7 @@ const loadSolverNames = async (
 ): Promise<string[]> => {
   // Use autorouter-pipelines/index.ts as the source of truth for benchmarkable solvers
   const pipelinesIndexPath = path.join(
-    process.cwd(),
+    process.env.BENCHMARK_SOLVER_ROOT ?? process.cwd(),
     "lib",
     "autorouter-pipelines",
     "index.ts",
@@ -835,7 +835,11 @@ const loadSolverNames = async (
   }
 
   // Resolve aliases from lib/index.ts (e.g. "X as Y")
-  const libIndexPath = path.join(process.cwd(), "lib", "index.ts")
+  const libIndexPath = path.join(
+    process.env.BENCHMARK_SOLVER_ROOT ?? process.cwd(),
+    "lib",
+    "index.ts",
+  )
   const libIndex = await readFile(libIndexPath, "utf8")
 
   const solverNames = [...pipelineNames].flatMap((name) => {
@@ -1847,6 +1851,8 @@ const main = async () => {
   )
   const output: string = `Benchmark Results (${effortLabel})\n\n${table}\n\nDataset: ${datasetName}\nScenarios: ${scenarios.length}\n\nTop solver failure buckets:\n${solverFailureSummaryText}\n\nTop timeout buckets:\n${timeoutSummaryText}\n\nTop failure buckets:\n${failureSummaryText}\n`
   const report: BenchmarkReport = {
+    solverRevision: process.env.BENCHMARK_SOLVER_REVISION,
+    drcRevision: process.env.BENCHMARK_DRC_REVISION,
     version: 1,
     datasetName,
     scenarioCount: scenarios.length,

--- a/scripts/benchmark/same-machine-results.ts
+++ b/scripts/benchmark/same-machine-results.ts
@@ -162,10 +162,42 @@ export const renderSameMachineBenchmarkResults = ({
   repository,
   runnerName,
 }: SameMachineBenchmarkInput): string => {
+  if (
+    !mainReport.drcRevision ||
+    mainReport.drcRevision !== prReport.drcRevision
+  ) {
+    throw new Error("Same-machine reports must use the same DRC revision")
+  }
+  if (
+    mainReport.solverRevision !== mainSha ||
+    prReport.solverRevision !== prSha
+  ) {
+    throw new Error("Report solver revisions must match the comparison refs")
+  }
   if (mainReport.datasetName !== prReport.datasetName) {
     throw new Error(
       `Dataset mismatch: main=${mainReport.datasetName}, PR=${prReport.datasetName}`,
     )
+  }
+  const mainKeys = new Set(mainReport.tests.map(testKey))
+  const prKeys = new Set(prReport.tests.map(testKey))
+  if (
+    mainKeys.size !== mainReport.tests.length ||
+    prKeys.size !== prReport.tests.length ||
+    mainKeys.size !== prKeys.size ||
+    [...mainKeys].some((key) => !prKeys.has(key))
+  ) {
+    throw new Error("Same-machine reports must contain identical unique cases")
+  }
+  for (const test of [...mainReport.tests, ...prReport.tests]) {
+    if (
+      test.didSolve &&
+      (test.drcErrorCount === undefined ||
+        !Number.isInteger(test.drcErrorCount) ||
+        test.drcErrorCount < 0)
+    ) {
+      throw new Error(`Missing or invalid DRC count for ${testKey(test)}`)
+    }
   }
 
   const mainSummaries = new Map(
@@ -179,6 +211,7 @@ export const renderSameMachineBenchmarkResults = ({
     "",
     `Dataset: \`${mainReport.datasetName}\` · Scenarios: ${mainReport.scenarioCount}`,
     `Main: [\`${mainSha.slice(0, 7)}\`](https://github.com/${repository}/commit/${mainSha}) · PR: [\`${prSha.slice(0, 7)}\`](https://github.com/${repository}/commit/${prSha})`,
+    `Both outputs use the same DRC conversion, rules, and dependencies from [\`${mainReport.drcRevision.slice(0, 7)}\`](https://github.com/${repository}/commit/${mainReport.drcRevision}).`,
     "",
     "| Solver | Metric | Main | PR | Delta |",
     "| --- | --- | ---: | ---: | ---: |",
@@ -228,8 +261,41 @@ export const renderSameMachineBenchmarkResults = ({
   const regressionCount = changedOutcomes.length - improvementCount
   lines.push(
     "",
-    `Outcome changes: **${improvementCount} improved**, **${regressionCount} regressed**. DRC issues are totaled across solved samples. Timing percentiles include solved and timed-out samples; negative timing deltas are faster.`,
+    `Pass/fail outcome changes: **${improvementCount} improved**, **${regressionCount} regressed**. DRC issues are totaled across solved samples. Timing percentiles include solved and timed-out samples; negative timing deltas are faster.`,
   )
+
+  const mainTests = new Map(
+    mainReport.tests.map((test) => [testKey(test), test]),
+  )
+  const changedDrcCounts = prReport.tests.flatMap((prTest) => {
+    const mainTest = mainTests.get(testKey(prTest))
+    if (
+      !mainTest?.didSolve ||
+      !prTest.didSolve ||
+      mainTest.drcErrorCount === prTest.drcErrorCount
+    ) {
+      return []
+    }
+    if (
+      mainTest.drcErrorCount === undefined ||
+      prTest.drcErrorCount === undefined
+    ) {
+      throw new Error(`Missing DRC count for ${testKey(prTest)}`)
+    }
+    return [
+      `| ${escapeTableCell(formatSolverName(prTest.solverName))} | ${prTest.sampleNumber} | ${mainTest.drcErrorCount} | ${prTest.drcErrorCount} | ${formatCountDelta(mainTest.drcErrorCount, prTest.drcErrorCount)} |`,
+    ]
+  })
+  if (changedDrcCounts.length > 0) {
+    lines.push(
+      "",
+      "DRC count changes on boards solved by both revisions (including boards that fail on both):",
+      "",
+      "| Solver | Sample | Main issues | PR issues | Delta |",
+      "| --- | ---: | ---: | ---: | ---: |",
+      ...changedDrcCounts,
+    )
+  }
 
   if (changedOutcomes.length > 0) {
     lines.push(

--- a/tests/__snapshots__/benchmark-common-drc-main.snap.svg
+++ b/tests/__snapshots__/benchmark-common-drc-main.snap.svg
@@ -1,0 +1,44 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="-1,0 1,0" data-type="line" data-label="" points="40,320 600,320" fill="none" stroke="rgba(0,128,0,0.5)" stroke-linejoin="round" stroke-width="28" stroke-dasharray="0.2 0.2"/></g><circle data-type="circle" data-label="" data-x="0" data-y="0" cx="320" cy="320" r="42" fill="blue" stroke="none" stroke-width="0.0035714285714285713"/><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":280,"c":0,"e":320,"b":0,"d":-280,"f":320};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script><g data-testid="relaxed-drc-summary"><rect x="12" y="12" width="300" height="44" rx="6" fill="white" stroke="#b91c1c"/><text x="24" y="40" font-family="Arial, sans-serif" font-size="20" font-weight="600" fill="#b91c1c">Relaxed DRC errors: 1</text></g></svg>

--- a/tests/__snapshots__/benchmark-common-drc-pr.snap.svg
+++ b/tests/__snapshots__/benchmark-common-drc-pr.snap.svg
@@ -1,0 +1,44 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="-1,0 -0.5,1 0.5,1 1,0" data-type="line" data-label="" points="40,439 180,159 460,159 600,439" fill="none" stroke="rgba(0,128,0,0.5)" stroke-linejoin="round" stroke-width="28" stroke-dasharray="0.2 0.2"/></g><circle data-type="circle" data-label="" data-x="0" data-y="0" cx="320" cy="439" r="42" fill="blue" stroke="none" stroke-width="0.0035714285714285713"/><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+                
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":280,"c":0,"e":320,"b":0,"d":-280,"f":439};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e; 
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+                
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script><g data-testid="relaxed-drc-summary"><rect x="12" y="12" width="300" height="44" rx="6" fill="white" stroke="#166534"/><text x="24" y="40" font-family="Arial, sans-serif" font-size="20" font-weight="600" fill="#166534">Relaxed DRC errors: 0</text></g></svg>

--- a/tests/benchmark-common-drc.test.ts
+++ b/tests/benchmark-common-drc.test.ts
@@ -1,0 +1,102 @@
+import { expect, test } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { EvaluateRelaxedDrcInput } from "../lib/testing/evaluate-relaxed-drc"
+import { getBugReportSnapshotSvg } from "../lib/testing/getBugReportSnapshotSvg"
+import { runTask } from "../scripts/benchmark/benchmark-run-task"
+import type { BenchmarkTask } from "../scripts/benchmark/benchmark-types"
+import "./fixtures/svg-matcher"
+
+test("one harness checks isolated solver checkouts and saves replayable routes", async (): Promise<void> => {
+  const directory = await mkdtemp(join(tmpdir(), "benchmark-common-drc-"))
+  const task: BenchmarkTask = {
+    datasetName: "test",
+    solverName: "FixtureSolver",
+    scenarioName: "via-span",
+    sampleNumber: 1,
+    scenario: {
+      layerCount: 4,
+      minTraceWidth: 0.1,
+      minViaDiameter: 0.3,
+      bounds: { minX: -2, minY: -2, maxX: 2, maxY: 2 },
+      obstacles: [],
+      connections: [
+        {
+          name: "SIGNAL",
+          pointsToConnect: [
+            { x: -1, y: 0, layer: "inner1", pcb_port_id: "pcb_port_a" },
+            { x: 1, y: 0, layer: "inner1", pcb_port_id: "pcb_port_b" },
+          ],
+        },
+      ],
+    },
+  }
+  try {
+    for (const [revision, traceY, expectedCount] of [
+      ["main", 0, 1],
+      ["pr", 1, 0],
+    ] as const) {
+      const solverRoot = join(directory, revision)
+      await Bun.write(
+        join(solverRoot, "tsconfig.json"),
+        JSON.stringify({
+          compilerOptions: { baseUrl: ".", paths: { "lib/*": ["lib/*"] } },
+        }),
+      )
+      await Bun.write(
+        join(solverRoot, "lib/route-config.ts"),
+        `export const traceY = ${JSON.stringify(traceY)}`,
+      )
+      await Bun.write(
+        join(solverRoot, "lib/index.ts"),
+        `import { traceY } from "lib/route-config"
+export class FixtureSolver {
+  solved = false
+  pipelineDef = []
+  timeSpentOnPhase = {}
+  solve() { this.solved = true }
+  getOutputSimplifiedPcbTraces() {
+    return [
+      { type: "pcb_trace", pcb_trace_id: "via", connection_name: "VIA", route: [
+        { route_type: "via", x: 0, y: 0, from_layer: "top", to_layer: "bottom" }
+      ] },
+      { type: "pcb_trace", pcb_trace_id: "signal", connection_name: "SIGNAL", route: [
+        { route_type: "wire", x: -1, y: 0, width: 0.1, layer: "inner1", start_pcb_port_id: "pcb_port_a" },
+        { route_type: "wire", x: -0.5, y: traceY, width: 0.1, layer: "inner1" },
+        { route_type: "wire", x: 0.5, y: traceY, width: 0.1, layer: "inner1" },
+        { route_type: "wire", x: 1, y: 0, width: 0.1, layer: "inner1", end_pcb_port_id: "pcb_port_b" }
+      ] }
+    ]
+  }
+}`,
+      )
+      const routedOutputDirectory = join(directory, revision, "outputs")
+      const result = await runTask(structuredClone(task), {
+        solverRoot,
+        routedOutputDirectory,
+      })
+      expect(result.error).toBeUndefined()
+      expect(result.didSolve).toBe(true)
+      expect(result.drcErrorCount).toBe(expectedCount)
+      const replay: EvaluateRelaxedDrcInput = await Bun.file(
+        join(routedOutputDirectory, "FixtureSolver-1.json"),
+      ).json()
+      expect(replay.inputSrj).toEqual(task.scenario)
+      expect(replay.routedTraces[0]!.route[0]).toMatchObject({
+        from_layer: "top",
+        to_layer: "bottom",
+      })
+      expect(replay.routedTraces[1]!.route[1]).toMatchObject({ y: traceY })
+      await expect(getBugReportSnapshotSvg(replay)).toMatchSvgSnapshot(
+        import.meta.path,
+        { svgName: revision },
+      )
+    }
+    await expect(
+      runTask(task, { solverRoot: join(directory, "missing") }),
+    ).rejects.toThrow()
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+})

--- a/tests/pr-benchmark-command.test.ts
+++ b/tests/pr-benchmark-command.test.ts
@@ -236,10 +236,12 @@ test("PR benchmark commands preserve arguments and fan-out behavior", () => {
   expect(
     benchmarkWorkflow.match(/benchmark-comment-comparison\.js/g),
   ).toHaveLength(2)
-  expect(benchmarkWorkflow).toContain("Checkout benchmark controller")
-  expect(benchmarkWorkflow).toContain(
-    "working-directory: same-machine-controller",
-  )
+  expect(
+    benchmarkWorkflow.match(
+      /BENCHMARK_DRC_REVISION: \$\{\{ steps.refs.outputs.pr_sha \}\}/g,
+    ),
+  ).toHaveLength(2)
+  expect(benchmarkWorkflow).toContain("working-directory: same-machine-pr")
   expect(benchmarkWorkflow).toContain("same-machine-results/main")
   expect(benchmarkWorkflow).toContain("same-machine-results/pr")
   expect(benchmarkWorkflow).toContain(

--- a/tests/same-machine-benchmark-results.test.ts
+++ b/tests/same-machine-benchmark-results.test.ts
@@ -24,6 +24,7 @@ test("same-machine benchmark comments compare matching reports", () => {
     overrides: Partial<BenchmarkReport>,
   ): BenchmarkReport => ({
     version: 1,
+    drcRevision: "b".repeat(40),
     datasetName: "srj18",
     scenarioCount: 2,
     effortLabel: "1x effort",
@@ -36,6 +37,7 @@ test("same-machine benchmark comments compare matching reports", () => {
     ...overrides,
   })
   const mainReport = makeReport({
+    solverRevision: "a".repeat(40),
     summary: [
       {
         solverName,
@@ -61,6 +63,7 @@ test("same-machine benchmark comments compare matching reports", () => {
     ],
   })
   const prReport = makeReport({
+    solverRevision: "b".repeat(40),
     summary: [
       {
         solverName,
@@ -98,6 +101,8 @@ test("same-machine benchmark comments compare matching reports", () => {
     "| Pipeline7 | Completion | 50.0% (🕒50.0%) | 100.0% (🕒0.0%) | +50.0 pp |",
   )
   expect(markdown).toContain("| Pipeline7 | DRC issues | 3 | 1 | -2 |")
+  expect(markdown).toContain("Both outputs use the same DRC conversion")
+  expect(markdown).toContain("| Pipeline7 | 2 | 3 | 1 | -2 |")
   expect(markdown).toContain("| Pipeline7 | Timeouts | 1 | 0 | -1 |")
   expect(markdown).toContain("| Pipeline7 | P50 time | 1.5s | 1.4s | -6.7% |")
   expect(markdown).toContain("| Pipeline7 | P60 time |")
@@ -105,7 +110,7 @@ test("same-machine benchmark comments compare matching reports", () => {
   expect(markdown).toContain("| Pipeline7 | P80 time |")
   expect(markdown).toContain("| Pipeline7 | P90 time |")
   expect(markdown).toContain("| Pipeline7 | P95 time |")
-  expect(markdown).toContain("Outcome changes: **1 improved**, **0 regressed**")
+  expect(markdown).toContain("Pass/fail outcome changes: **1 improved**, **0 regressed**")
   expect(markdown).toContain(
     "Timing percentiles include solved and timed-out samples",
   )

--- a/tests/same-machine-benchmark-results.test.ts
+++ b/tests/same-machine-benchmark-results.test.ts
@@ -110,7 +110,9 @@ test("same-machine benchmark comments compare matching reports", () => {
   expect(markdown).toContain("| Pipeline7 | P80 time |")
   expect(markdown).toContain("| Pipeline7 | P90 time |")
   expect(markdown).toContain("| Pipeline7 | P95 time |")
-  expect(markdown).toContain("Pass/fail outcome changes: **1 improved**, **0 regressed**")
+  expect(markdown).toContain(
+    "Pass/fail outcome changes: **1 improved**, **0 regressed**",
+  )
   expect(markdown).toContain(
     "Timing percentiles include solved and timed-out samples",
   )

--- a/tests/same-machine-benchmark-validation.test.ts
+++ b/tests/same-machine-benchmark-validation.test.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "bun:test"
+import type { BenchmarkReport } from "../scripts/benchmark/benchmark-types"
+import { renderSameMachineBenchmarkResults } from "../scripts/benchmark/same-machine-results"
+
+test("paired comparisons reject inconsistent checkers, refs, and case results", (): void => {
+  const report: BenchmarkReport = {
+    version: 1,
+    solverRevision: "a".repeat(40),
+    drcRevision: "c".repeat(40),
+    datasetName: "srj18",
+    scenarioCount: 1,
+    effortLabel: "1x effort",
+    summary: [],
+    solverFailureSummary: [],
+    timeoutSummary: [],
+    failureSummary: [],
+    snapshots: [],
+    tests: [
+      {
+        solverName: "Pipeline9",
+        scenarioName: "sample1",
+        sampleNumber: 1,
+        elapsedTimeMs: 1,
+        didSolve: true,
+        didTimeout: false,
+        relaxedDrcPassed: true,
+        drcErrorCount: 0,
+      },
+    ],
+  }
+  const input = {
+    mainReport: report,
+    prReport: { ...report, solverRevision: "b".repeat(40) },
+    mainSha: "a".repeat(40),
+    prSha: "b".repeat(40),
+    repository: "tscircuit/tscircuit-autorouter",
+    runnerName: "test",
+  }
+  for (const drcRevision of [undefined, "d".repeat(40)]) {
+    expect(() =>
+      renderSameMachineBenchmarkResults({
+        ...input,
+        prReport: { ...input.prReport, drcRevision },
+      }),
+    ).toThrow("same DRC revision")
+  }
+  expect(() =>
+    renderSameMachineBenchmarkResults({ ...input, prSha: "e".repeat(40) }),
+  ).toThrow("solver revisions")
+  expect(() =>
+    renderSameMachineBenchmarkResults({
+      ...input,
+      prReport: { ...input.prReport, tests: [] },
+    }),
+  ).toThrow("identical unique cases")
+  expect(() =>
+    renderSameMachineBenchmarkResults({
+      ...input,
+      prReport: {
+        ...input.prReport,
+        tests: [{ ...report.tests[0]!, drcErrorCount: undefined }],
+      },
+    }),
+  ).toThrow("Missing or invalid DRC count")
+})


### PR DESCRIPTION
Paired benchmarks previously ran each revision's DRC converter and checks, so an increase could reflect changed detection rules instead of worse routes. Run both solvers through the PR's common benchmark harness, dataset, DRC converter, rules, and checks dependencies. Load each solver and its dependencies from its own checkout; solver timing still excludes DRC and artifact rendering.

Record solver/checker revisions and reject comparisons with mismatched provenance, case sets, or missing DRC results. Show per-board DRC count changes even when both revisions fail a board. Save solved-board inputs and routed traces in the benchmark artifact for replay without rerouting.

A visual integration test loads two isolated checkouts with their own path aliases. The common checker catches an intermediate-layer via crossing in one output and clears the route that avoids it. Existing solver implementations are unchanged.

| Crossing detected | Route clears the via |
| --- | --- |
| ![Crossing](https://raw.githubusercontent.com/tscircuit/tscircuit-autorouter/5ff9ba10c640b3b657b834ec3fa28206dc04dc3e/tests/__snapshots__/benchmark-common-drc-main.snap.svg) | ![Clear route](https://raw.githubusercontent.com/tscircuit/tscircuit-autorouter/5ff9ba10c640b3b657b834ec3fa28206dc04dc3e/tests/__snapshots__/benchmark-common-drc-pr.snap.svg) |

Validation: all 17 benchmark-related tests pass (399 assertions); local typecheck/build pass. Snapshots were rendered and visually inspected. Dataset01 same-machine validation passes 85/85 with zero DRC errors on both revisions; all 85 saved main/PR board inputs are byte-identical. The raw reports record the same checker commit. SRJ18 completes 13/16 with 8/16 DRC passes, 98 issues, and one timeout on both revisions; all 13 saved main/PR board inputs are byte-identical. All nine final CI test shards, typecheck, build, formatting, and Vercel checks pass.

Paired runs compare main `0f18c99` with runtime code `817f40c`, using DRC from `817f40c` for both. The final commit `664966b` only updates the existing workflow test. [Dataset01 results](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/33980133700), [SRJ18 results](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/33980135051).
