### PR TITLE
Fix SRJ18 sample 8 with bounded clearance margin repair

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver.ts
@@ -13,6 +13,7 @@ import {
   combinePreloadedAndRoutedTraces,
   evaluateRelaxedDrc,
 } from "lib/testing/evaluate-relaxed-drc"
+import { convertToCircuitJson } from "lib/testing/utils/convertToCircuitJson"
 import type {
   Obstacle,
   SimpleRouteConnection,
@@ -24,7 +25,10 @@ import { convertHdRouteToSimplifiedRoute } from "lib/utils/convertHdRouteToSimpl
 import { mapZToLayerName } from "lib/utils/mapZToLayerName"
 import { Pipeline7AdaptiveDrcBranchPortfolioSolver } from "../AutoroutingPipeline7_MultiGraph/Pipeline7AdaptiveDrcBranchPortfolioSolver"
 import { createPipeline7HdRoutesToSimplifiedPcbTracesConverter } from "../AutoroutingPipeline7_MultiGraph/convertPipeline7HdRoutesToSimplifiedPcbTraces"
-import { applyPipeline9ClearancePrecisionRepairs } from "./applyPipeline9ClearancePrecisionRepairs"
+import {
+  applyPipeline9ClearancePrecisionRepairs,
+  type ClearanceMarginDrcEvaluator,
+} from "./applyPipeline9ClearancePrecisionRepairs"
 import { applyPipeline9RegionalB01Repairs } from "./applyPipeline9RegionalB01Repairs"
 import { applyPipeline9TerminalEscapeRelocations } from "./applyPipeline9TerminalEscapeRelocations"
 import { assignUniquePcbTraceIdsToNewTraces } from "./assignUniquePcbTraceIdsToNewTraces"
@@ -33,6 +37,7 @@ import {
   convertPreloadedTraceToHdRoutes,
 } from "./convertPreloadedTraceToHdRoutes"
 import { filterPipeline9DrcErrorsAgainstBaseline } from "./filterPipeline9DrcErrorsAgainstBaseline"
+import { getPipeline9ClearanceMarginErrors } from "./getPipeline9ClearanceMarginErrors"
 import { getPipeline9PreloadedTraceIdsInInitialDrcRegions } from "./getPipeline9PreloadedTraceIdsInInitialDrcRegions"
 import { getPipeline9PreloadedViaPairTraceGroups } from "./getPipeline9PreloadedViaPairTraceGroups"
 import { mergePipeline9MovablePreloadedVias } from "./mergePipeline9MovablePreloadedVias"
@@ -653,6 +658,7 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
   private cachedReferenceDrcEvaluator?: DrcEvaluator
   private clearancePrecisionDrcEvaluator?: DrcEvaluator
   private clearancePrecisionIndexedDrcEvaluator?: DrcEvaluator
+  private clearanceMarginDrcEvaluator?: ClearanceMarginDrcEvaluator
   private referenceDrcValidationCount = 0
   private referenceDrcFalseNegativeCount = 0
   private indexedDrcEvaluationCount = 0
@@ -1251,6 +1257,41 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
       hdRoutes,
     }): ReturnType<DrcEvaluator> =>
       referenceDrcEvaluator({ traces: [], routes, hdRoutes }, false)
+    const createMarginCircuitJson = (
+      routes: HighDensityRoute[],
+    ): AnyCircuitElement[] => {
+      const candidateDrcInput = prepareCandidateDrcInput(routes)
+      return convertToCircuitJson(
+        params.srjWithPointPairs,
+        candidateDrcInput.routedTraces,
+        {
+          minTraceWidth: params.originalSrj.minTraceWidth,
+          minViaDiameter: params.originalSrj.minViaDiameter,
+          originalSrj: params.originalSrj,
+          includeOriginalConnections: true,
+        },
+      )
+    }
+    let marginOriginalCircuit:
+      | { routes: HighDensityRoute[]; circuitJson: AnyCircuitElement[] }
+      | undefined
+    this.clearanceMarginDrcEvaluator = (
+      routes,
+      targets,
+      originalRoutes,
+    ): ReturnType<ClearanceMarginDrcEvaluator> => {
+      if (marginOriginalCircuit?.routes !== originalRoutes) {
+        marginOriginalCircuit = {
+          routes: originalRoutes,
+          circuitJson: createMarginCircuitJson(originalRoutes),
+        }
+      }
+      return getPipeline9ClearanceMarginErrors({
+        circuitJson: createMarginCircuitJson(routes),
+        originalCircuitJson: marginOriginalCircuit.circuitJson,
+        targets,
+      })
+    }
     this.clearancePrecisionIndexedDrcEvaluator = ({
       routes,
       hdRoutes,
@@ -1444,6 +1485,7 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
           connMap: this.params.connMap,
           indexedDrcEvaluator: this.clearancePrecisionIndexedDrcEvaluator!,
           candidateDrcEvaluator: this.clearancePrecisionDrcEvaluator!,
+          marginDrcEvaluator: this.clearanceMarginDrcEvaluator!,
           drcEvaluator: this.cachedReferenceDrcEvaluator!,
           initialErrors: exactReferenceDrcErrors,
           initialErrorsWithCenters: Array.isArray(exactReferenceDrcResult)

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver.ts
@@ -651,6 +651,8 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
   readonly exactRepairSolver?: Pipeline7AdaptiveDrcBranchPortfolioSolver
   private drcEvaluator?: DrcEvaluator
   private cachedReferenceDrcEvaluator?: DrcEvaluator
+  private clearancePrecisionDrcEvaluator?: DrcEvaluator
+  private clearancePrecisionIndexedDrcEvaluator?: DrcEvaluator
   private referenceDrcValidationCount = 0
   private referenceDrcFalseNegativeCount = 0
   private indexedDrcEvaluationCount = 0
@@ -1168,7 +1170,10 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
       }
     }
 
-    const referenceDrcEvaluator: DrcEvaluator = ({ routes, hdRoutes }) => {
+    const referenceDrcEvaluator = (
+      { routes, hdRoutes }: Parameters<DrcEvaluator>[0],
+      includeTraceContinuity = true,
+    ): ReturnType<DrcEvaluator> => {
       const evaluatedRoutes = routes ?? hdRoutes
       if (!evaluatedRoutes) {
         throw new Error("Pipeline9 reference DRC repair requires HD routes")
@@ -1178,7 +1183,7 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
         inputSrj: params.originalSrj,
         srjWithPointPairs: params.srjWithPointPairs,
         routedTraces: candidateDrcInput.routedTraces,
-        drcOptions: { traceClearance },
+        drcOptions: { traceClearance, includeTraceContinuity },
       })
       const evaluatedTraceIds = new Set(
         candidateDrcInput.evaluatedTraces.map((trace) => trace.pcb_trace_id),
@@ -1241,6 +1246,26 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
       return result
     }
     this.cachedReferenceDrcEvaluator = cachedReferenceDrcEvaluator
+    this.clearancePrecisionDrcEvaluator = ({
+      routes,
+      hdRoutes,
+    }): ReturnType<DrcEvaluator> =>
+      referenceDrcEvaluator({ traces: [], routes, hdRoutes }, false)
+    this.clearancePrecisionIndexedDrcEvaluator = ({
+      routes,
+      hdRoutes,
+    }): ReturnType<DrcEvaluator> => {
+      const evaluatedRoutes = routes ?? hdRoutes
+      if (!evaluatedRoutes) {
+        throw new Error("Pipeline9 clearance ranking requires HD routes")
+      }
+      const candidateDrcInput = prepareCandidateDrcInput(evaluatedRoutes)
+      // Ranking is private and must not populate the exact evaluator's cache
+      // with results that have not undergone its reference-zero validation.
+      return autoroutingDrcEngine.evaluate(
+        candidateDrcInput.evaluatedTraces as RepairSimplifiedPcbTraces,
+      )
+    }
 
     const drcEvaluator: DrcEvaluator = ({ routes, hdRoutes }) => {
       const evaluatedRoutes = routes ?? hdRoutes
@@ -1394,6 +1419,8 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
         MAX_POST_EXACT_PRECISION_PASS_INDEXED_ISSUE_COUNT
     let postExactReferenceDrcIssueCount: number | undefined
     let clearancePrecisionCandidateCount = 0
+    let clearancePrecisionCandidateValidationCount = 0
+    let clearancePrecisionReferenceValidationCount = 0
     let clearancePrecisionRepaired = false
     if (shouldRunPostExactPrecisionPass) {
       // The indexed evaluator can retain conservative false positives after the
@@ -1415,6 +1442,8 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
           newConnections: this.params.newConnections,
           syntheticConnectionNames: this.syntheticConnectionNames,
           connMap: this.params.connMap,
+          indexedDrcEvaluator: this.clearancePrecisionIndexedDrcEvaluator!,
+          candidateDrcEvaluator: this.clearancePrecisionDrcEvaluator!,
           drcEvaluator: this.cachedReferenceDrcEvaluator!,
           initialErrors: exactReferenceDrcErrors,
           initialErrorsWithCenters: Array.isArray(exactReferenceDrcResult)
@@ -1424,6 +1453,10 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
         })
         clearancePrecisionCandidateCount =
           precisionResult.attemptedCandidateCount
+        clearancePrecisionCandidateValidationCount =
+          precisionResult.candidateValidationCount
+        clearancePrecisionReferenceValidationCount =
+          precisionResult.referenceValidationCount
         clearancePrecisionRepaired = precisionResult.repaired
         if (precisionResult.repaired) {
           exactOutput = precisionResult.routes
@@ -1444,6 +1477,8 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
           postExactReferenceDrcIssueCount: 0,
           postExactReferenceAccepted: true,
           clearancePrecisionCandidateCount,
+          clearancePrecisionCandidateValidationCount,
+          clearancePrecisionReferenceValidationCount,
           clearancePrecisionRepaired,
           regionalB01RepairCandidateCount: 0,
           regionalB01RepairAcceptedCount: 0,
@@ -1528,6 +1563,8 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
       postExactReferenceDrcIssueCount,
       postExactReferenceAccepted: false,
       clearancePrecisionCandidateCount,
+      clearancePrecisionCandidateValidationCount,
+      clearancePrecisionReferenceValidationCount,
       clearancePrecisionRepaired,
       regionalB01RepairCandidateCount:
         regionalB01RepairResult.attemptedCandidateCount,

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver.ts
@@ -24,6 +24,7 @@ import { convertHdRouteToSimplifiedRoute } from "lib/utils/convertHdRouteToSimpl
 import { mapZToLayerName } from "lib/utils/mapZToLayerName"
 import { Pipeline7AdaptiveDrcBranchPortfolioSolver } from "../AutoroutingPipeline7_MultiGraph/Pipeline7AdaptiveDrcBranchPortfolioSolver"
 import { createPipeline7HdRoutesToSimplifiedPcbTracesConverter } from "../AutoroutingPipeline7_MultiGraph/convertPipeline7HdRoutesToSimplifiedPcbTraces"
+import { applyPipeline9ClearancePrecisionRepairs } from "./applyPipeline9ClearancePrecisionRepairs"
 import { applyPipeline9RegionalB01Repairs } from "./applyPipeline9RegionalB01Repairs"
 import { applyPipeline9TerminalEscapeRelocations } from "./applyPipeline9TerminalEscapeRelocations"
 import { assignUniquePcbTraceIdsToNewTraces } from "./assignUniquePcbTraceIdsToNewTraces"
@@ -1378,7 +1379,7 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
       return
     }
     if (!this.exactRepairSolver.solved) return
-    const exactOutput = this.exactRepairSolver.getOutput()
+    let exactOutput = this.exactRepairSolver.getOutput()
     const exactIndexedDrcIssueCountStat =
       this.exactRepairSolver.stats.finalDrcIssueCount
     const exactIndexedDrcIssueCount =
@@ -1392,6 +1393,8 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
       exactIndexedDrcIssueCount <=
         MAX_POST_EXACT_PRECISION_PASS_INDEXED_ISSUE_COUNT
     let postExactReferenceDrcIssueCount: number | undefined
+    let clearancePrecisionCandidateCount = 0
+    let clearancePrecisionRepaired = false
     if (shouldRunPostExactPrecisionPass) {
       // The indexed evaluator can retain conservative false positives after the
       // exact portfolio has produced a reference-clean result. Do not let later
@@ -1405,7 +1408,29 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
         ? exactReferenceDrcResult
         : exactReferenceDrcResult.errors
       postExactReferenceDrcIssueCount = exactReferenceDrcErrors.length
-      if (exactReferenceDrcErrors.length === 0) {
+      if (exactReferenceDrcErrors.length > 0) {
+        const precisionResult = applyPipeline9ClearancePrecisionRepairs({
+          srj: this.params.srj,
+          routes: exactOutput,
+          newConnections: this.params.newConnections,
+          syntheticConnectionNames: this.syntheticConnectionNames,
+          connMap: this.params.connMap,
+          drcEvaluator: this.cachedReferenceDrcEvaluator!,
+          initialErrors: exactReferenceDrcErrors,
+          initialErrorsWithCenters: Array.isArray(exactReferenceDrcResult)
+            ? exactReferenceDrcResult
+            : (exactReferenceDrcResult.errorsWithCenters ??
+              exactReferenceDrcResult.errors),
+        })
+        clearancePrecisionCandidateCount =
+          precisionResult.attemptedCandidateCount
+        clearancePrecisionRepaired = precisionResult.repaired
+        if (precisionResult.repaired) {
+          exactOutput = precisionResult.routes
+          postExactReferenceDrcIssueCount = 0
+        }
+      }
+      if (postExactReferenceDrcIssueCount === 0) {
         this.combinedOutput = exactOutput
         this.stats = {
           ...this.stats,
@@ -1418,6 +1443,8 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
           postExactReferenceValidationSkippedForIndexedIssueCount: false,
           postExactReferenceDrcIssueCount: 0,
           postExactReferenceAccepted: true,
+          clearancePrecisionCandidateCount,
+          clearancePrecisionRepaired,
           regionalB01RepairCandidateCount: 0,
           regionalB01RepairAcceptedCount: 0,
           regionalB01RepairFallbackCandidateCount: 0,
@@ -1500,6 +1527,8 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
         !shouldRunPostExactPrecisionPass,
       postExactReferenceDrcIssueCount,
       postExactReferenceAccepted: false,
+      clearancePrecisionCandidateCount,
+      clearancePrecisionRepaired,
       regionalB01RepairCandidateCount:
         regionalB01RepairResult.attemptedCandidateCount,
       regionalB01RepairAcceptedCount:

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/applyPipeline9ClearancePrecisionRepairs.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/applyPipeline9ClearancePrecisionRepairs.ts
@@ -36,6 +36,14 @@ type IndexedClearanceCandidate = {
 
 type Point = { x: number; y: number }
 
+export type ClearanceMarginDrcEvaluator = (
+  routes: HighDensityRoute[],
+  targets: Pipeline9DrcError[],
+  originalRoutes: HighDensityRoute[],
+) => Pipeline9DrcError[]
+
+export const CLEARANCE_PRECISION_MARGIN = 0.01
+
 const MAX_CLEARANCE_ERROR_COUNT = 8
 const MAX_PASSES = 8
 const FORCE_SCALES = [0.03, 0.1, 0.25]
@@ -134,6 +142,7 @@ export const applyPipeline9ClearancePrecisionRepairs = ({
   connMap,
   indexedDrcEvaluator,
   candidateDrcEvaluator,
+  marginDrcEvaluator,
   drcEvaluator,
   initialErrors,
   initialErrorsWithCenters = initialErrors,
@@ -145,6 +154,7 @@ export const applyPipeline9ClearancePrecisionRepairs = ({
   connMap: ConnectivityMap
   indexedDrcEvaluator: DrcEvaluator
   candidateDrcEvaluator: DrcEvaluator
+  marginDrcEvaluator: ClearanceMarginDrcEvaluator
   drcEvaluator: DrcEvaluator
   initialErrors: Pipeline9DrcError[]
   initialErrorsWithCenters?: Pipeline9DrcError[]
@@ -183,18 +193,43 @@ export const applyPipeline9ClearancePrecisionRepairs = ({
   })
   if (!initial) return unchanged
   let current: PreparedClearanceErrors = initial
+  const marginTargets = initial.errors
+  const initialMarginErrors = initial.errors.map((error) => ({
+    ...error,
+    minimum_clearance:
+      (error.minimum_clearance as number) + CLEARANCE_PRECISION_MARGIN,
+  }))
+  const initialMarginDeficit = getIndexedClearanceDeficit(initialMarginErrors)
+  if (initialMarginDeficit === undefined) return unchanged
+  let currentMargin: PreparedClearanceErrors = {
+    errors: initialMarginErrors,
+    deficit: initialMarginDeficit,
+  }
   let currentRoutes = routes
   let attemptedCandidateCount = 0
   let candidateValidationCount = 0
   let referenceValidationCount = 0
   for (let pass = 0; pass < MAX_PASSES; pass++) {
+    // Keep the original failing pairs active until their physical gaps have
+    // margin, even after the relaxed checker stops reporting those pairs.
+    const forceErrorsByPair = new Map<string, Pipeline9DrcError>()
+    for (const error of [...currentMargin.errors, ...current.errors]) {
+      const pairKey = JSON.stringify([
+        error.type,
+        error.pcb_trace_id,
+        error.pcb_pad_id,
+        error.pcb_via_id,
+      ])
+      forceErrorsByPair.set(pairKey, error)
+    }
+    const forceErrors = [...forceErrorsByPair.values()]
     let bestCandidate: IndexedClearanceCandidate | undefined
     for (const scale of FORCE_SCALES) {
       const candidateRoutes = cloneRoutes(currentRoutes)
       const changed = applyDrcErrorForces(
         srj as RepairSimpleRouteJson,
         candidateRoutes,
-        current.errors,
+        forceErrors,
         routeIndexByTraceId,
         scale,
         connMap,
@@ -233,7 +268,36 @@ export const applyPipeline9ClearancePrecisionRepairs = ({
     const candidateErrors = Array.isArray(candidateResult)
       ? candidateResult
       : candidateResult.errors
-    if (candidateErrors.length === 0) {
+    const prepared =
+      candidateErrors.length === 0
+        ? { errors: [], deficit: 0 }
+        : prepareClearanceErrors({
+            errors: candidateErrors,
+            errorsWithCenters: Array.isArray(candidateResult)
+              ? candidateResult
+              : (candidateResult.errorsWithCenters ?? candidateResult.errors),
+            routeIndexByTraceId,
+            padPositionById,
+          })
+    if (!prepared) break
+    // Measure only the selected candidate. Indexed ranking stays bounded to
+    // the existing three candidates without repeating exact margin checks.
+    const marginErrors = marginDrcEvaluator(
+      bestCandidate.routes,
+      marginTargets,
+      routes,
+    )
+    const preparedMargin =
+      marginErrors.length === 0
+        ? { errors: [], deficit: 0 }
+        : prepareClearanceErrors({
+            errors: marginErrors,
+            errorsWithCenters: marginErrors,
+            routeIndexByTraceId,
+            padPositionById,
+          })
+    if (!preparedMargin) break
+    if (candidateErrors.length === 0 && marginErrors.length === 0) {
       // Private geometry validation omits continuity. Publish only after every
       // full reference check passes, including continuity and errors with no center.
       referenceValidationCount++
@@ -256,19 +320,17 @@ export const applyPipeline9ClearancePrecisionRepairs = ({
       }
       break
     }
-    const prepared = prepareClearanceErrors({
-      errors: candidateErrors,
-      errorsWithCenters: Array.isArray(candidateResult)
-        ? candidateResult
-        : (candidateResult.errorsWithCenters ?? candidateResult.errors),
-      routeIndexByTraceId,
-      padPositionById,
-    })
     // A coupled move can temporarily split one deficit between two objects.
     // Such intermediate routes stay private until every reference error clears.
-    if (!prepared || prepared.deficit >= current.deficit - 1e-9) break
+    if (
+      prepared.deficit + preparedMargin.deficit >=
+      current.deficit + currentMargin.deficit - 1e-9
+    ) {
+      break
+    }
     currentRoutes = bestCandidate.routes
     current = prepared
+    currentMargin = preparedMargin
   }
   return {
     routes,

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/applyPipeline9ClearancePrecisionRepairs.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/applyPipeline9ClearancePrecisionRepairs.ts
@@ -1,0 +1,205 @@
+import type { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import type {
+  DrcEvaluator,
+  SimpleRouteJson as RepairSimpleRouteJson,
+} from "high-density-repair03/lib"
+import {
+  applyDrcErrorForces,
+  cloneRoutes,
+  materializeRoutes,
+} from "high-density-repair03/lib/solvers/GlobalDrcForceImproveSolver/solverHelpers"
+import type { SimpleRouteConnection, SimpleRouteJson } from "lib/types"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+import {
+  getPipeline9DrcErrorTraceIds,
+  getPipeline9RouteIndexByTraceId,
+  type Pipeline9DrcError,
+} from "./pipeline9JointDrcRepairUtils"
+
+type ClearancePrecisionRepairResult = {
+  routes: HighDensityRoute[]
+  attemptedCandidateCount: number
+  repaired: boolean
+}
+
+type PreparedClearanceErrors = {
+  errors: Pipeline9DrcError[]
+  deficit: number
+}
+
+type Point = { x: number; y: number }
+
+const MAX_CLEARANCE_ERROR_COUNT = 8
+const MAX_PASSES = 8
+const FORCE_SCALES = [0.03, 0.1, 0.25]
+
+const prepareClearanceErrors = ({
+  errors,
+  errorsWithCenters,
+  routeIndexByTraceId,
+  padPositionById,
+}: {
+  errors: Pipeline9DrcError[]
+  errorsWithCenters: Pipeline9DrcError[]
+  routeIndexByTraceId: ReadonlyMap<string, number>
+  padPositionById: ReadonlyMap<string, Point>
+}): PreparedClearanceErrors | undefined => {
+  if (errors.length === 0 || errors.length > MAX_CLEARANCE_ERROR_COUNT) {
+    return undefined
+  }
+  const preparedErrors: Pipeline9DrcError[] = []
+  let deficit = 0
+  for (const error of errors) {
+    const isViaTrace = error.type === "pcb_via_trace_clearance_error"
+    const isPadTrace = error.type === "pcb_pad_trace_clearance_error"
+    if (
+      (!isViaTrace && !isPadTrace) ||
+      typeof error.pcb_trace_id !== "string" ||
+      !routeIndexByTraceId.has(error.pcb_trace_id) ||
+      typeof error.actual_clearance !== "number" ||
+      !Number.isFinite(error.actual_clearance) ||
+      typeof error.minimum_clearance !== "number" ||
+      !Number.isFinite(error.minimum_clearance)
+    ) {
+      return undefined
+    }
+    const traceIds = getPipeline9DrcErrorTraceIds(error)
+    if (
+      (isViaTrace && traceIds.length < 2) ||
+      traceIds.some((traceId) => !routeIndexByTraceId.has(traceId))
+    ) {
+      return undefined
+    }
+    const centeredError = errorsWithCenters.find(
+      (candidate) =>
+        candidate.type === error.type &&
+        candidate.pcb_trace_id === error.pcb_trace_id &&
+        candidate.pcb_pad_id === error.pcb_pad_id &&
+        candidate.pcb_via_id === error.pcb_via_id,
+    )
+    const center = isPadTrace
+      ? typeof error.pcb_pad_id === "string"
+        ? padPositionById.get(error.pcb_pad_id)
+        : undefined
+      : (centeredError?.center ?? error.center)
+    if (!center || typeof center !== "object") return undefined
+    const point = center as Record<string, unknown>
+    if (
+      typeof point.x !== "number" ||
+      !Number.isFinite(point.x) ||
+      typeof point.y !== "number" ||
+      !Number.isFinite(point.y)
+    ) {
+      return undefined
+    }
+    preparedErrors.push({ ...error, center: { x: point.x, y: point.y } })
+    deficit += Math.max(0, error.minimum_clearance - error.actual_clearance)
+    if (!Number.isFinite(deficit)) return undefined
+  }
+  return { errors: preparedErrors, deficit }
+}
+
+/** Searches coupled clearance adjustments, publishing only reference-clean routes. */
+export const applyPipeline9ClearancePrecisionRepairs = ({
+  srj,
+  routes,
+  newConnections,
+  syntheticConnectionNames,
+  connMap,
+  drcEvaluator,
+  initialErrors,
+  initialErrorsWithCenters = initialErrors,
+}: {
+  srj: SimpleRouteJson
+  routes: HighDensityRoute[]
+  newConnections: SimpleRouteConnection[]
+  syntheticConnectionNames: ReadonlySet<string>
+  connMap: ConnectivityMap
+  drcEvaluator: DrcEvaluator
+  initialErrors: Pipeline9DrcError[]
+  initialErrorsWithCenters?: Pipeline9DrcError[]
+}): ClearancePrecisionRepairResult => {
+  const unchanged = { routes, attemptedCandidateCount: 0, repaired: false }
+  if ((srj.traces?.length ?? 0) > 0 || syntheticConnectionNames.size > 0) {
+    return unchanged
+  }
+  const routeIndexByTraceId = getPipeline9RouteIndexByTraceId({
+    routes,
+    newConnections,
+    syntheticConnectionNames,
+  })
+  const padPositionById = new Map<string, Point>()
+  for (const obstacle of srj.obstacles) {
+    for (const id of [
+      obstacle.obstacleId,
+      obstacle.circuitJsonMetadata?.pcb_smtpad_id,
+      obstacle.circuitJsonMetadata?.pcb_plated_hole_id,
+      obstacle.connectedTo[0],
+    ]) {
+      if (typeof id === "string") padPositionById.set(id, obstacle.center)
+    }
+  }
+  const initial = prepareClearanceErrors({
+    errors: initialErrors,
+    errorsWithCenters: initialErrorsWithCenters,
+    routeIndexByTraceId,
+    padPositionById,
+  })
+  if (!initial) return unchanged
+  let current: PreparedClearanceErrors = initial
+  let currentRoutes = routes
+  let attemptedCandidateCount = 0
+  for (let pass = 0; pass < MAX_PASSES; pass++) {
+    let bestRoutes = currentRoutes
+    let best: PreparedClearanceErrors = current
+    for (const scale of FORCE_SCALES) {
+      const candidateRoutes = cloneRoutes(currentRoutes)
+      const changed = applyDrcErrorForces(
+        srj as RepairSimpleRouteJson,
+        candidateRoutes,
+        current.errors,
+        routeIndexByTraceId,
+        scale,
+        connMap,
+        true,
+        true,
+        true,
+        false,
+      )
+      if (!changed) continue
+      const materializedRoutes = materializeRoutes(candidateRoutes)
+      attemptedCandidateCount++
+      const result = drcEvaluator({
+        traces: [],
+        routes: materializedRoutes,
+        hdRoutes: materializedRoutes,
+      })
+      const errors = Array.isArray(result) ? result : result.errors
+      if (errors.length === 0) {
+        return {
+          routes: materializedRoutes,
+          attemptedCandidateCount,
+          repaired: true,
+        }
+      }
+      const prepared = prepareClearanceErrors({
+        errors,
+        errorsWithCenters: Array.isArray(result)
+          ? result
+          : (result.errorsWithCenters ?? result.errors),
+        routeIndexByTraceId,
+        padPositionById,
+      })
+      // A coupled move can temporarily split one deficit between two objects.
+      // Such intermediate routes stay private until every reference error clears.
+      if (prepared && prepared.deficit < best.deficit - 1e-9) {
+        bestRoutes = materializedRoutes
+        best = prepared
+      }
+    }
+    if (bestRoutes === currentRoutes) break
+    currentRoutes = bestRoutes
+    current = best
+  }
+  return { routes, attemptedCandidateCount, repaired: false }
+}

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/applyPipeline9ClearancePrecisionRepairs.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/applyPipeline9ClearancePrecisionRepairs.ts
@@ -19,6 +19,8 @@ import {
 type ClearancePrecisionRepairResult = {
   routes: HighDensityRoute[]
   attemptedCandidateCount: number
+  candidateValidationCount: number
+  referenceValidationCount: number
   repaired: boolean
 }
 
@@ -27,11 +29,35 @@ type PreparedClearanceErrors = {
   deficit: number
 }
 
+type IndexedClearanceCandidate = {
+  routes: HighDensityRoute[]
+  deficit: number
+}
+
 type Point = { x: number; y: number }
 
 const MAX_CLEARANCE_ERROR_COUNT = 8
 const MAX_PASSES = 8
 const FORCE_SCALES = [0.03, 0.1, 0.25]
+
+const getIndexedClearanceDeficit = (
+  errors: Pipeline9DrcError[],
+): number | undefined => {
+  let deficit = 0
+  for (const error of errors) {
+    if (
+      typeof error.actual_clearance !== "number" ||
+      !Number.isFinite(error.actual_clearance) ||
+      typeof error.minimum_clearance !== "number" ||
+      !Number.isFinite(error.minimum_clearance)
+    ) {
+      return undefined
+    }
+    deficit += Math.max(0, error.minimum_clearance - error.actual_clearance)
+    if (!Number.isFinite(deficit)) return undefined
+  }
+  return deficit
+}
 
 const prepareClearanceErrors = ({
   errors,
@@ -106,6 +132,8 @@ export const applyPipeline9ClearancePrecisionRepairs = ({
   newConnections,
   syntheticConnectionNames,
   connMap,
+  indexedDrcEvaluator,
+  candidateDrcEvaluator,
   drcEvaluator,
   initialErrors,
   initialErrorsWithCenters = initialErrors,
@@ -115,11 +143,19 @@ export const applyPipeline9ClearancePrecisionRepairs = ({
   newConnections: SimpleRouteConnection[]
   syntheticConnectionNames: ReadonlySet<string>
   connMap: ConnectivityMap
+  indexedDrcEvaluator: DrcEvaluator
+  candidateDrcEvaluator: DrcEvaluator
   drcEvaluator: DrcEvaluator
   initialErrors: Pipeline9DrcError[]
   initialErrorsWithCenters?: Pipeline9DrcError[]
 }): ClearancePrecisionRepairResult => {
-  const unchanged = { routes, attemptedCandidateCount: 0, repaired: false }
+  const unchanged: ClearancePrecisionRepairResult = {
+    routes,
+    attemptedCandidateCount: 0,
+    candidateValidationCount: 0,
+    referenceValidationCount: 0,
+    repaired: false,
+  }
   if ((srj.traces?.length ?? 0) > 0 || syntheticConnectionNames.size > 0) {
     return unchanged
   }
@@ -149,9 +185,10 @@ export const applyPipeline9ClearancePrecisionRepairs = ({
   let current: PreparedClearanceErrors = initial
   let currentRoutes = routes
   let attemptedCandidateCount = 0
+  let candidateValidationCount = 0
+  let referenceValidationCount = 0
   for (let pass = 0; pass < MAX_PASSES; pass++) {
-    let bestRoutes = currentRoutes
-    let best: PreparedClearanceErrors = current
+    let bestCandidate: IndexedClearanceCandidate | undefined
     for (const scale of FORCE_SCALES) {
       const candidateRoutes = cloneRoutes(currentRoutes)
       const changed = applyDrcErrorForces(
@@ -169,37 +206,75 @@ export const applyPipeline9ClearancePrecisionRepairs = ({
       if (!changed) continue
       const materializedRoutes = materializeRoutes(candidateRoutes)
       attemptedCandidateCount++
-      const result = drcEvaluator({
+      const indexedResult = indexedDrcEvaluator({
         traces: [],
         routes: materializedRoutes,
         hdRoutes: materializedRoutes,
       })
-      const errors = Array.isArray(result) ? result : result.errors
-      if (errors.length === 0) {
+      const deficit = getIndexedClearanceDeficit(
+        Array.isArray(indexedResult) ? indexedResult : indexedResult.errors,
+      )
+      // Conservative indexed errors rank candidates only. Their absence never
+      // establishes that a candidate is reference-clean.
+      if (
+        deficit !== undefined &&
+        (!bestCandidate || deficit < bestCandidate.deficit)
+      ) {
+        bestCandidate = { routes: materializedRoutes, deficit }
+      }
+    }
+    if (!bestCandidate) break
+    candidateValidationCount++
+    const candidateResult = candidateDrcEvaluator({
+      traces: [],
+      routes: bestCandidate.routes,
+      hdRoutes: bestCandidate.routes,
+    })
+    const candidateErrors = Array.isArray(candidateResult)
+      ? candidateResult
+      : candidateResult.errors
+    if (candidateErrors.length === 0) {
+      // Private geometry validation omits continuity. Publish only after every
+      // full reference check passes, including continuity and errors with no center.
+      referenceValidationCount++
+      const referenceResult = drcEvaluator({
+        traces: [],
+        routes: bestCandidate.routes,
+        hdRoutes: bestCandidate.routes,
+      })
+      const referenceErrors = Array.isArray(referenceResult)
+        ? referenceResult
+        : referenceResult.errors
+      if (referenceErrors.length === 0) {
         return {
-          routes: materializedRoutes,
+          routes: bestCandidate.routes,
           attemptedCandidateCount,
+          candidateValidationCount,
+          referenceValidationCount,
           repaired: true,
         }
       }
-      const prepared = prepareClearanceErrors({
-        errors,
-        errorsWithCenters: Array.isArray(result)
-          ? result
-          : (result.errorsWithCenters ?? result.errors),
-        routeIndexByTraceId,
-        padPositionById,
-      })
-      // A coupled move can temporarily split one deficit between two objects.
-      // Such intermediate routes stay private until every reference error clears.
-      if (prepared && prepared.deficit < best.deficit - 1e-9) {
-        bestRoutes = materializedRoutes
-        best = prepared
-      }
+      break
     }
-    if (bestRoutes === currentRoutes) break
-    currentRoutes = bestRoutes
-    current = best
+    const prepared = prepareClearanceErrors({
+      errors: candidateErrors,
+      errorsWithCenters: Array.isArray(candidateResult)
+        ? candidateResult
+        : (candidateResult.errorsWithCenters ?? candidateResult.errors),
+      routeIndexByTraceId,
+      padPositionById,
+    })
+    // A coupled move can temporarily split one deficit between two objects.
+    // Such intermediate routes stay private until every reference error clears.
+    if (!prepared || prepared.deficit >= current.deficit - 1e-9) break
+    currentRoutes = bestCandidate.routes
+    current = prepared
   }
-  return { routes, attemptedCandidateCount, repaired: false }
+  return {
+    routes,
+    attemptedCandidateCount,
+    candidateValidationCount,
+    referenceValidationCount,
+    repaired: false,
+  }
 }

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/getPipeline9ClearanceMarginErrors.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/getPipeline9ClearanceMarginErrors.ts
@@ -78,7 +78,9 @@ export const getPipeline9ClearanceMarginErrors = ({
       }
       const originalOwner = originalTraces.get(originalObstacle.pcb_trace_id)
       if (!originalOwner) {
-        throw new Error("Pipeline9 clearance margin lost the original via owner")
+        throw new Error(
+          "Pipeline9 clearance margin lost the original via owner",
+        )
       }
       const originalTransitions = originalOwner.route.filter(
         (segment) => segment.route_type === "via",
@@ -177,7 +179,10 @@ export const getPipeline9ClearanceMarginErrors = ({
       errors.push({
         ...target,
         ...(obstacle.type === "pcb_via"
-          ? { pcb_via_id: obstacle.pcb_via_id, pcb_via_ids: [obstacle.pcb_via_id] }
+          ? {
+              pcb_via_id: obstacle.pcb_via_id,
+              pcb_via_ids: [obstacle.pcb_via_id],
+            }
           : {}),
         actual_clearance: actualClearance,
         minimum_clearance: minimumClearance,

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/getPipeline9ClearanceMarginErrors.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/getPipeline9ClearanceMarginErrors.ts
@@ -1,0 +1,191 @@
+import {
+  checkPadTraceClearance,
+  checkViaTraceClearance,
+} from "@tscircuit/checks"
+import type { AnyCircuitElement } from "circuit-json"
+import { CLEARANCE_PRECISION_MARGIN } from "./applyPipeline9ClearancePrecisionRepairs"
+import type { Pipeline9DrcError } from "./pipeline9JointDrcRepairUtils"
+
+/** Measures the original failing pairs beyond the reference checker's tolerance. */
+export const getPipeline9ClearanceMarginErrors = ({
+  circuitJson,
+  originalCircuitJson,
+  targets,
+}: {
+  circuitJson: AnyCircuitElement[]
+  originalCircuitJson: AnyCircuitElement[]
+  targets: Pipeline9DrcError[]
+}): Pipeline9DrcError[] => {
+  const traces = new Map(
+    circuitJson
+      .filter((element) => element.type === "pcb_trace")
+      .map((trace) => [trace.pcb_trace_id, trace]),
+  )
+  const originalTraces = new Map(
+    originalCircuitJson
+      .filter((element) => element.type === "pcb_trace")
+      .map((trace) => [trace.pcb_trace_id, trace]),
+  )
+  const vias = circuitJson.filter((element) => element.type === "pcb_via")
+  const obstacles = new Map<string, AnyCircuitElement>()
+  for (const element of circuitJson) {
+    if (element.type === "pcb_via") {
+      obstacles.set(element.pcb_via_id, element)
+    } else if (element.type === "pcb_smtpad") {
+      obstacles.set(element.pcb_smtpad_id, element)
+    } else if (element.type === "pcb_plated_hole") {
+      obstacles.set(element.pcb_plated_hole_id, element)
+    }
+  }
+  const errors: Pipeline9DrcError[] = []
+  for (const target of targets) {
+    const isVia = target.type === "pcb_via_trace_clearance_error"
+    const obstacleId = isVia ? target.pcb_via_id : target.pcb_pad_id
+    if (
+      (!isVia && target.type !== "pcb_pad_trace_clearance_error") ||
+      typeof target.pcb_trace_id !== "string" ||
+      typeof obstacleId !== "string" ||
+      typeof target.minimum_clearance !== "number" ||
+      !Number.isFinite(target.minimum_clearance) ||
+      target.minimum_clearance <= 0
+    ) {
+      throw new Error("Pipeline9 clearance margin requires a valid target pair")
+    }
+    const originalTrace = originalTraces.get(target.pcb_trace_id)
+    const originalObstacle = originalCircuitJson.find((element) =>
+      isVia
+        ? element.type === "pcb_via" && element.pcb_via_id === obstacleId
+        : (element.type === "pcb_smtpad" &&
+            element.pcb_smtpad_id === obstacleId) ||
+          (element.type === "pcb_plated_hole" &&
+            element.pcb_plated_hole_id === obstacleId),
+    )
+    if (!originalTrace || !originalObstacle) {
+      throw new Error(
+        `Pipeline9 clearance margin has no original target ${obstacleId}/${target.pcb_trace_id}`,
+      )
+    }
+    const trace = traces.get(target.pcb_trace_id)
+    let obstacle = obstacles.get(obstacleId)
+    if (isVia) {
+      if (
+        originalObstacle.type !== "pcb_via" ||
+        typeof originalObstacle.pcb_trace_id !== "string"
+      ) {
+        throw new Error(
+          "Pipeline9 clearance margin requires the original via owner",
+        )
+      }
+      const originalOwner = originalTraces.get(originalObstacle.pcb_trace_id)
+      if (!originalOwner) {
+        throw new Error("Pipeline9 clearance margin lost the original via owner")
+      }
+      const originalTransitions = originalOwner.route.filter(
+        (segment) => segment.route_type === "via",
+      )
+      const matchingTransitions = originalTransitions
+        .map((segment, index) => ({ segment, index }))
+        .filter(
+          ({ segment }) =>
+            segment.x === originalObstacle.x &&
+            segment.y === originalObstacle.y &&
+            originalObstacle.layers.includes(segment.from_layer) &&
+            originalObstacle.layers.includes(segment.to_layer) &&
+            ((segment.from_layer === originalObstacle.layers[0] &&
+              segment.to_layer === originalObstacle.layers.at(-1)) ||
+              (segment.to_layer === originalObstacle.layers[0] &&
+                segment.from_layer === originalObstacle.layers.at(-1))),
+        )
+        .filter(
+          ({ segment }, index, all) =>
+            all.findIndex(
+              (entry) =>
+                entry.segment.from_layer === segment.from_layer &&
+                entry.segment.to_layer === segment.to_layer,
+            ) === index,
+        )
+      if (matchingTransitions.length === 0) {
+        throw new Error(
+          "Pipeline9 clearance margin lost the original via transition",
+        )
+      }
+      // Opposite-direction transitions at one site have separate converter
+      // identities. Reject an ambiguous pair rather than infer its owner event.
+      if (matchingTransitions.length !== 1) {
+        return [{ type: "pipeline9_clearance_margin_identity_error" }]
+      }
+      const originalTransitionIndex = matchingTransitions[0]!.index
+      const owner = traces.get(originalObstacle.pcb_trace_id)
+      const transitions = owner?.route.filter(
+        (segment) => segment.route_type === "via",
+      )
+      if (
+        !transitions ||
+        transitions.length !== originalTransitions.length ||
+        transitions.some(
+          (segment, index) =>
+            segment.from_layer !== originalTransitions[index]!.from_layer ||
+            segment.to_layer !== originalTransitions[index]!.to_layer,
+        )
+      ) {
+        return [{ type: "pipeline9_clearance_margin_identity_error" }]
+      }
+      const transition = transitions[originalTransitionIndex]!
+      // Global via_N ids can shift when a shared-site move deduplicates vias.
+      // The owner's transition ordinal survives coordinate and wire edits.
+      // Coincident opposite-direction events may retain different diameters;
+      // measure the largest copper envelope at the selected physical site.
+      obstacle = vias
+        .filter(
+          (via) =>
+            via.x === transition.x &&
+            via.y === transition.y &&
+            via.layers.join() === originalObstacle.layers.join(),
+        )
+        .reduce<(typeof vias)[number] | undefined>(
+          (largest, via) =>
+            !largest || via.outer_diameter > largest.outer_diameter
+              ? via
+              : largest,
+          undefined,
+        )
+    }
+    if (!trace || !obstacle || !("x" in obstacle) || !("y" in obstacle)) {
+      return [{ type: "pipeline9_clearance_margin_identity_error" }]
+    }
+    // Each pair already failed reference DRC on different nets. Measure only
+    // those two objects; unrelated nearby copper keeps its original rules.
+    // A wider reporting radius exposes actual_clearance even when the normal
+    // checker accepts the pair using its floating-point tolerance.
+    const options = { minClearance: target.minimum_clearance + 1 }
+    const measuredErrors = isVia
+      ? checkViaTraceClearance([trace, obstacle], options)
+      : checkPadTraceClearance([trace, obstacle], options)
+    const minimumClearance =
+      target.minimum_clearance + CLEARANCE_PRECISION_MARGIN
+    for (const measured of measuredErrors) {
+      const actualClearance = measured.actual_clearance
+      if (
+        typeof actualClearance !== "number" ||
+        !Number.isFinite(actualClearance)
+      ) {
+        throw new Error(
+          "Pipeline9 clearance margin requires a finite measurement",
+        )
+      }
+      if (actualClearance >= minimumClearance) continue
+      errors.push({
+        ...target,
+        ...(obstacle.type === "pcb_via"
+          ? { pcb_via_id: obstacle.pcb_via_id, pcb_via_ids: [obstacle.pcb_via_id] }
+          : {}),
+        actual_clearance: actualClearance,
+        minimum_clearance: minimumClearance,
+        center: { x: obstacle.x, y: obstacle.y },
+      })
+    }
+  }
+  // The typed clearance checks omit actual overlaps. The caller must still
+  // require complete reference DRC, including overlap and continuity checks.
+  return errors
+}

--- a/tests/features/pipeline9-clearance-margin-measures-physical-gap.test.ts
+++ b/tests/features/pipeline9-clearance-margin-measures-physical-gap.test.ts
@@ -1,0 +1,73 @@
+import { checkViaTraceClearance } from "@tscircuit/checks"
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { getPipeline9ClearanceMarginErrors } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/getPipeline9ClearanceMarginErrors"
+
+test("clearance margin measures the copper gap beyond checker tolerance", (): void => {
+  for (const gap of [0.0995, 0.1095, 0.11, 0.1101, 0.12]) {
+    const traceY = 0.15 + 0.05 + gap
+    const circuitJson: AnyCircuitElement[] = [
+      {
+        type: "pcb_via",
+        pcb_via_id: "via",
+        pcb_trace_id: "via_owner",
+        x: 0,
+        y: 0,
+        outer_diameter: 0.3,
+        hole_diameter: 0.15,
+        layers: ["top", "bottom"],
+      },
+      {
+        type: "pcb_trace",
+        pcb_trace_id: "via_owner",
+        route: [
+          { route_type: "wire", x: -1, y: 0, width: 0.1, layer: "top" },
+          { route_type: "wire", x: 0, y: 0, width: 0.1, layer: "top" },
+          {
+            route_type: "via",
+            x: 0,
+            y: 0,
+            from_layer: "top",
+            to_layer: "bottom",
+          },
+          { route_type: "wire", x: 0, y: 0, width: 0.1, layer: "bottom" },
+          { route_type: "wire", x: 1, y: 0, width: 0.1, layer: "bottom" },
+        ],
+      },
+      {
+        type: "pcb_trace",
+        pcb_trace_id: "signal",
+        route: [
+          { route_type: "wire", x: -1, y: traceY, width: 0.1, layer: "top" },
+          { route_type: "wire", x: 1, y: traceY, width: 0.1, layer: "top" },
+        ],
+      },
+    ]
+    expect(
+      checkViaTraceClearance(circuitJson, { minClearance: 0.1 }),
+    ).toHaveLength(0)
+    const measured = checkViaTraceClearance(circuitJson, {
+      minClearance: 0.2,
+    })
+    expect(measured).toHaveLength(1)
+    expect(measured[0]!.actual_clearance).toBeCloseTo(gap, 10)
+    const errors = getPipeline9ClearanceMarginErrors({
+      circuitJson,
+      originalCircuitJson: circuitJson,
+      targets: [
+        {
+          type: "pcb_via_trace_clearance_error",
+          pcb_via_id: "via",
+          pcb_trace_id: "signal",
+          actual_clearance: 0.089,
+          minimum_clearance: 0.1,
+        },
+      ],
+    })
+    expect(errors).toHaveLength(gap < 0.11 ? 1 : 0)
+    if (gap < 0.11) {
+      expect(errors[0]!.actual_clearance).toBeCloseTo(gap, 10)
+      expect(errors[0]!.minimum_clearance).toBeCloseTo(0.11, 10)
+    }
+  }
+})

--- a/tests/features/pipeline9-clearance-margin-tracks-via-identity.test.ts
+++ b/tests/features/pipeline9-clearance-margin-tracks-via-identity.test.ts
@@ -1,0 +1,198 @@
+import { checkViaTraceClearance } from "@tscircuit/checks"
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import {
+  applyDrcErrorForces,
+  cloneRoutes,
+  materializeRoutes,
+} from "high-density-repair03/lib/solvers/GlobalDrcForceImproveSolver/solverHelpers"
+import { getPipeline9ClearanceMarginErrors } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/getPipeline9ClearanceMarginErrors"
+import { convertToCircuitJson } from "lib/testing/utils/convertToCircuitJson"
+import type { SimpleRouteJson, SimplifiedPcbTrace } from "lib/types"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+import { convertHdRouteToSimplifiedRoute } from "lib/utils/convertHdRouteToSimplifiedRoute"
+
+const viaRoute = (
+  connectionName: string,
+  rootConnectionName: string,
+  x: number,
+  y: number,
+): HighDensityRoute => ({
+  connectionName,
+  rootConnectionName,
+  traceThickness: 0.1,
+  viaDiameter: 0.3,
+  route: [
+    { x: x - 1, y, z: 0 },
+    { x, y, z: 0 },
+    { x, y, z: 1 },
+    { x: x + 1, y, z: 1 },
+  ],
+  vias: [{ x, y }],
+})
+
+test("clearance margin follows the owner's via transition after shared-site deduplication", (): void => {
+  const routes: HighDensityRoute[] = [
+    viaRoute("shared_a", "shared", 0, 0),
+    viaRoute("shared_b", "shared", 0, 0.0005),
+    viaRoute("target_owner", "target_owner", 3, 0),
+    viaRoute("later_owner", "later_owner", 6, 0),
+    {
+      connectionName: "shared_signal",
+      traceThickness: 0.1,
+      viaDiameter: 0.3,
+      route: [
+        { x: -1, y: 0.28, z: 0 },
+        { x: 1, y: 0.28, z: 0 },
+      ],
+      vias: [],
+    },
+    {
+      connectionName: "target_signal",
+      traceThickness: 0.1,
+      viaDiameter: 0.3,
+      route: [
+        { x: 2, y: 4.289, z: 0 },
+        { x: 4, y: 4.289, z: 0 },
+      ],
+      vias: [],
+    },
+  ]
+  // The target is the owner's second via, so owner identity alone is insufficient.
+  routes[2]!.route.push(
+    { x: 3, y: 4, z: 1 },
+    { x: 3, y: 4, z: 0 },
+    { x: 4, y: 4, z: 0 },
+  )
+  routes[2]!.vias.push({ x: 3, y: 4 })
+  const srj = {
+    bounds: { minX: -10, minY: -10, maxX: 10, maxY: 10 },
+    layerCount: 2,
+    minTraceWidth: 0.1,
+    obstacles: [],
+    connections: routes.map((route) => ({
+      name: route.connectionName,
+      pointsToConnect: [],
+    })),
+  } satisfies SimpleRouteJson
+  const getCircuitJson = (candidate: HighDensityRoute[]): AnyCircuitElement[] => {
+    const traces: SimplifiedPcbTrace[] = candidate.map((route) => ({
+      type: "pcb_trace",
+      pcb_trace_id: `${route.connectionName}_0`,
+      connection_name: route.rootConnectionName ?? route.connectionName,
+      route: convertHdRouteToSimplifiedRoute(route, 2),
+    }))
+    return convertToCircuitJson(srj, traces, { minViaDiameter: 0.3 })
+  }
+  const originalCircuitJson = getCircuitJson(routes)
+  const mutable = cloneRoutes(routes)
+  expect(
+    applyDrcErrorForces(
+      srj,
+      mutable,
+      [
+        {
+          type: "pcb_via_trace_clearance_error",
+          pcb_trace_id: "shared_signal_0",
+          pcb_trace_ids: ["shared_signal_0", "shared_a_0"],
+          pcb_via_id: "via_0",
+          pcb_via_ids: ["via_0"],
+          minimum_clearance: 0.1,
+          actual_clearance: 0.08,
+          center: { x: 0, y: 0 },
+        },
+      ],
+      new Map(routes.map((route, index) => [`${route.connectionName}_0`, index])),
+      0.03,
+      undefined,
+      true,
+      true,
+      true,
+      false,
+    ),
+  ).toBeTrue()
+  for (const point of mutable[5]!.route) point.y = 4.2995
+  const circuitJson = getCircuitJson(materializeRoutes(mutable))
+  const originalVia = originalCircuitJson.find(
+    (element) => element.type === "pcb_via" && element.pcb_via_id === "via_3",
+  )!
+  const renumberedVia = circuitJson.find(
+    (element) => element.type === "pcb_via" && element.pcb_via_id === "via_3",
+  )!
+  expect(originalVia).toMatchObject({ pcb_trace_id: "target_owner_0", y: 4 })
+  expect(renumberedVia).toMatchObject({ pcb_trace_id: "later_owner_0", y: 0 })
+  const targets = [
+    {
+      type: "pcb_via_trace_clearance_error",
+      pcb_trace_id: "target_signal_0",
+      pcb_trace_ids: ["target_signal_0", "target_owner_0"],
+      pcb_via_id: "via_3",
+      pcb_via_ids: ["via_3"],
+      minimum_clearance: 0.1,
+      actual_clearance: 0.089,
+    },
+  ]
+  const errors = getPipeline9ClearanceMarginErrors({
+    circuitJson,
+    originalCircuitJson,
+    targets,
+  })
+  expect(errors).toHaveLength(1)
+  expect(errors[0]!.actual_clearance).toBeCloseTo(0.0995, 10)
+  expect(errors[0]!.pcb_via_id).toBe("via_2")
+  expect(errors[0]!.pcb_via_ids).toEqual(["via_2"])
+  expect(errors[0]!.center).toEqual({ x: 3, y: 4 })
+  const relaxedErrors = checkViaTraceClearance(circuitJson, {
+    minClearance: 0.1,
+  })
+  expect(
+    relaxedErrors.some((error) => error.pcb_trace_id === "target_signal_0"),
+  ).toBeFalse()
+
+  for (const point of mutable[5]!.route) point.y = 4.312
+  const clearedCircuitJson = getCircuitJson(materializeRoutes(mutable))
+  expect(
+    getPipeline9ClearanceMarginErrors({
+      circuitJson: clearedCircuitJson,
+      originalCircuitJson,
+      targets,
+    }),
+  ).toHaveLength(0)
+
+  // Opposite-direction events can retain a larger copper diameter at the same
+  // site. Measuring the first converted via would overstate this clearance.
+  const siteVia = clearedCircuitJson.find(
+    (element) => element.type === "pcb_via" && element.pcb_via_id === "via_2",
+  )!
+  if (siteVia.type !== "pcb_via") throw new Error("Missing test via")
+  clearedCircuitJson.push({
+    ...siteVia,
+    pcb_via_id: "larger_reverse_via",
+    pcb_trace_id: "later_owner_0",
+    outer_diameter: 0.36,
+  })
+  const largerViaErrors = getPipeline9ClearanceMarginErrors({
+    circuitJson: clearedCircuitJson,
+    originalCircuitJson,
+    targets,
+  })
+  expect(largerViaErrors).toHaveLength(1)
+  expect(largerViaErrors[0]!.actual_clearance).toBeCloseTo(0.082, 10)
+  expect(largerViaErrors[0]!.pcb_via_id).toBe("larger_reverse_via")
+  clearedCircuitJson.pop()
+
+  const owner = clearedCircuitJson.find(
+    (element) =>
+      element.type === "pcb_trace" &&
+      element.pcb_trace_id === "target_owner_0",
+  )!
+  if (owner.type !== "pcb_trace") throw new Error("Missing test owner")
+  owner.route = owner.route.filter((segment) => segment.route_type !== "via")
+  expect(
+    getPipeline9ClearanceMarginErrors({
+      circuitJson: clearedCircuitJson,
+      originalCircuitJson,
+      targets,
+    }),
+  ).toEqual([{ type: "pipeline9_clearance_margin_identity_error" }])
+})

--- a/tests/features/pipeline9-clearance-margin-tracks-via-identity.test.ts
+++ b/tests/features/pipeline9-clearance-margin-tracks-via-identity.test.ts
@@ -75,7 +75,9 @@ test("clearance margin follows the owner's via transition after shared-site dedu
       pointsToConnect: [],
     })),
   } satisfies SimpleRouteJson
-  const getCircuitJson = (candidate: HighDensityRoute[]): AnyCircuitElement[] => {
+  const getCircuitJson = (
+    candidate: HighDensityRoute[],
+  ): AnyCircuitElement[] => {
     const traces: SimplifiedPcbTrace[] = candidate.map((route) => ({
       type: "pcb_trace",
       pcb_trace_id: `${route.connectionName}_0`,
@@ -102,7 +104,9 @@ test("clearance margin follows the owner's via transition after shared-site dedu
           center: { x: 0, y: 0 },
         },
       ],
-      new Map(routes.map((route, index) => [`${route.connectionName}_0`, index])),
+      new Map(
+        routes.map((route, index) => [`${route.connectionName}_0`, index]),
+      ),
       0.03,
       undefined,
       true,
@@ -183,8 +187,7 @@ test("clearance margin follows the owner's via transition after shared-site dedu
 
   const owner = clearedCircuitJson.find(
     (element) =>
-      element.type === "pcb_trace" &&
-      element.pcb_trace_id === "target_owner_0",
+      element.type === "pcb_trace" && element.pcb_trace_id === "target_owner_0",
   )!
   if (owner.type !== "pcb_trace") throw new Error("Missing test owner")
   owner.route = owner.route.filter((segment) => segment.route_type !== "via")

--- a/tests/features/pipeline9-clearance-precision-requires-all-errors-clean.test.ts
+++ b/tests/features/pipeline9-clearance-precision-requires-all-errors-clean.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "bun:test"
+import { applyPipeline9ClearancePrecisionRepairs } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/applyPipeline9ClearancePrecisionRepairs"
+import type { SimpleRouteJson } from "lib/types"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
+
+test("clearance precision preserves original routes when only centered errors are clean", (): void => {
+  const srj: SimpleRouteJson = {
+    bounds: { minX: -2, minY: -2, maxX: 2, maxY: 2 },
+    layerCount: 2,
+    minTraceWidth: 0.1,
+    obstacles: [],
+    connections: [
+      { name: "via_owner", pointsToConnect: [] },
+      { name: "signal", pointsToConnect: [] },
+    ],
+  }
+  const routes: HighDensityRoute[] = [
+    {
+      connectionName: "via_owner",
+      traceThickness: 0.1,
+      viaDiameter: 0.3,
+      route: [
+        { x: -1, y: 0, z: 0 },
+        { x: 0, y: 0, z: 0 },
+        { x: 0, y: 0, z: 1 },
+        { x: 1, y: 0, z: 1 },
+      ],
+      vias: [{ x: 0, y: 0 }],
+    },
+    {
+      connectionName: "signal",
+      traceThickness: 0.1,
+      viaDiameter: 0.3,
+      route: [-1, -0.5, 0.5, 1].map((x) => ({ x, y: 0.289, z: 0 })),
+      vias: [],
+    },
+  ]
+  const originalRoutes = structuredClone(routes)
+  let evaluationCount = 0
+  const result = applyPipeline9ClearancePrecisionRepairs({
+    srj,
+    routes,
+    newConnections: srj.connections,
+    syntheticConnectionNames: new Set(),
+    connMap: getConnectivityMapFromSimpleRouteJson(srj),
+    initialErrors: [
+      {
+        type: "pcb_via_trace_clearance_error",
+        pcb_trace_id: "signal_0",
+        pcb_trace_ids: ["signal_0", "via_owner_0"],
+        pcb_via_id: "via_0",
+        pcb_via_ids: ["via_0"],
+        actual_clearance: 0.089,
+        minimum_clearance: 0.1,
+        center: { x: 0, y: 0 },
+      },
+    ],
+    drcEvaluator: () => {
+      evaluationCount++
+      return {
+        errors: [{ type: "pcb_trace_error", message: "Missing connection" }],
+        errorsWithCenters: [],
+      }
+    },
+  })
+  expect(evaluationCount).toBeGreaterThan(0)
+  expect(result.repaired).toBeFalse()
+  expect(result.routes).toBe(routes)
+  expect(routes).toEqual(originalRoutes)
+  expect(result.attemptedCandidateCount).toBe(evaluationCount)
+  expect(result.attemptedCandidateCount).toBeLessThanOrEqual(24)
+})

--- a/tests/features/pipeline9-clearance-precision-requires-all-errors-clean.test.ts
+++ b/tests/features/pipeline9-clearance-precision-requires-all-errors-clean.test.ts
@@ -4,7 +4,7 @@ import type { SimpleRouteJson } from "lib/types"
 import type { HighDensityRoute } from "lib/types/high-density-types"
 import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
 
-test("clearance precision preserves original routes when only centered errors are clean", (): void => {
+test("clearance precision preserves original routes until full reference DRC passes", (): void => {
   const srj: SimpleRouteJson = {
     bounds: { minX: -2, minY: -2, maxX: 2, maxY: 2 },
     layerCount: 2,
@@ -38,6 +38,7 @@ test("clearance precision preserves original routes when only centered errors ar
   ]
   const originalRoutes = structuredClone(routes)
   let evaluationCount = 0
+  let indexedEvaluationCount = 0
   const result = applyPipeline9ClearancePrecisionRepairs({
     srj,
     routes,
@@ -56,6 +57,17 @@ test("clearance precision preserves original routes when only centered errors ar
         center: { x: 0, y: 0 },
       },
     ],
+    indexedDrcEvaluator: () => {
+      indexedEvaluationCount++
+      return [
+        {
+          type: "pcb_trace_error",
+          minimum_clearance: 1,
+          actual_clearance: indexedEvaluationCount === 1 ? 0 : 1,
+        },
+      ]
+    },
+    candidateDrcEvaluator: () => ({ errors: [], errorsWithCenters: [] }),
     drcEvaluator: () => {
       evaluationCount++
       return {
@@ -68,6 +80,9 @@ test("clearance precision preserves original routes when only centered errors ar
   expect(result.repaired).toBeFalse()
   expect(result.routes).toBe(routes)
   expect(routes).toEqual(originalRoutes)
-  expect(result.attemptedCandidateCount).toBe(evaluationCount)
+  expect(result.attemptedCandidateCount).toBe(indexedEvaluationCount)
+  expect(result.candidateValidationCount).toBe(1)
+  expect(result.referenceValidationCount).toBe(evaluationCount)
+  expect(result.referenceValidationCount).toBe(1)
   expect(result.attemptedCandidateCount).toBeLessThanOrEqual(24)
 })

--- a/tests/features/pipeline9-clearance-precision-requires-all-errors-clean.test.ts
+++ b/tests/features/pipeline9-clearance-precision-requires-all-errors-clean.test.ts
@@ -68,6 +68,7 @@ test("clearance precision preserves original routes until full reference DRC pas
       ]
     },
     candidateDrcEvaluator: () => ({ errors: [], errorsWithCenters: [] }),
+    marginDrcEvaluator: () => [],
     drcEvaluator: () => {
       evaluationCount++
       return {

--- a/tests/features/pipeline9-clearance-precision-requires-physical-margin.test.ts
+++ b/tests/features/pipeline9-clearance-precision-requires-physical-margin.test.ts
@@ -11,7 +11,8 @@ const getCircuitJson = (routes: HighDensityRoute[]): AnyCircuitElement[] => {
   const owner = routes[0]!
   const via = owner.vias[0]!
   const signal = routes[1]!
-  const ownerRoute: Extract<AnyCircuitElement, { type: "pcb_trace" }>["route"] = []
+  const ownerRoute: Extract<AnyCircuitElement, { type: "pcb_trace" }>["route"] =
+    []
   for (const [index, point] of owner.route.entries()) {
     const layer = point.z === 0 ? "top" : "bottom"
     ownerRoute.push({
@@ -134,9 +135,12 @@ test("clearance precision keeps a relaxed-clean candidate private until its phys
     },
     drcEvaluator: ({ routes: candidateRoutes }) => {
       referenceChecks++
-      const measured = checkViaTraceClearance(getCircuitJson(candidateRoutes!), {
-        minClearance: 0.2,
-      })
+      const measured = checkViaTraceClearance(
+        getCircuitJson(candidateRoutes!),
+        {
+          minClearance: 0.2,
+        },
+      )
       expect(measured).toHaveLength(1)
       expect(measured[0]!.actual_clearance).toBeGreaterThanOrEqual(0.11)
       return { errors: [], errorsWithCenters: [] }

--- a/tests/features/pipeline9-clearance-precision-requires-physical-margin.test.ts
+++ b/tests/features/pipeline9-clearance-precision-requires-physical-margin.test.ts
@@ -1,0 +1,154 @@
+import { checkViaTraceClearance } from "@tscircuit/checks"
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { applyPipeline9ClearancePrecisionRepairs } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/applyPipeline9ClearancePrecisionRepairs"
+import { getPipeline9ClearanceMarginErrors } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/getPipeline9ClearanceMarginErrors"
+import type { SimpleRouteJson } from "lib/types"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
+
+const getCircuitJson = (routes: HighDensityRoute[]): AnyCircuitElement[] => {
+  const owner = routes[0]!
+  const via = owner.vias[0]!
+  const signal = routes[1]!
+  const ownerRoute: Extract<AnyCircuitElement, { type: "pcb_trace" }>["route"] = []
+  for (const [index, point] of owner.route.entries()) {
+    const layer = point.z === 0 ? "top" : "bottom"
+    ownerRoute.push({
+      route_type: "wire",
+      x: point.x,
+      y: point.y,
+      width: 0.1,
+      layer,
+    })
+    const next = owner.route[index + 1]
+    if (next && point.z !== next.z) {
+      ownerRoute.push({
+        route_type: "via",
+        x: point.x,
+        y: point.y,
+        from_layer: layer,
+        to_layer: next.z === 0 ? "top" : "bottom",
+      })
+    }
+  }
+  return [
+    {
+      type: "pcb_via",
+      pcb_via_id: "via_0",
+      pcb_trace_id: "via_owner_0",
+      x: via.x,
+      y: via.y,
+      outer_diameter: 0.3,
+      hole_diameter: 0.15,
+      layers: ["top", "bottom"],
+    },
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "via_owner_0",
+      route: ownerRoute,
+    },
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "signal_0",
+      route: signal.route.map((point) => ({
+        route_type: "wire" as const,
+        x: point.x,
+        y: point.y,
+        width: 0.1,
+        layer: "top" as const,
+      })),
+    },
+  ]
+}
+
+test("clearance precision keeps a relaxed-clean candidate private until its physical margin passes", (): void => {
+  const srj: SimpleRouteJson = {
+    bounds: { minX: -2, minY: -2, maxX: 2, maxY: 2 },
+    layerCount: 2,
+    minTraceWidth: 0.1,
+    obstacles: [],
+    connections: [
+      { name: "via_owner", pointsToConnect: [] },
+      { name: "signal", pointsToConnect: [] },
+    ],
+  }
+  const routes: HighDensityRoute[] = [
+    {
+      connectionName: "via_owner",
+      traceThickness: 0.1,
+      viaDiameter: 0.3,
+      route: [
+        { x: -1, y: 0, z: 0 },
+        { x: 0, y: 0, z: 0 },
+        { x: 0, y: 0, z: 1 },
+        { x: 1, y: 0, z: 1 },
+      ],
+      vias: [{ x: 0, y: 0 }],
+    },
+    {
+      connectionName: "signal",
+      traceThickness: 0.1,
+      viaDiameter: 0.3,
+      route: [-1, -0.5, 0.5, 1].map((x) => ({ x, y: 0.289, z: 0 })),
+      vias: [],
+    },
+  ]
+  const originalRoutes = structuredClone(routes)
+  let cleanCandidatesWithoutMargin = 0
+  let referenceChecks = 0
+  const result = applyPipeline9ClearancePrecisionRepairs({
+    srj,
+    routes,
+    newConnections: srj.connections,
+    syntheticConnectionNames: new Set(),
+    connMap: getConnectivityMapFromSimpleRouteJson(srj),
+    initialErrors: [
+      {
+        type: "pcb_via_trace_clearance_error",
+        pcb_trace_id: "signal_0",
+        pcb_trace_ids: ["signal_0", "via_owner_0"],
+        pcb_via_id: "via_0",
+        pcb_via_ids: ["via_0"],
+        actual_clearance: 0.089,
+        minimum_clearance: 0.1,
+        center: { x: 0, y: 0 },
+      },
+    ],
+    indexedDrcEvaluator: () => [],
+    candidateDrcEvaluator: () => ({ errors: [], errorsWithCenters: [] }),
+    marginDrcEvaluator: (candidateRoutes, targets, initialRoutes) => {
+      const circuitJson = getCircuitJson(candidateRoutes)
+      const errors = getPipeline9ClearanceMarginErrors({
+        circuitJson,
+        originalCircuitJson: getCircuitJson(initialRoutes),
+        targets,
+      })
+      if (
+        errors.length > 0 &&
+        checkViaTraceClearance(circuitJson, { minClearance: 0.1 }).length === 0
+      ) {
+        cleanCandidatesWithoutMargin++
+      }
+      return errors
+    },
+    drcEvaluator: ({ routes: candidateRoutes }) => {
+      referenceChecks++
+      const measured = checkViaTraceClearance(getCircuitJson(candidateRoutes!), {
+        minClearance: 0.2,
+      })
+      expect(measured).toHaveLength(1)
+      expect(measured[0]!.actual_clearance).toBeGreaterThanOrEqual(0.11)
+      return { errors: [], errorsWithCenters: [] }
+    },
+  })
+  expect(cleanCandidatesWithoutMargin).toBeGreaterThan(0)
+  expect(result.repaired).toBeTrue()
+  expect(result.routes).not.toBe(routes)
+  expect(routes).toEqual(originalRoutes)
+  expect(referenceChecks).toBe(1)
+  expect(result.referenceValidationCount).toBe(1)
+  expect(result.candidateValidationCount).toBeGreaterThan(1)
+  expect(result.candidateValidationCount).toBeLessThanOrEqual(8)
+  expect(result.attemptedCandidateCount).toBeLessThanOrEqual(24)
+})

--- a/tests/features/pipeline9-srj18-sample8-relaxed-drc.test.ts
+++ b/tests/features/pipeline9-srj18-sample8-relaxed-drc.test.ts
@@ -1,3 +1,7 @@
+import {
+  checkPadTraceClearance,
+  checkViaTraceClearance,
+} from "@tscircuit/checks"
 import { expect, test } from "bun:test"
 import { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/AutoroutingPipelineSolver9_PreloadedTraceGraph"
 import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
@@ -14,12 +18,32 @@ test("Pipeline9 repairs SRJ18 sample 8's crowded trace/via clearances", async ()
 
   expect(solver.failed).toBeFalse()
   expect(solver.solved).toBeTrue()
-  const { errors } = evaluateRelaxedDrc({
+  const { errors, circuitJson } = evaluateRelaxedDrc({
     inputSrj: scenario,
     srjWithPointPairs: solver.srjWithPointPairs!,
     routedTraces: solver.getOutputSimplifiedPcbTraces(),
   })
   expect(errors).toHaveLength(0)
+  // A wider diagnostic radius reports physical gaps even after relaxed DRC
+  // accepts them. Keep this independent of the repair's margin evaluator.
+  const measuredPairs = new Map(
+    [
+      ...checkViaTraceClearance(circuitJson, { minClearance: 0.2 }),
+      ...checkPadTraceClearance(circuitJson, { minClearance: 0.2 }),
+    ].map((error) => [
+      `${error.type === "pcb_via_trace_clearance_error" ? error.pcb_via_id : error.pcb_pad_id}/${error.pcb_trace_id}`,
+      error.actual_clearance,
+    ]),
+  )
+  for (const pair of [
+    "via_58/source_trace_44__source_net_44_mst4_0",
+    "via_80/source_trace_48__source_net_48_mst0_0",
+    "via_250/source_trace_39__source_net_39_mst3_0",
+    "pcb_smtpad_50/source_trace_48__source_net_48_mst0_0",
+    "pcb_smtpad_312/source_trace_31__source_net_31_mst4_0",
+  ]) {
+    expect(measuredPairs.get(pair)).toBeGreaterThanOrEqual(0.11)
+  }
   const repairStats = solver.pipeline9JointDrcRepairSolver!.stats
   expect(repairStats.clearancePrecisionRepaired).toBeTrue()
   expect(repairStats.clearancePrecisionReferenceValidationCount).toBe(1)

--- a/tests/features/pipeline9-srj18-sample8-relaxed-drc.test.ts
+++ b/tests/features/pipeline9-srj18-sample8-relaxed-drc.test.ts
@@ -22,6 +22,10 @@ test("Pipeline9 repairs SRJ18 sample 8's crowded trace/via clearances", async ()
   expect(errors).toHaveLength(0)
   const repairStats = solver.pipeline9JointDrcRepairSolver!.stats
   expect(repairStats.clearancePrecisionRepaired).toBeTrue()
+  expect(repairStats.clearancePrecisionReferenceValidationCount).toBe(1)
+  expect(
+    Number(repairStats.clearancePrecisionCandidateValidationCount),
+  ).toBeLessThanOrEqual(8)
   expect(Number(repairStats.clearancePrecisionCandidateCount)).toBeGreaterThan(
     0,
   )

--- a/tests/features/pipeline9-srj18-sample8-relaxed-drc.test.ts
+++ b/tests/features/pipeline9-srj18-sample8-relaxed-drc.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/AutoroutingPipelineSolver9_PreloadedTraceGraph"
+import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
+import { loadScenarioBySampleNumber } from "../../scripts/benchmark/scenarios"
+
+test("Pipeline9 repairs SRJ18 sample 8's crowded trace/via clearances", async () => {
+  const { scenario } = await loadScenarioBySampleNumber("srj18", 8)
+  const solver = new AutoroutingPipelineSolver9_PreloadedTraceGraph(
+    structuredClone(scenario),
+    { cacheProvider: null, effort: 1 },
+  )
+
+  solver.solve()
+
+  expect(solver.failed).toBeFalse()
+  expect(solver.solved).toBeTrue()
+  const { errors } = evaluateRelaxedDrc({
+    inputSrj: scenario,
+    srjWithPointPairs: solver.srjWithPointPairs!,
+    routedTraces: solver.getOutputSimplifiedPcbTraces(),
+  })
+  expect(errors).toHaveLength(0)
+  const repairStats = solver.pipeline9JointDrcRepairSolver!.stats
+  expect(repairStats.clearancePrecisionRepaired).toBeTrue()
+  expect(Number(repairStats.clearancePrecisionCandidateCount)).toBeGreaterThan(0)
+  expect(Number(repairStats.clearancePrecisionCandidateCount)).toBeLessThanOrEqual(
+    24,
+  )
+})

--- a/tests/features/pipeline9-srj18-sample8-relaxed-drc.test.ts
+++ b/tests/features/pipeline9-srj18-sample8-relaxed-drc.test.ts
@@ -22,8 +22,10 @@ test("Pipeline9 repairs SRJ18 sample 8's crowded trace/via clearances", async ()
   expect(errors).toHaveLength(0)
   const repairStats = solver.pipeline9JointDrcRepairSolver!.stats
   expect(repairStats.clearancePrecisionRepaired).toBeTrue()
-  expect(Number(repairStats.clearancePrecisionCandidateCount)).toBeGreaterThan(0)
-  expect(Number(repairStats.clearancePrecisionCandidateCount)).toBeLessThanOrEqual(
-    24,
+  expect(Number(repairStats.clearancePrecisionCandidateCount)).toBeGreaterThan(
+    0,
   )
+  expect(
+    Number(repairStats.clearancePrecisionCandidateCount),
+  ).toBeLessThanOrEqual(24)
 })

--- a/tests/features/pipeline9-srj18-sample9-reference-clean-exact-output.test.ts
+++ b/tests/features/pipeline9-srj18-sample9-reference-clean-exact-output.test.ts
@@ -22,6 +22,8 @@ test("Pipeline9 preserves SRJ18 sample 9's reference-clean exact output", async 
     postExactReferenceValidationSkippedForIndexedIssueCount: false,
     postExactReferenceDrcIssueCount: 0,
     postExactReferenceAccepted: true,
+    clearancePrecisionCandidateCount: 0,
+    clearancePrecisionRepaired: false,
     terminalEscapeSkippedForIndexedIssueCount: false,
     terminalEscapeCandidateCount: 0,
     terminalEscapeAcceptedCount: 0,

--- a/tests/features/pipeline9-srj18-sample9-reference-clean-exact-output.test.ts
+++ b/tests/features/pipeline9-srj18-sample9-reference-clean-exact-output.test.ts
@@ -23,6 +23,8 @@ test("Pipeline9 preserves SRJ18 sample 9's reference-clean exact output", async 
     postExactReferenceDrcIssueCount: 0,
     postExactReferenceAccepted: true,
     clearancePrecisionCandidateCount: 0,
+    clearancePrecisionCandidateValidationCount: 0,
+    clearancePrecisionReferenceValidationCount: 0,
     clearancePrecisionRepaired: false,
     terminalEscapeSkippedForIndexedIssueCount: false,
     terminalEscapeCandidateCount: 0,


### PR DESCRIPTION
SRJ18 sample 8 finishes routing on main with four relaxed DRC clearance errors. A bounded precision repair now moves the affected copper and keeps the original failing contacts active until their physical gaps exceed the configured clearance by 0.010 mm. A candidate is published only when complete reference DRC also reports zero errors.

The nominal rule is 0.100 mm. These gaps are measured independently from the final paired benchmark geometry and verified against the unchanged checker:

| Original failing contact | Main gap | PR gap |
| --- | ---: | ---: |
| Pad 50 / trace 48 | 0.035534 mm | 0.112000 mm |
| Via 80 / trace 48 | 0.074049 mm | 0.118265 mm |
| Via 250 / trace 39 | 0.094492 mm | 0.115191 mm |
| Via 58 / trace 44 | 0.088911 mm | 0.126626 mm |

This margin requirement applies to contacts failing at the repair stage, not every clearance on the board. Pad 312 / trace 31 is a geometric tradeoff: its already-clear final main gap decreases from 0.173596 mm to 0.119563 mm, remaining above the 0.110 mm repair target.

The search moves shared via sites together, uses the referenced pad's position for pad forces, and ranks candidates with the existing indexed evaluator. It is bounded to 24 candidates and eight passes; sample 8 uses 21 candidates, seven selected-candidate validations, and one complete reference validation including continuity. Already reference-clean output, preloaded copper, synthetic sections, and unsupported remaining errors skip the search. Unsuccessful repairs preserve the input routes.

Original via targets are tracked through their owning trace's layer transition, so shared-site movement and via renumbering cannot substitute another contact. Coincident via geometry is measured using the largest copper diameter. The checker, tolerances, benchmark settings, dependencies, trace widths, and via diameters are unchanged.

Validation:

- All nine CI test shards, typecheck, build, formatting check, Vercel build, and no-ID-hacks check pass on `61d59ac1`.
- The full sample 8 test independently measures all five contacts handled by the repair stage at or above 0.110 mm, with zero relaxed DRC errors.
- Focused tests cover physical gaps beyond checker tolerance, withholding relaxed-clean candidates until margin passes, full-reference connectivity rejection, via renumbering, coincident copper, and unsupported identity changes.
- Sample 9 preserves its already-clean output; focused Pipeline9 tests also cover declared clearances, static connectivity, and samples 12 and 13. Local build and typecheck pass.

The following paired Blacksmith runs compare main `fb6c6d77` with PR `61d59ac1`, using the workflow and defaults behind `/benchmark-all --same-machine`. Each main/PR pair runs sequentially on the same machine.

| Dataset | Completed | Relaxed DRC passes | DRC issues | Timeouts | Average vias |
| --- | --- | --- | --- | --- | --- |
| [dataset01](https://github.com/tscircuit/tscircuit-autorouter/pull/2421#issuecomment-5555352847) | 85 → 85 | 85 → 85 | 0 → 0 | 0 → 0 | 37.52 → 37.52 |
| [dataset01 repeat](https://github.com/tscircuit/tscircuit-autorouter/pull/2421#issuecomment-5555383076) | 85 → 85 | 85 → 85 | 0 → 0 | 0 → 0 | 37.52 → 37.52 |
| [SRJ18](https://github.com/tscircuit/tscircuit-autorouter/pull/2421#issuecomment-5555352971) | 13 → 13 | 8 → 9 | 98 → 94 | 1 → 1 | 210.85 → 210.85 |

Across all 101 distinct samples, there are no lost solves, lost DRC passes, new timeouts, increased per-sample DRC issue counts, or via count changes. The existing timeout remains SRJ18 sample 6. Only sample 8's output SVG changes; the other 97 solved outputs are byte-identical. Both dataset01 repetitions are retained.

Sample 8 improves from 175.276 s to 172.240 s (−1.73%), including joint DRC repair from 41.040 s to 38.221 s (−6.87%). The repository regression detector reports no regressions, but some timing percentile rows do increase; those results are preserved here rather than treating the detector's threshold as proof of zero performance cost.

| Dataset | P50 | P60 | P70 | P80 | P90 | P95 |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| dataset01 | −7.1% | −4.4% | −6.8% | −8.7% | −5.8% | +3.6% |
| dataset01 repeat | +7.4% | −4.5% | +1.5% | −3.6% | +2.5% | +0.5% |
| SRJ18 | −1.0% | +10.3% | −1.7% | −3.3% | +1.4% | +2.5% |

SRJ18 sample 11's 15.0 s increase drives P60, with 9.1 s in unchanged port pathing. Sample 2 increases from 301.773 s to 314.218 s, including joint repair from 94.990 s to 101.882 s; it remains 45.782 s below the 360 s timeout. Focused execution counters confirm that neither sample runs the new precision search: sample 2 has 20 indexed residuals, above the existing 16-error gate; sample 11 is already reference-clean. Both record zero new precision candidates and zero new candidate/reference validations. Their recorded upstream iteration counts also match main. This supports run-to-run variation in unchanged work, but the positive timing rows remain visible and do not establish that every percentile is unchanged.
