### PR TITLE
Repair inherited Pipeline9 copper and preserve stitching terminal layers

### DIFF
--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -13,6 +13,32 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  inherited-copper-and-stitching:
+    if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'version-bumps/')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.3.8
+
+      - name: Install dependencies
+        run: bun install
+
+      # Keep the focused ownership and shared-stitch contracts observable even
+      # when an unrelated large-board test consumes a balanced shard's budget.
+      - name: Run inherited copper and stitching regressions
+        run: |
+          bun test \
+            tests/features/pipeline9-joint-drc-*.test.ts \
+            tests/features/pipeline9-srj23-sample49-inherited-copper-repair.test.ts \
+            tests/stitch-solver \
+            --timeout 300000
+
   test:
     if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'version-bumps/')
     runs-on: ubuntu-latest

--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -37,6 +37,7 @@ jobs:
             tests/features/pipeline9-joint-drc-*.test.ts \
             tests/features/pipeline9-srj23-sample49-inherited-copper-repair.test.ts \
             tests/features/pipeline7-srj20-sample169-multi-crossing-drc.test.ts \
+            tests/features/pipeline9-srj23-sample21-regional-b01-repair.test.ts \
             tests/stitch-solver \
             --timeout 300000
 

--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -44,6 +44,7 @@ jobs:
             tests/features/pipeline7-srj20-sample169-multi-crossing-drc.test.ts \
             tests/features/pipeline9-srj23-sample21-regional-b01-repair.test.ts \
             tests/features/pipeline9-srj18-sample13-bounded-post-exact-precision.test.ts \
+            tests/features/pipeline9-srj18-sample3-terminal-ownership.test.ts \
             tests/features/pipeline4-dataset01-circuit011-visual.test.ts \
             tests/bugs/bugreport59-82431e.test.ts \
             tests/bugs/bugreport88-9a86ed.test.ts \

--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -35,9 +35,14 @@ jobs:
         run: |
           bun test \
             tests/features/pipeline9-joint-drc-*.test.ts \
+            tests/features/pipeline9-inherited-drc-*.test.ts \
             tests/features/pipeline9-srj23-sample49-inherited-copper-repair.test.ts \
             tests/features/pipeline7-srj20-sample169-multi-crossing-drc.test.ts \
             tests/features/pipeline9-srj23-sample21-regional-b01-repair.test.ts \
+            tests/features/pipeline9-srj18-sample13-bounded-post-exact-precision.test.ts \
+            tests/features/pipeline4-dataset01-circuit011-visual.test.ts \
+            tests/bugs/bugreport59-82431e.test.ts \
+            tests/bugs/bugreport88-9a86ed.test.ts \
             tests/stitch-solver \
             --timeout 300000
 

--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -36,7 +36,11 @@ jobs:
           bun test \
             tests/features/pipeline9-joint-drc-*.test.ts \
             tests/features/pipeline9-inherited-drc-*.test.ts \
+            tests/features/pipeline9-minimal-preloaded-trace-graph.test.ts \
+            tests/features/pipeline7-dataset01-circuit143-trace-clearance.test.ts \
             tests/features/pipeline9-srj23-sample49-inherited-copper-repair.test.ts \
+            tests/features/pipeline9-srj23-sample26-stitch-plated-hole.test.ts \
+            tests/features/pipeline9-srj23-sample45-stitch-completion.test.ts \
             tests/features/pipeline7-srj20-sample169-multi-crossing-drc.test.ts \
             tests/features/pipeline9-srj23-sample21-regional-b01-repair.test.ts \
             tests/features/pipeline9-srj18-sample13-bounded-post-exact-precision.test.ts \

--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -36,6 +36,7 @@ jobs:
           bun test \
             tests/features/pipeline9-joint-drc-*.test.ts \
             tests/features/pipeline9-srj23-sample49-inherited-copper-repair.test.ts \
+            tests/features/pipeline7-srj20-sample169-multi-crossing-drc.test.ts \
             tests/stitch-solver \
             --timeout 300000
 

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/AutoroutingPipelineSolver9_PreloadedTraceGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/AutoroutingPipelineSolver9_PreloadedTraceGraph.ts
@@ -85,6 +85,7 @@ import {
   type PreloadedHighDensityRoute,
 } from "./convertPreloadedTraceToHdRoutes"
 import { Pipeline9HighDensitySolver } from "./Pipeline9HighDensitySolver"
+import { Pipeline9InheritedDrcRepairSolver } from "./Pipeline9InheritedDrcRepairSolver"
 import { Pipeline9JointDrcRepairSolver } from "./Pipeline9JointDrcRepairSolver"
 import { PreloadedTraceGraphSolver } from "./PreloadedTraceGraphSolver"
 import { PreprocessSimpleRouteJsonWithoutTraceObstaclesSolver } from "./PreprocessSimpleRouteJsonWithoutTraceObstaclesSolver"
@@ -261,6 +262,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
   highDensityStitchSolver?: MultipleHighDensityRouteStitchSolver3
   globalDrcForceImproveSolver?: GlobalDrcForceImproveSolver
   pipeline9JointDrcRepairSolver?: Pipeline9JointDrcRepairSolver
+  pipeline9InheritedDrcRepairSolver?: Pipeline9InheritedDrcRepairSolver
   singleLayerNodeMerger?: SingleLayerNodeMergerSolver
   strawSolver?: StrawSolver
   deadEndSolver?: DeadEndSolver
@@ -852,6 +854,37 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
       },
     ),
     definePipelineStep(
+      "pipeline9InheritedDrcRepairSolver",
+      Pipeline9InheritedDrcRepairSolver,
+      (cms) => {
+        const jointRepair = cms.pipeline9JointDrcRepairSolver
+        if (!jointRepair || !jointRepair.solved || jointRepair.failed) {
+          throw new Error(
+            "Pipeline9 inherited repair requires completed joint repair",
+          )
+        }
+        const updatedPreloadedTraces = jointRepair.getUpdatedPreloadedTraces()
+        const srjWithRepairedPreloadedTraces = {
+          ...jointRepair.params.srjWithPointPairs,
+          traces: updatedPreloadedTraces,
+        }
+        return [
+          {
+            ...jointRepair.params,
+            srj: srjWithRepairedPreloadedTraces,
+            srjWithPointPairs: srjWithRepairedPreloadedTraces,
+            newHdRoutes: jointRepair.getOutput(),
+            updatedPreloadedTraces,
+            mutatedPreloadedTraceIds: new Set(
+              jointRepair
+                .getMutatedPreloadedTraces()
+                .map((trace) => trace.pcb_trace_id),
+            ),
+          },
+        ]
+      },
+    ),
+    definePipelineStep(
       "lengthMatchingPostProcessingSolver",
       LengthMatchingPostProcessingSolver,
       (cms) => {
@@ -880,7 +913,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
             )
           }
         }
-        const hdRoutes = cms.pipeline9JointDrcRepairSolver!.getOutput()
+        const hdRoutes = cms.pipeline9InheritedDrcRepairSolver!.getOutput()
         const differentialPairs = (cms.srj.differentialPairs ?? []).map(
           (pair) => {
             const connectionNames = pair.connectionNames.map(
@@ -1212,6 +1245,8 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
       this.globalDrcForceImproveSolver?.visualize()
     const pipeline9JointDrcRepairViz =
       this.pipeline9JointDrcRepairSolver?.visualize()
+    const pipeline9InheritedDrcRepairViz =
+      this.pipeline9InheritedDrcRepairSolver?.visualize()
     const visualizations = [
       problemViz,
       processedProblemViz,
@@ -1243,6 +1278,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
       traceWidthViz,
       globalDrcForceImproveViz,
       pipeline9JointDrcRepairViz,
+      pipeline9InheritedDrcRepairViz,
       lengthMatchingPostProcessingViz,
       powerTraceExpansionViz,
       this.solved
@@ -1331,6 +1367,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
       return hdRoutes
     }
     return (
+      this.pipeline9InheritedDrcRepairSolver?.getOutput() ??
       this.pipeline9JointDrcRepairSolver?.getOutput() ??
       this.globalDrcForceImproveSolver?.getOutput() ??
       this.traceWidthSolver?.getHdRoutesWithWidths() ??
@@ -1457,6 +1494,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
 
   getUpdatedPreloadedTraces(): SimplifiedPcbTraces {
     return (
+      this.pipeline9InheritedDrcRepairSolver?.getUpdatedPreloadedTraces() ??
       this.pipeline9JointDrcRepairSolver?.getUpdatedPreloadedTraces() ??
       this.getPreloadedTraceUpdatesAfterHighDensity().updatedPreloadedTraces
     )
@@ -1464,6 +1502,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
 
   getMutatedPreloadedTraces(): SimplifiedPcbTraces {
     return (
+      this.pipeline9InheritedDrcRepairSolver?.getMutatedPreloadedTraces() ??
       this.pipeline9JointDrcRepairSolver?.getMutatedPreloadedTraces() ??
       this.getPreloadedTraceUpdatesAfterHighDensity().mutatedPreloadedTraces
     )

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9InheritedDrcRepairSolver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9InheritedDrcRepairSolver.ts
@@ -1,0 +1,322 @@
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
+import type { SimplifiedPcbTrace } from "lib/types"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+import { mapZToLayerName } from "lib/utils/mapZToLayerName"
+import {
+  type MovablePreloadedSection,
+  Pipeline9JointDrcRepairSolver,
+  type Pipeline9JointDrcRepairSolverParams,
+  type Pipeline9PreloadedTraceReconstruction,
+} from "./Pipeline9JointDrcRepairSolver"
+import { isPipeline9JointDrcOutputNoWorse } from "./isPipeline9JointDrcOutputNoWorse"
+import { preparePipeline9DrcRoutedTracesWithMetadata } from "./preparePipeline9DrcRoutedTraces"
+
+type InheritedMovablePreloadedSection = MovablePreloadedSection & {
+  anchorStart: HighDensityRoute["route"][number]
+  anchorEnd: HighDensityRoute["route"][number]
+}
+
+/**
+ * Repairs inherited ordinary copper only after the existing joint repair has
+ * finished. Its full published board is the incumbent, never the earlier
+ * global-repair output. Native Repair03 and the original joint policy remain
+ * unchanged; this layer specializes ownership and publication only.
+ */
+export class Pipeline9InheritedDrcRepairSolver extends Pipeline9JointDrcRepairSolver {
+  private readonly incumbentParams: Pipeline9JointDrcRepairSolverParams
+  private inheritedOutputAccepted = false
+
+  constructor(params: Pipeline9JointDrcRepairSolverParams) {
+    // Native search may mutate its working geometry. Keep the previously
+    // accepted stage's complete board separate from every speculative input.
+    const searchConnMap = new ConnectivityMap(
+      structuredClone(params.connMap.netMap),
+    )
+    // Merged net keys may share one member array. Reconstructing only netMap
+    // changes its primary ID according to key order; retain both maps exactly.
+    searchConnMap.idToNetMap = { ...params.connMap.idToNetMap }
+    super({
+      ...params,
+      connMap: searchConnMap,
+      srj: structuredClone(params.srj),
+      srjWithPointPairs: structuredClone(params.srjWithPointPairs),
+      originalSrj: structuredClone(params.originalSrj),
+      newConnections: structuredClone(params.newConnections),
+      newHdRoutes: structuredClone(params.newHdRoutes),
+      updatedPreloadedTraces: structuredClone(params.updatedPreloadedTraces),
+      mutatedPreloadedTraceIds: new Set(params.mutatedPreloadedTraceIds),
+      obstacles: structuredClone(params.obstacles),
+      colorMap: { ...params.colorMap },
+    })
+    this.incumbentParams = params
+    this.stats = {
+      ...this.stats,
+      jointOutputValidationAttempted: false,
+      jointOutputAccepted: false,
+      jointOutputRejectedForSectionAnchor: false,
+      jointOutputRejectedForTerminalMetadata: false,
+      jointOutputRejectedForDrcRegression: false,
+      publishedJointDrcIssueCount:
+        this.publicationContext.currentDrcResult.errors.length,
+      inheritedRepairSkippedForEmptyOwnership:
+        this.movablePreloadedSections.length === 0,
+    }
+    // This layer owns ordinary preloaded sections, not a second search over
+    // purely new HD routes. Empty ownership is normal completed work.
+    if (this.movablePreloadedSections.length === 0) {
+      this.solved = true
+      this.activeSubSolver = null
+    }
+  }
+
+  override getSolverName(): string {
+    return "Pipeline9InheritedDrcRepairSolver"
+  }
+
+  override getConstructorParams(): [Pipeline9JointDrcRepairSolverParams] {
+    return [this.incumbentParams]
+  }
+
+  protected override selectDrcErrors<TError extends Record<string, unknown>>(
+    input: {
+      errors: TError[]
+      baselineErrors: Array<Record<string, unknown>>
+      originalTraceIdByPreparedTraceId?: ReadonlyMap<string, string>
+    },
+  ): TError[] {
+    // Provenance does not exempt an ordinary wire from this layer's objective.
+    // Keep the complete official set, including inherited same-ID worsening.
+    return input.errors
+  }
+
+  protected override prepareMovablePreloadedSection(
+    section: MovablePreloadedSection,
+  ): InheritedMovablePreloadedSection {
+    const route = section.hdRoute.route.map(
+      (point): HighDensityRoute["route"][number] => {
+        const taggedWire = section.originalTrace.route.find(
+          (primitive): boolean =>
+            primitive.route_type === "wire" &&
+            primitive.x === point.x &&
+            primitive.y === point.y &&
+            primitive.layer ===
+              mapZToLayerName(point.z, this.params.layerCount) &&
+            (primitive.start_pcb_port_id !== undefined ||
+              primitive.end_pcb_port_id !== undefined),
+        )
+        return taggedWire?.route_type === "wire"
+          ? {
+              ...point,
+              pcb_port_id:
+                taggedWire.start_pcb_port_id ?? taggedWire.end_pcb_port_id,
+            }
+          : point
+      },
+    )
+    if (route.length < 2) {
+      throw new Error("Pipeline9 inherited repair requires two section anchors")
+    }
+    return {
+      ...section,
+      hdRoute: { ...section.hdRoute, route },
+      anchorStart: { ...route[0]! },
+      anchorEnd: { ...route.at(-1)! },
+    }
+  }
+
+  protected override rebuildPreloadedTrace(
+    input: Pipeline9PreloadedTraceReconstruction,
+  ): SimplifiedPcbTrace {
+    const rebuilt = super.rebuildPreloadedTrace(input)
+    return {
+      ...rebuilt,
+      route: rebuilt.route.map(
+        (point): SimplifiedPcbTrace["route"][number] => {
+          const originalPoint =
+            point.route_type === "wire"
+              ? input.originalTrace.route.find(
+                  (primitive): boolean =>
+                    primitive.route_type === "wire" &&
+                    primitive.x === point.x &&
+                    primitive.y === point.y &&
+                    primitive.layer === point.layer &&
+                    (primitive.start_pcb_port_id !== undefined ||
+                      primitive.end_pcb_port_id !== undefined),
+                )
+              : undefined
+          if (
+            point.route_type !== "wire" ||
+            originalPoint?.route_type !== "wire"
+          ) {
+            return point
+          }
+          return {
+            ...point,
+            ...(originalPoint.start_pcb_port_id === undefined
+              ? {}
+              : { start_pcb_port_id: originalPoint.start_pcb_port_id }),
+            ...(originalPoint.end_pcb_port_id === undefined
+              ? {}
+              : { end_pcb_port_id: originalPoint.end_pcb_port_id }),
+          }
+        },
+      ),
+    }
+  }
+
+  private validateInheritedOutput(routes: HighDensityRoute[]): boolean {
+    const params = this.params
+    const { currentDrcResult, convertNewRoutes, traceClearance } =
+      this.publicationContext
+    this.stats.jointOutputValidationAttempted = true
+    this.stats.jointOutputRejectedForSectionAnchor = false
+    this.stats.jointOutputRejectedForTerminalMetadata = false
+    this.stats.jointOutputRejectedForDrcRegression = false
+    this.stats.publishedJointDrcIssueCount = currentDrcResult.errors.length
+    // Synthetic section boundaries anchor on real terminals or protected
+    // through-obstacle spans. A section must not detach from either end.
+    const inheritedSections =
+      this.movablePreloadedSections as InheritedMovablePreloadedSection[]
+    for (const section of inheritedSections) {
+      const candidateSections = routes.filter(
+        (route) => route.connectionName === section.syntheticConnectionName,
+      )
+      if (candidateSections.length !== 1) {
+        throw new Error(
+          `Pipeline9 joint output requires one section "${section.syntheticConnectionName}"`,
+        )
+      }
+      const candidate = candidateSections[0]!
+      const start = candidate.route[0]
+      const end = candidate.route.at(-1)
+      const originalStart = section.anchorStart
+      const originalEnd = section.anchorEnd
+      if (
+        !start ||
+        !end ||
+        start.x !== originalStart.x ||
+        start.y !== originalStart.y ||
+        start.z !== originalStart.z ||
+        end.x !== originalEnd.x ||
+        end.y !== originalEnd.y ||
+        end.z !== originalEnd.z
+      ) {
+        this.stats.jointOutputRejectedForSectionAnchor = true
+        return false
+      }
+    }
+    const changedPreloadedTraceIds = new Set([
+      ...params.mutatedPreloadedTraceIds,
+      ...this.movablePreloadedSections.map(
+        (section) => section.originalTrace.pcb_trace_id,
+      ),
+    ])
+    // Check the exact public reconstruction, not the separate synthetic
+    // sections used for search. Reattach every protected primitive first.
+    const updatedPreloadedTraces = this.rebuildUpdatedPreloadedTraces(routes)
+    for (const [
+      index,
+      originalTrace,
+    ] of params.updatedPreloadedTraces.entries()) {
+      const updatedTrace = updatedPreloadedTraces[index]!
+      for (const primitive of originalTrace.route) {
+        if (
+          primitive.route_type !== "wire" ||
+          (primitive.start_pcb_port_id === undefined &&
+            primitive.end_pcb_port_id === undefined)
+        ) {
+          continue
+        }
+        const terminalPreserved = updatedTrace.route.some(
+          (point): boolean =>
+            point.route_type === "wire" &&
+            point.x === primitive.x &&
+            point.y === primitive.y &&
+            point.layer === primitive.layer &&
+            point.start_pcb_port_id === primitive.start_pcb_port_id &&
+            point.end_pcb_port_id === primitive.end_pcb_port_id,
+        )
+        if (!terminalPreserved) {
+          this.stats.jointOutputRejectedForTerminalMetadata = true
+          return false
+        }
+      }
+    }
+    const preparedOutput = preparePipeline9DrcRoutedTracesWithMetadata({
+      originalPreloadedTraces: params.originalSrj.traces ?? [],
+      mutatedPreloadedTraces: updatedPreloadedTraces.filter((trace) =>
+        changedPreloadedTraceIds.has(trace.pcb_trace_id),
+      ),
+      newTraces: convertNewRoutes(
+        routes.filter(
+          (route) => !this.syntheticConnectionNames.has(route.connectionName),
+        ),
+      ),
+    })
+    const candidateDrc = evaluateRelaxedDrc({
+      inputSrj: params.originalSrj,
+      srjWithPointPairs: params.srjWithPointPairs,
+      routedTraces: preparedOutput.routedTraces,
+      drcOptions: { traceClearance },
+    })
+    this.stats.jointOutputCandidateDrcIssueCount = candidateDrc.errors.length
+    const noWorse = isPipeline9JointDrcOutputNoWorse({
+      candidate: {
+        errors: candidateDrc.errors.map(
+          (error): Record<string, unknown> => ({ ...error }),
+        ),
+        circuitJson: candidateDrc.circuitJson,
+      },
+      current: {
+        errors: currentDrcResult.errors.map(
+          (error): Record<string, unknown> => ({ ...error }),
+        ),
+        circuitJson: currentDrcResult.circuitJson,
+      },
+    })
+    this.stats.jointOutputRejectedForDrcRegression = !noWorse
+    this.stats.publishedJointDrcIssueCount = noWorse
+      ? candidateDrc.errors.length
+      : currentDrcResult.errors.length
+    return noWorse
+  }
+
+  protected override publishValidatedOutput(routes: HighDensityRoute[]): void {
+    this.inheritedOutputAccepted = this.validateInheritedOutput(routes)
+    this.stats.jointOutputAccepted = this.inheritedOutputAccepted
+    // Rejected optimization proposals preserve the complete incoming board.
+    // Solver failures still propagate through the inherited incremental loop.
+    super.publishValidatedOutput(
+      this.inheritedOutputAccepted ? routes : this.inputNewHdRoutes,
+    )
+  }
+
+  override getOutput(): HighDensityRoute[] {
+    if (!this.inheritedOutputAccepted) {
+      return this.incumbentParams.newHdRoutes
+    }
+    return super.getOutput()
+  }
+
+  override getUpdatedPreloadedTraces(): SimplifiedPcbTrace[] {
+    if (!this.inheritedOutputAccepted) {
+      return this.incumbentParams.updatedPreloadedTraces
+    }
+    return this.rebuildUpdatedPreloadedTraces(this.getCombinedOutput())
+  }
+
+  override getMutatedPreloadedTraces(): SimplifiedPcbTrace[] {
+    const mutatedTraceIds = new Set([
+      ...this.incumbentParams.mutatedPreloadedTraceIds,
+      ...(this.inheritedOutputAccepted
+        ? this.movablePreloadedSections.map(
+            (section) => section.originalTrace.pcb_trace_id,
+          )
+        : []),
+    ])
+    return this.getUpdatedPreloadedTraces().filter((trace) =>
+      mutatedTraceIds.has(trace.pcb_trace_id),
+    )
+  }
+}

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9InheritedDrcRepairSolver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9InheritedDrcRepairSolver.ts
@@ -78,13 +78,13 @@ export class Pipeline9InheritedDrcRepairSolver extends Pipeline9JointDrcRepairSo
     return [this.incumbentParams]
   }
 
-  protected override selectDrcErrors<TError extends Record<string, unknown>>(
-    input: {
-      errors: TError[]
-      baselineErrors: Array<Record<string, unknown>>
-      originalTraceIdByPreparedTraceId?: ReadonlyMap<string, string>
-    },
-  ): TError[] {
+  protected override selectDrcErrors<
+    TError extends Record<string, unknown>,
+  >(input: {
+    errors: TError[]
+    baselineErrors: Array<Record<string, unknown>>
+    originalTraceIdByPreparedTraceId?: ReadonlyMap<string, string>
+  }): TError[] {
     // Provenance does not exempt an ordinary wire from this layer's objective.
     // Keep the complete official set, including inherited same-ID worsening.
     return input.errors
@@ -131,37 +131,35 @@ export class Pipeline9InheritedDrcRepairSolver extends Pipeline9JointDrcRepairSo
     const rebuilt = super.rebuildPreloadedTrace(input)
     return {
       ...rebuilt,
-      route: rebuilt.route.map(
-        (point): SimplifiedPcbTrace["route"][number] => {
-          const originalPoint =
-            point.route_type === "wire"
-              ? input.originalTrace.route.find(
-                  (primitive): boolean =>
-                    primitive.route_type === "wire" &&
-                    primitive.x === point.x &&
-                    primitive.y === point.y &&
-                    primitive.layer === point.layer &&
-                    (primitive.start_pcb_port_id !== undefined ||
-                      primitive.end_pcb_port_id !== undefined),
-                )
-              : undefined
-          if (
-            point.route_type !== "wire" ||
-            originalPoint?.route_type !== "wire"
-          ) {
-            return point
-          }
-          return {
-            ...point,
-            ...(originalPoint.start_pcb_port_id === undefined
-              ? {}
-              : { start_pcb_port_id: originalPoint.start_pcb_port_id }),
-            ...(originalPoint.end_pcb_port_id === undefined
-              ? {}
-              : { end_pcb_port_id: originalPoint.end_pcb_port_id }),
-          }
-        },
-      ),
+      route: rebuilt.route.map((point): SimplifiedPcbTrace["route"][number] => {
+        const originalPoint =
+          point.route_type === "wire"
+            ? input.originalTrace.route.find(
+                (primitive): boolean =>
+                  primitive.route_type === "wire" &&
+                  primitive.x === point.x &&
+                  primitive.y === point.y &&
+                  primitive.layer === point.layer &&
+                  (primitive.start_pcb_port_id !== undefined ||
+                    primitive.end_pcb_port_id !== undefined),
+              )
+            : undefined
+        if (
+          point.route_type !== "wire" ||
+          originalPoint?.route_type !== "wire"
+        ) {
+          return point
+        }
+        return {
+          ...point,
+          ...(originalPoint.start_pcb_port_id === undefined
+            ? {}
+            : { start_pcb_port_id: originalPoint.start_pcb_port_id }),
+          ...(originalPoint.end_pcb_port_id === undefined
+            ? {}
+            : { end_pcb_port_id: originalPoint.end_pcb_port_id }),
+        }
+      }),
     }
   }
 
@@ -176,8 +174,8 @@ export class Pipeline9InheritedDrcRepairSolver extends Pipeline9JointDrcRepairSo
     this.stats.publishedJointDrcIssueCount = currentDrcResult.errors.length
     // Synthetic section boundaries anchor on real terminals or protected
     // through-obstacle spans. A section must not detach from either end.
-    const inheritedSections =
-      this.movablePreloadedSections as InheritedMovablePreloadedSection[]
+    const inheritedSections = this
+      .movablePreloadedSections as InheritedMovablePreloadedSection[]
     for (const section of inheritedSections) {
       const candidateSections = routes.filter(
         (route) => route.connectionName === section.syntheticConnectionName,

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver.ts
@@ -290,8 +290,7 @@ const combinePreloadedTraceSectionGroup = ({
     if (taggedWire?.route_type === "wire") {
       route[index] = {
         ...point,
-        pcb_port_id:
-          taggedWire.start_pcb_port_id ?? taggedWire.end_pcb_port_id,
+        pcb_port_id: taggedWire.start_pcb_port_id ?? taggedWire.end_pcb_port_id,
       }
     }
   }
@@ -1055,8 +1054,7 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
       ])
       // Check the exact public reconstruction, not the separate synthetic
       // sections used for search. Reattach every protected primitive first.
-      const updatedPreloadedTraces =
-        this.rebuildUpdatedPreloadedTraces(routes)
+      const updatedPreloadedTraces = this.rebuildUpdatedPreloadedTraces(routes)
       for (const [
         index,
         originalTrace,
@@ -1087,8 +1085,8 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
       }
       const preparedOutput = preparePipeline9DrcRoutedTracesWithMetadata({
         originalPreloadedTraces: params.originalSrj.traces ?? [],
-        mutatedPreloadedTraces: updatedPreloadedTraces.filter(
-          (trace) => changedPreloadedTraceIds.has(trace.pcb_trace_id),
+        mutatedPreloadedTraces: updatedPreloadedTraces.filter((trace) =>
+          changedPreloadedTraceIds.has(trace.pcb_trace_id),
         ),
         newTraces: convertNewRoutes(
           routes.filter(

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver.ts
@@ -31,9 +31,9 @@ import {
   type PreloadedHighDensityRoute,
   convertPreloadedTraceToHdRoutes,
 } from "./convertPreloadedTraceToHdRoutes"
-import { filterPipeline9DrcErrorsAgainstBaseline } from "./filterPipeline9DrcErrorsAgainstBaseline"
 import { getPipeline9PreloadedTraceIdsInInitialDrcRegions } from "./getPipeline9PreloadedTraceIdsInInitialDrcRegions"
 import { getPipeline9PreloadedViaPairTraceGroups } from "./getPipeline9PreloadedViaPairTraceGroups"
+import { isPipeline9JointDrcOutputNoWorse } from "./isPipeline9JointDrcOutputNoWorse"
 import { mergePipeline9MovablePreloadedVias } from "./mergePipeline9MovablePreloadedVias"
 import { normalizePipeline9DrcErrorsForRepair } from "./normalizePipeline9DrcErrorsForRepair"
 import {
@@ -78,6 +78,8 @@ type MovablePreloadedSection = {
   syntheticConnectionName: string
   evaluationTraceId: string
   hdRoute: HighDensityRoute
+  anchorStart: HighDensityRoute["route"][number]
+  anchorEnd: HighDensityRoute["route"][number]
 }
 
 type PreloadedTraceSectionGroup = {
@@ -89,7 +91,6 @@ type PreloadedTraceSectionGroup = {
 type PreparedCandidateDrcInput = {
   evaluatedTraces: SimplifiedPcbTrace[]
   movableTraceIds: ReadonlySet<string>
-  originalTraceIdByEvaluationTraceId: ReadonlyMap<string, string>
   routedTraces: SimplifiedPcbTrace[]
   solverTraceIdByEvaluationTraceId: ReadonlyMap<string, string>
 }
@@ -222,11 +223,13 @@ const combinePreloadedTraceSectionGroup = ({
   sectionGroup,
   syntheticConnectionName,
   connMap,
+  layerCount,
 }: {
   trace: SimplifiedPcbTrace
   sectionGroup: PreloadedTraceSectionGroup
   syntheticConnectionName: string
   connMap: ConnectivityMap
+  layerCount: number
 }): HighDensityRoute => {
   const traceSections = sectionGroup.routes
   if (traceSections.length === 0) {
@@ -270,6 +273,26 @@ const combinePreloadedTraceSectionGroup = ({
     route[route.length - 1] = {
       ...route.at(-1)!,
       pcb_port_id: endPcbPortId,
+    }
+  }
+  // Preserve real interior terminal identities too. Synthetic section ends
+  // alone do not describe a preloaded trace that visits another tagged pad.
+  for (const [index, point] of route.entries()) {
+    const taggedWire = trace.route.find(
+      (primitive): boolean =>
+        primitive.route_type === "wire" &&
+        primitive.x === point.x &&
+        primitive.y === point.y &&
+        primitive.layer === mapZToLayerName(point.z, layerCount) &&
+        (primitive.start_pcb_port_id !== undefined ||
+          primitive.end_pcb_port_id !== undefined),
+    )
+    if (taggedWire?.route_type === "wire") {
+      route[index] = {
+        ...point,
+        pcb_port_id:
+          taggedWire.start_pcb_port_id ?? taggedWire.end_pcb_port_id,
+      }
     }
   }
 
@@ -572,12 +595,43 @@ const rebuildPreloadedTraceFromSections = ({
         `Pipeline9 found overlapping repaired sections for preloaded trace "${originalTrace.pcb_trace_id}"`,
       )
     }
+    const repairedRoute = repairedSection.route.map(
+      (point): SimplifiedPcbTrace["route"][number] => {
+        const originalPoint =
+          point.route_type === "wire"
+            ? originalTrace.route.find(
+                (primitive): boolean =>
+                  primitive.route_type === "wire" &&
+                  primitive.x === point.x &&
+                  primitive.y === point.y &&
+                  primitive.layer === point.layer &&
+                  (primitive.start_pcb_port_id !== undefined ||
+                    primitive.end_pcb_port_id !== undefined),
+              )
+            : undefined
+        if (
+          point.route_type !== "wire" ||
+          originalPoint?.route_type !== "wire"
+        ) {
+          return point
+        }
+        return {
+          ...point,
+          ...(originalPoint.start_pcb_port_id === undefined
+            ? {}
+            : { start_pcb_port_id: originalPoint.start_pcb_port_id }),
+          ...(originalPoint.end_pcb_port_id === undefined
+            ? {}
+            : { end_pcb_port_id: originalPoint.end_pcb_port_id }),
+        }
+      },
+    )
     rebuiltRoute.push(
       ...originalTrace.route.slice(
         originalRoutePosition,
         repairedSection.routePositionStart,
       ),
-      ...repairedSection.route,
+      ...repairedRoute,
     )
     originalRoutePosition = repairedSection.routePositionEnd + 1
   }
@@ -660,6 +714,8 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
     ReturnType<DrcEvaluator>
   >()
   private combinedOutput?: HighDensityRoute[]
+  private jointOutputAccepted = false
+  private validatePublishedOutput?: (routes: HighDensityRoute[]) => boolean
 
   private cacheIndexedDrcResult(
     candidateKey: DrcCandidateKey,
@@ -718,21 +774,6 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
       routedTraces: [],
       drcOptions: { traceClearance },
     })
-    const baselineEvaluatedTraceIds = new Set(
-      (params.originalSrj.traces ?? []).map((trace) => trace.pcb_trace_id),
-    )
-    const baselineErrors = addAutoroutingViaTraceIds({
-      errors: baselineDrc.errors as unknown as Array<Record<string, unknown>>,
-      circuitJson: baselineDrc.circuitJson,
-      evaluatedTraceIds: baselineEvaluatedTraceIds,
-    })
-    const baselineErrorsWithCenters = addAutoroutingViaTraceIds({
-      errors: baselineDrc.errorsWithCenters as unknown as Array<
-        Record<string, unknown>
-      >,
-      circuitJson: baselineDrc.circuitJson,
-      evaluatedTraceIds: baselineEvaluatedTraceIds,
-    })
     const currentDrcResult = evaluateRelaxedDrc({
       inputSrj: params.originalSrj,
       srjWithPointPairs: params.srjWithPointPairs,
@@ -761,18 +802,11 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
     })
     const currentDrc = {
       ...currentDrcResult,
-      errors: filterPipeline9DrcErrorsAgainstBaseline({
-        errors: currentErrors,
-        baselineErrors,
-        originalTraceIdByPreparedTraceId:
-          preparedCurrentOutput.originalPreloadedTraceIdByPreparedTraceId,
-      }),
-      errorsWithCenters: filterPipeline9DrcErrorsAgainstBaseline({
-        errors: currentErrorsWithCenters,
-        baselineErrors: baselineErrorsWithCenters,
-        originalTraceIdByPreparedTraceId:
-          preparedCurrentOutput.originalPreloadedTraceIdByPreparedTraceId,
-      }),
+      // Input provenance does not make an ordinary wire's violation exempt.
+      // Select from the complete current board; section extraction below still
+      // keeps protected through-obstacle primitives outside repair ownership.
+      errors: currentErrors,
+      errorsWithCenters: currentErrorsWithCenters,
     }
     const preparedTraceIdsInErrors = getTraceIdsFromDrcErrors({
       errors: currentDrc.errors as unknown as Array<Record<string, unknown>>,
@@ -837,18 +871,22 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
       for (const [traceSectionIndex, sectionGroup] of sectionGroups.entries()) {
         const movableSectionIndex = this.movablePreloadedSections.length
         const syntheticConnectionName = `pipeline9_preloaded_drc_${movableSectionIndex}`
+        const hdRoute = combinePreloadedTraceSectionGroup({
+          trace,
+          sectionGroup,
+          syntheticConnectionName,
+          connMap: params.connMap,
+          layerCount: params.layerCount,
+        })
         this.movablePreloadedSections.push({
           originalTrace: trace,
           originalRoutePositionStart: sectionGroup.routePositionStart,
           originalRoutePositionEnd: sectionGroup.routePositionEnd,
           syntheticConnectionName,
           evaluationTraceId: `${trace.pcb_trace_id}__pipeline9_section_${traceSectionIndex}`,
-          hdRoute: combinePreloadedTraceSectionGroup({
-            trace,
-            sectionGroup,
-            syntheticConnectionName,
-            connMap: params.connMap,
-          }),
+          hdRoute,
+          anchorStart: { ...hdRoute.route[0]! },
+          anchorEnd: { ...hdRoute.route.at(-1)! },
         })
       }
     }
@@ -960,11 +998,130 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
       exactRepairConfiguredViaInPadMaxIterations: EXACT_REPAIR_MAX_ITERATIONS,
       exactRepairConfiguredBroadMaxIterations:
         EXACT_REPAIR_BROAD_MAX_ITERATIONS,
+      jointOutputValidationAttempted: false,
+      jointOutputAccepted: false,
+      jointOutputRejectedForSectionAnchor: false,
+      jointOutputRejectedForTerminalMetadata: false,
+      jointOutputRejectedForDrcRegression: false,
+      publishedJointDrcIssueCount: currentDrc.errors.length,
     }
 
     if (currentDrc.errors.length === 0) {
       this.solved = true
       return
+    }
+
+    this.validatePublishedOutput = (routes: HighDensityRoute[]): boolean => {
+      this.stats.jointOutputValidationAttempted = true
+      this.stats.jointOutputRejectedForSectionAnchor = false
+      this.stats.jointOutputRejectedForTerminalMetadata = false
+      this.stats.jointOutputRejectedForDrcRegression = false
+      this.stats.publishedJointDrcIssueCount = currentDrcResult.errors.length
+      // Synthetic section boundaries anchor on real terminals or protected
+      // through-obstacle spans. A section must not detach from either end.
+      for (const section of this.movablePreloadedSections) {
+        const candidateSections = routes.filter(
+          (route) => route.connectionName === section.syntheticConnectionName,
+        )
+        if (candidateSections.length !== 1) {
+          throw new Error(
+            `Pipeline9 joint output requires one section "${section.syntheticConnectionName}"`,
+          )
+        }
+        const candidate = candidateSections[0]!
+        const start = candidate.route[0]
+        const end = candidate.route.at(-1)
+        const originalStart = section.anchorStart
+        const originalEnd = section.anchorEnd
+        if (
+          !start ||
+          !end ||
+          start.x !== originalStart.x ||
+          start.y !== originalStart.y ||
+          start.z !== originalStart.z ||
+          end.x !== originalEnd.x ||
+          end.y !== originalEnd.y ||
+          end.z !== originalEnd.z
+        ) {
+          this.stats.jointOutputRejectedForSectionAnchor = true
+          return false
+        }
+      }
+      const changedPreloadedTraceIds = new Set([
+        ...params.mutatedPreloadedTraceIds,
+        ...this.movablePreloadedSections.map(
+          (section) => section.originalTrace.pcb_trace_id,
+        ),
+      ])
+      // Check the exact public reconstruction, not the separate synthetic
+      // sections used for search. Reattach every protected primitive first.
+      const updatedPreloadedTraces =
+        this.rebuildUpdatedPreloadedTraces(routes)
+      for (const [
+        index,
+        originalTrace,
+      ] of params.updatedPreloadedTraces.entries()) {
+        const updatedTrace = updatedPreloadedTraces[index]!
+        for (const primitive of originalTrace.route) {
+          if (
+            primitive.route_type !== "wire" ||
+            (primitive.start_pcb_port_id === undefined &&
+              primitive.end_pcb_port_id === undefined)
+          ) {
+            continue
+          }
+          const terminalPreserved = updatedTrace.route.some(
+            (point): boolean =>
+              point.route_type === "wire" &&
+              point.x === primitive.x &&
+              point.y === primitive.y &&
+              point.layer === primitive.layer &&
+              point.start_pcb_port_id === primitive.start_pcb_port_id &&
+              point.end_pcb_port_id === primitive.end_pcb_port_id,
+          )
+          if (!terminalPreserved) {
+            this.stats.jointOutputRejectedForTerminalMetadata = true
+            return false
+          }
+        }
+      }
+      const preparedOutput = preparePipeline9DrcRoutedTracesWithMetadata({
+        originalPreloadedTraces: params.originalSrj.traces ?? [],
+        mutatedPreloadedTraces: updatedPreloadedTraces.filter(
+          (trace) => changedPreloadedTraceIds.has(trace.pcb_trace_id),
+        ),
+        newTraces: convertNewRoutes(
+          routes.filter(
+            (route) => !this.syntheticConnectionNames.has(route.connectionName),
+          ),
+        ),
+      })
+      const candidateDrc = evaluateRelaxedDrc({
+        inputSrj: params.originalSrj,
+        srjWithPointPairs: params.srjWithPointPairs,
+        routedTraces: preparedOutput.routedTraces,
+        drcOptions: { traceClearance },
+      })
+      this.stats.jointOutputCandidateDrcIssueCount = candidateDrc.errors.length
+      const noWorse = isPipeline9JointDrcOutputNoWorse({
+        candidate: {
+          errors: candidateDrc.errors.map(
+            (error): Record<string, unknown> => ({ ...error }),
+          ),
+          circuitJson: candidateDrc.circuitJson,
+        },
+        current: {
+          errors: currentDrcResult.errors.map(
+            (error): Record<string, unknown> => ({ ...error }),
+          ),
+          circuitJson: currentDrcResult.circuitJson,
+        },
+      })
+      this.stats.jointOutputRejectedForDrcRegression = !noWorse
+      this.stats.publishedJointDrcIssueCount = noWorse
+        ? candidateDrc.errors.length
+        : currentDrcResult.errors.length
+      return noWorse
     }
 
     const movableOriginalTraceIds = new Set(
@@ -1013,25 +1170,6 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
           ) + Math.max(traceClearance, viaClearance),
       },
     )
-    const autoroutingBaselineDrcResult = autoroutingDrcEngine.evaluate(
-      (params.originalSrj.traces ?? []) as RepairSimplifiedPcbTraces,
-    )
-    const autoroutingBaselineViaCircuitJson = getAutoroutingViaElements(
-      params.originalSrj.traces ?? [],
-    )
-    const autoroutingBaselineDrc = {
-      ...autoroutingBaselineDrcResult,
-      errors: addAutoroutingViaTraceIds({
-        errors: autoroutingBaselineDrcResult.errors,
-        circuitJson: autoroutingBaselineViaCircuitJson,
-        evaluatedTraceIds: baselineEvaluatedTraceIds,
-      }),
-      errorsWithCenters: addAutoroutingViaTraceIds({
-        errors: autoroutingBaselineDrcResult.errorsWithCenters,
-        circuitJson: autoroutingBaselineViaCircuitJson,
-        evaluatedTraceIds: baselineEvaluatedTraceIds,
-      }),
-    }
     let referenceDrcCandidateCache:
       | {
           candidateKey: string
@@ -1051,7 +1189,6 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
         params.originalSrj.traces ?? [],
       )
       const replacedOriginalTraceIds = new Set<string>()
-      const originalTraceIdByEvaluationTraceId = new Map<string, string>()
       const evaluatedMovablePreloadedTraces = this.movablePreloadedSections.map(
         (movableSection) => {
           const evaluatedRoute = evaluatedRoutes.find(
@@ -1064,10 +1201,6 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
             )
           }
           const originalTraceId = movableSection.originalTrace.pcb_trace_id
-          originalTraceIdByEvaluationTraceId.set(
-            movableSection.evaluationTraceId,
-            originalTraceId,
-          )
           const replacesOriginalTrace =
             !replacedOriginalTraceIds.has(originalTraceId)
           replacedOriginalTraceIds.add(originalTraceId)
@@ -1119,7 +1252,6 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
       return {
         evaluatedTraces,
         movableTraceIds,
-        originalTraceIdByEvaluationTraceId,
         routedTraces,
         solverTraceIdByEvaluationTraceId,
       }
@@ -1196,22 +1328,9 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
         circuitJson: evaluatedDrc.circuitJson,
         evaluatedTraceIds,
       })
-      const evaluatedNewErrors = filterPipeline9DrcErrorsAgainstBaseline({
-        errors: evaluatedErrors,
-        baselineErrors,
-        originalTraceIdByPreparedTraceId:
-          candidateDrcInput.originalTraceIdByEvaluationTraceId,
-      })
-      const evaluatedNewErrorsWithCenters =
-        filterPipeline9DrcErrorsAgainstBaseline({
-          errors: evaluatedErrorsWithCenters,
-          baselineErrors: baselineErrorsWithCenters,
-          originalTraceIdByPreparedTraceId:
-            candidateDrcInput.originalTraceIdByEvaluationTraceId,
-        })
       return normalizeCandidateDrcResult({
-        errors: evaluatedNewErrors,
-        errorsWithCenters: evaluatedNewErrorsWithCenters,
+        errors: evaluatedErrors,
+        errorsWithCenters: evaluatedErrorsWithCenters,
         circuitJson: evaluatedDrc.circuitJson,
         movableTraceIds: candidateDrcInput.movableTraceIds,
         solverTraceIdByEvaluationTraceId:
@@ -1278,25 +1397,7 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
         circuitJson: viaCircuitJson,
         evaluatedTraceIds,
       })
-      const evaluatedNewErrors = filterPipeline9DrcErrorsAgainstBaseline({
-        errors: evaluatedErrors,
-        baselineErrors: autoroutingBaselineDrc.errors as unknown as Array<
-          Record<string, unknown>
-        >,
-        originalTraceIdByPreparedTraceId:
-          candidateDrcInput.originalTraceIdByEvaluationTraceId,
-      })
-      const evaluatedNewErrorsWithCenters =
-        filterPipeline9DrcErrorsAgainstBaseline({
-          errors: evaluatedErrorsWithCenters,
-          baselineErrors:
-            autoroutingBaselineDrc.errorsWithCenters as unknown as Array<
-              Record<string, unknown>
-            >,
-          originalTraceIdByPreparedTraceId:
-            candidateDrcInput.originalTraceIdByEvaluationTraceId,
-        })
-      if (evaluatedNewErrors.length === 0) {
+      if (evaluatedErrors.length === 0) {
         const validationCountBefore = this.referenceDrcValidationCount
         const referenceResult = cachedReferenceDrcEvaluator({
           traces: [],
@@ -1318,8 +1419,8 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
         return referenceResult
       }
       const candidateDrcResult = normalizeCandidateDrcResult({
-        errors: evaluatedNewErrors,
-        errorsWithCenters: evaluatedNewErrorsWithCenters,
+        errors: evaluatedErrors,
+        errorsWithCenters: evaluatedErrorsWithCenters,
         circuitJson: viaCircuitJson,
         movableTraceIds: candidateDrcInput.movableTraceIds,
         solverTraceIdByEvaluationTraceId:
@@ -1406,7 +1507,6 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
         : exactReferenceDrcResult.errors
       postExactReferenceDrcIssueCount = exactReferenceDrcErrors.length
       if (exactReferenceDrcErrors.length === 0) {
-        this.combinedOutput = exactOutput
         this.stats = {
           ...this.stats,
           ...this.exactRepairSolver.stats,
@@ -1440,6 +1540,7 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
           indexedDrcCandidateCacheSize: this.indexedDrcCandidateCache.size,
           indexedDrcCandidateCacheCapacity: INDEXED_DRC_CANDIDATE_CACHE_SIZE,
         }
+        this.publishValidatedOutput(exactOutput)
         this.solved = true
         return
       }
@@ -1487,7 +1588,6 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
         0.15,
       effort: this.params.effort,
     })
-    this.combinedOutput = regionalB01RepairResult.routes
     this.stats = {
       ...this.stats,
       ...this.exactRepairSolver.stats,
@@ -1536,7 +1636,21 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
       indexedDrcCandidateCacheSize: this.indexedDrcCandidateCache.size,
       indexedDrcCandidateCacheCapacity: INDEXED_DRC_CANDIDATE_CACHE_SIZE,
     }
+    this.publishValidatedOutput(regionalB01RepairResult.routes)
     this.solved = true
+  }
+
+  private publishValidatedOutput(routes: HighDensityRoute[]): void {
+    if (!this.validatePublishedOutput) {
+      throw new Error("Pipeline9 joint output requires its publication check")
+    }
+    this.jointOutputAccepted = this.validatePublishedOutput(routes)
+    this.stats.jointOutputAccepted = this.jointOutputAccepted
+    // A completed optimization proposal may be rejected by the reference
+    // gate. Keep the complete incumbent; solver failures still propagate.
+    this.combinedOutput = this.jointOutputAccepted
+      ? routes
+      : this.inputNewHdRoutes
   }
 
   private getCombinedOutput(): HighDensityRoute[] {
@@ -1553,9 +1667,11 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
     )
   }
 
-  getUpdatedPreloadedTraces(): SimplifiedPcbTrace[] {
+  private rebuildUpdatedPreloadedTraces(
+    routes: HighDensityRoute[],
+  ): SimplifiedPcbTrace[] {
     const outputRouteByConnectionName = new Map(
-      this.getCombinedOutput().map((route) => [route.connectionName, route]),
+      routes.map((route) => [route.connectionName, route]),
     )
     const repairedSectionsByOriginalTraceId = new Map<
       string,
@@ -1618,12 +1734,21 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
     )
   }
 
+  getUpdatedPreloadedTraces(): SimplifiedPcbTrace[] {
+    if (!this.jointOutputAccepted) {
+      return this.inputUpdatedPreloadedTraces
+    }
+    return this.rebuildUpdatedPreloadedTraces(this.getCombinedOutput())
+  }
+
   getMutatedPreloadedTraces(): SimplifiedPcbTrace[] {
     const mutatedTraceIds = new Set([
       ...this.params.mutatedPreloadedTraceIds,
-      ...this.movablePreloadedSections.map(
-        (movableSection) => movableSection.originalTrace.pcb_trace_id,
-      ),
+      ...(this.jointOutputAccepted
+        ? this.movablePreloadedSections.map(
+            (movableSection) => movableSection.originalTrace.pcb_trace_id,
+          )
+        : []),
     ])
     return this.getUpdatedPreloadedTraces().filter((trace) =>
       mutatedTraceIds.has(trace.pcb_trace_id),

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver.ts
@@ -31,9 +31,9 @@ import {
   type PreloadedHighDensityRoute,
   convertPreloadedTraceToHdRoutes,
 } from "./convertPreloadedTraceToHdRoutes"
+import { filterPipeline9DrcErrorsAgainstBaseline } from "./filterPipeline9DrcErrorsAgainstBaseline"
 import { getPipeline9PreloadedTraceIdsInInitialDrcRegions } from "./getPipeline9PreloadedTraceIdsInInitialDrcRegions"
 import { getPipeline9PreloadedViaPairTraceGroups } from "./getPipeline9PreloadedViaPairTraceGroups"
-import { isPipeline9JointDrcOutputNoWorse } from "./isPipeline9JointDrcOutputNoWorse"
 import { mergePipeline9MovablePreloadedVias } from "./mergePipeline9MovablePreloadedVias"
 import { normalizePipeline9DrcErrorsForRepair } from "./normalizePipeline9DrcErrorsForRepair"
 import {
@@ -54,7 +54,7 @@ const INDEXED_DRC_CANDIDATE_CACHE_SIZE = 64
 
 type DrcCandidateKey = string & { readonly __brand: "DrcCandidateKey" }
 
-type Pipeline9JointDrcRepairSolverParams = {
+export type Pipeline9JointDrcRepairSolverParams = {
   srj: SimpleRouteJson
   srjWithPointPairs: SimpleRouteJson
   originalSrj: SimpleRouteJson
@@ -71,15 +71,13 @@ type Pipeline9JointDrcRepairSolverParams = {
   colorMap: Record<string, string>
 }
 
-type MovablePreloadedSection = {
+export type MovablePreloadedSection = {
   originalTrace: SimplifiedPcbTrace
   originalRoutePositionStart: number
   originalRoutePositionEnd: number
   syntheticConnectionName: string
   evaluationTraceId: string
   hdRoute: HighDensityRoute
-  anchorStart: HighDensityRoute["route"][number]
-  anchorEnd: HighDensityRoute["route"][number]
 }
 
 type PreloadedTraceSectionGroup = {
@@ -91,6 +89,7 @@ type PreloadedTraceSectionGroup = {
 type PreparedCandidateDrcInput = {
   evaluatedTraces: SimplifiedPcbTrace[]
   movableTraceIds: ReadonlySet<string>
+  originalTraceIdByEvaluationTraceId: ReadonlyMap<string, string>
   routedTraces: SimplifiedPcbTrace[]
   solverTraceIdByEvaluationTraceId: ReadonlyMap<string, string>
 }
@@ -223,13 +222,11 @@ const combinePreloadedTraceSectionGroup = ({
   sectionGroup,
   syntheticConnectionName,
   connMap,
-  layerCount,
 }: {
   trace: SimplifiedPcbTrace
   sectionGroup: PreloadedTraceSectionGroup
   syntheticConnectionName: string
   connMap: ConnectivityMap
-  layerCount: number
 }): HighDensityRoute => {
   const traceSections = sectionGroup.routes
   if (traceSections.length === 0) {
@@ -273,25 +270,6 @@ const combinePreloadedTraceSectionGroup = ({
     route[route.length - 1] = {
       ...route.at(-1)!,
       pcb_port_id: endPcbPortId,
-    }
-  }
-  // Preserve real interior terminal identities too. Synthetic section ends
-  // alone do not describe a preloaded trace that visits another tagged pad.
-  for (const [index, point] of route.entries()) {
-    const taggedWire = trace.route.find(
-      (primitive): boolean =>
-        primitive.route_type === "wire" &&
-        primitive.x === point.x &&
-        primitive.y === point.y &&
-        primitive.layer === mapZToLayerName(point.z, layerCount) &&
-        (primitive.start_pcb_port_id !== undefined ||
-          primitive.end_pcb_port_id !== undefined),
-    )
-    if (taggedWire?.route_type === "wire") {
-      route[index] = {
-        ...point,
-        pcb_port_id: taggedWire.start_pcb_port_id ?? taggedWire.end_pcb_port_id,
-      }
     }
   }
 
@@ -573,17 +551,19 @@ const createSyntheticConnection = (
   }
 }
 
-const rebuildPreloadedTraceFromSections = ({
-  originalTrace,
-  repairedSections,
-}: {
+export type Pipeline9PreloadedTraceReconstruction = {
   originalTrace: SimplifiedPcbTrace
   repairedSections: Array<{
     routePositionStart: number
     routePositionEnd: number
     route: SimplifiedPcbTrace["route"]
   }>
-}): SimplifiedPcbTrace => {
+}
+
+const rebuildPreloadedTraceFromSections = ({
+  originalTrace,
+  repairedSections,
+}: Pipeline9PreloadedTraceReconstruction): SimplifiedPcbTrace => {
   const rebuiltRoute: SimplifiedPcbTrace["route"] = []
   let originalRoutePosition = 0
   for (const repairedSection of [...repairedSections].sort(
@@ -594,43 +574,12 @@ const rebuildPreloadedTraceFromSections = ({
         `Pipeline9 found overlapping repaired sections for preloaded trace "${originalTrace.pcb_trace_id}"`,
       )
     }
-    const repairedRoute = repairedSection.route.map(
-      (point): SimplifiedPcbTrace["route"][number] => {
-        const originalPoint =
-          point.route_type === "wire"
-            ? originalTrace.route.find(
-                (primitive): boolean =>
-                  primitive.route_type === "wire" &&
-                  primitive.x === point.x &&
-                  primitive.y === point.y &&
-                  primitive.layer === point.layer &&
-                  (primitive.start_pcb_port_id !== undefined ||
-                    primitive.end_pcb_port_id !== undefined),
-              )
-            : undefined
-        if (
-          point.route_type !== "wire" ||
-          originalPoint?.route_type !== "wire"
-        ) {
-          return point
-        }
-        return {
-          ...point,
-          ...(originalPoint.start_pcb_port_id === undefined
-            ? {}
-            : { start_pcb_port_id: originalPoint.start_pcb_port_id }),
-          ...(originalPoint.end_pcb_port_id === undefined
-            ? {}
-            : { end_pcb_port_id: originalPoint.end_pcb_port_id }),
-        }
-      },
-    )
     rebuiltRoute.push(
       ...originalTrace.route.slice(
         originalRoutePosition,
         repairedSection.routePositionStart,
       ),
-      ...repairedRoute,
+      ...repairedSection.route,
     )
     originalRoutePosition = repairedSection.routePositionEnd + 1
   }
@@ -713,8 +662,13 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
     ReturnType<DrcEvaluator>
   >()
   private combinedOutput?: HighDensityRoute[]
-  private jointOutputAccepted = false
-  private validatePublishedOutput?: (routes: HighDensityRoute[]) => boolean
+  protected readonly publicationContext: {
+    currentDrcResult: ReturnType<typeof evaluateRelaxedDrc>
+    convertNewRoutes: ReturnType<
+      typeof createPipeline7HdRoutesToSimplifiedPcbTracesConverter
+    >
+    traceClearance: number
+  }
 
   private cacheIndexedDrcResult(
     candidateKey: DrcCandidateKey,
@@ -773,12 +727,32 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
       routedTraces: [],
       drcOptions: { traceClearance },
     })
+    const baselineEvaluatedTraceIds = new Set(
+      (params.originalSrj.traces ?? []).map((trace) => trace.pcb_trace_id),
+    )
+    const baselineErrors = addAutoroutingViaTraceIds({
+      errors: baselineDrc.errors as unknown as Array<Record<string, unknown>>,
+      circuitJson: baselineDrc.circuitJson,
+      evaluatedTraceIds: baselineEvaluatedTraceIds,
+    })
+    const baselineErrorsWithCenters = addAutoroutingViaTraceIds({
+      errors: baselineDrc.errorsWithCenters as unknown as Array<
+        Record<string, unknown>
+      >,
+      circuitJson: baselineDrc.circuitJson,
+      evaluatedTraceIds: baselineEvaluatedTraceIds,
+    })
     const currentDrcResult = evaluateRelaxedDrc({
       inputSrj: params.originalSrj,
       srjWithPointPairs: params.srjWithPointPairs,
       routedTraces: preparedCurrentOutput.routedTraces,
       drcOptions: { traceClearance },
     })
+    this.publicationContext = {
+      currentDrcResult,
+      convertNewRoutes,
+      traceClearance,
+    }
     const currentEvaluatedTraceIds = new Set(
       combinePreloadedAndRoutedTraces(
         params.originalSrj.traces ?? [],
@@ -801,11 +775,18 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
     })
     const currentDrc = {
       ...currentDrcResult,
-      // Input provenance does not make an ordinary wire's violation exempt.
-      // Select from the complete current board; section extraction below still
-      // keeps protected through-obstacle primitives outside repair ownership.
-      errors: currentErrors,
-      errorsWithCenters: currentErrorsWithCenters,
+      errors: this.selectDrcErrors({
+        errors: currentErrors,
+        baselineErrors,
+        originalTraceIdByPreparedTraceId:
+          preparedCurrentOutput.originalPreloadedTraceIdByPreparedTraceId,
+      }),
+      errorsWithCenters: this.selectDrcErrors({
+        errors: currentErrorsWithCenters,
+        baselineErrors: baselineErrorsWithCenters,
+        originalTraceIdByPreparedTraceId:
+          preparedCurrentOutput.originalPreloadedTraceIdByPreparedTraceId,
+      }),
     }
     const preparedTraceIdsInErrors = getTraceIdsFromDrcErrors({
       errors: currentDrc.errors as unknown as Array<Record<string, unknown>>,
@@ -870,23 +851,21 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
       for (const [traceSectionIndex, sectionGroup] of sectionGroups.entries()) {
         const movableSectionIndex = this.movablePreloadedSections.length
         const syntheticConnectionName = `pipeline9_preloaded_drc_${movableSectionIndex}`
-        const hdRoute = combinePreloadedTraceSectionGroup({
-          trace,
-          sectionGroup,
-          syntheticConnectionName,
-          connMap: params.connMap,
-          layerCount: params.layerCount,
-        })
-        this.movablePreloadedSections.push({
-          originalTrace: trace,
-          originalRoutePositionStart: sectionGroup.routePositionStart,
-          originalRoutePositionEnd: sectionGroup.routePositionEnd,
-          syntheticConnectionName,
-          evaluationTraceId: `${trace.pcb_trace_id}__pipeline9_section_${traceSectionIndex}`,
-          hdRoute,
-          anchorStart: { ...hdRoute.route[0]! },
-          anchorEnd: { ...hdRoute.route.at(-1)! },
-        })
+        this.movablePreloadedSections.push(
+          this.prepareMovablePreloadedSection({
+            originalTrace: trace,
+            originalRoutePositionStart: sectionGroup.routePositionStart,
+            originalRoutePositionEnd: sectionGroup.routePositionEnd,
+            syntheticConnectionName,
+            evaluationTraceId: `${trace.pcb_trace_id}__pipeline9_section_${traceSectionIndex}`,
+            hdRoute: combinePreloadedTraceSectionGroup({
+              trace,
+              sectionGroup,
+              syntheticConnectionName,
+              connMap: params.connMap,
+            }),
+          }),
+        )
       }
     }
     this.syntheticConnectionNames = new Set(
@@ -997,129 +976,11 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
       exactRepairConfiguredViaInPadMaxIterations: EXACT_REPAIR_MAX_ITERATIONS,
       exactRepairConfiguredBroadMaxIterations:
         EXACT_REPAIR_BROAD_MAX_ITERATIONS,
-      jointOutputValidationAttempted: false,
-      jointOutputAccepted: false,
-      jointOutputRejectedForSectionAnchor: false,
-      jointOutputRejectedForTerminalMetadata: false,
-      jointOutputRejectedForDrcRegression: false,
-      publishedJointDrcIssueCount: currentDrc.errors.length,
     }
 
     if (currentDrc.errors.length === 0) {
       this.solved = true
       return
-    }
-
-    this.validatePublishedOutput = (routes: HighDensityRoute[]): boolean => {
-      this.stats.jointOutputValidationAttempted = true
-      this.stats.jointOutputRejectedForSectionAnchor = false
-      this.stats.jointOutputRejectedForTerminalMetadata = false
-      this.stats.jointOutputRejectedForDrcRegression = false
-      this.stats.publishedJointDrcIssueCount = currentDrcResult.errors.length
-      // Synthetic section boundaries anchor on real terminals or protected
-      // through-obstacle spans. A section must not detach from either end.
-      for (const section of this.movablePreloadedSections) {
-        const candidateSections = routes.filter(
-          (route) => route.connectionName === section.syntheticConnectionName,
-        )
-        if (candidateSections.length !== 1) {
-          throw new Error(
-            `Pipeline9 joint output requires one section "${section.syntheticConnectionName}"`,
-          )
-        }
-        const candidate = candidateSections[0]!
-        const start = candidate.route[0]
-        const end = candidate.route.at(-1)
-        const originalStart = section.anchorStart
-        const originalEnd = section.anchorEnd
-        if (
-          !start ||
-          !end ||
-          start.x !== originalStart.x ||
-          start.y !== originalStart.y ||
-          start.z !== originalStart.z ||
-          end.x !== originalEnd.x ||
-          end.y !== originalEnd.y ||
-          end.z !== originalEnd.z
-        ) {
-          this.stats.jointOutputRejectedForSectionAnchor = true
-          return false
-        }
-      }
-      const changedPreloadedTraceIds = new Set([
-        ...params.mutatedPreloadedTraceIds,
-        ...this.movablePreloadedSections.map(
-          (section) => section.originalTrace.pcb_trace_id,
-        ),
-      ])
-      // Check the exact public reconstruction, not the separate synthetic
-      // sections used for search. Reattach every protected primitive first.
-      const updatedPreloadedTraces = this.rebuildUpdatedPreloadedTraces(routes)
-      for (const [
-        index,
-        originalTrace,
-      ] of params.updatedPreloadedTraces.entries()) {
-        const updatedTrace = updatedPreloadedTraces[index]!
-        for (const primitive of originalTrace.route) {
-          if (
-            primitive.route_type !== "wire" ||
-            (primitive.start_pcb_port_id === undefined &&
-              primitive.end_pcb_port_id === undefined)
-          ) {
-            continue
-          }
-          const terminalPreserved = updatedTrace.route.some(
-            (point): boolean =>
-              point.route_type === "wire" &&
-              point.x === primitive.x &&
-              point.y === primitive.y &&
-              point.layer === primitive.layer &&
-              point.start_pcb_port_id === primitive.start_pcb_port_id &&
-              point.end_pcb_port_id === primitive.end_pcb_port_id,
-          )
-          if (!terminalPreserved) {
-            this.stats.jointOutputRejectedForTerminalMetadata = true
-            return false
-          }
-        }
-      }
-      const preparedOutput = preparePipeline9DrcRoutedTracesWithMetadata({
-        originalPreloadedTraces: params.originalSrj.traces ?? [],
-        mutatedPreloadedTraces: updatedPreloadedTraces.filter((trace) =>
-          changedPreloadedTraceIds.has(trace.pcb_trace_id),
-        ),
-        newTraces: convertNewRoutes(
-          routes.filter(
-            (route) => !this.syntheticConnectionNames.has(route.connectionName),
-          ),
-        ),
-      })
-      const candidateDrc = evaluateRelaxedDrc({
-        inputSrj: params.originalSrj,
-        srjWithPointPairs: params.srjWithPointPairs,
-        routedTraces: preparedOutput.routedTraces,
-        drcOptions: { traceClearance },
-      })
-      this.stats.jointOutputCandidateDrcIssueCount = candidateDrc.errors.length
-      const noWorse = isPipeline9JointDrcOutputNoWorse({
-        candidate: {
-          errors: candidateDrc.errors.map(
-            (error): Record<string, unknown> => ({ ...error }),
-          ),
-          circuitJson: candidateDrc.circuitJson,
-        },
-        current: {
-          errors: currentDrcResult.errors.map(
-            (error): Record<string, unknown> => ({ ...error }),
-          ),
-          circuitJson: currentDrcResult.circuitJson,
-        },
-      })
-      this.stats.jointOutputRejectedForDrcRegression = !noWorse
-      this.stats.publishedJointDrcIssueCount = noWorse
-        ? candidateDrc.errors.length
-        : currentDrcResult.errors.length
-      return noWorse
     }
 
     const movableOriginalTraceIds = new Set(
@@ -1168,6 +1029,25 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
           ) + Math.max(traceClearance, viaClearance),
       },
     )
+    const autoroutingBaselineDrcResult = autoroutingDrcEngine.evaluate(
+      (params.originalSrj.traces ?? []) as RepairSimplifiedPcbTraces,
+    )
+    const autoroutingBaselineViaCircuitJson = getAutoroutingViaElements(
+      params.originalSrj.traces ?? [],
+    )
+    const autoroutingBaselineDrc = {
+      ...autoroutingBaselineDrcResult,
+      errors: addAutoroutingViaTraceIds({
+        errors: autoroutingBaselineDrcResult.errors,
+        circuitJson: autoroutingBaselineViaCircuitJson,
+        evaluatedTraceIds: baselineEvaluatedTraceIds,
+      }),
+      errorsWithCenters: addAutoroutingViaTraceIds({
+        errors: autoroutingBaselineDrcResult.errorsWithCenters,
+        circuitJson: autoroutingBaselineViaCircuitJson,
+        evaluatedTraceIds: baselineEvaluatedTraceIds,
+      }),
+    }
     let referenceDrcCandidateCache:
       | {
           candidateKey: string
@@ -1187,6 +1067,7 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
         params.originalSrj.traces ?? [],
       )
       const replacedOriginalTraceIds = new Set<string>()
+      const originalTraceIdByEvaluationTraceId = new Map<string, string>()
       const evaluatedMovablePreloadedTraces = this.movablePreloadedSections.map(
         (movableSection) => {
           const evaluatedRoute = evaluatedRoutes.find(
@@ -1199,6 +1080,10 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
             )
           }
           const originalTraceId = movableSection.originalTrace.pcb_trace_id
+          originalTraceIdByEvaluationTraceId.set(
+            movableSection.evaluationTraceId,
+            originalTraceId,
+          )
           const replacesOriginalTrace =
             !replacedOriginalTraceIds.has(originalTraceId)
           replacedOriginalTraceIds.add(originalTraceId)
@@ -1250,6 +1135,7 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
       return {
         evaluatedTraces,
         movableTraceIds,
+        originalTraceIdByEvaluationTraceId,
         routedTraces,
         solverTraceIdByEvaluationTraceId,
       }
@@ -1326,9 +1212,21 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
         circuitJson: evaluatedDrc.circuitJson,
         evaluatedTraceIds,
       })
-      return normalizeCandidateDrcResult({
+      const evaluatedNewErrors = this.selectDrcErrors({
         errors: evaluatedErrors,
-        errorsWithCenters: evaluatedErrorsWithCenters,
+        baselineErrors,
+        originalTraceIdByPreparedTraceId:
+          candidateDrcInput.originalTraceIdByEvaluationTraceId,
+      })
+      const evaluatedNewErrorsWithCenters = this.selectDrcErrors({
+        errors: evaluatedErrorsWithCenters,
+        baselineErrors: baselineErrorsWithCenters,
+        originalTraceIdByPreparedTraceId:
+          candidateDrcInput.originalTraceIdByEvaluationTraceId,
+      })
+      return normalizeCandidateDrcResult({
+        errors: evaluatedNewErrors,
+        errorsWithCenters: evaluatedNewErrorsWithCenters,
         circuitJson: evaluatedDrc.circuitJson,
         movableTraceIds: candidateDrcInput.movableTraceIds,
         solverTraceIdByEvaluationTraceId:
@@ -1395,7 +1293,24 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
         circuitJson: viaCircuitJson,
         evaluatedTraceIds,
       })
-      if (evaluatedErrors.length === 0) {
+      const evaluatedNewErrors = this.selectDrcErrors({
+        errors: evaluatedErrors,
+        baselineErrors: autoroutingBaselineDrc.errors as unknown as Array<
+          Record<string, unknown>
+        >,
+        originalTraceIdByPreparedTraceId:
+          candidateDrcInput.originalTraceIdByEvaluationTraceId,
+      })
+      const evaluatedNewErrorsWithCenters = this.selectDrcErrors({
+        errors: evaluatedErrorsWithCenters,
+        baselineErrors:
+          autoroutingBaselineDrc.errorsWithCenters as unknown as Array<
+            Record<string, unknown>
+          >,
+        originalTraceIdByPreparedTraceId:
+          candidateDrcInput.originalTraceIdByEvaluationTraceId,
+      })
+      if (evaluatedNewErrors.length === 0) {
         const validationCountBefore = this.referenceDrcValidationCount
         const referenceResult = cachedReferenceDrcEvaluator({
           traces: [],
@@ -1417,8 +1332,8 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
         return referenceResult
       }
       const candidateDrcResult = normalizeCandidateDrcResult({
-        errors: evaluatedErrors,
-        errorsWithCenters: evaluatedErrorsWithCenters,
+        errors: evaluatedNewErrors,
+        errorsWithCenters: evaluatedNewErrorsWithCenters,
         circuitJson: viaCircuitJson,
         movableTraceIds: candidateDrcInput.movableTraceIds,
         solverTraceIdByEvaluationTraceId:
@@ -1505,6 +1420,7 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
         : exactReferenceDrcResult.errors
       postExactReferenceDrcIssueCount = exactReferenceDrcErrors.length
       if (exactReferenceDrcErrors.length === 0) {
+        this.publishValidatedOutput(exactOutput)
         this.stats = {
           ...this.stats,
           ...this.exactRepairSolver.stats,
@@ -1538,7 +1454,6 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
           indexedDrcCandidateCacheSize: this.indexedDrcCandidateCache.size,
           indexedDrcCandidateCacheCapacity: INDEXED_DRC_CANDIDATE_CACHE_SIZE,
         }
-        this.publishValidatedOutput(exactOutput)
         this.solved = true
         return
       }
@@ -1586,6 +1501,7 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
         0.15,
       effort: this.params.effort,
     })
+    this.publishValidatedOutput(regionalB01RepairResult.routes)
     this.stats = {
       ...this.stats,
       ...this.exactRepairSolver.stats,
@@ -1634,24 +1550,34 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
       indexedDrcCandidateCacheSize: this.indexedDrcCandidateCache.size,
       indexedDrcCandidateCacheCapacity: INDEXED_DRC_CANDIDATE_CACHE_SIZE,
     }
-    this.publishValidatedOutput(regionalB01RepairResult.routes)
     this.solved = true
   }
 
-  private publishValidatedOutput(routes: HighDensityRoute[]): void {
-    if (!this.validatePublishedOutput) {
-      throw new Error("Pipeline9 joint output requires its publication check")
-    }
-    this.jointOutputAccepted = this.validatePublishedOutput(routes)
-    this.stats.jointOutputAccepted = this.jointOutputAccepted
-    // A completed optimization proposal may be rejected by the reference
-    // gate. Keep the complete incumbent; solver failures still propagate.
-    this.combinedOutput = this.jointOutputAccepted
-      ? routes
-      : this.inputNewHdRoutes
+  protected selectDrcErrors<TError extends Record<string, unknown>>(input: {
+    errors: TError[]
+    baselineErrors: Array<Record<string, unknown>>
+    originalTraceIdByPreparedTraceId?: ReadonlyMap<string, string>
+  }): TError[] {
+    return filterPipeline9DrcErrorsAgainstBaseline(input)
   }
 
-  private getCombinedOutput(): HighDensityRoute[] {
+  protected prepareMovablePreloadedSection(
+    section: MovablePreloadedSection,
+  ): MovablePreloadedSection {
+    return section
+  }
+
+  protected rebuildPreloadedTrace(
+    input: Pipeline9PreloadedTraceReconstruction,
+  ): SimplifiedPcbTrace {
+    return rebuildPreloadedTraceFromSections(input)
+  }
+
+  protected publishValidatedOutput(routes: HighDensityRoute[]): void {
+    this.combinedOutput = routes
+  }
+
+  protected getCombinedOutput(): HighDensityRoute[] {
     return (
       this.combinedOutput ??
       this.exactRepairSolver?.getOutput() ??
@@ -1665,7 +1591,7 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
     )
   }
 
-  private rebuildUpdatedPreloadedTraces(
+  protected rebuildUpdatedPreloadedTraces(
     routes: HighDensityRoute[],
   ): SimplifiedPcbTrace[] {
     const outputRouteByConnectionName = new Map(
@@ -1719,7 +1645,7 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
           }
           return [
             originalTraceId,
-            rebuildPreloadedTraceFromSections({
+            this.rebuildPreloadedTrace({
               originalTrace,
               repairedSections,
             }),
@@ -1733,20 +1659,15 @@ export class Pipeline9JointDrcRepairSolver extends BaseSolver {
   }
 
   getUpdatedPreloadedTraces(): SimplifiedPcbTrace[] {
-    if (!this.jointOutputAccepted) {
-      return this.inputUpdatedPreloadedTraces
-    }
     return this.rebuildUpdatedPreloadedTraces(this.getCombinedOutput())
   }
 
   getMutatedPreloadedTraces(): SimplifiedPcbTrace[] {
     const mutatedTraceIds = new Set([
       ...this.params.mutatedPreloadedTraceIds,
-      ...(this.jointOutputAccepted
-        ? this.movablePreloadedSections.map(
-            (movableSection) => movableSection.originalTrace.pcb_trace_id,
-          )
-        : []),
+      ...this.movablePreloadedSections.map(
+        (movableSection) => movableSection.originalTrace.pcb_trace_id,
+      ),
     ])
     return this.getUpdatedPreloadedTraces().filter((trace) =>
       mutatedTraceIds.has(trace.pcb_trace_id),

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/isPipeline9JointDrcOutputNoWorse.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/isPipeline9JointDrcOutputNoWorse.ts
@@ -121,7 +121,6 @@ const getCopperErrorPair = (
     typeof error.pcb_trace_id === "string" ? error.pcb_trace_id : undefined
   let participantIds: string[]
   let expectedKinds: CopperParticipant["kind"][]
-  let relation = "copper-gap"
   if (errorType === "pcb_pad_trace_clearance_error") {
     if (!traceId || typeof error.pcb_pad_id !== "string") {
       throw new Error("Pipeline9 joint pad DRC requires both copper identities")
@@ -146,41 +145,36 @@ const getCopperErrorPair = (
     }
     participantIds = error.pcb_via_ids as string[]
     expectedKinds = ["via", "via"]
-    const errorId = error.pcb_error_id
-    if (
-      typeof errorId !== "string" ||
-      (!errorId.startsWith("same_net_vias_close_") &&
-        !errorId.startsWith("different_net_vias_close_"))
-    ) {
-      throw new Error(
-        "Pipeline9 joint via-spacing DRC requires its net relation",
-      )
-    }
-    relation = errorId.startsWith("same_net_")
-      ? "same-net-via-gap"
-      : "different-net-via-gap"
-  } else if (
-    errorType === "pcb_trace_error" &&
-    typeof error.pcb_trace_error_id === "string" &&
-    error.pcb_trace_error_id.startsWith("overlap_")
-  ) {
-    const prefix = `overlap_${traceId}_`
-    if (!traceId || !error.pcb_trace_error_id.startsWith(prefix)) {
-      throw new Error("Pipeline9 joint overlap DRC requires its primary trace")
-    }
-    const otherId = error.pcb_trace_error_id.slice(prefix.length)
-    participantIds = [traceId, otherId]
-    expectedKinds = ["trace"]
-    if (
-      error.pcb_via_id === otherId ||
-      (Array.isArray(error.pcb_via_ids) && error.pcb_via_ids.includes(otherId))
-    ) {
-      expectedKinds.push("via")
-    } else if (
-      Array.isArray(error.pcb_trace_ids) &&
-      error.pcb_trace_ids.includes(otherId)
-    ) {
-      expectedKinds.push("trace")
+  } else if (errorType === "pcb_trace_error" && traceId) {
+    const viaIds = new Set([
+      ...(typeof error.pcb_via_id === "string" ? [error.pcb_via_id] : []),
+      ...(Array.isArray(error.pcb_via_ids)
+        ? error.pcb_via_ids.filter(
+            (id): id is string => typeof id === "string",
+          )
+        : []),
+    ])
+    if (viaIds.size === 1) {
+      participantIds = [traceId, ...viaIds]
+      expectedKinds = ["trace", "via"]
+    } else if (typeof error.pcb_pad_id === "string" && viaIds.size === 0) {
+      participantIds = [traceId, error.pcb_pad_id]
+      expectedKinds = ["trace", "obstacle"]
+    } else if (Array.isArray(error.pcb_trace_ids) && viaIds.size === 0) {
+      participantIds = [
+        ...new Set([
+          traceId,
+          ...error.pcb_trace_ids.filter(
+            (id): id is string => typeof id === "string",
+          ),
+        ]),
+      ]
+      if (participantIds.length !== 2) return undefined
+      expectedKinds = ["trace", "trace"]
+    } else {
+      // Diagnostic IDs are opaque, not a source of participant metadata.
+      // Unannotated generic findings require exact retention or full removal.
+      return undefined
     }
   } else {
     return undefined
@@ -189,11 +183,18 @@ const getCopperErrorPair = (
     return resolveCopperParticipant(elementsById, id, expectedKinds[index])
       .identity
   })
-  return JSON.stringify([relation, ...identities.sort()])
+  // A changed required clearance is a different constraint, even if its
+  // physical participants and measured gap happen to remain the same.
+  return JSON.stringify([
+    "copper-gap",
+    error.minimum_clearance,
+    ...identities.sort(),
+  ])
 }
 
 const getErrorGroups = (snapshot: JointDrcSnapshot): Map<string, number[]> => {
   const elementsById = getCopperElementsById(snapshot.circuitJson)
+  let completeCopperContext: string | undefined
   const groups = new Map<string, number[]>()
   for (const error of snapshot.errors) {
     const pair = getCopperErrorPair(error, elementsById)
@@ -214,14 +215,26 @@ const getErrorGroups = (snapshot: JointDrcSnapshot): Map<string, number[]> => {
       const match = error.message.match(/gap: (-?\d+(?:\.\d+)?)mm/)
       if (match) gap = Number.parseFloat(match[1]!)
     }
-    // Generic too-close errors expose only the official checker's rounded
-    // message measurement. Contacts have no measured gap, so require their
-    // exact record to remain unchanged or disappear. Do not manufacture a
-    // score for connectivity, board-edge, or unknown findings either.
+    // Diagnostic IDs cannot prove unchanged copper ownership. If a generic
+    // error omits its participants, retaining its record requires the entire
+    // evaluated copper context to stay unchanged. This deliberately rejects
+    // unrelated repairs while an unannotated generic finding remains.
+    let exactContext = pair
+    if (
+      pair === undefined &&
+      (error.type ?? error.error_type) === "pcb_trace_error"
+    ) {
+      completeCopperContext ??= JSON.stringify(
+        [...elementsById.values()].flat().map(stringifyDrcRecord).sort(),
+      )
+      exactContext = completeCopperContext
+    }
+    // Annotated contacts expose no measured gap: retain their exact record
+    // AND physical pair or remove them. Never invent a penetration score.
     const key =
       pair !== undefined && gap !== undefined
         ? pair
-        : `exact:${stringifyDrcRecord(error)}`
+        : JSON.stringify(["exact", exactContext, stringifyDrcRecord(error)])
     const severities = groups.get(key) ?? []
     severities.push(gap === undefined ? 0 : -gap)
     groups.set(key, severities)

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/isPipeline9JointDrcOutputNoWorse.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/isPipeline9JointDrcOutputNoWorse.ts
@@ -149,9 +149,7 @@ const getCopperErrorPair = (
     const viaIds = new Set([
       ...(typeof error.pcb_via_id === "string" ? [error.pcb_via_id] : []),
       ...(Array.isArray(error.pcb_via_ids)
-        ? error.pcb_via_ids.filter(
-            (id): id is string => typeof id === "string",
-          )
+        ? error.pcb_via_ids.filter((id): id is string => typeof id === "string")
         : []),
     ])
     if (viaIds.size === 1) {

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/isPipeline9JointDrcOutputNoWorse.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/isPipeline9JointDrcOutputNoWorse.ts
@@ -1,0 +1,261 @@
+import type { AnyCircuitElement } from "circuit-json"
+
+type DrcError = Record<string, unknown>
+
+type JointDrcSnapshot = {
+  errors: readonly DrcError[]
+  circuitJson: readonly AnyCircuitElement[]
+}
+
+type CopperParticipant = {
+  kind: "trace" | "via" | "obstacle"
+  identity: string
+}
+
+type CopperElementsById = Map<string, Record<string, unknown>[]>
+
+const stringifyDrcRecord = (value: unknown): string => {
+  if (Array.isArray(value)) {
+    return `[${value.map(stringifyDrcRecord).join(",")}]`
+  }
+  if (value !== null && typeof value === "object") {
+    return `{${Object.entries(value)
+      .filter(([, entry]) => entry !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(
+        ([key, entry]) => `${JSON.stringify(key)}:${stringifyDrcRecord(entry)}`,
+      )
+      .join(",")}}`
+  }
+  return JSON.stringify(value) ?? "undefined"
+}
+
+const getCopperElementsById = (
+  circuitJson: readonly AnyCircuitElement[],
+): CopperElementsById => {
+  const elementsById: CopperElementsById = new Map()
+  for (const circuitElement of circuitJson) {
+    const element = circuitElement as unknown as Record<string, unknown>
+    const type = element.type
+    if (
+      type !== "pcb_trace" &&
+      type !== "pcb_via" &&
+      type !== "pcb_smtpad" &&
+      type !== "pcb_plated_hole" &&
+      type !== "pcb_hole" &&
+      type !== "pcb_keepout"
+    ) {
+      continue
+    }
+    const id = element[`${type}_id`]
+    if (typeof id !== "string" || id.length === 0) continue
+    const elements = elementsById.get(id) ?? []
+    elements.push(element)
+    elementsById.set(id, elements)
+  }
+  return elementsById
+}
+
+const resolveCopperParticipant = (
+  elementsById: CopperElementsById,
+  id: string,
+  expectedKind: CopperParticipant["kind"] | undefined,
+): CopperParticipant => {
+  const elements = (elementsById.get(id) ?? []).filter((element) => {
+    const kind =
+      element.type === "pcb_trace"
+        ? "trace"
+        : element.type === "pcb_via"
+          ? "via"
+          : "obstacle"
+    return expectedKind === undefined || kind === expectedKind
+  })
+  if (elements.length !== 1) {
+    throw new Error(
+      `Pipeline9 joint DRC cannot resolve copper participant "${id}"`,
+    )
+  }
+  const element = elements[0]!
+  if (element.type !== "pcb_via") {
+    return {
+      kind: element.type === "pcb_trace" ? "trace" : "obstacle",
+      identity: JSON.stringify([element.type, id]),
+    }
+  }
+  if (
+    typeof element.pcb_trace_id !== "string" ||
+    typeof element.x !== "number" ||
+    !Number.isFinite(element.x) ||
+    typeof element.y !== "number" ||
+    !Number.isFinite(element.y) ||
+    !Array.isArray(element.layers) ||
+    element.layers.length === 0 ||
+    !element.layers.every((layer) => typeof layer === "string")
+  ) {
+    throw new Error(
+      "Pipeline9 joint DRC output requires a via owner and physical site",
+    )
+  }
+  // Serialized via numbers change when unrelated routes insert or remove
+  // vias. A residual violation must retain its physical site, not merely
+  // its owner's name. Without via lineage, moved residual sites are rejected;
+  // a moved via with no remaining violation needs no identity match.
+  return {
+    kind: "via",
+    identity: JSON.stringify([
+      element.type,
+      element.pcb_trace_id,
+      element.x,
+      element.y,
+      [...element.layers].sort(),
+    ]),
+  }
+}
+
+const getCopperErrorPair = (
+  error: DrcError,
+  elementsById: CopperElementsById,
+): string | undefined => {
+  const errorType = error.type ?? error.error_type
+  const traceId =
+    typeof error.pcb_trace_id === "string" ? error.pcb_trace_id : undefined
+  let participantIds: string[]
+  let expectedKinds: CopperParticipant["kind"][]
+  let relation = "copper-gap"
+  if (errorType === "pcb_pad_trace_clearance_error") {
+    if (!traceId || typeof error.pcb_pad_id !== "string") {
+      throw new Error("Pipeline9 joint pad DRC requires both copper identities")
+    }
+    participantIds = [traceId, error.pcb_pad_id]
+    expectedKinds = ["trace", "obstacle"]
+  } else if (errorType === "pcb_via_trace_clearance_error") {
+    if (!traceId || typeof error.pcb_via_id !== "string") {
+      throw new Error("Pipeline9 joint via DRC requires both copper identities")
+    }
+    participantIds = [traceId, error.pcb_via_id]
+    expectedKinds = ["trace", "via"]
+  } else if (errorType === "pcb_via_clearance_error") {
+    if (
+      !Array.isArray(error.pcb_via_ids) ||
+      error.pcb_via_ids.length !== 2 ||
+      !error.pcb_via_ids.every((id) => typeof id === "string")
+    ) {
+      throw new Error(
+        "Pipeline9 joint via-spacing DRC requires two via identities",
+      )
+    }
+    participantIds = error.pcb_via_ids as string[]
+    expectedKinds = ["via", "via"]
+    const errorId = error.pcb_error_id
+    if (
+      typeof errorId !== "string" ||
+      (!errorId.startsWith("same_net_vias_close_") &&
+        !errorId.startsWith("different_net_vias_close_"))
+    ) {
+      throw new Error(
+        "Pipeline9 joint via-spacing DRC requires its net relation",
+      )
+    }
+    relation = errorId.startsWith("same_net_")
+      ? "same-net-via-gap"
+      : "different-net-via-gap"
+  } else if (
+    errorType === "pcb_trace_error" &&
+    typeof error.pcb_trace_error_id === "string" &&
+    error.pcb_trace_error_id.startsWith("overlap_")
+  ) {
+    const prefix = `overlap_${traceId}_`
+    if (!traceId || !error.pcb_trace_error_id.startsWith(prefix)) {
+      throw new Error("Pipeline9 joint overlap DRC requires its primary trace")
+    }
+    const otherId = error.pcb_trace_error_id.slice(prefix.length)
+    participantIds = [traceId, otherId]
+    expectedKinds = ["trace"]
+    if (
+      error.pcb_via_id === otherId ||
+      (Array.isArray(error.pcb_via_ids) && error.pcb_via_ids.includes(otherId))
+    ) {
+      expectedKinds.push("via")
+    } else if (
+      Array.isArray(error.pcb_trace_ids) &&
+      error.pcb_trace_ids.includes(otherId)
+    ) {
+      expectedKinds.push("trace")
+    }
+  } else {
+    return undefined
+  }
+  const identities = participantIds.map((id, index) => {
+    return resolveCopperParticipant(elementsById, id, expectedKinds[index])
+      .identity
+  })
+  return JSON.stringify([relation, ...identities.sort()])
+}
+
+const getErrorGroups = (snapshot: JointDrcSnapshot): Map<string, number[]> => {
+  const elementsById = getCopperElementsById(snapshot.circuitJson)
+  const groups = new Map<string, number[]>()
+  for (const error of snapshot.errors) {
+    const pair = getCopperErrorPair(error, elementsById)
+    let gap: number | undefined
+    if (pair && error.actual_clearance !== undefined) {
+      if (
+        typeof error.actual_clearance !== "number" ||
+        !Number.isFinite(error.actual_clearance) ||
+        typeof error.minimum_clearance !== "number" ||
+        !Number.isFinite(error.minimum_clearance)
+      ) {
+        throw new Error(
+          "Pipeline9 joint DRC requires finite clearance measurements",
+        )
+      }
+      gap = error.actual_clearance
+    } else if (pair && typeof error.message === "string") {
+      const match = error.message.match(/gap: (-?\d+(?:\.\d+)?)mm/)
+      if (match) gap = Number.parseFloat(match[1]!)
+    }
+    // Generic too-close errors expose only the official checker's rounded
+    // message measurement. Contacts have no measured gap, so require their
+    // exact record to remain unchanged or disappear. Do not manufacture a
+    // score for connectivity, board-edge, or unknown findings either.
+    const key =
+      pair !== undefined && gap !== undefined
+        ? pair
+        : `exact:${stringifyDrcRecord(error)}`
+    const severities = groups.get(key) ?? []
+    severities.push(gap === undefined ? 0 : -gap)
+    groups.set(key, severities)
+  }
+  for (const severities of groups.values()) {
+    severities.sort((left, right) => right - left)
+  }
+  return groups
+}
+
+/** Checks unfiltered output without exchanging or worsening DRCs. */
+export const isPipeline9JointDrcOutputNoWorse = ({
+  candidate,
+  current,
+}: {
+  candidate: JointDrcSnapshot
+  current: JointDrcSnapshot
+}): boolean => {
+  if (candidate.errors.length > current.errors.length) return false
+  // A fully reference-clean output has no retained participants to match.
+  if (candidate.errors.length === 0) return true
+  const currentGroups = getErrorGroups(current)
+  const candidateGroups = getErrorGroups(candidate)
+  for (const [pair, candidateSeverities] of candidateGroups) {
+    const currentSeverities = currentGroups.get(pair)
+    if (
+      !currentSeverities ||
+      candidateSeverities.length > currentSeverities.length ||
+      candidateSeverities.some(
+        (severity, index) => severity > currentSeverities[index]!,
+      )
+    ) {
+      return false
+    }
+  }
+  return true
+}

--- a/lib/solvers/RouteStitchingSolver/MultipleHighDensityRouteStitchSolver3.ts
+++ b/lib/solvers/RouteStitchingSolver/MultipleHighDensityRouteStitchSolver3.ts
@@ -3,13 +3,12 @@ import { ConnectivityMap } from "connectivity-map"
 import { GraphicsObject } from "graphics-debug"
 import { SimpleRouteConnection } from "lib/types"
 import { HighDensityIntraNodeRoute } from "lib/types/high-density-types"
-import { getConnectionPointLayer } from "lib/types/srj-types"
 import { getJumpersGraphics } from "lib/utils/getJumperGraphics"
-import { mapLayerNameToZ } from "lib/utils/mapLayerNameToZ"
 import { BaseSolver } from "../BaseSolver"
 import { safeTransparentize } from "../colors"
 import { RouteStitchClearanceValidator } from "./route-stitch-clearance-validator"
 import { SingleHighDensityRouteStitchSolver3 } from "./SingleHighDensityRouteStitchSolver3"
+import { getStitchTerminal } from "./getStitchTerminal"
 import {
   EndpointClusterIndex,
   hasStitchableGapBetweenUnsolvedRoutes,
@@ -244,20 +243,14 @@ export class MultipleHighDensityRouteStitchSolver3 extends BaseSolver {
       let end: Point3
 
       if (candidateEndpoints.length >= 2) {
-        const globalStart = {
-          ...connection.pointsToConnect[0],
-          z: mapLayerNameToZ(
-            getConnectionPointLayer(connection.pointsToConnect[0]),
-            params.layerCount,
-          ),
-        }
-        const globalEnd = {
-          ...connection.pointsToConnect[1],
-          z: mapLayerNameToZ(
-            getConnectionPointLayer(connection.pointsToConnect[1]),
-            params.layerCount,
-          ),
-        }
+        const globalStart = getStitchTerminal(
+          connection.pointsToConnect[0],
+          params.layerCount,
+        )
+        const globalEnd = getStitchTerminal(
+          connection.pointsToConnect[1],
+          params.layerCount,
+        )
         ;({ start, end } = selectIslandEndpoints({
           possibleEndpoints: candidateEndpoints,
           globalStart,
@@ -280,20 +273,14 @@ export class MultipleHighDensityRouteStitchSolver3 extends BaseSolver {
           terminals: [globalStart, globalEnd],
         })
       } else {
-        start = {
-          ...connection.pointsToConnect[0],
-          z: mapLayerNameToZ(
-            getConnectionPointLayer(connection.pointsToConnect[0]),
-            params.layerCount,
-          ),
-        }
-        end = {
-          ...connection.pointsToConnect[1],
-          z: mapLayerNameToZ(
-            getConnectionPointLayer(connection.pointsToConnect[1]),
-            params.layerCount,
-          ),
-        }
+        start = getStitchTerminal(
+          connection.pointsToConnect[0],
+          params.layerCount,
+        )
+        end = getStitchTerminal(
+          connection.pointsToConnect[1],
+          params.layerCount,
+        )
       }
 
       const selectedHdRoutes = selectRoutesAlongEndpointPath({
@@ -343,20 +330,14 @@ export class MultipleHighDensityRouteStitchSolver3 extends BaseSolver {
 
       if (!connection) return unsolvedRoutes
 
-      const start = {
-        ...connection.pointsToConnect[0],
-        z: mapLayerNameToZ(
-          getConnectionPointLayer(connection.pointsToConnect[0]),
-          params.layerCount,
-        ),
-      }
-      const end = {
-        ...connection.pointsToConnect[1],
-        z: mapLayerNameToZ(
-          getConnectionPointLayer(connection.pointsToConnect[1]),
-          params.layerCount,
-        ),
-      }
+      const start = getStitchTerminal(
+        connection.pointsToConnect[0],
+        params.layerCount,
+      )
+      const end = getStitchTerminal(
+        connection.pointsToConnect[1],
+        params.layerCount,
+      )
 
       const hdRoutes = unsolvedRoutes.flatMap(
         (unsolvedRoute) => unsolvedRoute.hdRoutes,

--- a/lib/solvers/RouteStitchingSolver/MultipleHighDensityRouteStitchSolver3.ts
+++ b/lib/solvers/RouteStitchingSolver/MultipleHighDensityRouteStitchSolver3.ts
@@ -8,7 +8,7 @@ import { BaseSolver } from "../BaseSolver"
 import { safeTransparentize } from "../colors"
 import { RouteStitchClearanceValidator } from "./route-stitch-clearance-validator"
 import { SingleHighDensityRouteStitchSolver3 } from "./SingleHighDensityRouteStitchSolver3"
-import { getStitchTerminal } from "./getStitchTerminal"
+import { type StitchTerminal, getStitchTerminal } from "./getStitchTerminal"
 import {
   EndpointClusterIndex,
   hasStitchableGapBetweenUnsolvedRoutes,
@@ -208,25 +208,44 @@ export class MultipleHighDensityRouteStitchSolver3 extends BaseSolver {
       )!
 
       const possibleEndpoints1 = hdRoutes.flatMap((r) => [
-        r.route[0],
-        r.route[r.route.length - 1],
+        r.startPcbPortId
+          ? { ...r.route[0], pcb_port_id: r.startPcbPortId }
+          : r.route[0],
+        r.endPcbPortId
+          ? {
+              ...r.route[r.route.length - 1],
+              pcb_port_id: r.endPcbPortId,
+            }
+          : r.route[r.route.length - 1],
       ])
 
-      const possibleEndpointsByHash = new Map<
-        string,
-        { x: number; y: number; z: number }
-      >()
-      const possibleEndpoints2 = []
+      const possibleEndpointsByHash = new Map<string, StitchTerminal>()
+      const possibleEndpoints2: StitchTerminal[] = []
       for (const possibleEndpoint1 of possibleEndpoints1) {
         const pointHash = this.endpointIndex.getEndpointKey(
           hdRoutes[0].connectionName,
           possibleEndpoint1,
         )
-        if (!possibleEndpointsByHash.has(pointHash)) {
+        const existingEndpoint = possibleEndpointsByHash.get(pointHash)
+        if (
+          existingEndpoint?.pcb_port_id &&
+          possibleEndpoint1.pcb_port_id &&
+          existingEndpoint.pcb_port_id !== possibleEndpoint1.pcb_port_id
+        ) {
+          throw new Error(
+            `Route stitching found conflicting PCB terminal claims "${existingEndpoint.pcb_port_id}" and "${possibleEndpoint1.pcb_port_id}" in one endpoint cluster`,
+          )
+        }
+        if (
+          !existingEndpoint ||
+          (!existingEndpoint.pcb_port_id && possibleEndpoint1.pcb_port_id)
+        ) {
           possibleEndpointsByHash.set(pointHash, possibleEndpoint1)
         }
-        if (pointHashCounts.get(pointHash) === 1) {
-          possibleEndpoints2.push(possibleEndpoint1)
+      }
+      for (const [pointHash, endpoint] of possibleEndpointsByHash) {
+        if (endpoint.pcb_port_id || pointHashCounts.get(pointHash) === 1) {
+          possibleEndpoints2.push(endpoint)
         }
       }
 
@@ -239,8 +258,8 @@ export class MultipleHighDensityRouteStitchSolver3 extends BaseSolver {
         continue
       }
 
-      let start: Point3
-      let end: Point3
+      let start: StitchTerminal
+      let end: StitchTerminal
 
       if (candidateEndpoints.length >= 2) {
         const globalStart = getStitchTerminal(

--- a/lib/solvers/RouteStitchingSolver/MultipleHighDensityRouteStitchSolver3.ts
+++ b/lib/solvers/RouteStitchingSolver/MultipleHighDensityRouteStitchSolver3.ts
@@ -1,4 +1,4 @@
-import { distance, type Point3 } from "@tscircuit/math-utils"
+import { distance } from "@tscircuit/math-utils"
 import { ConnectivityMap } from "connectivity-map"
 import { GraphicsObject } from "graphics-debug"
 import { SimpleRouteConnection } from "lib/types"
@@ -8,9 +8,12 @@ import { BaseSolver } from "../BaseSolver"
 import { safeTransparentize } from "../colors"
 import { RouteStitchClearanceValidator } from "./route-stitch-clearance-validator"
 import { SingleHighDensityRouteStitchSolver3 } from "./SingleHighDensityRouteStitchSolver3"
+import { getRouteStitchEndpoint } from "./getRouteStitchEndpoint"
 import { type StitchTerminal, getStitchTerminal } from "./getStitchTerminal"
 import {
   EndpointClusterIndex,
+  type OrderedRouteStitchEntry,
+  type RouteStitchPathSelection,
   hasStitchableGapBetweenUnsolvedRoutes,
   selectIslandEndpoints,
   selectRoutesAlongEndpointPath,
@@ -24,8 +27,9 @@ import {
 export type UnsolvedRoute3 = {
   connectionName: string
   hdRoutes: HighDensityIntraNodeRoute[]
-  start: Point3
-  end: Point3
+  orderedRoutePath?: OrderedRouteStitchEntry[]
+  start: StitchTerminal
+  end: StitchTerminal
 }
 
 export class MultipleHighDensityRouteStitchSolver3 extends BaseSolver {
@@ -47,12 +51,14 @@ export class MultipleHighDensityRouteStitchSolver3 extends BaseSolver {
   private canStitchBetweenTerminals(params: {
     connectionName: string
     hdRoutes: HighDensityIntraNodeRoute[]
-    start: Point3
-    end: Point3
-  }) {
+    start: StitchTerminal
+    end: StitchTerminal
+    orderedRoutePath?: OrderedRouteStitchEntry[]
+  }): boolean {
     const stitchSolver = new SingleHighDensityRouteStitchSolver3({
       connectionName: params.connectionName,
       hdRoutes: params.hdRoutes,
+      orderedRoutePath: params.orderedRoutePath,
       start: params.start,
       end: params.end,
       colorMap: this.colorMap,
@@ -73,7 +79,7 @@ export class MultipleHighDensityRouteStitchSolver3 extends BaseSolver {
       stitchSolver.step()
     }
 
-    if (stitchSolver.failed) return false
+    if (stitchSolver.failed || !stitchSolver.solved) return false
 
     const routeStart = stitchSolver.mergedHdRoute.route[0]
     const routeEnd =
@@ -97,9 +103,9 @@ export class MultipleHighDensityRouteStitchSolver3 extends BaseSolver {
     rootConnectionName?: string
     hdRoutes: HighDensityIntraNodeRoute[]
     allHdRoutes: HighDensityIntraNodeRoute[]
-    start: Point3
-    end: Point3
-  }) {
+    start: StitchTerminal
+    end: StitchTerminal
+  }): RouteStitchPathSelection | null {
     const rootConnectionName = params.rootConnectionName
     if (!rootConnectionName) return null
 
@@ -114,7 +120,7 @@ export class MultipleHighDensityRouteStitchSolver3 extends BaseSolver {
       return null
     }
 
-    const pathRoutes = selectRoutesAlongEndpointPath({
+    const selection = selectRoutesAlongEndpointPath({
       connectionName: params.connectionName,
       hdRoutes: sameRootRoutes,
       start: params.start,
@@ -123,16 +129,16 @@ export class MultipleHighDensityRouteStitchSolver3 extends BaseSolver {
       canStitchBetweenTerminals: (selection) =>
         this.canStitchBetweenTerminals(selection),
     })
+    if (!selection) return null
+    const pathRoutes = selection.hdRoutes
 
     const includesSharedRootBridge = pathRoutes.some(
       (route) => !currentRouteSet.has(route),
     )
-    // The endpoint path helper returns all candidate routes as a fallback when
-    // no path is found, so only accept a strict same-root subset.
-    if (!includesSharedRootBridge || pathRoutes.length >= sameRootRoutes.length)
-      return null
+    // A shared-root selection must actually add a bridge to this island.
+    if (!includesSharedRootBridge) return null
 
-    return pathRoutes
+    return selection
   }
 
   constructor(params: {
@@ -170,8 +176,8 @@ export class MultipleHighDensityRouteStitchSolver3 extends BaseSolver {
 
     for (let i = 0; i < canonicalHdRoutes.length; i++) {
       const hdRoute = canonicalHdRoutes[i]
-      const start = hdRoute.route[0]
-      const end = hdRoute.route[hdRoute.route.length - 1]
+      const start = getRouteStitchEndpoint(hdRoute, "first")
+      const end = getRouteStitchEndpoint(hdRoute, "last")
       routeIslandConnections.push([
         `route_island_${i}`,
         this.endpointIndex.getEndpointKey(hdRoute.connectionName, start),
@@ -208,15 +214,8 @@ export class MultipleHighDensityRouteStitchSolver3 extends BaseSolver {
       )!
 
       const possibleEndpoints1 = hdRoutes.flatMap((r) => [
-        r.startPcbPortId
-          ? { ...r.route[0], pcb_port_id: r.startPcbPortId }
-          : r.route[0],
-        r.endPcbPortId
-          ? {
-              ...r.route[r.route.length - 1],
-              pcb_port_id: r.endPcbPortId,
-            }
-          : r.route[r.route.length - 1],
+        getRouteStitchEndpoint(r, "first"),
+        getRouteStitchEndpoint(r, "last"),
       ])
 
       const possibleEndpointsByHash = new Map<string, StitchTerminal>()
@@ -302,19 +301,11 @@ export class MultipleHighDensityRouteStitchSolver3 extends BaseSolver {
         )
       }
 
-      const selectedHdRoutes = selectRoutesAlongEndpointPath({
-        connectionName: hdRoutes[0].connectionName,
-        hdRoutes,
-        start,
-        end,
-        endpointIndex: this.endpointIndex,
-        canStitchBetweenTerminals: (selection) =>
-          this.canStitchBetweenTerminals(selection),
-      })
-
+      // Keep provisional islands intact until their connection-level merge
+      // is known; a nearby spur is not itself a required terminal path.
       this.unsolvedRoutes.push({
         connectionName: hdRoutes[0].connectionName,
-        hdRoutes: selectedHdRoutes,
+        hdRoutes,
         start,
         end,
       })
@@ -376,27 +367,39 @@ export class MultipleHighDensityRouteStitchSolver3 extends BaseSolver {
           : null
 
       if (!hasDegenerateRoute && !hasStitchableGap && !sharedRootPathRoutes) {
-        return unsolvedRoutes
+        return unsolvedRoutes.map((route): UnsolvedRoute3 => {
+          const selection = selectRoutesAlongEndpointPath({
+            ...route,
+            endpointIndex: this.endpointIndex,
+            canStitchBetweenTerminals: (candidate) =>
+              this.canStitchBetweenTerminals(candidate),
+          })
+          if (!selection) {
+            throw new Error(
+              `No endpoint path connects the final route island for "${connectionName}"`,
+            )
+          }
+          return { ...route, ...selection }
+        })
       }
 
-      return [
-        {
+      const selection =
+        sharedRootPathRoutes ??
+        selectRoutesAlongEndpointPath({
           connectionName,
-          hdRoutes:
-            sharedRootPathRoutes ??
-            selectRoutesAlongEndpointPath({
-              connectionName,
-              hdRoutes,
-              start,
-              end,
-              endpointIndex: this.endpointIndex,
-              canStitchBetweenTerminals: (selection) =>
-                this.canStitchBetweenTerminals(selection),
-            }),
+          hdRoutes,
           start,
           end,
-        },
-      ]
+          endpointIndex: this.endpointIndex,
+          canStitchBetweenTerminals: (candidate) =>
+            this.canStitchBetweenTerminals(candidate),
+        })
+      if (!selection) {
+        throw new Error(
+          `No endpoint path connects the merged route islands for "${connectionName}"`,
+        )
+      }
+      return [{ connectionName, ...selection, start, end }]
     })
 
     this.MAX_ITERATIONS = 100e3
@@ -428,6 +431,7 @@ export class MultipleHighDensityRouteStitchSolver3 extends BaseSolver {
     this.activeSolver = new SingleHighDensityRouteStitchSolver3({
       connectionName: unsolvedRoute.connectionName,
       hdRoutes: unsolvedRoute.hdRoutes,
+      orderedRoutePath: unsolvedRoute.orderedRoutePath,
       start: unsolvedRoute.start,
       end: unsolvedRoute.end,
       colorMap: this.colorMap,

--- a/lib/solvers/RouteStitchingSolver/MultipleHighDensityRouteStitchSolver3.ts
+++ b/lib/solvers/RouteStitchingSolver/MultipleHighDensityRouteStitchSolver3.ts
@@ -79,7 +79,23 @@ export class MultipleHighDensityRouteStitchSolver3 extends BaseSolver {
       stitchSolver.step()
     }
 
-    if (stitchSolver.failed || !stitchSolver.solved) return false
+    if (stitchSolver.failed || !stitchSolver.solved) {
+      throw new Error(
+        `Selected route stitching path for "${params.connectionName}" failed physical validation: ${JSON.stringify({
+          error: stitchSolver.error,
+          solved: stitchSolver.solved,
+          failed: stitchSolver.failed,
+          start: params.start,
+          end: params.end,
+          mergedRoute: stitchSolver.mergedHdRoute,
+          remainingRoutes: stitchSolver.remainingHdRoutes,
+          orderedRoutePath: params.orderedRoutePath,
+          allowedLayerTransitionPointKeys: this.allowedLayerTransitionPointKeys
+            ? [...this.allowedLayerTransitionPointKeys]
+            : undefined,
+        })}`,
+      )
+    }
 
     const routeStart = stitchSolver.mergedHdRoute.route[0]
     const routeEnd =
@@ -92,10 +108,23 @@ export class MultipleHighDensityRouteStitchSolver3 extends BaseSolver {
     const swappedDistance =
       distance(routeStart, params.end) + distance(routeEnd, params.start)
 
-    return (
-      Math.min(directDistance, swappedDistance) <=
+    if (
+      Math.min(directDistance, swappedDistance) >
       MAX_TERMINAL_STITCH_GAP_DISTANCE_3
-    )
+    ) {
+      throw new Error(
+        `Selected route stitching path for "${params.connectionName}" did not reach both terminals: ${JSON.stringify({
+          start: params.start,
+          end: params.end,
+          routeStart,
+          routeEnd,
+          directDistance,
+          swappedDistance,
+          orderedRoutePath: params.orderedRoutePath,
+        })}`,
+      )
+    }
+    return true
   }
 
   private getSharedRootPathRoutes(params: {
@@ -376,7 +405,12 @@ export class MultipleHighDensityRouteStitchSolver3 extends BaseSolver {
           })
           if (!selection) {
             throw new Error(
-              `No endpoint path connects the final route island for "${connectionName}"`,
+              `No endpoint path connects the final route island for "${connectionName}": ${JSON.stringify({
+                start: route.start,
+                end: route.end,
+                hdRoutes: route.hdRoutes,
+                clusters: this.endpointIndex.getClusters(connectionName),
+              })}`,
             )
           }
           return { ...route, ...selection }
@@ -396,7 +430,12 @@ export class MultipleHighDensityRouteStitchSolver3 extends BaseSolver {
         })
       if (!selection) {
         throw new Error(
-          `No endpoint path connects the merged route islands for "${connectionName}"`,
+          `No endpoint path connects the merged route islands for "${connectionName}": ${JSON.stringify({
+            start,
+            end,
+            hdRoutes,
+            clusters: this.endpointIndex.getClusters(connectionName),
+          })}`,
         )
       }
       return [{ connectionName, ...selection, start, end }]

--- a/lib/solvers/RouteStitchingSolver/MultipleHighDensityRouteStitchSolver3.ts
+++ b/lib/solvers/RouteStitchingSolver/MultipleHighDensityRouteStitchSolver3.ts
@@ -81,19 +81,22 @@ export class MultipleHighDensityRouteStitchSolver3 extends BaseSolver {
 
     if (stitchSolver.failed || !stitchSolver.solved) {
       throw new Error(
-        `Selected route stitching path for "${params.connectionName}" failed physical validation: ${JSON.stringify({
-          error: stitchSolver.error,
-          solved: stitchSolver.solved,
-          failed: stitchSolver.failed,
-          start: params.start,
-          end: params.end,
-          mergedRoute: stitchSolver.mergedHdRoute,
-          remainingRoutes: stitchSolver.remainingHdRoutes,
-          orderedRoutePath: params.orderedRoutePath,
-          allowedLayerTransitionPointKeys: this.allowedLayerTransitionPointKeys
-            ? [...this.allowedLayerTransitionPointKeys]
-            : undefined,
-        })}`,
+        `Selected route stitching path for "${params.connectionName}" failed physical validation: ${JSON.stringify(
+          {
+            error: stitchSolver.error,
+            solved: stitchSolver.solved,
+            failed: stitchSolver.failed,
+            start: params.start,
+            end: params.end,
+            mergedRoute: stitchSolver.mergedHdRoute,
+            remainingRoutes: stitchSolver.remainingHdRoutes,
+            orderedRoutePath: params.orderedRoutePath,
+            allowedLayerTransitionPointKeys: this
+              .allowedLayerTransitionPointKeys
+              ? [...this.allowedLayerTransitionPointKeys]
+              : undefined,
+          },
+        )}`,
       )
     }
 
@@ -113,15 +116,17 @@ export class MultipleHighDensityRouteStitchSolver3 extends BaseSolver {
       MAX_TERMINAL_STITCH_GAP_DISTANCE_3
     ) {
       throw new Error(
-        `Selected route stitching path for "${params.connectionName}" did not reach both terminals: ${JSON.stringify({
-          start: params.start,
-          end: params.end,
-          routeStart,
-          routeEnd,
-          directDistance,
-          swappedDistance,
-          orderedRoutePath: params.orderedRoutePath,
-        })}`,
+        `Selected route stitching path for "${params.connectionName}" did not reach both terminals: ${JSON.stringify(
+          {
+            start: params.start,
+            end: params.end,
+            routeStart,
+            routeEnd,
+            directDistance,
+            swappedDistance,
+            orderedRoutePath: params.orderedRoutePath,
+          },
+        )}`,
       )
     }
     return true
@@ -155,7 +160,9 @@ export class MultipleHighDensityRouteStitchSolver3 extends BaseSolver {
       start: params.start,
       end: params.end,
       endpointIndex: this.endpointIndex,
-      canStitchBetweenTerminals: (selection) =>
+      isStitchSegmentClear: (segment): boolean =>
+        this.clearanceValidator.isSegmentClear(segment),
+      canStitchBetweenTerminals: (selection): boolean =>
         this.canStitchBetweenTerminals(selection),
     })
     if (!selection) return null
@@ -400,17 +407,21 @@ export class MultipleHighDensityRouteStitchSolver3 extends BaseSolver {
           const selection = selectRoutesAlongEndpointPath({
             ...route,
             endpointIndex: this.endpointIndex,
-            canStitchBetweenTerminals: (candidate) =>
+            isStitchSegmentClear: (segment): boolean =>
+              this.clearanceValidator.isSegmentClear(segment),
+            canStitchBetweenTerminals: (candidate): boolean =>
               this.canStitchBetweenTerminals(candidate),
           })
           if (!selection) {
             throw new Error(
-              `No endpoint path connects the final route island for "${connectionName}": ${JSON.stringify({
-                start: route.start,
-                end: route.end,
-                hdRoutes: route.hdRoutes,
-                clusters: this.endpointIndex.getClusters(connectionName),
-              })}`,
+              `No endpoint path connects the final route island for "${connectionName}": ${JSON.stringify(
+                {
+                  start: route.start,
+                  end: route.end,
+                  hdRoutes: route.hdRoutes,
+                  clusters: this.endpointIndex.getClusters(connectionName),
+                },
+              )}`,
             )
           }
           return { ...route, ...selection }
@@ -425,17 +436,21 @@ export class MultipleHighDensityRouteStitchSolver3 extends BaseSolver {
           start,
           end,
           endpointIndex: this.endpointIndex,
-          canStitchBetweenTerminals: (candidate) =>
+          isStitchSegmentClear: (segment): boolean =>
+            this.clearanceValidator.isSegmentClear(segment),
+          canStitchBetweenTerminals: (candidate): boolean =>
             this.canStitchBetweenTerminals(candidate),
         })
       if (!selection) {
         throw new Error(
-          `No endpoint path connects the merged route islands for "${connectionName}": ${JSON.stringify({
-            start,
-            end,
-            hdRoutes,
-            clusters: this.endpointIndex.getClusters(connectionName),
-          })}`,
+          `No endpoint path connects the merged route islands for "${connectionName}": ${JSON.stringify(
+            {
+              start,
+              end,
+              hdRoutes,
+              clusters: this.endpointIndex.getClusters(connectionName),
+            },
+          )}`,
         )
       }
       return [{ connectionName, ...selection, start, end }]

--- a/lib/solvers/RouteStitchingSolver/SingleHighDensityRouteStitchSolver3.ts
+++ b/lib/solvers/RouteStitchingSolver/SingleHighDensityRouteStitchSolver3.ts
@@ -93,8 +93,7 @@ export class SingleHighDensityRouteStitchSolver3 extends BaseSolver {
     // via element, so reuse only the exact already represented transition.
     const fromZ =
       orientation === "forward" ? transitionStart.z : transitionEnd.z
-    const toZ =
-      orientation === "forward" ? transitionEnd.z : transitionStart.z
+    const toZ = orientation === "forward" ? transitionEnd.z : transitionStart.z
     for (let index = 0; index < route.route.length - 1; index += 1) {
       const start = route.route[index]!
       const end = route.route[index + 1]!
@@ -151,10 +150,8 @@ export class SingleHighDensityRouteStitchSolver3 extends BaseSolver {
         this.error = `Terminal stitch for "${opts.connectionName}" requires an existing via between terminal layers`
         return
       }
-      const routePoints = [
-        { x: opts.start.x, y: opts.start.y, z: commonLayer },
-      ]
-      const vias = []
+      const routePoints = [{ x: opts.start.x, y: opts.start.y, z: commonLayer }]
+      const vias: HighDensityIntraNodeRoute["vias"] = []
 
       const stitchStart = routePoints[routePoints.length - 1]!
       const stitchEnd = { x: opts.end.x, y: opts.end.y, z: commonLayer }
@@ -392,8 +389,7 @@ export class SingleHighDensityRouteStitchSolver3 extends BaseSolver {
       ) {
         if (
           !this.isPlanarStitchClear(lastMergedPoint, terminalPoint) &&
-          (requiresTerminalVia ||
-            this.stitchClearanceMode === "require_clear")
+          (requiresTerminalVia || this.stitchClearanceMode === "require_clear")
         ) {
           this.failed = true
           this.error = `Terminal stitch for "${this.mergedHdRoute.connectionName}" violates copper clearance`

--- a/lib/solvers/RouteStitchingSolver/SingleHighDensityRouteStitchSolver3.ts
+++ b/lib/solvers/RouteStitchingSolver/SingleHighDensityRouteStitchSolver3.ts
@@ -4,6 +4,7 @@ import { HighDensityIntraNodeRoute } from "lib/types/high-density-types"
 import { getJumpersGraphics } from "lib/utils/getJumperGraphics"
 import { getXyPointKey } from "lib/autorouter-pipelines/AutoroutingPipeline8/getXyPointKey"
 import { BaseSolver } from "../BaseSolver"
+import type { StitchTerminal } from "./getStitchTerminal"
 import type { IsStitchSegmentClear } from "./route-stitch-clearance-validator"
 import {
   comparePoints,
@@ -18,7 +19,6 @@ const GAP_PENALTY = 100000
 const GEOMETRIC_TOLERANCE = 1e-3
 const COLLISION_PENALTY = MAX_STITCH_GAP_DISTANCE_3 + DISTANCE_TIE_TOLERANCE
 type RoutePoint = HighDensityIntraNodeRoute["route"][number]
-type StitchTerminal = Point3 & { pcb_port_id?: string }
 export type StitchClearanceMode = "require_clear" | "prefer_clear"
 export {
   MAX_STITCH_GAP_DISTANCE_3,
@@ -67,6 +67,55 @@ export class SingleHighDensityRouteStitchSolver3 extends BaseSolver {
     })
   }
 
+  private hasExistingTerminalVia(
+    transitionStart: Point3,
+    transitionEnd: Point3,
+    route: HighDensityIntraNodeRoute,
+    orientation: "forward" | "reverse",
+  ): boolean {
+    if (
+      this.allowedLayerTransitionPointKeys &&
+      !this.allowedLayerTransitionPointKeys.has(getXyPointKey(transitionStart))
+    ) {
+      return false
+    }
+    if (
+      route.viaDiameter !== this.mergedHdRoute.viaDiameter ||
+      !route.vias.some(
+        (via): boolean =>
+          via.x === transitionStart.x && via.y === transitionStart.y,
+      )
+    ) {
+      return false
+    }
+    // Public materialization identifies vias by their directed layer pair.
+    // A reversed or partial-span traversal would create another overlapping
+    // via element, so reuse only the exact already represented transition.
+    const fromZ =
+      orientation === "forward" ? transitionStart.z : transitionEnd.z
+    const toZ =
+      orientation === "forward" ? transitionEnd.z : transitionStart.z
+    for (let index = 0; index < route.route.length - 1; index += 1) {
+      const start = route.route[index]!
+      const end = route.route[index + 1]!
+      if (
+        start.toNextSegmentType !== "through_obstacle" &&
+        start.x === transitionStart.x &&
+        start.y === transitionStart.y &&
+        end.x === transitionEnd.x &&
+        end.y === transitionEnd.y &&
+        start.x === end.x &&
+        start.y === end.y &&
+        start.z !== end.z &&
+        start.z === fromZ &&
+        end.z === toZ
+      ) {
+        return true
+      }
+    }
+    return false
+  }
+
   constructor(opts: {
     connectionName: string
     hdRoutes: HighDensityIntraNodeRoute[]
@@ -92,28 +141,23 @@ export class SingleHighDensityRouteStitchSolver3 extends BaseSolver {
       this.start = opts.start
       this.end = opts.end
       const traceThickness = opts.defaultTraceThickness ?? 0.15
+      const startLayers = opts.start.availableZ ?? [opts.start.z]
+      const endLayers = opts.end.availableZ ?? [opts.end.z]
+      const commonLayer = startLayers.find((z): boolean =>
+        endLayers.includes(z),
+      )
+      if (commonLayer === undefined) {
+        this.failed = true
+        this.error = `Terminal stitch for "${opts.connectionName}" requires an existing via between terminal layers`
+        return
+      }
       const routePoints = [
-        { x: opts.start.x, y: opts.start.y, z: opts.start.z },
+        { x: opts.start.x, y: opts.start.y, z: commonLayer },
       ]
       const vias = []
 
-      if (opts.start.z !== opts.end.z) {
-        if (
-          opts.allowedLayerTransitionPointKeys &&
-          !opts.allowedLayerTransitionPointKeys.has(getXyPointKey(opts.start))
-        ) {
-          this.failed = true
-          this.error = `Layer transition at ${getXyPointKey(
-            opts.start,
-          )} is not allowed`
-          return
-        }
-        routePoints.push({ x: opts.start.x, y: opts.start.y, z: opts.end.z })
-        vias.push({ x: opts.start.x, y: opts.start.y })
-      }
-
       const stitchStart = routePoints[routePoints.length - 1]!
-      const stitchEnd = { x: opts.end.x, y: opts.end.y, z: opts.end.z }
+      const stitchEnd = { x: opts.end.x, y: opts.end.y, z: commonLayer }
       const stitchSegment = {
         connectionName: opts.connectionName,
         start: stitchStart,
@@ -269,7 +313,9 @@ export class SingleHighDensityRouteStitchSolver3 extends BaseSolver {
         {
           x: this.start.x,
           y: this.start.y,
-          z: closestFirstRoutePoint.z,
+          z: this.start.availableZ?.includes(closestFirstRoutePoint.z)
+            ? closestFirstRoutePoint.z
+            : this.start.z,
         },
       ],
       vias: [],
@@ -309,20 +355,45 @@ export class SingleHighDensityRouteStitchSolver3 extends BaseSolver {
     return { firstRoute: this.remainingHdRoutes[0] }
   }
 
-  _step() {
+  _step(): void {
     if (this.remainingHdRoutes.length === 0) {
       const lastMergedPoint =
         this.mergedHdRoute.route[this.mergedHdRoute.route.length - 1]
-      const terminalPoint = { ...this.end, z: lastMergedPoint.z }
+      const terminalZ = this.end.availableZ?.includes(lastMergedPoint.z)
+        ? lastMergedPoint.z
+        : this.end.z
+      const requiresTerminalVia = lastMergedPoint.z !== terminalZ
+      const terminalPoint = {
+        x: this.end.x,
+        y: this.end.y,
+        z: lastMergedPoint.z,
+      }
       const terminalDistance = distance(lastMergedPoint, terminalPoint)
 
       if (
-        terminalDistance > GEOMETRIC_TOLERANCE &&
+        requiresTerminalVia &&
+        (terminalDistance > MAX_TERMINAL_STITCH_GAP_DISTANCE_3 ||
+          !this.hasExistingTerminalVia(
+            terminalPoint,
+            this.end,
+            this.mergedHdRoute,
+            "forward",
+          ))
+      ) {
+        this.failed = true
+        this.error = `Terminal stitch for "${this.mergedHdRoute.connectionName}" cannot reach terminal layer ${terminalZ} without an existing allowed via`
+        return
+      }
+
+      if (
+        (terminalDistance > GEOMETRIC_TOLERANCE ||
+          (requiresTerminalVia && terminalDistance > 0)) &&
         terminalDistance <= MAX_TERMINAL_STITCH_GAP_DISTANCE_3
       ) {
         if (
           !this.isPlanarStitchClear(lastMergedPoint, terminalPoint) &&
-          this.stitchClearanceMode === "require_clear"
+          (requiresTerminalVia ||
+            this.stitchClearanceMode === "require_clear")
         ) {
           this.failed = true
           this.error = `Terminal stitch for "${this.mergedHdRoute.connectionName}" violates copper clearance`
@@ -335,12 +406,21 @@ export class SingleHighDensityRouteStitchSolver3 extends BaseSolver {
         })
       }
 
+      if (requiresTerminalVia) {
+        this.mergedHdRoute.route.push({
+          x: this.end.x,
+          y: this.end.y,
+          z: terminalZ,
+        })
+      }
+
       this.solved = true
       return
     }
 
     const lastMergedPoint =
       this.mergedHdRoute.route[this.mergedHdRoute.route.length - 1]
+    const startsAtTerminal = this.mergedHdRoute.route.length === 1
 
     let closestRouteIndex = -1
     let matchedOn: "first" | "last" = "first"
@@ -373,6 +453,15 @@ export class SingleHighDensityRouteStitchSolver3 extends BaseSolver {
         }
       } else if (
         distToFirst < GEOMETRIC_TOLERANCE &&
+        (!startsAtTerminal ||
+          (lastMergedPoint.x === firstPointInCandidate.x &&
+            lastMergedPoint.y === firstPointInCandidate.y &&
+            this.hasExistingTerminalVia(
+              lastMergedPoint,
+              firstPointInCandidate,
+              hdRoute,
+              "forward",
+            ))) &&
         (!this.allowedLayerTransitionPointKeys ||
           this.allowedLayerTransitionPointKeys.has(
             getXyPointKey(firstPointInCandidate),
@@ -405,6 +494,15 @@ export class SingleHighDensityRouteStitchSolver3 extends BaseSolver {
         }
       } else if (
         distToLast < GEOMETRIC_TOLERANCE &&
+        (!startsAtTerminal ||
+          (lastMergedPoint.x === lastPointInCandidate.x &&
+            lastMergedPoint.y === lastPointInCandidate.y &&
+            this.hasExistingTerminalVia(
+              lastMergedPoint,
+              lastPointInCandidate,
+              hdRoute,
+              "reverse",
+            ))) &&
         (!this.allowedLayerTransitionPointKeys ||
           this.allowedLayerTransitionPointKeys.has(
             getXyPointKey(lastPointInCandidate),
@@ -424,6 +522,11 @@ export class SingleHighDensityRouteStitchSolver3 extends BaseSolver {
       if (blockedByCollision) {
         this.failed = true
         this.error = `Route stitch for "${this.mergedHdRoute.connectionName}" violates copper clearance`
+        return
+      }
+      if (startsAtTerminal) {
+        this.failed = true
+        this.error = `Route stitch for "${this.mergedHdRoute.connectionName}" cannot leave terminal layer ${lastMergedPoint.z} without an existing allowed via`
         return
       }
       this.remainingHdRoutes = []

--- a/lib/solvers/RouteStitchingSolver/SingleHighDensityRouteStitchSolver3.ts
+++ b/lib/solvers/RouteStitchingSolver/SingleHighDensityRouteStitchSolver3.ts
@@ -5,19 +5,20 @@ import { getJumpersGraphics } from "lib/utils/getJumperGraphics"
 import { getXyPointKey } from "lib/autorouter-pipelines/AutoroutingPipeline8/getXyPointKey"
 import { BaseSolver } from "../BaseSolver"
 import type { StitchTerminal } from "./getStitchTerminal"
+import { getRouteStitchOrientation } from "./getRouteStitchOrientation"
 import type { IsStitchSegmentClear } from "./route-stitch-clearance-validator"
 import type { OrderedRouteStitchEntry } from "./routeStitchingEndpointHelpers"
 import {
   comparePoints,
   compareRoutes,
   DISTANCE_TIE_TOLERANCE,
+  GEOMETRIC_STITCH_TOLERANCE as GEOMETRIC_TOLERANCE,
   MAX_STITCH_GAP_DISTANCE_3,
   MAX_TERMINAL_STITCH_GAP_DISTANCE_3,
 } from "./routeStitchingShared"
 
 const VIA_PENALTY = 1000
 const GAP_PENALTY = 100000
-const GEOMETRIC_TOLERANCE = 1e-3
 const COLLISION_PENALTY = MAX_STITCH_GAP_DISTANCE_3 + DISTANCE_TIE_TOLERANCE
 type RoutePoint = HighDensityIntraNodeRoute["route"][number]
 export type StitchClearanceMode = "require_clear" | "prefer_clear"
@@ -235,65 +236,29 @@ export class SingleHighDensityRouteStitchSolver3 extends BaseSolver {
       for (const taggedPcbPortId of taggedPcbPortIds) {
         if (!expectedPcbPortIds.has(taggedPcbPortId)) {
           throw new Error(
-            `SingleHighDensityRouteStitchSolver3 found unknown PCB terminal "${taggedPcbPortId}" on "${opts.connectionName}": ${JSON.stringify({
-              start: opts.start,
-              end: opts.end,
-              expectedPcbPortIds: [...expectedPcbPortIds],
-              offendingRoutes: canonicalHdRoutes.filter(
-                (route): boolean =>
-                  route.startPcbPortId === taggedPcbPortId ||
-                  route.endPcbPortId === taggedPcbPortId,
-              ),
-              orderedRoutePath: opts.orderedRoutePath,
-            })}`,
+            `SingleHighDensityRouteStitchSolver3 found unknown PCB terminal "${taggedPcbPortId}" on "${opts.connectionName}": ${JSON.stringify(
+              {
+                start: opts.start,
+                end: opts.end,
+                expectedPcbPortIds: [...expectedPcbPortIds],
+                offendingRoutes: canonicalHdRoutes.filter(
+                  (route): boolean =>
+                    route.startPcbPortId === taggedPcbPortId ||
+                    route.endPcbPortId === taggedPcbPortId,
+                ),
+                orderedRoutePath: opts.orderedRoutePath,
+              },
+            )}`,
           )
         }
       }
     }
 
-    let bestDist = Infinity
-    let firstRoute = canonicalHdRoutes[0]
-    let orientation: "start-to-end" | "end-to-start" = "start-to-end"
-
-    for (const route of canonicalHdRoutes) {
-      const firstPoint = route.route[0]
-      const lastPoint = route.route[route.route.length - 1]
-
-      const distStartToFirst = distance(opts.start, firstPoint)
-      const distStartToLast = distance(opts.start, lastPoint)
-      const distEndToFirst = distance(opts.end, firstPoint)
-      const distEndToLast = distance(opts.end, lastPoint)
-
-      const minDist = Math.min(
-        distStartToFirst,
-        distStartToLast,
-        distEndToFirst,
-        distEndToLast,
-      )
-
-      if (
-        minDist < bestDist - DISTANCE_TIE_TOLERANCE ||
-        (Math.abs(minDist - bestDist) <= DISTANCE_TIE_TOLERANCE &&
-          compareRoutes(route, firstRoute!) < 0)
-      ) {
-        bestDist = minDist
-        firstRoute = route
-        if (
-          Math.min(distEndToFirst, distEndToLast) <
-            Math.min(distStartToFirst, distStartToLast) -
-              DISTANCE_TIE_TOLERANCE ||
-          (Math.abs(
-            Math.min(distEndToFirst, distEndToLast) -
-              Math.min(distStartToFirst, distStartToLast),
-          ) <= DISTANCE_TIE_TOLERANCE &&
-            comparePoints(opts.end, opts.start) < 0)
-        ) {
-          orientation = "end-to-start"
-        } else {
-          orientation = "start-to-end"
-        }
-      }
-    }
+    let { firstRoute, orientation } = getRouteStitchOrientation({
+      hdRoutes: canonicalHdRoutes,
+      start: opts.start,
+      end: opts.end,
+    })
 
     if (this.remainingOrderedRoutePath && orientation === "end-to-start") {
       this.remainingOrderedRoutePath = [...this.remainingOrderedRoutePath]

--- a/lib/solvers/RouteStitchingSolver/SingleHighDensityRouteStitchSolver3.ts
+++ b/lib/solvers/RouteStitchingSolver/SingleHighDensityRouteStitchSolver3.ts
@@ -6,6 +6,7 @@ import { getXyPointKey } from "lib/autorouter-pipelines/AutoroutingPipeline8/get
 import { BaseSolver } from "../BaseSolver"
 import type { StitchTerminal } from "./getStitchTerminal"
 import type { IsStitchSegmentClear } from "./route-stitch-clearance-validator"
+import type { OrderedRouteStitchEntry } from "./routeStitchingEndpointHelpers"
 import {
   comparePoints,
   compareRoutes,
@@ -51,6 +52,7 @@ export class SingleHighDensityRouteStitchSolver3 extends BaseSolver {
 
   mergedHdRoute!: HighDensityIntraNodeRoute
   remainingHdRoutes: HighDensityIntraNodeRoute[]
+  private remainingOrderedRoutePath?: OrderedRouteStitchEntry[]
   start: StitchTerminal
   end: StitchTerminal
   colorMap: Record<string, string>
@@ -118,6 +120,7 @@ export class SingleHighDensityRouteStitchSolver3 extends BaseSolver {
   constructor(opts: {
     connectionName: string
     hdRoutes: HighDensityIntraNodeRoute[]
+    orderedRoutePath?: OrderedRouteStitchEntry[]
     start: StitchTerminal
     end: StitchTerminal
     colorMap?: Record<string, string>
@@ -129,6 +132,23 @@ export class SingleHighDensityRouteStitchSolver3 extends BaseSolver {
     stitchClearanceMode: StitchClearanceMode
   }) {
     super()
+    if (opts.orderedRoutePath) {
+      const pathRouteSet = new Set(
+        opts.orderedRoutePath.map(
+          (entry): HighDensityIntraNodeRoute => entry.route,
+        ),
+      )
+      if (
+        opts.orderedRoutePath.length !== opts.hdRoutes.length ||
+        pathRouteSet.size !== opts.hdRoutes.length ||
+        opts.hdRoutes.some((route): boolean => !pathRouteSet.has(route))
+      ) {
+        throw new Error(
+          `Ordered stitching path for "${opts.connectionName}" does not match its input routes`,
+        )
+      }
+      this.remainingOrderedRoutePath = [...opts.orderedRoutePath]
+    }
     const canonicalHdRoutes = [...opts.hdRoutes].sort(compareRoutes)
     this.remainingHdRoutes = canonicalHdRoutes
     this.colorMap = opts.colorMap ?? {}
@@ -265,6 +285,12 @@ export class SingleHighDensityRouteStitchSolver3 extends BaseSolver {
       }
     }
 
+    const firstPathEntry = this.remainingOrderedRoutePath?.[0]
+    if (firstPathEntry) {
+      firstRoute = firstPathEntry.route
+      orientation = "start-to-end"
+    }
+
     if (orientation === "start-to-end") {
       this.start = opts.start
       this.end = opts.end
@@ -277,10 +303,13 @@ export class SingleHighDensityRouteStitchSolver3 extends BaseSolver {
     const firstRouteLastPoint = firstRoute.route[firstRoute.route.length - 1]
     const distToFirst = distance(this.start, firstRouteFirstPoint)
     const distToLast = distance(this.start, firstRouteLastPoint)
-    const closestFirstRoutePoint =
-      distToFirst < distToLast - DISTANCE_TIE_TOLERANCE ||
-      (Math.abs(distToFirst - distToLast) <= DISTANCE_TIE_TOLERANCE &&
-        comparePoints(firstRouteFirstPoint, firstRouteLastPoint) <= 0)
+    const closestFirstRoutePoint = firstPathEntry
+      ? firstPathEntry.matchedOn === "first"
+        ? firstRouteFirstPoint
+        : firstRouteLastPoint
+      : distToFirst < distToLast - DISTANCE_TIE_TOLERANCE ||
+          (Math.abs(distToFirst - distToLast) <= DISTANCE_TIE_TOLERANCE &&
+            comparePoints(firstRouteFirstPoint, firstRouteLastPoint) <= 0)
         ? firstRouteFirstPoint
         : firstRouteLastPoint
     const closestFirstRoutePcbPortId =
@@ -417,6 +446,7 @@ export class SingleHighDensityRouteStitchSolver3 extends BaseSolver {
     const lastMergedPoint =
       this.mergedHdRoute.route[this.mergedHdRoute.route.length - 1]
     const startsAtTerminal = this.mergedHdRoute.route.length === 1
+    const nextPathEntry = this.remainingOrderedRoutePath?.[0]
 
     let closestRouteIndex = -1
     let matchedOn: "first" | "last" = "first"
@@ -425,6 +455,7 @@ export class SingleHighDensityRouteStitchSolver3 extends BaseSolver {
 
     for (let i = 0; i < this.remainingHdRoutes.length; i++) {
       const hdRoute = this.remainingHdRoutes[i]
+      if (nextPathEntry && hdRoute !== nextPathEntry.route) continue
       const firstPointInCandidate = hdRoute.route[0]
       const lastPointInCandidate = hdRoute.route[hdRoute.route.length - 1]
 
@@ -466,7 +497,10 @@ export class SingleHighDensityRouteStitchSolver3 extends BaseSolver {
         scoreFirst = VIA_PENALTY + distToFirst
       }
 
-      if (scoreFirst < bestScore) {
+      if (
+        (!nextPathEntry || nextPathEntry.matchedOn === "first") &&
+        scoreFirst < bestScore
+      ) {
         bestScore = scoreFirst
         closestRouteIndex = i
         matchedOn = "first"
@@ -507,7 +541,10 @@ export class SingleHighDensityRouteStitchSolver3 extends BaseSolver {
         scoreLast = VIA_PENALTY + distToLast
       }
 
-      if (scoreLast < bestScore) {
+      if (
+        (!nextPathEntry || nextPathEntry.matchedOn === "last") &&
+        scoreLast < bestScore
+      ) {
         bestScore = scoreLast
         closestRouteIndex = i
         matchedOn = "last"
@@ -515,6 +552,11 @@ export class SingleHighDensityRouteStitchSolver3 extends BaseSolver {
     }
 
     if (closestRouteIndex === -1) {
+      if (nextPathEntry) {
+        this.failed = true
+        this.error = `Ordered route stitch for "${this.mergedHdRoute.connectionName}" cannot follow its selected endpoint path`
+        return
+      }
       if (blockedByCollision) {
         this.failed = true
         this.error = `Route stitch for "${this.mergedHdRoute.connectionName}" violates copper clearance`
@@ -531,6 +573,7 @@ export class SingleHighDensityRouteStitchSolver3 extends BaseSolver {
 
     const hdRouteToMerge = this.remainingHdRoutes[closestRouteIndex]
     this.remainingHdRoutes.splice(closestRouteIndex, 1)
+    if (nextPathEntry) this.remainingOrderedRoutePath!.shift()
 
     let pointsToAdd: RoutePoint[]
     if (matchedOn === "first") {

--- a/lib/solvers/RouteStitchingSolver/SingleHighDensityRouteStitchSolver3.ts
+++ b/lib/solvers/RouteStitchingSolver/SingleHighDensityRouteStitchSolver3.ts
@@ -235,7 +235,17 @@ export class SingleHighDensityRouteStitchSolver3 extends BaseSolver {
       for (const taggedPcbPortId of taggedPcbPortIds) {
         if (!expectedPcbPortIds.has(taggedPcbPortId)) {
           throw new Error(
-            `SingleHighDensityRouteStitchSolver3 found unknown PCB terminal "${taggedPcbPortId}" on "${opts.connectionName}"`,
+            `SingleHighDensityRouteStitchSolver3 found unknown PCB terminal "${taggedPcbPortId}" on "${opts.connectionName}": ${JSON.stringify({
+              start: opts.start,
+              end: opts.end,
+              expectedPcbPortIds: [...expectedPcbPortIds],
+              offendingRoutes: canonicalHdRoutes.filter(
+                (route): boolean =>
+                  route.startPcbPortId === taggedPcbPortId ||
+                  route.endPcbPortId === taggedPcbPortId,
+              ),
+              orderedRoutePath: opts.orderedRoutePath,
+            })}`,
           )
         }
       }
@@ -285,10 +295,19 @@ export class SingleHighDensityRouteStitchSolver3 extends BaseSolver {
       }
     }
 
+    if (this.remainingOrderedRoutePath && orientation === "end-to-start") {
+      this.remainingOrderedRoutePath = [...this.remainingOrderedRoutePath]
+        .reverse()
+        .map(
+          (entry): OrderedRouteStitchEntry => ({
+            route: entry.route,
+            matchedOn: entry.matchedOn === "first" ? "last" : "first",
+          }),
+        )
+    }
     const firstPathEntry = this.remainingOrderedRoutePath?.[0]
     if (firstPathEntry) {
       firstRoute = firstPathEntry.route
-      orientation = "start-to-end"
     }
 
     if (orientation === "start-to-end") {

--- a/lib/solvers/RouteStitchingSolver/getRouteStitchEndpoint.ts
+++ b/lib/solvers/RouteStitchingSolver/getRouteStitchEndpoint.ts
@@ -1,0 +1,22 @@
+import type { HighDensityIntraNodeRoute } from "lib/types/high-density-types"
+import type { StitchTerminal } from "./getStitchTerminal"
+
+export const getRouteStitchEndpoint = (
+  route: HighDensityIntraNodeRoute,
+  endpoint: "first" | "last",
+): StitchTerminal => {
+  const point = route.route[endpoint === "first" ? 0 : route.route.length - 1]
+  if (!point) {
+    throw new Error(
+      `Route stitching received an empty route for "${route.connectionName}"`,
+    )
+  }
+  const pcbPortId =
+    endpoint === "first" ? route.startPcbPortId : route.endPcbPortId
+  if (pcbPortId && point.pcb_port_id && pcbPortId !== point.pcb_port_id) {
+    throw new Error(
+      `Route stitching found conflicting PCB terminal identities on the ${endpoint} endpoint of "${route.connectionName}"`,
+    )
+  }
+  return pcbPortId ? { ...point, pcb_port_id: pcbPortId } : point
+}

--- a/lib/solvers/RouteStitchingSolver/getRouteStitchOrientation.ts
+++ b/lib/solvers/RouteStitchingSolver/getRouteStitchOrientation.ts
@@ -45,7 +45,8 @@ export const getRouteStitchOrientation = (params: {
       firstRoute = route
       if (
         Math.min(distEndToFirst, distEndToLast) <
-          Math.min(distStartToFirst, distStartToLast) - DISTANCE_TIE_TOLERANCE ||
+          Math.min(distStartToFirst, distStartToLast) -
+            DISTANCE_TIE_TOLERANCE ||
         (Math.abs(
           Math.min(distEndToFirst, distEndToLast) -
             Math.min(distStartToFirst, distStartToLast),

--- a/lib/solvers/RouteStitchingSolver/getRouteStitchOrientation.ts
+++ b/lib/solvers/RouteStitchingSolver/getRouteStitchOrientation.ts
@@ -1,0 +1,62 @@
+import { distance, type Point3 } from "@tscircuit/math-utils"
+import type { HighDensityIntraNodeRoute } from "lib/types/high-density-types"
+import {
+  comparePoints,
+  compareRoutes,
+  DISTANCE_TIE_TOLERANCE,
+} from "./routeStitchingShared"
+
+export type RouteStitchOrientation = "start-to-end" | "end-to-start"
+
+export const getRouteStitchOrientation = (params: {
+  hdRoutes: HighDensityIntraNodeRoute[]
+  start: Point3
+  end: Point3
+}): {
+  firstRoute: HighDensityIntraNodeRoute
+  orientation: RouteStitchOrientation
+} => {
+  const canonicalHdRoutes = [...params.hdRoutes].sort(compareRoutes)
+  let firstRoute = canonicalHdRoutes[0]
+  if (!firstRoute) {
+    throw new Error("Route stitching orientation requires a physical fragment")
+  }
+  let bestDist = Infinity
+  let orientation: RouteStitchOrientation = "start-to-end"
+  for (const route of canonicalHdRoutes) {
+    const firstPoint = route.route[0]!
+    const lastPoint = route.route[route.route.length - 1]!
+    const distStartToFirst = distance(params.start, firstPoint)
+    const distStartToLast = distance(params.start, lastPoint)
+    const distEndToFirst = distance(params.end, firstPoint)
+    const distEndToLast = distance(params.end, lastPoint)
+    const minDist = Math.min(
+      distStartToFirst,
+      distStartToLast,
+      distEndToFirst,
+      distEndToLast,
+    )
+    if (
+      minDist < bestDist - DISTANCE_TIE_TOLERANCE ||
+      (Math.abs(minDist - bestDist) <= DISTANCE_TIE_TOLERANCE &&
+        compareRoutes(route, firstRoute) < 0)
+    ) {
+      bestDist = minDist
+      firstRoute = route
+      if (
+        Math.min(distEndToFirst, distEndToLast) <
+          Math.min(distStartToFirst, distStartToLast) - DISTANCE_TIE_TOLERANCE ||
+        (Math.abs(
+          Math.min(distEndToFirst, distEndToLast) -
+            Math.min(distStartToFirst, distStartToLast),
+        ) <= DISTANCE_TIE_TOLERANCE &&
+          comparePoints(params.end, params.start) < 0)
+      ) {
+        orientation = "end-to-start"
+      } else {
+        orientation = "start-to-end"
+      }
+    }
+  }
+  return { firstRoute, orientation }
+}

--- a/lib/solvers/RouteStitchingSolver/getStitchTerminal.ts
+++ b/lib/solvers/RouteStitchingSolver/getStitchTerminal.ts
@@ -1,0 +1,24 @@
+import type { Point3 } from "@tscircuit/math-utils"
+import {
+  type ConnectionPoint,
+  getConnectionPointLayers,
+} from "lib/types/srj-types"
+import { mapLayerNameToZ } from "lib/utils/mapLayerNameToZ"
+
+export type StitchTerminal = Point3 & {
+  pcb_port_id?: string
+  availableZ?: readonly number[]
+}
+
+export const getStitchTerminal = (
+  point: ConnectionPoint,
+  layerCount: number,
+): StitchTerminal => {
+  const availableZ = getConnectionPointLayers(point).map(
+    (layer: string): number => mapLayerNameToZ(layer, layerCount),
+  )
+  if (availableZ.length === 0) {
+    throw new Error("Route stitching received a terminal with no copper layer")
+  }
+  return { ...point, z: availableZ[0]!, availableZ }
+}

--- a/lib/solvers/RouteStitchingSolver/routeStitchingEndpointHelpers.ts
+++ b/lib/solvers/RouteStitchingSolver/routeStitchingEndpointHelpers.ts
@@ -381,10 +381,7 @@ export const selectRoutesAlongEndpointPath = (params: {
   const costsByHash = new Map<string, EndpointPathCost>([
     [startHash, { gapCount: 0, hopCount: 0 }],
   ])
-  const prevByHash = new Map<
-    string,
-    { prevHash: string; edge: EndpointEdge }
-  >()
+  const prevByHash = new Map<string, { prevHash: string; edge: EndpointEdge }>()
 
   while (pendingHashes.size > 0) {
     let currentHash: string | undefined

--- a/lib/solvers/RouteStitchingSolver/routeStitchingEndpointHelpers.ts
+++ b/lib/solvers/RouteStitchingSolver/routeStitchingEndpointHelpers.ts
@@ -1,5 +1,6 @@
 import { distance, type Point3 } from "@tscircuit/math-utils"
 import type { HighDensityIntraNodeRoute } from "lib/types/high-density-types"
+import { getRouteStitchEndpoint } from "./getRouteStitchEndpoint"
 import type { StitchTerminal } from "./getStitchTerminal"
 import {
   comparePoints,
@@ -17,13 +18,28 @@ export const ENDPOINT_MATCH_TOLERANCE = 0.1
 type EndpointEdge = {
   nextHash: string
   routeIndex: number | null
+  matchedOn?: "first" | "last"
 }
+
+export type OrderedRouteStitchEntry = {
+  route: HighDensityIntraNodeRoute
+  matchedOn: "first" | "last"
+}
+
+export type RouteStitchPathSelection = {
+  hdRoutes: HighDensityIntraNodeRoute[]
+  orderedRoutePath?: OrderedRouteStitchEntry[]
+}
+
+type EndpointPathCost = { gapCount: number; hopCount: number }
+type EndpointCluster = { key: string; point: StitchTerminal }
 
 export type CanStitchBetweenTerminals = (params: {
   connectionName: string
   hdRoutes: HighDensityIntraNodeRoute[]
-  start: Point3
-  end: Point3
+  start: StitchTerminal
+  end: StitchTerminal
+  orderedRoutePath?: OrderedRouteStitchEntry[]
 }) => boolean
 
 /**
@@ -31,21 +47,38 @@ export type CanStitchBetweenTerminals = (params: {
  * fragments that terminate at effectively the same location share one key.
  */
 export class EndpointClusterIndex {
-  private endpointClusters = new Map<
-    string,
-    Array<{ key: string; point: Point3 }>
-  >()
+  private endpointClusters = new Map<string, EndpointCluster[]>()
+  private assignedEndpointKeys = new Map<string, Map<string, string>>()
 
   constructor(private readonly preferSameLayerTerminalEndpoints = false) {}
 
-  getEndpointKey(connectionName: string, point: Point3) {
+  getEndpointKey(connectionName: string, point: StitchTerminal): string {
+    const pointIdentity = JSON.stringify([
+      point.x,
+      point.y,
+      point.z,
+      point.pcb_port_id,
+    ])
+    const assignedKeys =
+      this.assignedEndpointKeys.get(connectionName) ?? new Map<string, string>()
+    const assignedKey = assignedKeys.get(pointIdentity)
+    if (assignedKey !== undefined) return assignedKey
     const clusters = this.endpointClusters.get(connectionName) ?? []
 
-    let bestCluster: { key: string; point: Point3 } | undefined
+    let bestCluster: EndpointCluster | undefined
     let bestDistance = Infinity
 
     for (const cluster of clusters) {
       if (cluster.point.z !== point.z) continue
+      // Nearby same-net pads can overlap while remaining distinct terminals.
+      // Their route boundaries must not lose identity through fuzzy matching.
+      if (
+        cluster.point.pcb_port_id &&
+        point.pcb_port_id &&
+        cluster.point.pcb_port_id !== point.pcb_port_id
+      ) {
+        continue
+      }
       const clusterDistance = distance(cluster.point, point)
       if (
         clusterDistance <= ENDPOINT_MATCH_TOLERANCE &&
@@ -60,38 +93,55 @@ export class EndpointClusterIndex {
     }
 
     if (bestCluster) {
+      if (!bestCluster.point.pcb_port_id && point.pcb_port_id) {
+        bestCluster.point = {
+          ...bestCluster.point,
+          pcb_port_id: point.pcb_port_id,
+        }
+      }
+      assignedKeys.set(pointIdentity, bestCluster.key)
+      this.assignedEndpointKeys.set(connectionName, assignedKeys)
       return bestCluster.key
     }
 
     const key = `${connectionName}:endpoint_${clusters.length}`
     clusters.push({
       key,
-      point: { x: point.x, y: point.y, z: point.z },
+      point: { ...point },
     })
+    assignedKeys.set(pointIdentity, key)
+    this.assignedEndpointKeys.set(connectionName, assignedKeys)
     this.endpointClusters.set(connectionName, clusters)
     return key
   }
 
-  getClusters(connectionName: string) {
+  getClusters(connectionName: string): EndpointCluster[] {
     return this.endpointClusters.get(connectionName) ?? []
   }
 
   getClosestEndpointKey(
     connectionName: string,
     routes: HighDensityIntraNodeRoute[],
-    point: Point3,
-  ) {
+    point: StitchTerminal,
+  ): string | null {
     const routeEndpoints = routes.flatMap((route) => [
-      route.route[0]!,
-      route.route[route.route.length - 1]!,
+      getRouteStitchEndpoint(route, "first"),
+      getRouteStitchEndpoint(route, "last"),
     ])
-    const sameLayerEndpoints = routeEndpoints.filter(
+    const claimedEndpoints = point.pcb_port_id
+      ? routeEndpoints.filter(
+          (endpoint): boolean => endpoint.pcb_port_id === point.pcb_port_id,
+        )
+      : []
+    const matchingEndpoints =
+      claimedEndpoints.length > 0 ? claimedEndpoints : routeEndpoints
+    const sameLayerEndpoints = matchingEndpoints.filter(
       (endpoint) => endpoint.z === point.z,
     )
     const candidateEndpoints =
       this.preferSameLayerTerminalEndpoints && sameLayerEndpoints.length > 0
         ? sameLayerEndpoints
-        : routeEndpoints
+        : matchingEndpoints
     let bestHash: string | null = null
     let bestEndpoint: Point3 | null = null
     let bestDist = Infinity
@@ -122,7 +172,7 @@ const addAdjacencyEdge = (
   adjacency: Map<string, EndpointEdge[]>,
   fromHash: string,
   edge: EndpointEdge,
-) => {
+): void => {
   const entries = adjacency.get(fromHash) ?? []
   if (
     entries.some(
@@ -142,10 +192,10 @@ const addAdjacencyEdge = (
  * terminals, with deterministic tie-breaking.
  */
 export const selectIslandEndpoints = (params: {
-  possibleEndpoints: Point3[]
-  globalStart: Point3
-  globalEnd: Point3
-}) => {
+  possibleEndpoints: StitchTerminal[]
+  globalStart: StitchTerminal
+  globalEnd: StitchTerminal
+}): { start: StitchTerminal; end: StitchTerminal } => {
   const sortedEndpoints = [...params.possibleEndpoints].sort(comparePoints)
   const start = sortedEndpoints.reduce((bestPoint, point) => {
     const pointDistance = distance(point, params.globalStart)
@@ -229,18 +279,18 @@ export const snapIslandEndpointToNearestTerminal = (params: {
 
 /**
  * Returns the route islands on the deterministic endpoint path between the
- * chosen terminals. If the subset cannot actually stitch to both terminals,
- * the full route set is returned instead.
+ * chosen terminals, minimizing newly introduced gaps before route hops.
+ * A rejected path must not become an unvalidated superset of route islands.
  */
 export const selectRoutesAlongEndpointPath = (params: {
   connectionName: string
   hdRoutes: HighDensityIntraNodeRoute[]
-  start: Point3
-  end: Point3
+  start: StitchTerminal
+  end: StitchTerminal
   endpointIndex: EndpointClusterIndex
   canStitchBetweenTerminals: CanStitchBetweenTerminals
-}) => {
-  if (params.hdRoutes.length <= 2) return params.hdRoutes
+}): RouteStitchPathSelection | null => {
+  if (params.hdRoutes.length <= 2) return { hdRoutes: params.hdRoutes }
 
   const canonicalHdRoutes = [...params.hdRoutes].sort(compareRoutes)
 
@@ -256,7 +306,7 @@ export const selectRoutesAlongEndpointPath = (params: {
   )
 
   if (!startHash || !endHash || startHash === endHash) {
-    return canonicalHdRoutes
+    return null
   }
 
   const adjacency = new Map<string, EndpointEdge[]>()
@@ -265,20 +315,22 @@ export const selectRoutesAlongEndpointPath = (params: {
     const route = canonicalHdRoutes[i]!
     const routeStartHash = params.endpointIndex.getEndpointKey(
       params.connectionName,
-      route.route[0]!,
+      getRouteStitchEndpoint(route, "first"),
     )
     const routeEndHash = params.endpointIndex.getEndpointKey(
       params.connectionName,
-      route.route[route.route.length - 1]!,
+      getRouteStitchEndpoint(route, "last"),
     )
 
     addAdjacencyEdge(adjacency, routeStartHash, {
       nextHash: routeEndHash,
       routeIndex: i,
+      matchedOn: "first",
     })
     addAdjacencyEdge(adjacency, routeEndHash, {
       nextHash: routeStartHash,
       routeIndex: i,
+      matchedOn: "last",
     })
   }
 
@@ -324,46 +376,89 @@ export const selectRoutesAlongEndpointPath = (params: {
     )
   }
 
-  const queue = [startHash]
-  const visitedHashes = new Set<string>([startHash])
+  const pendingHashes = new Set<string>([startHash])
+  const settledHashes = new Set<string>()
+  const costsByHash = new Map<string, EndpointPathCost>([
+    [startHash, { gapCount: 0, hopCount: 0 }],
+  ])
   const prevByHash = new Map<
     string,
-    { prevHash: string; routeIndex: number | null }
+    { prevHash: string; edge: EndpointEdge }
   >()
 
-  while (queue.length > 0) {
-    const currentHash = queue.shift()!
+  while (pendingHashes.size > 0) {
+    let currentHash: string | undefined
+    let currentCost: EndpointPathCost | undefined
+    for (const candidateHash of pendingHashes) {
+      const candidateCost = costsByHash.get(candidateHash)!
+      if (
+        !currentCost ||
+        candidateCost.gapCount < currentCost.gapCount ||
+        (candidateCost.gapCount === currentCost.gapCount &&
+          candidateCost.hopCount < currentCost.hopCount)
+      ) {
+        currentHash = candidateHash
+        currentCost = candidateCost
+      }
+    }
+    if (currentHash === undefined || currentCost === undefined) {
+      throw new Error("Route stitching path queue lost its endpoint cost")
+    }
+    pendingHashes.delete(currentHash)
+    settledHashes.add(currentHash)
     if (currentHash === endHash) break
 
     for (const edge of adjacency.get(currentHash) ?? []) {
-      if (visitedHashes.has(edge.nextHash)) continue
-      visitedHashes.add(edge.nextHash)
+      if (settledHashes.has(edge.nextHash)) continue
+      const nextCost: EndpointPathCost = {
+        gapCount: currentCost.gapCount + (edge.routeIndex === null ? 1 : 0),
+        hopCount: currentCost.hopCount + 1,
+      }
+      const previousCost = costsByHash.get(edge.nextHash)
+      if (
+        previousCost &&
+        (previousCost.gapCount < nextCost.gapCount ||
+          (previousCost.gapCount === nextCost.gapCount &&
+            previousCost.hopCount <= nextCost.hopCount))
+      ) {
+        continue
+      }
+      costsByHash.set(edge.nextHash, nextCost)
       prevByHash.set(edge.nextHash, {
         prevHash: currentHash,
-        routeIndex: edge.routeIndex,
+        edge,
       })
-      queue.push(edge.nextHash)
+      pendingHashes.add(edge.nextHash)
     }
   }
 
-  if (!visitedHashes.has(endHash)) return canonicalHdRoutes
+  if (!settledHashes.has(endHash)) return null
 
-  const selectedRouteIndexesInReverse: number[] = []
+  const selectedEntriesInReverse: OrderedRouteStitchEntry[] = []
   let cursorHash = endHash
   while (cursorHash !== startHash) {
     const prev = prevByHash.get(cursorHash)
-    if (!prev) return canonicalHdRoutes
-    if (prev.routeIndex !== null) {
-      selectedRouteIndexesInReverse.push(prev.routeIndex)
+    if (!prev) {
+      throw new Error("Route stitching path lost its predecessor endpoint")
+    }
+    if (prev.edge.routeIndex !== null) {
+      if (!prev.edge.matchedOn) {
+        throw new Error("Route stitching path lost its route orientation")
+      }
+      selectedEntriesInReverse.push({
+        route: canonicalHdRoutes[prev.edge.routeIndex]!,
+        matchedOn: prev.edge.matchedOn,
+      })
     }
     cursorHash = prev.prevHash
   }
 
-  if (selectedRouteIndexesInReverse.length === 0) return params.hdRoutes
+  if (selectedEntriesInReverse.length === 0) return null
 
-  const selectedHdRoutes = selectedRouteIndexesInReverse
-    .reverse()
-    .map((routeIndex) => canonicalHdRoutes[routeIndex]!)
+  const orderedRoutePath = selectedEntriesInReverse.reverse()
+  const selectedHdRoutes = orderedRoutePath.map(
+    (entry): HighDensityIntraNodeRoute => entry.route,
+  )
 
   if (
     selectedHdRoutes.length > 0 &&
@@ -372,12 +467,15 @@ export const selectRoutesAlongEndpointPath = (params: {
       hdRoutes: selectedHdRoutes,
       start: params.start,
       end: params.end,
+      orderedRoutePath,
     })
   ) {
-    return canonicalHdRoutes
+    throw new Error(
+      `Selected route stitching path for "${params.connectionName}" cannot connect its terminals without violating stitch constraints`,
+    )
   }
 
-  return selectedHdRoutes
+  return { hdRoutes: selectedHdRoutes, orderedRoutePath }
 }
 
 export const hasStitchableGapBetweenUnsolvedRoutes = (

--- a/lib/solvers/RouteStitchingSolver/routeStitchingEndpointHelpers.ts
+++ b/lib/solvers/RouteStitchingSolver/routeStitchingEndpointHelpers.ts
@@ -2,9 +2,10 @@ import { distance, type Point3 } from "@tscircuit/math-utils"
 import type { HighDensityIntraNodeRoute } from "lib/types/high-density-types"
 import { getRouteStitchEndpoint } from "./getRouteStitchEndpoint"
 import type { StitchTerminal } from "./getStitchTerminal"
+import type { IsStitchSegmentClear } from "./route-stitch-clearance-validator"
+import { selectDirectedRouteStitchPath } from "./selectDirectedRouteStitchPath"
 import {
   comparePoints,
-  compareRoutes,
   DISTANCE_TIE_TOLERANCE,
   MAX_STITCH_GAP_DISTANCE_3,
   MAX_TERMINAL_STITCH_GAP_DISTANCE_3,
@@ -14,12 +15,6 @@ import {
  * Endpoints within this tolerance are treated as the same island endpoint.
  */
 export const ENDPOINT_MATCH_TOLERANCE = 0.1
-
-type EndpointEdge = {
-  nextHash: string
-  routeIndex: number | null
-  matchedOn?: "first" | "last"
-}
 
 export type OrderedRouteStitchEntry = {
   route: HighDensityIntraNodeRoute
@@ -31,7 +26,6 @@ export type RouteStitchPathSelection = {
   orderedRoutePath?: OrderedRouteStitchEntry[]
 }
 
-type EndpointPathCost = { gapCount: number; hopCount: number }
 type EndpointCluster = { key: string; point: StitchTerminal }
 
 export type CanStitchBetweenTerminals = (params: {
@@ -168,25 +162,6 @@ export class EndpointClusterIndex {
   }
 }
 
-const addAdjacencyEdge = (
-  adjacency: Map<string, EndpointEdge[]>,
-  fromHash: string,
-  edge: EndpointEdge,
-): void => {
-  const entries = adjacency.get(fromHash) ?? []
-  if (
-    entries.some(
-      (existingEdge) =>
-        existingEdge.nextHash === edge.nextHash &&
-        existingEdge.routeIndex === edge.routeIndex,
-    )
-  ) {
-    return
-  }
-  entries.push(edge)
-  adjacency.set(fromHash, entries)
-}
-
 /**
  * Chooses the island endpoints that best align to the requested connection
  * terminals, with deterministic tie-breaking.
@@ -288,177 +263,17 @@ export const selectRoutesAlongEndpointPath = (params: {
   start: StitchTerminal
   end: StitchTerminal
   endpointIndex: EndpointClusterIndex
+  isStitchSegmentClear: IsStitchSegmentClear
   canStitchBetweenTerminals: CanStitchBetweenTerminals
 }): RouteStitchPathSelection | null => {
   if (params.hdRoutes.length <= 2) return { hdRoutes: params.hdRoutes }
 
-  const canonicalHdRoutes = [...params.hdRoutes].sort(compareRoutes)
-
-  const startHash = params.endpointIndex.getClosestEndpointKey(
-    params.connectionName,
-    canonicalHdRoutes,
-    params.start,
-  )
-  const endHash = params.endpointIndex.getClosestEndpointKey(
-    params.connectionName,
-    canonicalHdRoutes,
-    params.end,
-  )
-
-  if (!startHash || !endHash || startHash === endHash) {
-    return null
-  }
-
-  const adjacency = new Map<string, EndpointEdge[]>()
-
-  for (let i = 0; i < canonicalHdRoutes.length; i++) {
-    const route = canonicalHdRoutes[i]!
-    const routeStartHash = params.endpointIndex.getEndpointKey(
-      params.connectionName,
-      getRouteStitchEndpoint(route, "first"),
-    )
-    const routeEndHash = params.endpointIndex.getEndpointKey(
-      params.connectionName,
-      getRouteStitchEndpoint(route, "last"),
-    )
-
-    addAdjacencyEdge(adjacency, routeStartHash, {
-      nextHash: routeEndHash,
-      routeIndex: i,
-      matchedOn: "first",
-    })
-    addAdjacencyEdge(adjacency, routeEndHash, {
-      nextHash: routeStartHash,
-      routeIndex: i,
-      matchedOn: "last",
-    })
-  }
-
-  const sortedEndpointClusters = [
-    ...params.endpointIndex.getClusters(params.connectionName),
-  ].sort((a, b) => comparePoints(a.point, b.point))
-  for (let i = 0; i < sortedEndpointClusters.length; i++) {
-    const endpointA = sortedEndpointClusters[i]!
-    for (let j = i + 1; j < sortedEndpointClusters.length; j++) {
-      const endpointB = sortedEndpointClusters[j]!
-      if (endpointA.point.z !== endpointB.point.z) continue
-      if (
-        distance(endpointA.point, endpointB.point) > MAX_STITCH_GAP_DISTANCE_3
-      )
-        continue
-
-      addAdjacencyEdge(adjacency, endpointA.key, {
-        nextHash: endpointB.key,
-        routeIndex: null,
-      })
-      addAdjacencyEdge(adjacency, endpointB.key, {
-        nextHash: endpointA.key,
-        routeIndex: null,
-      })
-    }
-  }
-
-  for (const [hash, edges] of adjacency.entries()) {
-    adjacency.set(
-      hash,
-      [...edges].sort((a, b) => {
-        if (a.routeIndex === null && b.routeIndex !== null) return 1
-        if (a.routeIndex !== null && b.routeIndex === null) return -1
-        if (a.routeIndex !== null && b.routeIndex !== null) {
-          const routeCmp = compareRoutes(
-            canonicalHdRoutes[a.routeIndex]!,
-            canonicalHdRoutes[b.routeIndex]!,
-          )
-          if (routeCmp !== 0) return routeCmp
-        }
-        return a.nextHash.localeCompare(b.nextHash)
-      }),
-    )
-  }
-
-  const pendingHashes = new Set<string>([startHash])
-  const settledHashes = new Set<string>()
-  const costsByHash = new Map<string, EndpointPathCost>([
-    [startHash, { gapCount: 0, hopCount: 0 }],
-  ])
-  const prevByHash = new Map<string, { prevHash: string; edge: EndpointEdge }>()
-
-  while (pendingHashes.size > 0) {
-    let currentHash: string | undefined
-    let currentCost: EndpointPathCost | undefined
-    for (const candidateHash of pendingHashes) {
-      const candidateCost = costsByHash.get(candidateHash)!
-      if (
-        !currentCost ||
-        candidateCost.gapCount < currentCost.gapCount ||
-        (candidateCost.gapCount === currentCost.gapCount &&
-          candidateCost.hopCount < currentCost.hopCount)
-      ) {
-        currentHash = candidateHash
-        currentCost = candidateCost
-      }
-    }
-    if (currentHash === undefined || currentCost === undefined) {
-      throw new Error("Route stitching path queue lost its endpoint cost")
-    }
-    pendingHashes.delete(currentHash)
-    settledHashes.add(currentHash)
-    if (currentHash === endHash) break
-
-    for (const edge of adjacency.get(currentHash) ?? []) {
-      if (settledHashes.has(edge.nextHash)) continue
-      const nextCost: EndpointPathCost = {
-        gapCount: currentCost.gapCount + (edge.routeIndex === null ? 1 : 0),
-        hopCount: currentCost.hopCount + 1,
-      }
-      const previousCost = costsByHash.get(edge.nextHash)
-      if (
-        previousCost &&
-        (previousCost.gapCount < nextCost.gapCount ||
-          (previousCost.gapCount === nextCost.gapCount &&
-            previousCost.hopCount <= nextCost.hopCount))
-      ) {
-        continue
-      }
-      costsByHash.set(edge.nextHash, nextCost)
-      prevByHash.set(edge.nextHash, {
-        prevHash: currentHash,
-        edge,
-      })
-      pendingHashes.add(edge.nextHash)
-    }
-  }
-
-  if (!settledHashes.has(endHash)) return null
-
-  const selectedEntriesInReverse: OrderedRouteStitchEntry[] = []
-  let cursorHash = endHash
-  while (cursorHash !== startHash) {
-    const prev = prevByHash.get(cursorHash)
-    if (!prev) {
-      throw new Error("Route stitching path lost its predecessor endpoint")
-    }
-    if (prev.edge.routeIndex !== null) {
-      if (!prev.edge.matchedOn) {
-        throw new Error("Route stitching path lost its route orientation")
-      }
-      selectedEntriesInReverse.push({
-        route: canonicalHdRoutes[prev.edge.routeIndex]!,
-        matchedOn: prev.edge.matchedOn,
-      })
-    }
-    cursorHash = prev.prevHash
-  }
-
-  if (selectedEntriesInReverse.length === 0) return null
-
-  const orderedRoutePath = selectedEntriesInReverse.reverse()
+  const orderedRoutePath = selectDirectedRouteStitchPath(params)
+  if (!orderedRoutePath) return null
   const selectedHdRoutes = orderedRoutePath.map(
     (entry): HighDensityIntraNodeRoute => entry.route,
   )
-
   if (
-    selectedHdRoutes.length > 0 &&
     !params.canStitchBetweenTerminals({
       connectionName: params.connectionName,
       hdRoutes: selectedHdRoutes,
@@ -471,7 +286,6 @@ export const selectRoutesAlongEndpointPath = (params: {
       `Selected route stitching path for "${params.connectionName}" cannot connect its terminals without violating stitch constraints`,
     )
   }
-
   return { hdRoutes: selectedHdRoutes, orderedRoutePath }
 }
 

--- a/lib/solvers/RouteStitchingSolver/routeStitchingEndpointHelpers.ts
+++ b/lib/solvers/RouteStitchingSolver/routeStitchingEndpointHelpers.ts
@@ -1,5 +1,6 @@
 import { distance, type Point3 } from "@tscircuit/math-utils"
 import type { HighDensityIntraNodeRoute } from "lib/types/high-density-types"
+import type { StitchTerminal } from "./getStitchTerminal"
 import {
   comparePoints,
   compareRoutes,
@@ -181,10 +182,31 @@ export const selectIslandEndpoints = (params: {
  * already close enough to be considered the same stitch target.
  */
 export const snapIslandEndpointToNearestTerminal = (params: {
-  islandEndpoint: Point3
-  terminals: Point3[]
-}) => {
-  const sortedTerminals = [...params.terminals].sort(comparePoints)
+  islandEndpoint: StitchTerminal
+  terminals: StitchTerminal[]
+}): StitchTerminal => {
+  if (params.islandEndpoint.pcb_port_id) {
+    const claimedTerminal = params.terminals.find(
+      (terminal): boolean =>
+        terminal.pcb_port_id === params.islandEndpoint.pcb_port_id,
+    )
+    if (!claimedTerminal) {
+      throw new Error(
+        `Route stitching found unknown PCB terminal "${params.islandEndpoint.pcb_port_id}" on an island endpoint`,
+      )
+    }
+    return claimedTerminal
+  }
+  // A nearby boundary on another layer is not a physical terminal claim.
+  // Keep it as an island boundary instead of inventing a terminal transition.
+  const sortedTerminals = params.terminals
+    .filter(
+      (terminal): boolean =>
+        terminal.z === params.islandEndpoint.z ||
+        terminal.availableZ?.includes(params.islandEndpoint.z) === true,
+    )
+    .sort(comparePoints)
+  if (sortedTerminals.length === 0) return params.islandEndpoint
   let closestTerminal = sortedTerminals[0]
   let closestDistance = distance(params.islandEndpoint, closestTerminal)
 

--- a/lib/solvers/RouteStitchingSolver/routeStitchingShared.ts
+++ b/lib/solvers/RouteStitchingSolver/routeStitchingShared.ts
@@ -6,6 +6,7 @@ import type { HighDensityIntraNodeRoute } from "lib/types/high-density-types"
  * geometric candidates. Keeping this shared makes route selection stable.
  */
 export const DISTANCE_TIE_TOLERANCE = 1e-9
+export const GEOMETRIC_STITCH_TOLERANCE = 1e-3
 
 /**
  * Maximum same-layer gap that can be bridged while stitching route islands.

--- a/lib/solvers/RouteStitchingSolver/selectDirectedRouteStitchPath.ts
+++ b/lib/solvers/RouteStitchingSolver/selectDirectedRouteStitchPath.ts
@@ -1,0 +1,289 @@
+import { distance, type Point3 } from "@tscircuit/math-utils"
+import type { HighDensityIntraNodeRoute } from "lib/types/high-density-types"
+import { getRouteStitchEndpoint } from "./getRouteStitchEndpoint"
+import {
+  getRouteStitchOrientation,
+  type RouteStitchOrientation,
+} from "./getRouteStitchOrientation"
+import type { StitchTerminal } from "./getStitchTerminal"
+import type { IsStitchSegmentClear } from "./route-stitch-clearance-validator"
+import type { OrderedRouteStitchEntry } from "./routeStitchingEndpointHelpers"
+import {
+  compareRoutes,
+  GEOMETRIC_STITCH_TOLERANCE,
+  MAX_STITCH_GAP_DISTANCE_3,
+  MAX_TERMINAL_STITCH_GAP_DISTANCE_3,
+} from "./routeStitchingShared"
+
+type DirectedFragment = OrderedRouteStitchEntry & {
+  start: StitchTerminal
+  end: StitchTerminal
+}
+type PathCost = { gapCount: number; routeCount: number }
+type SearchState = {
+  fragmentIndex: number
+  traceThickness: number
+  orientationAnchorIndex: number
+  cost: PathCost
+  previousKey: string | null
+}
+
+const comparePathCosts = (first: PathCost, second: PathCost): number => {
+  if (first.gapCount !== second.gapCount) {
+    return first.gapCount - second.gapCount
+  }
+  return first.routeCount - second.routeCount
+}
+
+/**
+ * Search states mean that a complete directed physical fragment was consumed.
+ * Each edge is the actual next exit-to-entry join, not a chain of hypothetical
+ * gap waypoints that the single-route stitcher cannot reproduce.
+ */
+export const selectDirectedRouteStitchPath = (params: {
+  connectionName: string
+  hdRoutes: HighDensityIntraNodeRoute[]
+  start: StitchTerminal
+  end: StitchTerminal
+  isStitchSegmentClear: IsStitchSegmentClear
+}): OrderedRouteStitchEntry[] | null => {
+  const fragments = [...params.hdRoutes].sort(compareRoutes).flatMap(
+    (route): DirectedFragment[] => {
+      const first = getRouteStitchEndpoint(route, "first")
+      const last = getRouteStitchEndpoint(route, "last")
+      return [
+        { route, matchedOn: "first", start: first, end: last },
+        { route, matchedOn: "last", start: last, end: first },
+      ]
+    },
+  )
+  const gapCosts = new Map<string, number | null>()
+  const routeIndexes = new Map<HighDensityIntraNodeRoute, number>()
+  const routeOrientations = new Map<
+    HighDensityIntraNodeRoute,
+    RouteStitchOrientation
+  >()
+  for (const [index, fragment] of fragments.entries()) {
+    routeIndexes.set(fragment.route, index)
+    routeOrientations.set(
+      fragment.route,
+      getRouteStitchOrientation({
+        hdRoutes: [fragment.route],
+        start: params.start,
+        end: params.end,
+      }).orientation,
+    )
+  }
+  const getGapCost = (
+    from: Point3,
+    to: Point3,
+    traceThickness: number,
+    maximumDistance: number,
+  ): number | null => {
+    // A layer change belongs to represented via copper in a fragment. An
+    // endpoint adjacency alone must not synthesize a terminal or blind via.
+    if (from.z !== to.z) return null
+    const gapDistance = distance(from, to)
+    if (gapDistance < GEOMETRIC_STITCH_TOLERANCE) return 0
+    if (gapDistance > maximumDistance) return null
+    const key = JSON.stringify([
+      from.x,
+      from.y,
+      from.z,
+      to.x,
+      to.y,
+      to.z,
+      traceThickness,
+    ])
+    const cachedCost = gapCosts.get(key)
+    if (cachedCost !== undefined) return cachedCost
+    const cost = params.isStitchSegmentClear({
+      connectionName: params.connectionName,
+      start: from,
+      end: to,
+      traceThickness,
+    })
+      ? 1
+      : null
+    gapCosts.set(key, cost)
+    return cost
+  }
+  let bestPath: { path: OrderedRouteStitchEntry[]; cost: PathCost } | undefined
+  // Each direction is screened at the width of its actual first fragment.
+  // Only candidates agreeing with Single3's unchanged native orientation are
+  // eligible, so reversing a plan cannot silently change its clearance width.
+  for (const searchDirection of ["start-to-end", "end-to-start"] as const) {
+    const searchStart =
+      searchDirection === "start-to-end" ? params.start : params.end
+    const searchEnd =
+      searchDirection === "start-to-end" ? params.end : params.start
+    const states = new Map<string, SearchState>()
+    const pendingKeys = new Set<string>()
+    const settledKeys = new Set<string>()
+
+    for (const [fragmentIndex, fragment] of fragments.entries()) {
+      if (
+        fragment.start.pcb_port_id &&
+        searchStart.pcb_port_id &&
+        fragment.start.pcb_port_id !== searchStart.pcb_port_id
+      ) {
+        continue
+      }
+      const start = {
+        ...searchStart,
+        z: searchStart.availableZ?.includes(fragment.start.z)
+          ? fragment.start.z
+          : searchStart.z,
+      }
+      const traceThickness = fragment.route.traceThickness
+      const gapCount = getGapCost(
+        start,
+        fragment.start,
+        traceThickness,
+        MAX_STITCH_GAP_DISTANCE_3,
+      )
+      if (gapCount === null) continue
+      const orientationAnchorIndex = routeIndexes.get(fragment.route)!
+      const key = `${fragmentIndex}:${traceThickness}:${orientationAnchorIndex}`
+      states.set(key, {
+        fragmentIndex,
+        traceThickness,
+        orientationAnchorIndex,
+        cost: { gapCount, routeCount: 1 },
+        previousKey: null,
+      })
+      pendingKeys.add(key)
+    }
+
+    let goal: { key: string; cost: PathCost } | undefined
+    while (pendingKeys.size > 0) {
+      let currentKey: string | undefined
+      let currentState: SearchState | undefined
+      for (const key of pendingKeys) {
+        const candidate = states.get(key)!
+        if (
+          !currentState ||
+          comparePathCosts(candidate.cost, currentState.cost) < 0
+        ) {
+          currentKey = key
+          currentState = candidate
+        }
+      }
+      if (currentKey === undefined || currentState === undefined) {
+        throw new Error("Directed stitch search lost its pending state")
+      }
+      if (goal && comparePathCosts(currentState.cost, goal.cost) >= 0) break
+      pendingKeys.delete(currentKey)
+      settledKeys.add(currentKey)
+      const current = fragments[currentState.fragmentIndex]!
+      const end = {
+        ...searchEnd,
+        z: searchEnd.availableZ?.includes(current.end.z)
+          ? current.end.z
+          : searchEnd.z,
+      }
+      const endClaimMatches =
+        !current.end.pcb_port_id ||
+        !searchEnd.pcb_port_id ||
+        current.end.pcb_port_id === searchEnd.pcb_port_id
+      const endGapCount = endClaimMatches
+        ? getGapCost(
+            current.end,
+            end,
+            currentState.traceThickness,
+            MAX_TERMINAL_STITCH_GAP_DISTANCE_3,
+          )
+        : null
+      const nativeOrientation = routeOrientations.get(
+        fragments[currentState.orientationAnchorIndex]!.route,
+      )
+      if (endGapCount !== null && nativeOrientation === searchDirection) {
+        const cost = {
+          gapCount: currentState.cost.gapCount + endGapCount,
+          routeCount: currentState.cost.routeCount,
+        }
+        if (!goal || comparePathCosts(cost, goal.cost) < 0) {
+          goal = { key: currentKey, cost }
+        }
+      }
+
+      for (const [fragmentIndex, next] of fragments.entries()) {
+        const gapCount = getGapCost(
+          current.end,
+          next.start,
+          currentState.traceThickness,
+          MAX_STITCH_GAP_DISTANCE_3,
+        )
+        if (gapCount === null) continue
+        let ancestorKey: string | null = currentKey
+        let routeAlreadyConsumed = false
+        const ancestorRoutes: HighDensityIntraNodeRoute[] = []
+        while (ancestorKey !== null) {
+          const ancestor = states.get(ancestorKey)
+          if (!ancestor) {
+            throw new Error("Directed stitch search lost its route history")
+          }
+          const ancestorRoute = fragments[ancestor.fragmentIndex]!.route
+          ancestorRoutes.push(ancestorRoute)
+          if (ancestorRoute === next.route) {
+            routeAlreadyConsumed = true
+            break
+          }
+          ancestorKey = ancestor.previousKey
+        }
+        if (routeAlreadyConsumed) continue
+        const orientationAnchor = getRouteStitchOrientation({
+          hdRoutes: [...ancestorRoutes, next.route],
+          start: params.start,
+          end: params.end,
+        }).firstRoute
+        const orientationAnchorIndex = routeIndexes.get(orientationAnchor)!
+        const key = `${fragmentIndex}:${currentState.traceThickness}:${orientationAnchorIndex}`
+        if (settledKeys.has(key)) continue
+        const cost = {
+          gapCount: currentState.cost.gapCount + gapCount,
+          routeCount: currentState.cost.routeCount + 1,
+        }
+        const previousState = states.get(key)
+        if (previousState && comparePathCosts(previousState.cost, cost) <= 0) {
+          continue
+        }
+        states.set(key, {
+          fragmentIndex,
+          traceThickness: currentState.traceThickness,
+          orientationAnchorIndex,
+          cost,
+          previousKey: currentKey,
+        })
+        pendingKeys.add(key)
+      }
+    }
+
+    if (!goal) continue
+    const pathInReverse: OrderedRouteStitchEntry[] = []
+    let cursorKey: string | null = goal.key
+    while (cursorKey !== null) {
+      const state = states.get(cursorKey)
+      if (!state) {
+        throw new Error("Directed stitch search lost its predecessor state")
+      }
+      const fragment = fragments[state.fragmentIndex]!
+      pathInReverse.push({ route: fragment.route, matchedOn: fragment.matchedOn })
+      cursorKey = state.previousKey
+    }
+    const path = pathInReverse.reverse()
+    const canonicalPath =
+      searchDirection === "start-to-end"
+        ? path
+        : [...path].reverse().map(
+            (entry): OrderedRouteStitchEntry => ({
+              route: entry.route,
+              matchedOn: entry.matchedOn === "first" ? "last" : "first",
+            }),
+          )
+    if (!bestPath || comparePathCosts(goal.cost, bestPath.cost) < 0) {
+      bestPath = { path: canonicalPath, cost: goal.cost }
+    }
+  }
+  return bestPath ? bestPath.path : null
+}

--- a/lib/solvers/RouteStitchingSolver/selectDirectedRouteStitchPath.ts
+++ b/lib/solvers/RouteStitchingSolver/selectDirectedRouteStitchPath.ts
@@ -47,16 +47,16 @@ export const selectDirectedRouteStitchPath = (params: {
   end: StitchTerminal
   isStitchSegmentClear: IsStitchSegmentClear
 }): OrderedRouteStitchEntry[] | null => {
-  const fragments = [...params.hdRoutes].sort(compareRoutes).flatMap(
-    (route): DirectedFragment[] => {
+  const fragments = [...params.hdRoutes]
+    .sort(compareRoutes)
+    .flatMap((route): DirectedFragment[] => {
       const first = getRouteStitchEndpoint(route, "first")
       const last = getRouteStitchEndpoint(route, "last")
       return [
         { route, matchedOn: "first", start: first, end: last },
         { route, matchedOn: "last", start: last, end: first },
       ]
-    },
-  )
+    })
   const gapCosts = new Map<string, number | null>()
   const routeIndexes = new Map<HighDensityIntraNodeRoute, number>()
   const routeOrientations = new Map<
@@ -268,7 +268,10 @@ export const selectDirectedRouteStitchPath = (params: {
         throw new Error("Directed stitch search lost its predecessor state")
       }
       const fragment = fragments[state.fragmentIndex]!
-      pathInReverse.push({ route: fragment.route, matchedOn: fragment.matchedOn })
+      pathInReverse.push({
+        route: fragment.route,
+        matchedOn: fragment.matchedOn,
+      })
       cursorKey = state.previousKey
     }
     const path = pathInReverse.reverse()

--- a/tests/bugs/bugreport59-82431e.test.ts
+++ b/tests/bugs/bugreport59-82431e.test.ts
@@ -89,8 +89,9 @@ test("bugreport59-82431e keeps effort 2 vias on preplaced assignable vias", () =
         : null
       const representedVerticalSpans = reportedRoutes
         ? reportedRoutes.flatMap((route): RepresentedVerticalSpan[] =>
-            route.route.slice(0, -1).flatMap(
-              (start, pointIndex): RepresentedVerticalSpan[] => {
+            route.route
+              .slice(0, -1)
+              .flatMap((start, pointIndex): RepresentedVerticalSpan[] => {
                 const end = route.route[pointIndex + 1]!
                 if (
                   start.x !== end.x ||
@@ -108,8 +109,7 @@ test("bugreport59-82431e keeps effort 2 vias on preplaced assignable vias", () =
                     throughObstacle:
                       start.toNextSegmentType === "through_obstacle",
                     listedInRouteVias: route.vias.some(
-                      (via): boolean =>
-                        via.x === start.x && via.y === start.y,
+                      (via): boolean => via.x === start.x && via.y === start.y,
                     ),
                     allowlisted:
                       stitchInput?.allowedLayerTransitionPointKeys?.has(
@@ -117,8 +117,7 @@ test("bugreport59-82431e keeps effort 2 vias on preplaced assignable vias", () =
                       ),
                   },
                 ]
-              },
-            ),
+              }),
           )
         : null
       console.error(
@@ -143,8 +142,7 @@ test("bugreport59-82431e keeps effort 2 vias on preplaced assignable vias", () =
               : [...stitchInput.allowedLayerTransitionPointKeys],
           assignableViaObstacles: solver.originalSrj.obstacles.filter(
             (obstacle): boolean =>
-              obstacle.netIsAssignable === true &&
-              obstacle.layers.length > 1,
+              obstacle.netIsAssignable === true && obstacle.layers.length > 1,
           ),
           handoffRoutes: reportedRoutes,
           representedVerticalSpans,

--- a/tests/bugs/bugreport59-82431e.test.ts
+++ b/tests/bugs/bugreport59-82431e.test.ts
@@ -4,9 +4,26 @@ import bugReport from "../../fixtures/bug-reports/bugreport59-82431e/bugreport59
   type: "json",
 }
 import type { SimpleRouteJson } from "lib/types"
+import type { MultipleHighDensityRouteStitchSolver3 } from "lib/solvers/RouteStitchingSolver/MultipleHighDensityRouteStitchSolver3"
 import { getLastStepSvg } from "../fixtures/getLastStepSvg"
 import { getAssignableViaPointKeys } from "lib/autorouter-pipelines/AutoroutingPipeline8/assignableViaUtils"
 import { getXyPointKey } from "lib/autorouter-pipelines/AutoroutingPipeline8/getXyPointKey"
+
+type StitchInput = ConstructorParameters<
+  typeof MultipleHighDensityRouteStitchSolver3
+>[0]
+type IndexedStitchRoute = StitchInput["hdRoutes"][number] & {
+  routeIndex: number
+}
+type RepresentedVerticalSpan = {
+  routeIndex: number
+  pointIndex: number
+  start: IndexedStitchRoute["route"][number]
+  end: IndexedStitchRoute["route"][number]
+  throughObstacle: boolean
+  listedInRouteVias: boolean
+  allowlisted: boolean | undefined
+}
 
 const srj = bugReport.simple_route_json as SimpleRouteJson
 
@@ -23,7 +40,118 @@ test("bugreport59-82431e.json", () => {
 
 test("bugreport59-82431e keeps effort 2 vias on preplaced assignable vias", () => {
   const solver = new AutoroutingPipelineSolver8(srj, { effort: 2 })
-  solver.solve()
+  const stitchStep = solver.pipelineDef.find(
+    (step): boolean => step.solverName === "highDensityStitchSolver",
+  )
+  if (!stitchStep) {
+    throw new Error("Pipeline8 is missing its high-density stitch stage")
+  }
+  const getStitchParams = stitchStep.getConstructorParams
+  const stitchCapture: { input?: StitchInput } = {}
+  // Capture the actual constructor input chosen by Pipeline8, including its
+  // merged fixed-via fragments, before a failing constructor can change state.
+  stitchStep.getConstructorParams = ((
+    instance: AutoroutingPipelineSolver8,
+  ): [StitchInput] => {
+    const params = getStitchParams(instance) as [StitchInput]
+    stitchCapture.input = structuredClone(params[0])
+    return params
+  }) as typeof stitchStep.getConstructorParams
+
+  let solveError: unknown
+  try {
+    solver.solve()
+  } catch (error) {
+    solveError = error
+    throw error
+  } finally {
+    stitchStep.getConstructorParams = getStitchParams
+    if (solveError !== undefined || !solver.solved) {
+      const stitchInput = stitchCapture.input
+      const errorMessage =
+        solveError instanceof Error
+          ? solveError.message
+          : String(solveError ?? solver.error)
+      const connectionName = errorMessage.match(/for "([^"]+)"/)?.[1]
+      const reportedRoutes = stitchInput
+        ? stitchInput.hdRoutes
+            .map(
+              (route, routeIndex): IndexedStitchRoute => ({
+                routeIndex,
+                ...route,
+              }),
+            )
+            .filter(
+              (route): boolean =>
+                connectionName === undefined ||
+                route.connectionName === connectionName,
+            )
+        : null
+      const representedVerticalSpans = reportedRoutes
+        ? reportedRoutes.flatMap((route): RepresentedVerticalSpan[] =>
+            route.route.slice(0, -1).flatMap(
+              (start, pointIndex): RepresentedVerticalSpan[] => {
+                const end = route.route[pointIndex + 1]!
+                if (
+                  start.x !== end.x ||
+                  start.y !== end.y ||
+                  start.z === end.z
+                ) {
+                  return []
+                }
+                return [
+                  {
+                    routeIndex: route.routeIndex,
+                    pointIndex,
+                    start,
+                    end,
+                    throughObstacle:
+                      start.toNextSegmentType === "through_obstacle",
+                    listedInRouteVias: route.vias.some(
+                      (via): boolean =>
+                        via.x === start.x && via.y === start.y,
+                    ),
+                    allowlisted:
+                      stitchInput?.allowedLayerTransitionPointKeys?.has(
+                        getXyPointKey(start),
+                      ),
+                  },
+                ]
+              },
+            ),
+          )
+        : null
+      console.error(
+        "BUGREPORT59_STITCH_FAILURE",
+        JSON.stringify({
+          phase: solver.getCurrentPhase(),
+          error: errorMessage,
+          stack: solveError instanceof Error ? solveError.stack : null,
+          solved: solver.solved,
+          failed: solver.failed,
+          connectionName,
+          capturedActualStitchInput: stitchInput !== undefined,
+          layerCount: stitchInput?.layerCount,
+          terminalDeclarations: stitchInput?.connections.filter(
+            (connection): boolean =>
+              connectionName === undefined ||
+              connection.name === connectionName,
+          ),
+          allowedLayerTransitionPointKeys:
+            stitchInput?.allowedLayerTransitionPointKeys === undefined
+              ? null
+              : [...stitchInput.allowedLayerTransitionPointKeys],
+          assignableViaObstacles: solver.originalSrj.obstacles.filter(
+            (obstacle): boolean =>
+              obstacle.netIsAssignable === true &&
+              obstacle.layers.length > 1,
+          ),
+          handoffRoutes: reportedRoutes,
+          representedVerticalSpans,
+        }),
+      )
+    }
+  }
 
   const allowedViaPointKeys = getAssignableViaPointKeys(srj.obstacles)
   const outputVias = solver

--- a/tests/features/pipeline7-srj20-sample169-multi-crossing-drc.test.ts
+++ b/tests/features/pipeline7-srj20-sample169-multi-crossing-drc.test.ts
@@ -29,6 +29,13 @@ test("Pipeline7 keeps srj20 sample169 DRC-clean after multi-crossing simplificat
               mergedStart: mergedPoints?.[0],
               mergedEnd: mergedPoints?.[mergedPoints.length - 1],
               remainingRouteCount: activeStitch.remainingHdRoutes.length,
+              inputHdRoutes: solver.highDensityRepairSolver
+                ?.getOutput()
+                .filter(
+                  (route): boolean =>
+                    route.connectionName ===
+                    activeStitch.mergedHdRoute?.connectionName,
+                ),
             }
           : null,
       }),

--- a/tests/features/pipeline7-srj20-sample169-multi-crossing-drc.test.ts
+++ b/tests/features/pipeline7-srj20-sample169-multi-crossing-drc.test.ts
@@ -9,6 +9,32 @@ test("Pipeline7 keeps srj20 sample169 DRC-clean after multi-crossing simplificat
 
   solver.solve()
 
+  if (!solver.solved) {
+    const stitchSolver = solver.highDensityStitchSolver
+    const activeStitch = stitchSolver?.activeSolver
+    const mergedPoints = activeStitch?.mergedHdRoute?.route
+    console.error(
+      JSON.stringify({
+        event: "pipeline7-srj20-sample169-routing-failure",
+        phase: solver.getCurrentPhase(),
+        failed: solver.failed,
+        error: solver.error,
+        stitchError: stitchSolver?.error,
+        activeStitch: activeStitch
+          ? {
+              error: activeStitch.error,
+              connectionName: activeStitch.mergedHdRoute?.connectionName,
+              start: activeStitch.start,
+              end: activeStitch.end,
+              mergedStart: mergedPoints?.[0],
+              mergedEnd: mergedPoints?.[mergedPoints.length - 1],
+              remainingRouteCount: activeStitch.remainingHdRoutes.length,
+            }
+          : null,
+      }),
+    )
+  }
+
   expect(solver.solved).toBe(true)
   const routedTraces = solver.getOutputSimplifiedPcbTraces()
   const { errors } = evaluateRelaxedDrc({

--- a/tests/features/pipeline7-srj20-sample169-multi-crossing-drc.test.ts
+++ b/tests/features/pipeline7-srj20-sample169-multi-crossing-drc.test.ts
@@ -71,25 +71,32 @@ test("Pipeline7 keeps srj20 sample169 DRC-clean after multi-crossing simplificat
     0,
   )
 
-  if (viaCount !== 33) {
+  if (viaCount !== 33 || errors.length > 0) {
     console.error(
       JSON.stringify({
-        event: "pipeline7-srj20-sample169-via-count-mismatch",
+        event: "pipeline7-srj20-sample169-output-regression",
         viaCount,
-        routedVias: routedTraces.map((trace): RoutedViaSummary => ({
-          connectionName: trace.connection_name,
-          vias: trace.route.filter((point): boolean => point.route_type === "via"),
-        })),
+        errors,
+        routedVias: routedTraces.map(
+          (trace): RoutedViaSummary => ({
+            connectionName: trace.connection_name,
+            vias: trace.route.filter(
+              (point): boolean => point.route_type === "via",
+            ),
+          }),
+        ),
         stitchedVias: solver.highDensityStitchSolver?.mergedHdRoutes.map(
           (route): StitchedViaSummary => ({
             connectionName: route.connectionName,
             vias: route.vias,
-            transitions: route.route.flatMap((point, index): ViaTransition[] => {
-              const next = route.route[index + 1]
-              return next && point.z !== next.z
-                ? [{ start: point, end: next }]
-                : []
-            }),
+            transitions: route.route.flatMap(
+              (point, index): ViaTransition[] => {
+                const next = route.route[index + 1]
+                return next && point.z !== next.z
+                  ? [{ start: point, end: next }]
+                  : []
+              },
+            ),
           }),
         ),
       }),

--- a/tests/features/pipeline7-srj20-sample169-multi-crossing-drc.test.ts
+++ b/tests/features/pipeline7-srj20-sample169-multi-crossing-drc.test.ts
@@ -1,7 +1,23 @@
 import { expect, test } from "bun:test"
 import { AutoroutingPipelineSolver7_MultiGraph } from "lib"
 import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
+import type { SimplifiedPcbTrace } from "lib/types"
+import type { HighDensityIntraNodeRoute } from "lib/types/high-density-types"
 import { loadScenarioBySampleNumber } from "scripts/benchmark/scenarios"
+
+type ViaTransition = {
+  start: HighDensityIntraNodeRoute["route"][number]
+  end: HighDensityIntraNodeRoute["route"][number]
+}
+type RoutedViaSummary = {
+  connectionName: SimplifiedPcbTrace["connection_name"]
+  vias: SimplifiedPcbTrace["route"]
+}
+type StitchedViaSummary = {
+  connectionName: string
+  vias: HighDensityIntraNodeRoute["vias"]
+  transitions: ViaTransition[]
+}
 
 test("Pipeline7 keeps srj20 sample169 DRC-clean after multi-crossing simplification", async () => {
   const { scenario } = await loadScenarioBySampleNumber("srj20", 169)
@@ -54,6 +70,31 @@ test("Pipeline7 keeps srj20 sample169 DRC-clean after multi-crossing simplificat
       sum + trace.route.filter((point) => point.route_type === "via").length,
     0,
   )
+
+  if (viaCount !== 33) {
+    console.error(
+      JSON.stringify({
+        event: "pipeline7-srj20-sample169-via-count-mismatch",
+        viaCount,
+        routedVias: routedTraces.map((trace): RoutedViaSummary => ({
+          connectionName: trace.connection_name,
+          vias: trace.route.filter((point): boolean => point.route_type === "via"),
+        })),
+        stitchedVias: solver.highDensityStitchSolver?.mergedHdRoutes.map(
+          (route): StitchedViaSummary => ({
+            connectionName: route.connectionName,
+            vias: route.vias,
+            transitions: route.route.flatMap((point, index): ViaTransition[] => {
+              const next = route.route[index + 1]
+              return next && point.z !== next.z
+                ? [{ start: point, end: next }]
+                : []
+            }),
+          }),
+        ),
+      }),
+    )
+  }
 
   expect(errors).toHaveLength(0)
   expect(viaCount).toBe(33)

--- a/tests/features/pipeline9-inherited-drc-empty-ownership.test.ts
+++ b/tests/features/pipeline9-inherited-drc-empty-ownership.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "bun:test"
+import { Pipeline9InheritedDrcRepairSolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9InheritedDrcRepairSolver"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
+import { createPipeline9InheritedPadClearanceFixture } from "../fixtures/create-pipeline9-inherited-pad-clearance-fixture"
+
+test("Pipeline9 inherited repair does no native search without ordinary preloaded ownership", (): void => {
+  const fixture = createPipeline9InheritedPadClearanceFixture()
+  const srj = structuredClone(fixture.srj)
+  srj.traces = []
+  const newRoutes: HighDensityRoute[] = [
+    {
+      connectionName: "preloaded",
+      rootConnectionName: "preloaded",
+      traceThickness: 0.1,
+      viaDiameter: 0.3,
+      route: [
+        { x: -2, y: -0.34, z: 0, pcb_port_id: "preloaded_start" },
+        { x: -0.6, y: -0.34, z: 0 },
+        { x: 0.6, y: -0.34, z: 0 },
+        { x: 2, y: -0.34, z: 0, pcb_port_id: "preloaded_end" },
+      ],
+      vias: [],
+    },
+  ]
+  const solver = new Pipeline9InheritedDrcRepairSolver({
+    ...fixture.solver.getConstructorParams()[0],
+    srj,
+    srjWithPointPairs: srj,
+    originalSrj: srj,
+    newConnections: srj.connections,
+    newHdRoutes: newRoutes,
+    updatedPreloadedTraces: srj.traces,
+    connMap: getConnectivityMapFromSimpleRouteJson(srj),
+    obstacles: srj.obstacles,
+  })
+
+  expect(solver.stats.initialJointDrcIssueCount).toBe(1)
+  expect(solver.movablePreloadedSections).toHaveLength(0)
+  expect(solver.stats.inheritedRepairSkippedForEmptyOwnership).toBeTrue()
+  expect(solver.solved).toBeTrue()
+  expect(solver.failed).toBeFalse()
+  solver.step()
+  expect(solver.iterations).toBe(0)
+  expect(solver.exactRepairSolver?.iterations).toBe(0)
+  expect(solver.activeSubSolver).toBeNull()
+  expect(solver.getOutput()).toBe(newRoutes)
+  expect(solver.getUpdatedPreloadedTraces()).toBe(srj.traces)
+  expect(solver.getMutatedPreloadedTraces()).toEqual([])
+})

--- a/tests/features/pipeline9-inherited-drc-preserves-joint-incumbent.test.ts
+++ b/tests/features/pipeline9-inherited-drc-preserves-joint-incumbent.test.ts
@@ -1,0 +1,203 @@
+import { expect, test } from "bun:test"
+import { convertPipeline7HdRoutesToSimplifiedPcbTraces } from "lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/convertPipeline7HdRoutesToSimplifiedPcbTraces"
+import { asRegionalRoutes } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/applyPipeline9RegionalB01Repairs"
+import { Pipeline9InheritedDrcRepairSolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9InheritedDrcRepairSolver"
+import { Pipeline9JointDrcRepairSolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver"
+import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
+import type { SimpleRouteConnection } from "lib/types"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
+import { createPipeline9InheritedPadClearanceFixture } from "../fixtures/create-pipeline9-inherited-pad-clearance-fixture"
+
+test("Pipeline9 inherited rejection preserves the completed joint board despite speculative mutation", (): void => {
+  const fixture = createPipeline9InheritedPadClearanceFixture()
+  const originalSrj = structuredClone(fixture.srj)
+  const newConnection: SimpleRouteConnection = {
+    name: "new_bottom_route",
+    pointsToConnect: [
+      {
+        x: -2,
+        y: 1.25,
+        layer: "bottom",
+        pointId: "bottom_start",
+        pcb_port_id: "bottom_start",
+      },
+      {
+        x: 2,
+        y: 1.25,
+        layer: "bottom",
+        pointId: "bottom_end",
+        pcb_port_id: "bottom_end",
+      },
+    ],
+  }
+  originalSrj.connections.push(newConnection)
+  for (const point of newConnection.pointsToConnect) {
+    originalSrj.obstacles.push({
+      type: "rect",
+      center: { x: point.x, y: point.y },
+      width: 0.5,
+      height: 0.5,
+      layers: ["bottom"],
+      connectedTo: [point.pcb_port_id!],
+      circuitJsonMetadata: {
+        pcb_smtpad_id: `pad_${point.pcb_port_id}`,
+        pcb_port_id: point.pcb_port_id,
+      },
+    })
+  }
+  const newRoute: HighDensityRoute = {
+    connectionName: newConnection.name,
+    rootConnectionName: newConnection.name,
+    traceThickness: 0.1,
+    viaDiameter: 0.3,
+    route: [
+      { x: -2, y: 1.25, z: 1, pcb_port_id: "bottom_start" },
+      { x: 0, y: 1.25, z: 1 },
+      { x: 2, y: 1.25, z: 1, pcb_port_id: "bottom_end" },
+    ],
+    vias: [],
+  }
+  const preMutatedTrace = structuredClone(originalSrj.traces![0]!)
+  preMutatedTrace.__replaces_pcb_trace_id = preMutatedTrace.pcb_trace_id
+  for (const point of preMutatedTrace.route.slice(1, -1)) {
+    if (point.route_type === "wire") point.y = -0.36
+  }
+  const callerConnMap = getConnectivityMapFromSimpleRouteJson(originalSrj)
+  callerConnMap.addConnections([["completed_joint_alias"]])
+  const primaryNet = callerConnMap.getNetConnectedToId("preloaded")
+  const aliasNet = callerConnMap.getNetConnectedToId("completed_joint_alias")
+  if (!primaryNet || !aliasNet) {
+    throw new Error("Expected two established connectivity networks")
+  }
+  callerConnMap.addConnections([["preloaded", "completed_joint_alias"]])
+  expect(callerConnMap.netMap[aliasNet]).toBe(callerConnMap.netMap[primaryNet])
+  const previousJoint = new Pipeline9JointDrcRepairSolver({
+    ...fixture.solver.getConstructorParams()[0],
+    srj: originalSrj,
+    srjWithPointPairs: originalSrj,
+    originalSrj,
+    newConnections: [newConnection],
+    newHdRoutes: [newRoute],
+    updatedPreloadedTraces: [preMutatedTrace],
+    mutatedPreloadedTraceIds: new Set([preMutatedTrace.pcb_trace_id]),
+    obstacles: originalSrj.obstacles,
+    connMap: callerConnMap,
+  })
+  // The original joint stage still excludes inherited baseline errors.
+  expect(previousJoint.solved).toBeTrue()
+  expect(previousJoint.stats.initialJointDrcIssueCount).toBe(0)
+  expect(previousJoint.movablePreloadedSections).toHaveLength(0)
+  const acceptedNewRoutes = previousJoint.getOutput()
+  const acceptedPreloads = previousJoint.getUpdatedPreloadedTraces()
+  const acceptedSnapshot = structuredClone({
+    newRoutes: acceptedNewRoutes,
+    preloads: acceptedPreloads,
+    originalSrj,
+    connectivity: {
+      netMap: callerConnMap.netMap,
+      idToNetMap: callerConnMap.idToNetMap,
+    },
+  })
+  const next = new Pipeline9InheritedDrcRepairSolver({
+    ...previousJoint.params,
+    newHdRoutes: acceptedNewRoutes,
+    updatedPreloadedTraces: acceptedPreloads,
+    mutatedPreloadedTraceIds: new Set(
+      previousJoint
+        .getMutatedPreloadedTraces()
+        .map((trace) => trace.pcb_trace_id),
+    ),
+  })
+  expect(next.stats.initialJointDrcIssueCount).toBe(1)
+  expect(next.inputNewHdRoutes).not.toBe(acceptedNewRoutes)
+  expect(next.inputNewHdRoutes[0]).not.toBe(acceptedNewRoutes[0])
+  expect(next.inputUpdatedPreloadedTraces[0]).not.toBe(acceptedPreloads[0])
+  expect(next.params.connMap).not.toBe(callerConnMap)
+  expect(next.params.connMap.netMap).toEqual(callerConnMap.netMap)
+  expect(next.params.connMap.idToNetMap).toEqual(callerConnMap.idToNetMap)
+  expect(next.params.connMap.netMap[aliasNet]).toBe(
+    next.params.connMap.netMap[primaryNet],
+  )
+  expect(next.params.connMap.netMap[aliasNet]).not.toBe(
+    callerConnMap.netMap[aliasNet],
+  )
+  const workingRoutes = next.exactRepairSolver!.params.hdRoutes
+  const workingNewRoute = workingRoutes.find(
+    (route) => route.connectionName === newConnection.name,
+  )
+  const workingPreload = workingRoutes.find((route) =>
+    next.syntheticConnectionNames.has(route.connectionName),
+  )
+  if (!workingNewRoute || !workingPreload) {
+    throw new Error("Expected both new and preloaded speculative routes")
+  }
+  // Exercise the actual regional search helper that adds splice aliases.
+  const regionalRoutes = asRegionalRoutes(
+    [workingNewRoute, structuredClone(workingNewRoute)],
+    next.params.connMap,
+  )
+  for (const regionalRoute of regionalRoutes) {
+    expect(
+      next.params.connMap.areIdsConnected(
+        regionalRoute.connectionName,
+        newConnection.name,
+      ),
+    ).toBeTrue()
+    expect(
+      callerConnMap.getNetConnectedToId(regionalRoute.connectionName),
+    ).toBeUndefined()
+  }
+
+  // Controlled publication contract, not native replay. Mutate the actual
+  // search inputs, then reject a same-pair regression from 0.06 to 0.02 mm.
+  workingNewRoute.route[1]!.y = 1
+  for (const point of workingPreload.route.slice(1, -1)) point.y = -0.32
+  next["publishValidatedOutput"](workingRoutes)
+
+  expect(next.stats.jointOutputRejectedForDrcRegression).toBeTrue()
+  expect(next.stats.jointOutputAccepted).toBeFalse()
+  expect(next.stats.publishedJointDrcIssueCount).toBe(1)
+  expect(next.getOutput()).toBe(acceptedNewRoutes)
+  expect(next.getOutput()[0]).toBe(newRoute)
+  expect(next.getUpdatedPreloadedTraces()).toBe(acceptedPreloads)
+  expect(next.getMutatedPreloadedTraces()).toEqual([preMutatedTrace])
+  expect(next.getMutatedPreloadedTraces()[0]).toBe(preMutatedTrace)
+  expect({
+    newRoutes: acceptedNewRoutes,
+    preloads: acceptedPreloads,
+    originalSrj,
+    connectivity: {
+      netMap: callerConnMap.netMap,
+      idToNetMap: callerConnMap.idToNetMap,
+    },
+  }).toEqual(acceptedSnapshot)
+  expect(callerConnMap.netMap[aliasNet]).toBe(callerConnMap.netMap[primaryNet])
+  expect(callerConnMap.getNetConnectedToId("completed_joint_alias")).toBe(
+    primaryNet,
+  )
+  const retained = evaluateRelaxedDrc({
+    inputSrj: originalSrj,
+    srjWithPointPairs: originalSrj,
+    routedTraces: [
+      ...next.getMutatedPreloadedTraces(),
+      ...convertPipeline7HdRoutesToSimplifiedPcbTraces({
+        connections: [newConnection],
+        originalConnections: originalSrj.connections,
+        hdRoutes: next.getOutput(),
+        layerCount: originalSrj.layerCount,
+        obstacles: originalSrj.obstacles,
+        defaultViaHoleDiameter: 0.15,
+        connMap: previousJoint.params.connMap,
+      }),
+    ],
+  })
+  expect(retained.errors).toHaveLength(1)
+  const padError = retained.errors.find(
+    (error) => error.type === "pcb_pad_trace_clearance_error",
+  )
+  if (padError?.type !== "pcb_pad_trace_clearance_error") {
+    throw new Error("Expected the joint incumbent's inherited pad finding")
+  }
+  expect(padError.actual_clearance).toBeCloseTo(0.06)
+})

--- a/tests/features/pipeline9-joint-drc-inherited-error-visibility.test.ts
+++ b/tests/features/pipeline9-joint-drc-inherited-error-visibility.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "bun:test"
+import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
+import { createPipeline9InheritedPadClearanceFixture } from "../fixtures/create-pipeline9-inherited-pad-clearance-fixture"
+
+test("Pipeline9 keeps an inherited pad pair visible when its clearance worsens", (): void => {
+  const { srj, originalSrj, trace, solver } =
+    createPipeline9InheritedPadClearanceFixture()
+  const evaluate = solver.exactRepairSolver?.params.drcEvaluator
+  expect(evaluate).toBeDefined()
+  if (!evaluate) throw new Error("Expected inherited copper DRC evaluator")
+  const initialRoutes = solver.movablePreloadedSections.map(
+    (section) => structuredClone(section.hdRoute),
+  )
+  const worsenedRoutes = structuredClone(initialRoutes)
+  for (const point of worsenedRoutes[0]!.route.slice(1, -1)) {
+    point.y = -0.32
+  }
+  const initial = evaluate({ traces: [], routes: initialRoutes })
+  const worsened = evaluate({ traces: [], routes: worsenedRoutes })
+  if (Array.isArray(initial) || Array.isArray(worsened)) {
+    throw new Error("Expected indexed DRC errors with centers")
+  }
+  expect(initial.errors).toHaveLength(1)
+  expect(worsened.errors).toHaveLength(1)
+  expect(worsened.errors[0]).toMatchObject({
+    type: "pcb_pad_trace_clearance_error",
+    pcb_trace_id: initial.errors[0]?.pcb_trace_id,
+    pcb_pad_id: "pad_foreign",
+  })
+  expect(Number(worsened.errors[0]?.actual_clearance)).toBeLessThan(
+    Number(initial.errors[0]?.actual_clearance),
+  )
+
+  // Independently verify that this is the same official pair, not a mock
+  // finding or a new identifier that happens to escape baseline filtering.
+  const worsenedTrace = structuredClone(trace)
+  worsenedTrace.__replaces_pcb_trace_id = trace.pcb_trace_id
+  for (const point of worsenedTrace.route.slice(1, -1)) {
+    if (point.route_type === "wire") point.y = -0.32
+  }
+  const baseline = evaluateRelaxedDrc({
+    inputSrj: srj,
+    srjWithPointPairs: srj,
+    routedTraces: [],
+  })
+  const officialWorsened = evaluateRelaxedDrc({
+    inputSrj: srj,
+    srjWithPointPairs: srj,
+    routedTraces: [worsenedTrace],
+  })
+  expect(baseline.errors).toHaveLength(1)
+  expect(officialWorsened.errors).toHaveLength(1)
+  const initialError = baseline.errors[0]!
+  const worsenedError = officialWorsened.errors[0]!
+  if (
+    initialError.type !== "pcb_pad_trace_clearance_error" ||
+    worsenedError.type !== "pcb_pad_trace_clearance_error"
+  ) {
+    throw new Error("Expected genuine pad-to-trace clearance findings")
+  }
+  expect(worsenedError.pcb_pad_trace_clearance_error_id).toBe(
+    initialError.pcb_pad_trace_clearance_error_id,
+  )
+  expect(Number(worsenedError.actual_clearance)).toBeLessThan(
+    Number(initialError.actual_clearance),
+  )
+  expect(srj).toEqual(originalSrj)
+})

--- a/tests/features/pipeline9-joint-drc-inherited-error-visibility.test.ts
+++ b/tests/features/pipeline9-joint-drc-inherited-error-visibility.test.ts
@@ -8,8 +8,8 @@ test("Pipeline9 keeps an inherited pad pair visible when its clearance worsens",
   const evaluate = solver.exactRepairSolver?.params.drcEvaluator
   expect(evaluate).toBeDefined()
   if (!evaluate) throw new Error("Expected inherited copper DRC evaluator")
-  const initialRoutes = solver.movablePreloadedSections.map(
-    (section) => structuredClone(section.hdRoute),
+  const initialRoutes = solver.movablePreloadedSections.map((section) =>
+    structuredClone(section.hdRoute),
   )
   const worsenedRoutes = structuredClone(initialRoutes)
   for (const point of worsenedRoutes[0]!.route.slice(1, -1)) {

--- a/tests/features/pipeline9-joint-drc-inherited-interior-terminal.test.ts
+++ b/tests/features/pipeline9-joint-drc-inherited-interior-terminal.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test"
-import { Pipeline9JointDrcRepairSolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver"
+import { Pipeline9InheritedDrcRepairSolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9InheritedDrcRepairSolver"
 import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
 import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
 import { createPipeline9InheritedPadClearanceFixture } from "../fixtures/create-pipeline9-inherited-pad-clearance-fixture"
@@ -54,7 +54,7 @@ test("Pipeline9 rejects a DRC-clean proposal that moves a real interior terminal
     ],
   })
   const originalSrj = structuredClone(srj)
-  const solver = new Pipeline9JointDrcRepairSolver({
+  const solver = new Pipeline9InheritedDrcRepairSolver({
     ...fixture.solver.params,
     srj,
     srjWithPointPairs: srj,
@@ -64,7 +64,7 @@ test("Pipeline9 rejects a DRC-clean proposal that moves a real interior terminal
     obstacles: srj.obstacles,
   })
   const section = solver.movablePreloadedSections.find(
-    (candidate) => candidate.originalTrace === trace,
+    (candidate) => candidate.originalTrace.pcb_trace_id === trace.pcb_trace_id,
   )
   if (!section) throw new Error("Expected the inherited trace to be selected")
   expect(section.hdRoute.route[1]).toMatchObject({

--- a/tests/features/pipeline9-joint-drc-inherited-interior-terminal.test.ts
+++ b/tests/features/pipeline9-joint-drc-inherited-interior-terminal.test.ts
@@ -1,0 +1,95 @@
+import { expect, test } from "bun:test"
+import { Pipeline9JointDrcRepairSolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver"
+import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
+import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
+import { createPipeline9InheritedPadClearanceFixture } from "../fixtures/create-pipeline9-inherited-pad-clearance-fixture"
+
+test("Pipeline9 rejects a DRC-clean proposal that moves a real interior terminal", (): void => {
+  const fixture = createPipeline9InheritedPadClearanceFixture()
+  // Extend only a cloned test input, before constructing the solver under test.
+  const srj = structuredClone(fixture.srj)
+  const trace = srj.traces![0]!
+  const terminal = trace.route[1]!
+  if (terminal.route_type !== "wire") {
+    throw new Error("Expected an interior wire terminal in the fixture")
+  }
+  terminal.start_pcb_port_id = "preloaded_interior"
+  srj.connections[0]!.pointsToConnect.splice(1, 0, {
+    x: terminal.x,
+    y: terminal.y,
+    layer: terminal.layer,
+    pointId: "preloaded_interior",
+    pcb_port_id: "preloaded_interior",
+  })
+  srj.obstacles.push({
+    type: "rect",
+    center: { x: terminal.x, y: terminal.y },
+    width: 0.1,
+    height: 0.1,
+    layers: ["top"],
+    connectedTo: ["preloaded_interior"],
+    circuitJsonMetadata: {
+      pcb_smtpad_id: "pad_interior",
+      pcb_port_id: "preloaded_interior",
+    },
+  })
+  const originalSrj = structuredClone(srj)
+  const solver = new Pipeline9JointDrcRepairSolver({
+    ...fixture.solver.params,
+    srj,
+    srjWithPointPairs: srj,
+    originalSrj: srj,
+    updatedPreloadedTraces: srj.traces!,
+    connMap: getConnectivityMapFromSimpleRouteJson(srj),
+    obstacles: srj.obstacles,
+  })
+  const section = solver.movablePreloadedSections[0]!
+  expect(section.hdRoute.route[1]).toMatchObject({
+    x: terminal.x,
+    y: terminal.y,
+    z: 0,
+    pcb_port_id: "preloaded_interior",
+  })
+  const exactRepair = solver.exactRepairSolver
+  if (!exactRepair) throw new Error("Expected inherited copper exact repair")
+  const unchangedCandidate = structuredClone(exactRepair.params.hdRoutes)
+
+  // Publication-state contract: unchanged geometry must preserve the raw tag.
+  solver["publishValidatedOutput"](unchangedCandidate)
+
+  expect(solver.stats.jointOutputAccepted).toBeTrue()
+  expect(solver.getUpdatedPreloadedTraces()[0]?.route[1]).toEqual(terminal)
+  const movedCandidate = structuredClone(unchangedCandidate)
+  for (const point of movedCandidate[0]!.route.slice(1, -1)) {
+    point.y = -0.5
+  }
+  const movedTrace = structuredClone(trace)
+  movedTrace.__replaces_pcb_trace_id = trace.pcb_trace_id
+  for (const point of movedTrace.route.slice(1, -1)) {
+    if (point.route_type === "wire") point.y = -0.5
+  }
+  expect(
+    evaluateRelaxedDrc({
+      inputSrj: srj,
+      srjWithPointPairs: srj,
+      routedTraces: [],
+    }).errors,
+  ).toHaveLength(1)
+  expect(
+    evaluateRelaxedDrc({
+      inputSrj: srj,
+      srjWithPointPairs: srj,
+      routedTraces: [movedTrace],
+    }).errors,
+  ).toHaveLength(0)
+
+  solver["publishValidatedOutput"](movedCandidate)
+
+  expect(solver.stats.jointOutputAccepted).toBeFalse()
+  expect(solver.stats.jointOutputRejectedForTerminalMetadata).toBeTrue()
+  expect(solver.stats.publishedJointDrcIssueCount).toBe(1)
+  expect(solver.getUpdatedPreloadedTraces()).toBe(srj.traces!)
+  expect(solver.getUpdatedPreloadedTraces()[0]?.route[1]).toBe(terminal)
+  expect(solver.getMutatedPreloadedTraces()).toEqual([])
+  expect(srj).toEqual(originalSrj)
+})

--- a/tests/features/pipeline9-joint-drc-inherited-interior-terminal.test.ts
+++ b/tests/features/pipeline9-joint-drc-inherited-interior-terminal.test.ts
@@ -84,8 +84,7 @@ test("Pipeline9 rejects a DRC-clean proposal that moves a real interior terminal
   expect(solver.getUpdatedPreloadedTraces()[0]?.route[1]).toEqual(terminal)
   const movedCandidate = structuredClone(unchangedCandidate)
   const movedSection = movedCandidate.find(
-    (candidate) =>
-      candidate.connectionName === section.syntheticConnectionName,
+    (candidate) => candidate.connectionName === section.syntheticConnectionName,
   )
   if (!movedSection) {
     throw new Error("Expected the inherited candidate section")

--- a/tests/features/pipeline9-joint-drc-inherited-interior-terminal.test.ts
+++ b/tests/features/pipeline9-joint-drc-inherited-interior-terminal.test.ts
@@ -33,6 +33,26 @@ test("Pipeline9 rejects a DRC-clean proposal that moves a real interior terminal
       pcb_port_id: "preloaded_interior",
     },
   })
+  // Model the fanout as a real same-net branch with this pad as an endpoint.
+  // The official continuity checker does not infer a port connection from
+  // a tagged interior point on the other trace alone.
+  srj.traces!.push({
+    type: "pcb_trace",
+    pcb_trace_id: "interior_terminal_fanout",
+    connection_name: "preloaded",
+    connectsTo: ["preloaded_start", "preloaded_interior"],
+    route: [
+      structuredClone(trace.route[0]!),
+      {
+        route_type: "wire",
+        x: terminal.x,
+        y: terminal.y,
+        width: terminal.width,
+        layer: terminal.layer,
+        end_pcb_port_id: "preloaded_interior",
+      },
+    ],
+  })
   const originalSrj = structuredClone(srj)
   const solver = new Pipeline9JointDrcRepairSolver({
     ...fixture.solver.params,
@@ -43,7 +63,10 @@ test("Pipeline9 rejects a DRC-clean proposal that moves a real interior terminal
     connMap: getConnectivityMapFromSimpleRouteJson(srj),
     obstacles: srj.obstacles,
   })
-  const section = solver.movablePreloadedSections[0]!
+  const section = solver.movablePreloadedSections.find(
+    (candidate) => candidate.originalTrace === trace,
+  )
+  if (!section) throw new Error("Expected the inherited trace to be selected")
   expect(section.hdRoute.route[1]).toMatchObject({
     x: terminal.x,
     y: terminal.y,
@@ -60,7 +83,14 @@ test("Pipeline9 rejects a DRC-clean proposal that moves a real interior terminal
   expect(solver.stats.jointOutputAccepted).toBeTrue()
   expect(solver.getUpdatedPreloadedTraces()[0]?.route[1]).toEqual(terminal)
   const movedCandidate = structuredClone(unchangedCandidate)
-  for (const point of movedCandidate[0]!.route.slice(1, -1)) {
+  const movedSection = movedCandidate.find(
+    (candidate) =>
+      candidate.connectionName === section.syntheticConnectionName,
+  )
+  if (!movedSection) {
+    throw new Error("Expected the inherited candidate section")
+  }
+  for (const point of movedSection.route.slice(1, -1)) {
     point.y = -0.5
   }
   const movedTrace = structuredClone(trace)
@@ -68,20 +98,25 @@ test("Pipeline9 rejects a DRC-clean proposal that moves a real interior terminal
   for (const point of movedTrace.route.slice(1, -1)) {
     if (point.route_type === "wire") point.y = -0.5
   }
-  expect(
-    evaluateRelaxedDrc({
-      inputSrj: srj,
-      srjWithPointPairs: srj,
-      routedTraces: [],
-    }).errors,
-  ).toHaveLength(1)
-  expect(
-    evaluateRelaxedDrc({
-      inputSrj: srj,
-      srjWithPointPairs: srj,
-      routedTraces: [movedTrace],
-    }).errors,
-  ).toHaveLength(0)
+  const baseline = evaluateRelaxedDrc({
+    inputSrj: srj,
+    srjWithPointPairs: srj,
+    routedTraces: [],
+  })
+  const movedDrc = evaluateRelaxedDrc({
+    inputSrj: srj,
+    srjWithPointPairs: srj,
+    routedTraces: [movedTrace],
+  })
+  console.log(
+    JSON.stringify({
+      fixture: "inherited-interior-terminal",
+      baselineErrors: baseline.errors,
+      movedErrors: movedDrc.errors,
+    }),
+  )
+  expect(baseline.errors).toHaveLength(1)
+  expect(movedDrc.errors).toHaveLength(0)
 
   solver["publishValidatedOutput"](movedCandidate)
 

--- a/tests/features/pipeline9-joint-drc-inherited-pad-clearance.test.ts
+++ b/tests/features/pipeline9-joint-drc-inherited-pad-clearance.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "bun:test"
+import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
+import { createPipeline9InheritedPadClearanceFixture } from "../fixtures/create-pipeline9-inherited-pad-clearance-fixture"
+
+test("Pipeline9 repairs an inherited ordinary trace without changing its pads or terminals", (): void => {
+  const { srj, originalSrj, trace, solver } =
+    createPipeline9InheritedPadClearanceFixture()
+  const baseline = evaluateRelaxedDrc({
+    inputSrj: srj,
+    srjWithPointPairs: srj,
+    routedTraces: [],
+  })
+
+  // The defect exists before routing; no mutation marker promotes this trace.
+  expect(baseline.errors).toHaveLength(1)
+  expect(baseline.errors[0]).toMatchObject({
+    type: "pcb_pad_trace_clearance_error",
+    pcb_trace_id: trace.pcb_trace_id,
+    pcb_pad_id: "pad_foreign",
+  })
+  expect(solver.params.mutatedPreloadedTraceIds.size).toBe(0)
+  expect(solver.stats.baselineJointDrcIssueCount).toBe(1)
+  expect(solver.stats.initialJointDrcIssueCount).toBe(1)
+  expect(solver.movablePreloadedSections).toHaveLength(1)
+
+  solver.solve()
+
+  expect(solver.solved).toBeTrue()
+  expect(solver.failed).toBeFalse()
+  expect(solver.getOutput()).toEqual([])
+  const repaired = solver.getMutatedPreloadedTraces()
+  expect(repaired).toHaveLength(1)
+  expect(repaired[0]?.__replaces_pcb_trace_id).toBe(trace.pcb_trace_id)
+  expect(repaired[0]?.route).not.toEqual(trace.route)
+  expect(repaired[0]?.route[0]).toEqual(trace.route[0])
+  expect(repaired[0]?.route.at(-1)).toEqual(trace.route.at(-1))
+  const finalDrc = evaluateRelaxedDrc({
+    inputSrj: srj,
+    srjWithPointPairs: srj,
+    routedTraces: repaired,
+  })
+  expect(finalDrc.errors).toHaveLength(0)
+  expect(srj).toEqual(originalSrj)
+})

--- a/tests/features/pipeline9-joint-drc-inherited-publication-regression.test.ts
+++ b/tests/features/pipeline9-joint-drc-inherited-publication-regression.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "bun:test"
+import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
+import { createPipeline9InheritedPadClearanceFixture } from "../fixtures/create-pipeline9-inherited-pad-clearance-fixture"
+
+test("Pipeline9 publication rejects worse inherited copper without leaking repaired sections", (): void => {
+  const { srj, originalSrj, trace, solver } =
+    createPipeline9InheritedPadClearanceFixture()
+  const exactRepairSolver = solver.exactRepairSolver
+  if (!exactRepairSolver) {
+    throw new Error("Expected inherited copper to enter exact repair")
+  }
+  const originalPreloadedTraces = solver.inputUpdatedPreloadedTraces
+  const originalTraceRoute = trace.route
+  const initialRoutes = structuredClone(exactRepairSolver.params.hdRoutes)
+  expect(initialRoutes).toHaveLength(1)
+  const worseningCandidate = structuredClone(initialRoutes)
+  for (const point of worseningCandidate[0]!.route.slice(1, -1)) {
+    point.y = -0.32
+  }
+
+  // Controlled publication-state contract, not a native optimizer replay:
+  // submit a same-pair 0.04 -> 0.02 mm clearance regression at the real gate.
+  solver["publishValidatedOutput"](worseningCandidate)
+
+  expect(solver.stats.jointOutputValidationAttempted).toBeTrue()
+  expect(solver.stats.jointOutputRejectedForDrcRegression).toBeTrue()
+  expect(solver.stats.jointOutputAccepted).toBeFalse()
+  expect(solver.stats.jointOutputCandidateDrcIssueCount).toBe(1)
+  expect(solver.stats.publishedJointDrcIssueCount).toBe(1)
+  expect(solver.getOutput()).toEqual([])
+  expect(solver.getMutatedPreloadedTraces()).toEqual([])
+  expect(solver.getUpdatedPreloadedTraces()).toBe(originalPreloadedTraces)
+  expect(solver.getUpdatedPreloadedTraces()[0]).toBe(trace)
+  expect(solver.getUpdatedPreloadedTraces()[0]?.route).toBe(originalTraceRoute)
+  expect(srj).toEqual(originalSrj)
+  const retainedDrc = evaluateRelaxedDrc({
+    inputSrj: srj,
+    srjWithPointPairs: srj,
+    routedTraces: solver.getMutatedPreloadedTraces(),
+  })
+  expect(retainedDrc.errors).toHaveLength(1)
+  const retainedError = retainedDrc.errors[0]!
+  if (retainedError.type !== "pcb_pad_trace_clearance_error") {
+    throw new Error("Expected the original inherited pad-clearance error")
+  }
+  expect(retainedError.actual_clearance).toBeCloseTo(0.04)
+
+  // Positive control: identical terminals and section ownership, but enough
+  // interior clearance. The gate must not reject every preloaded proposal.
+  const cleanCandidate = structuredClone(initialRoutes)
+  for (const point of cleanCandidate[0]!.route.slice(1, -1)) {
+    point.y = -0.5
+  }
+  solver["publishValidatedOutput"](cleanCandidate)
+
+  expect(solver.stats.jointOutputRejectedForDrcRegression).toBeFalse()
+  expect(solver.stats.jointOutputAccepted).toBeTrue()
+  expect(solver.stats.jointOutputCandidateDrcIssueCount).toBe(0)
+  expect(solver.stats.publishedJointDrcIssueCount).toBe(0)
+  expect(solver.getOutput()).toEqual([])
+  const published = solver.getMutatedPreloadedTraces()
+  expect(published).toHaveLength(1)
+  expect(published[0]?.__replaces_pcb_trace_id).toBe(trace.pcb_trace_id)
+  expect(published[0]?.route[0]).toEqual(originalTraceRoute[0])
+  expect(published[0]?.route.at(-1)).toEqual(originalTraceRoute.at(-1))
+  expect(
+    evaluateRelaxedDrc({
+      inputSrj: srj,
+      srjWithPointPairs: srj,
+      routedTraces: published,
+    }).errors,
+  ).toHaveLength(0)
+  expect(srj).toEqual(originalSrj)
+})

--- a/tests/features/pipeline9-joint-drc-inherited-publication-regression.test.ts
+++ b/tests/features/pipeline9-joint-drc-inherited-publication-regression.test.ts
@@ -9,7 +9,8 @@ test("Pipeline9 publication rejects worse inherited copper without leaking repai
   if (!exactRepairSolver) {
     throw new Error("Expected inherited copper to enter exact repair")
   }
-  const originalPreloadedTraces = solver.inputUpdatedPreloadedTraces
+  const originalPreloadedTraces =
+    solver.getConstructorParams()[0].updatedPreloadedTraces
   const originalTraceRoute = trace.route
   const initialRoutes = structuredClone(exactRepairSolver.params.hdRoutes)
   expect(initialRoutes).toHaveLength(1)

--- a/tests/features/pipeline9-joint-drc-inherited-through-obstacle.test.ts
+++ b/tests/features/pipeline9-joint-drc-inherited-through-obstacle.test.ts
@@ -16,6 +16,12 @@ test("Pipeline9 repairs inherited wire sections without moving through-obstacle 
     srjWithPointPairs: srj,
     routedTraces: [],
   })
+  console.log(
+    JSON.stringify({
+      fixture: "inherited-through-obstacle",
+      baselineErrors: baseline.errors,
+    }),
+  )
   expect(baseline.errors).toHaveLength(1)
   expect(solver.movablePreloadedSections).toHaveLength(2)
   expect(solver.fixedPreloadedObstacleRoutes).toHaveLength(1)

--- a/tests/features/pipeline9-joint-drc-inherited-through-obstacle.test.ts
+++ b/tests/features/pipeline9-joint-drc-inherited-through-obstacle.test.ts
@@ -1,0 +1,66 @@
+import { expect, test } from "bun:test"
+import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
+import { createPipeline9InheritedPadClearanceFixture } from "../fixtures/create-pipeline9-inherited-pad-clearance-fixture"
+
+test("Pipeline9 repairs inherited wire sections without moving through-obstacle copper", (): void => {
+  const { srj, originalSrj, trace, solver } =
+    createPipeline9InheritedPadClearanceFixture(true)
+  const protectedSpan = trace.route.find(
+    (point) => point.route_type === "through_obstacle",
+  )
+  if (!protectedSpan || protectedSpan.route_type !== "through_obstacle") {
+    throw new Error("Expected a protected through-obstacle primitive")
+  }
+  const baseline = evaluateRelaxedDrc({
+    inputSrj: srj,
+    srjWithPointPairs: srj,
+    routedTraces: [],
+  })
+  expect(baseline.errors).toHaveLength(1)
+  expect(solver.movablePreloadedSections).toHaveLength(2)
+  expect(solver.fixedPreloadedObstacleRoutes).toHaveLength(1)
+  expect(solver.fixedPreloadedObstacleRoutes[0]?.isThroughObstacle).toBeTrue()
+  for (const section of solver.movablePreloadedSections) {
+    expect(
+      trace.route
+        .slice(
+          section.originalRoutePositionStart,
+          section.originalRoutePositionEnd + 1,
+        )
+        .some((point) => point.route_type === "through_obstacle"),
+    ).toBeFalse()
+  }
+
+  solver.solve()
+
+  expect(solver.solved).toBeTrue()
+  expect(solver.failed).toBeFalse()
+  const repaired = solver.getMutatedPreloadedTraces()
+  expect(repaired).toHaveLength(1)
+  const repairedRoute = repaired[0]!.route
+  const spanIndex = repairedRoute.findIndex(
+    (point) => point.route_type === "through_obstacle",
+  )
+  expect(spanIndex).toBeGreaterThan(0)
+  expect(repairedRoute[spanIndex]).toEqual(protectedSpan)
+  expect(repairedRoute[spanIndex - 1]).toMatchObject({
+    route_type: "wire",
+    ...protectedSpan.start,
+    layer: protectedSpan.from_layer,
+  })
+  expect(repairedRoute[spanIndex + 1]).toMatchObject({
+    route_type: "wire",
+    ...protectedSpan.end,
+    layer: protectedSpan.to_layer,
+  })
+  expect(repairedRoute[0]).toEqual(trace.route[0])
+  expect(repairedRoute.at(-1)).toEqual(trace.route.at(-1))
+  expect(
+    evaluateRelaxedDrc({
+      inputSrj: srj,
+      srjWithPointPairs: srj,
+      routedTraces: repaired,
+    }).errors,
+  ).toHaveLength(0)
+  expect(srj).toEqual(originalSrj)
+})

--- a/tests/features/pipeline9-joint-drc-output-copper-quality.test.ts
+++ b/tests/features/pipeline9-joint-drc-output-copper-quality.test.ts
@@ -47,6 +47,11 @@ test("Pipeline9 rejects copper pair replacement and worsening", () => {
     },
     {
       current: initial,
+      candidate: [{ ...padError("pad_a", 0.05), minimum_clearance: 0.2 }],
+      accepted: false,
+    },
+    {
+      current: initial,
       candidate: [padError("pad_a", 0.09), padError("pad_b", 0.03)],
       accepted: false,
     },
@@ -110,6 +115,7 @@ test("Pipeline9 rejects copper pair replacement and worsening", () => {
   const traceContact = {
     type: "pcb_trace_error",
     pcb_trace_id: "ordinary",
+    pcb_trace_ids: ["ordinary", "other"],
     pcb_trace_error_id: "overlap_ordinary_other",
     message: "Traces are too close (gap: 0.020mm)",
   }
@@ -129,6 +135,24 @@ test("Pipeline9 rejects copper pair replacement and worsening", () => {
       },
     }),
   ).toBe(true)
+  const unannotatedTraceContact = {
+    ...traceContact,
+    pcb_trace_ids: undefined,
+  }
+  expect(
+    isPipeline9JointDrcOutputNoWorse({
+      current: { errors: [unannotatedTraceContact], circuitJson },
+      candidate: {
+        errors: [
+          {
+            ...unannotatedTraceContact,
+            message: "Traces are too close (gap: 0.040mm)",
+          },
+        ],
+        circuitJson,
+      },
+    }),
+  ).toBe(false)
   expect(() =>
     isPipeline9JointDrcOutputNoWorse({
       current: { errors: initial, circuitJson },

--- a/tests/features/pipeline9-joint-drc-output-copper-quality.test.ts
+++ b/tests/features/pipeline9-joint-drc-output-copper-quality.test.ts
@@ -1,0 +1,144 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { isPipeline9JointDrcOutputNoWorse } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/isPipeline9JointDrcOutputNoWorse"
+
+test("Pipeline9 rejects copper pair replacement and worsening", () => {
+  const circuitJson = [
+    { type: "pcb_trace", pcb_trace_id: "ordinary" },
+    { type: "pcb_trace", pcb_trace_id: "other" },
+    { type: "pcb_smtpad", pcb_smtpad_id: "pad_a" },
+    { type: "pcb_smtpad", pcb_smtpad_id: "pad_b" },
+    { type: "pcb_smtpad", pcb_smtpad_id: "pad_c" },
+  ] as AnyCircuitElement[]
+  const padError = (
+    padId: string,
+    actualClearance: number,
+  ): Record<string, unknown> => ({
+    type: "pcb_pad_trace_clearance_error",
+    pcb_pad_trace_clearance_error_id: `pad_trace_clearance_${padId}_ordinary`,
+    pcb_trace_id: "ordinary",
+    pcb_pad_id: padId,
+    minimum_clearance: 0.1,
+    actual_clearance: actualClearance,
+    center: { x: 0, y: 0 },
+  })
+  const initial = [padError("pad_a", 0.02), padError("pad_b", 0.04)]
+  const comparisons: Array<{
+    current: Record<string, unknown>[]
+    candidate: Record<string, unknown>[]
+    accepted: boolean
+  }> = [
+    { current: initial, candidate: initial, accepted: true },
+    { current: initial, candidate: [], accepted: true },
+    {
+      current: initial,
+      candidate: [padError("pad_c", 0.09)],
+      accepted: false,
+    },
+    {
+      current: initial,
+      candidate: [padError("pad_a", 0.01)],
+      accepted: false,
+    },
+    {
+      current: initial,
+      candidate: [padError("pad_a", 0.02 - Number.EPSILON)],
+      accepted: false,
+    },
+    {
+      current: initial,
+      candidate: [padError("pad_a", 0.09), padError("pad_b", 0.03)],
+      accepted: false,
+    },
+    {
+      current: initial,
+      candidate: [padError("pad_a", 0.09), padError("pad_a", 0.09)],
+      accepted: false,
+    },
+    {
+      current: [padError("pad_a", 0.01), padError("pad_a", 0.08)],
+      candidate: [padError("pad_a", 0.07), padError("pad_a", 0.07)],
+      accepted: false,
+    },
+    {
+      current: initial,
+      candidate: [{ ...padError("pad_a", 0.05), center: { x: 2, y: 3 } }],
+      accepted: true,
+    },
+  ]
+  for (const comparison of comparisons) {
+    expect(
+      isPipeline9JointDrcOutputNoWorse({
+        current: { errors: comparison.current, circuitJson },
+        candidate: { errors: comparison.candidate, circuitJson },
+      }),
+    ).toBe(comparison.accepted)
+  }
+
+  const contact = {
+    type: "pcb_trace_error",
+    pcb_trace_id: "ordinary",
+    pcb_trace_error_id: "overlap_ordinary_pad_a",
+    message:
+      'PCB trace ordinary overlaps with pcb_smtpad "pad_a" (accidental contact)',
+  }
+  expect(
+    isPipeline9JointDrcOutputNoWorse({
+      current: { errors: [contact], circuitJson },
+      candidate: { errors: [padError("pad_a", 0.03)], circuitJson },
+    }),
+  ).toBe(false)
+  expect(
+    isPipeline9JointDrcOutputNoWorse({
+      current: { errors: [contact], circuitJson },
+      candidate: { errors: [contact], circuitJson },
+    }),
+  ).toBe(true)
+  expect(
+    isPipeline9JointDrcOutputNoWorse({
+      current: { errors: [contact], circuitJson },
+      candidate: { errors: [], circuitJson },
+    }),
+  ).toBe(true)
+  expect(
+    isPipeline9JointDrcOutputNoWorse({
+      current: { errors: [padError("pad_a", 0.03)], circuitJson },
+      candidate: { errors: [contact], circuitJson },
+    }),
+  ).toBe(false)
+
+  const traceContact = {
+    type: "pcb_trace_error",
+    pcb_trace_id: "ordinary",
+    pcb_trace_error_id: "overlap_ordinary_other",
+    message: "Traces are too close (gap: 0.020mm)",
+  }
+  expect(
+    isPipeline9JointDrcOutputNoWorse({
+      current: { errors: [traceContact], circuitJson },
+      candidate: {
+        errors: [
+          {
+            ...traceContact,
+            pcb_trace_id: "other",
+            pcb_trace_error_id: "overlap_other_ordinary",
+            message: "Traces are too close (gap: 0.040mm)",
+          },
+        ],
+        circuitJson,
+      },
+    }),
+  ).toBe(true)
+  expect(() =>
+    isPipeline9JointDrcOutputNoWorse({
+      current: { errors: initial, circuitJson },
+      candidate: { errors: [padError("missing_pad", 0.05)], circuitJson },
+    }),
+  ).toThrow("cannot resolve copper participant")
+  expect(() =>
+    isPipeline9JointDrcOutputNoWorse({
+      current: { errors: initial, circuitJson },
+      candidate: { errors: [padError("pad_a", Number.NaN)], circuitJson },
+    }),
+  ).toThrow("finite clearance measurements")
+})

--- a/tests/features/pipeline9-joint-drc-output-noncopper-quality.test.ts
+++ b/tests/features/pipeline9-joint-drc-output-noncopper-quality.test.ts
@@ -1,0 +1,87 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { isPipeline9JointDrcOutputNoWorse } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/isPipeline9JointDrcOutputNoWorse"
+
+test("Pipeline9 preserves non-copper DRC findings", () => {
+  const circuitJson = [
+    { type: "pcb_trace", pcb_trace_id: "ordinary" },
+    { type: "pcb_smtpad", pcb_smtpad_id: "pad_a" },
+    { type: "pcb_smtpad", pcb_smtpad_id: "pad_b" },
+  ] as AnyCircuitElement[]
+  const padErrors = ["pad_a", "pad_b"].map((padId) => ({
+    type: "pcb_pad_trace_clearance_error",
+    pcb_trace_id: "ordinary",
+    pcb_pad_id: padId,
+    minimum_clearance: 0.1,
+    actual_clearance: 0.02,
+  }))
+  const missingConnection = {
+    type: "pcb_trace_error",
+    pcb_trace_id: "ordinary",
+    pcb_trace_error_id: "missing_connection_ordinary_terminal_a",
+    message: "Trace ordinary is missing a connection to terminal_a",
+  }
+  const boardEdge = {
+    type: "pcb_trace_error",
+    pcb_trace_id: "ordinary",
+    pcb_trace_error_id: "trace_too_close_to_board_ordinary_segment_0",
+    message: "Trace too close to board edge (0.020mm < 0.100mm required)",
+    center: { x: 0, y: 1 },
+  }
+  const unknown = {
+    type: "future_drc_error",
+    detail: { b: 2, a: 1 },
+    identities: ["ordinary", "terminal_a"],
+  }
+  for (const error of [missingConnection, boardEdge, unknown]) {
+    expect(
+      isPipeline9JointDrcOutputNoWorse({
+        current: { errors: padErrors, circuitJson },
+        candidate: { errors: [error], circuitJson },
+      }),
+    ).toBe(false)
+    expect(
+      isPipeline9JointDrcOutputNoWorse({
+        current: { errors: [error, ...padErrors], circuitJson },
+        candidate: { errors: [error], circuitJson },
+      }),
+    ).toBe(true)
+  }
+  for (const error of [
+    {
+      ...missingConnection,
+      pcb_trace_error_id: "missing_connection_ordinary_terminal_b",
+    },
+    {
+      ...boardEdge,
+      message: "Trace too close to board edge (0.010mm < 0.100mm required)",
+    },
+    { ...boardEdge, center: { x: 0, y: 2 } },
+    { ...unknown, detail: { a: 1, b: 3 } },
+  ]) {
+    expect(
+      isPipeline9JointDrcOutputNoWorse({
+        current: {
+          errors: [missingConnection, boardEdge, unknown],
+          circuitJson,
+        },
+        candidate: { errors: [error], circuitJson },
+      }),
+    ).toBe(false)
+  }
+  expect(
+    isPipeline9JointDrcOutputNoWorse({
+      current: { errors: [unknown], circuitJson },
+      candidate: {
+        errors: [
+          {
+            identities: ["ordinary", "terminal_a"],
+            detail: { a: 1, b: 2 },
+            type: "future_drc_error",
+          },
+        ],
+        circuitJson,
+      },
+    }),
+  ).toBe(true)
+})

--- a/tests/features/pipeline9-joint-drc-output-participant-collisions.test.ts
+++ b/tests/features/pipeline9-joint-drc-output-participant-collisions.test.ts
@@ -48,19 +48,46 @@ test("Pipeline9 resolves involved copper using explicit roles", () => {
       candidate: { errors: [], circuitJson },
     }),
   ).toBe(true)
-  expect(() =>
+  expect(
     isPipeline9JointDrcOutputNoWorse({
       current: { errors: [genericError], circuitJson },
       candidate: { errors: [genericError], circuitJson },
     }),
-  ).toThrow("cannot resolve copper participant")
+  ).toBe(true)
+  expect(
+    isPipeline9JointDrcOutputNoWorse({
+      current: { errors: [genericError], circuitJson },
+      candidate: {
+        errors: [{ ...genericError, pcb_trace_error_id: "opaque-diagnostic" }],
+        circuitJson,
+      },
+    }),
+  ).toBe(false)
+  const changedViaContext = circuitJson.map((element) =>
+    element.type === "pcb_via" && element.pcb_via_id === "via_7"
+      ? { ...element, pcb_trace_id: "via_7", x: 1 }
+      : element,
+  )
+  for (const error of [
+    genericError,
+    {
+      ...genericError,
+      pcb_via_id: "via_7",
+      message: "PCB trace ordinary overlaps with a via (accidental contact)",
+    },
+  ]) {
+    expect(
+      isPipeline9JointDrcOutputNoWorse({
+        current: { errors: [error], circuitJson },
+        candidate: { errors: [error], circuitJson: changedViaContext },
+      }),
+    ).toBe(false)
+  }
   expect(() =>
     isPipeline9JointDrcOutputNoWorse({
       current: { errors: [typedViaError], circuitJson },
       candidate: {
-        errors: [
-          { ...typedViaError, pcb_via_id: "unrelated_ownerless_via" },
-        ],
+        errors: [{ ...typedViaError, pcb_via_id: "unrelated_ownerless_via" }],
         circuitJson,
       },
     }),

--- a/tests/features/pipeline9-joint-drc-output-participant-collisions.test.ts
+++ b/tests/features/pipeline9-joint-drc-output-participant-collisions.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { isPipeline9JointDrcOutputNoWorse } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/isPipeline9JointDrcOutputNoWorse"
+
+test("Pipeline9 resolves involved copper using explicit roles", () => {
+  const circuitJson = [
+    { type: "pcb_trace", pcb_trace_id: "ordinary" },
+    { type: "pcb_trace", pcb_trace_id: "via_7" },
+    {
+      type: "pcb_via",
+      pcb_via_id: "via_7",
+      pcb_trace_id: "ordinary",
+      x: 0,
+      y: 0,
+      layers: ["top", "bottom"],
+    },
+    { type: "pcb_via", pcb_via_id: "unrelated_ownerless_via" },
+  ] as AnyCircuitElement[]
+  const typedViaError = {
+    type: "pcb_via_trace_clearance_error",
+    pcb_via_trace_clearance_error_id: "via_trace_clearance_via_7_via_7",
+    pcb_trace_id: "via_7",
+    pcb_via_id: "via_7",
+    minimum_clearance: 0.1,
+    actual_clearance: 0.02,
+  }
+  const genericError = {
+    type: "pcb_trace_error",
+    pcb_trace_id: "ordinary",
+    pcb_trace_error_id: "overlap_ordinary_via_7",
+    message: "PCB traces are too close (gap: 0.020mm)",
+  }
+  for (const error of [
+    typedViaError,
+    { ...genericError, pcb_trace_ids: ["ordinary", "via_7"] },
+    { ...genericError, pcb_via_id: "via_7" },
+  ]) {
+    expect(
+      isPipeline9JointDrcOutputNoWorse({
+        current: { errors: [error], circuitJson },
+        candidate: { errors: [error], circuitJson },
+      }),
+    ).toBe(true)
+  }
+  expect(
+    isPipeline9JointDrcOutputNoWorse({
+      current: { errors: [], circuitJson },
+      candidate: { errors: [], circuitJson },
+    }),
+  ).toBe(true)
+  expect(() =>
+    isPipeline9JointDrcOutputNoWorse({
+      current: { errors: [genericError], circuitJson },
+      candidate: { errors: [genericError], circuitJson },
+    }),
+  ).toThrow("cannot resolve copper participant")
+  expect(() =>
+    isPipeline9JointDrcOutputNoWorse({
+      current: { errors: [typedViaError], circuitJson },
+      candidate: {
+        errors: [
+          { ...typedViaError, pcb_via_id: "unrelated_ownerless_via" },
+        ],
+        circuitJson,
+      },
+    }),
+  ).toThrow("requires a via owner and physical site")
+})

--- a/tests/features/pipeline9-joint-drc-output-via-identity.test.ts
+++ b/tests/features/pipeline9-joint-drc-output-via-identity.test.ts
@@ -88,16 +88,20 @@ test("Pipeline9 matches residual vias by physical site", () => {
     isPipeline9JointDrcOutputNoWorse({
       current,
       candidate: {
-        errors: [
-          {
-            ...reindexedError,
-            pcb_error_id: "same_net_vias_close_via_12_via_7",
-          },
-        ],
+        errors: [{ ...reindexedError, minimum_clearance: 0.2 }],
         circuitJson: reindexedCircuit,
       },
     }),
   ).toBe(false)
+  expect(
+    isPipeline9JointDrcOutputNoWorse({
+      current,
+      candidate: {
+        errors: [{ ...reindexedError, pcb_error_id: "opaque-diagnostic" }],
+        circuitJson: reindexedCircuit,
+      },
+    }),
+  ).toBe(true)
 
   const traceViaContact = {
     type: "pcb_trace_error",

--- a/tests/features/pipeline9-joint-drc-output-via-identity.test.ts
+++ b/tests/features/pipeline9-joint-drc-output-via-identity.test.ts
@@ -1,0 +1,154 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { isPipeline9JointDrcOutputNoWorse } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/isPipeline9JointDrcOutputNoWorse"
+
+test("Pipeline9 matches residual vias by physical site", () => {
+  const makeCircuit = (
+    firstId: string,
+    secondId: string,
+    firstX = 0,
+    firstOwner = "ordinary",
+  ): AnyCircuitElement[] =>
+    [
+      { type: "pcb_trace", pcb_trace_id: "ordinary" },
+      { type: "pcb_trace", pcb_trace_id: "other" },
+      {
+        type: "pcb_via",
+        pcb_via_id: firstId,
+        pcb_trace_id: firstOwner,
+        x: firstX,
+        y: 0,
+        layers: ["top", "bottom"],
+      },
+      {
+        type: "pcb_via",
+        pcb_via_id: secondId,
+        pcb_trace_id: "other",
+        x: 0.25,
+        y: 0,
+        layers: ["bottom", "top"],
+      },
+    ] as AnyCircuitElement[]
+  const currentError = {
+    type: "pcb_via_clearance_error",
+    pcb_error_id: "different_net_vias_close_via_0_via_1",
+    pcb_via_ids: ["via_0", "via_1"],
+    minimum_clearance: 0.1,
+    actual_clearance: 0.03,
+  }
+  const reindexedError = {
+    ...currentError,
+    pcb_error_id: "different_net_vias_close_via_12_via_7",
+    pcb_via_ids: ["via_7", "via_12"],
+  }
+  const current = {
+    errors: [currentError],
+    circuitJson: makeCircuit("via_0", "via_1"),
+  }
+  const reindexedCircuit = makeCircuit("via_12", "via_7").reverse()
+  expect(
+    isPipeline9JointDrcOutputNoWorse({
+      current,
+      candidate: { errors: [reindexedError], circuitJson: reindexedCircuit },
+    }),
+  ).toBe(true)
+  for (const circuitJson of [
+    makeCircuit("via_12", "via_7", 0.02),
+    makeCircuit("via_12", "via_7", 0, "other"),
+  ]) {
+    expect(
+      isPipeline9JointDrcOutputNoWorse({
+        current,
+        candidate: {
+          errors: [{ ...reindexedError, actual_clearance: 0.08 }],
+          circuitJson,
+        },
+      }),
+    ).toBe(false)
+  }
+  expect(
+    isPipeline9JointDrcOutputNoWorse({
+      current,
+      candidate: {
+        errors: [],
+        circuitJson: makeCircuit("via_12", "via_7", -1),
+      },
+    }),
+  ).toBe(true)
+  expect(
+    isPipeline9JointDrcOutputNoWorse({
+      current,
+      candidate: {
+        errors: [{ ...reindexedError, actual_clearance: 0.02 }],
+        circuitJson: reindexedCircuit,
+      },
+    }),
+  ).toBe(false)
+  expect(
+    isPipeline9JointDrcOutputNoWorse({
+      current,
+      candidate: {
+        errors: [
+          {
+            ...reindexedError,
+            pcb_error_id: "same_net_vias_close_via_12_via_7",
+          },
+        ],
+        circuitJson: reindexedCircuit,
+      },
+    }),
+  ).toBe(false)
+
+  const traceViaContact = {
+    type: "pcb_trace_error",
+    pcb_trace_id: "other",
+    pcb_trace_error_id: "overlap_other_via_0",
+    message:
+      'PCB trace other overlaps with pcb_via "via_0" (accidental contact)',
+  }
+  expect(
+    isPipeline9JointDrcOutputNoWorse({
+      current: { ...current, errors: [traceViaContact] },
+      candidate: {
+        errors: [
+          {
+            type: "pcb_via_trace_clearance_error",
+            pcb_via_trace_clearance_error_id:
+              "via_trace_clearance_via_12_other",
+            pcb_via_id: "via_12",
+            pcb_trace_id: "other",
+            actual_clearance: 0.04,
+            minimum_clearance: 0.1,
+          },
+        ],
+        circuitJson: reindexedCircuit,
+      },
+    }),
+  ).toBe(false)
+  expect(
+    isPipeline9JointDrcOutputNoWorse({
+      current: { ...current, errors: [traceViaContact] },
+      candidate: {
+        errors: [
+          {
+            ...traceViaContact,
+            pcb_trace_id: "ordinary",
+            pcb_trace_error_id: "overlap_ordinary_via_7",
+          },
+        ],
+        circuitJson: reindexedCircuit,
+      },
+    }),
+  ).toBe(false)
+  expect(() =>
+    isPipeline9JointDrcOutputNoWorse({
+      current,
+      candidate: {
+        errors: [reindexedError],
+        circuitJson: reindexedCircuit.filter(
+          (element) => element.type !== "pcb_via",
+        ),
+      },
+    }),
+  ).toThrow("cannot resolve copper participant")
+})

--- a/tests/features/pipeline9-minimal-preloaded-trace-graph.test.ts
+++ b/tests/features/pipeline9-minimal-preloaded-trace-graph.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "bun:test"
 import { AutoroutingPipelineSolver7_MultiGraph } from "lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph"
 import { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/AutoroutingPipelineSolver9_PreloadedTraceGraph"
 import { Pipeline9HighDensitySolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9HighDensitySolver"
+import { Pipeline9InheritedDrcRepairSolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9InheritedDrcRepairSolver"
 import { TraceSimplificationSolver } from "lib/solvers/TraceSimplificationSolver/TraceSimplificationSolver"
 import type { SimpleRouteJson } from "lib/types"
 import scenario from "./preexisting-connected-traces/srj/preexisting-connected-traces06.srj.json" with {
@@ -105,7 +106,7 @@ test("Pipeline9 owns copied stages with minimal preloaded-trace changes", () => 
   const pipeline7SharedStageCount = pipeline7.pipelineDef.filter(
     (step) => step.solverName !== "exactGeometryDrcForceImproveSolver",
   ).length
-  expect(solver.pipelineDef).toHaveLength(pipeline7SharedStageCount + 3)
+  expect(solver.pipelineDef).toHaveLength(pipeline7SharedStageCount + 4)
   for (const stageName of [
     "highDensityForceImproveSolver",
     "highDensityRepairSolver",
@@ -124,6 +125,18 @@ test("Pipeline9 owns copied stages with minimal preloaded-trace changes", () => 
     )?.solverClass,
   ).toBe(Pipeline9HighDensitySolver)
   const pipeline9StageNames = solver.pipelineDef.map((step) => step.solverName)
+  const inheritedRepairStep = solver.pipelineDef.find(
+    (step) => step.solverName === "pipeline9InheritedDrcRepairSolver",
+  )
+  expect(inheritedRepairStep?.solverClass).toBe(
+    Pipeline9InheritedDrcRepairSolver,
+  )
+  expect(pipeline9StageNames.indexOf("pipeline9InheritedDrcRepairSolver")).toBe(
+    pipeline9StageNames.indexOf("pipeline9JointDrcRepairSolver") + 1,
+  )
+  expect(pipeline9StageNames.indexOf("pipeline9InheritedDrcRepairSolver")).toBe(
+    pipeline9StageNames.indexOf("lengthMatchingPostProcessingSolver") - 1,
+  )
   const mutatedPreloadSimplificationStep = solver.pipelineDef.find(
     (step) => step.solverName === "mutatedPreloadedTraceSimplificationSolver",
   )

--- a/tests/features/pipeline9-srj18-sample3-terminal-ownership.test.ts
+++ b/tests/features/pipeline9-srj18-sample3-terminal-ownership.test.ts
@@ -1,0 +1,94 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/AutoroutingPipelineSolver9_PreloadedTraceGraph"
+import type { MultipleHighDensityRouteStitchSolver3 } from "lib/solvers/RouteStitchingSolver/MultipleHighDensityRouteStitchSolver3"
+import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
+import { loadScenarioBySampleNumber } from "../../scripts/benchmark/scenarios"
+
+type StitchInput = ConstructorParameters<
+  typeof MultipleHighDensityRouteStitchSolver3
+>[0]
+type FragmentOwnership = {
+  connectionName: string
+  rootConnectionName?: string
+  regionId?: string
+  startPcbPortId?: string
+  endPcbPortId?: string
+  start: StitchInput["hdRoutes"][number]["route"][number] | undefined
+  end: StitchInput["hdRoutes"][number]["route"][number] | undefined
+}
+
+test("Pipeline9 preserves SRJ18 sample3's child-terminal ownership and clean completion", async (): Promise<void> => {
+  const { scenario } = await loadScenarioBySampleNumber("srj18", 3)
+  const solver = new AutoroutingPipelineSolver9_PreloadedTraceGraph(
+    structuredClone(scenario),
+    { cacheProvider: null, effort: 1 },
+  )
+  const stitchStep = solver.pipelineDef.find(
+    (step): boolean => step.solverName === "highDensityStitchSolver",
+  )
+  if (!stitchStep) {
+    throw new Error("Pipeline9 is missing its high-density stitch stage")
+  }
+  const getStitchParams = stitchStep.getConstructorParams
+  const capture: { input?: StitchInput } = {}
+  stitchStep.getConstructorParams = ((
+    instance: AutoroutingPipelineSolver9_PreloadedTraceGraph,
+  ): [StitchInput] => {
+    const params = getStitchParams(instance) as [StitchInput]
+    capture.input = structuredClone(params[0])
+    return params
+  }) as typeof stitchStep.getConstructorParams
+
+  let solveError: unknown
+  try {
+    solver.solve()
+  } catch (error) {
+    solveError = error
+    throw error
+  } finally {
+    stitchStep.getConstructorParams = getStitchParams
+    if (solveError !== undefined || !solver.solved) {
+      const errorMessage =
+        solveError instanceof Error ? solveError.message : String(solver.error)
+      const connectionName = errorMessage.match(/(?:on|for) "([^"]+)"/)?.[1]
+      console.error(
+        "SRJ18_SAMPLE3_TERMINAL_OWNERSHIP_FAILURE",
+        JSON.stringify({
+          phase: solver.getCurrentPhase(),
+          connectionName,
+          childPairDeclarations: capture.input?.connections.filter(
+            (connection): boolean => connection.name === connectionName,
+          ),
+          inputFragmentOwnership: capture.input?.hdRoutes
+            .filter(
+              (route): boolean => route.connectionName === connectionName,
+            )
+            .map(
+              (route): FragmentOwnership => ({
+                connectionName: route.connectionName,
+                rootConnectionName: route.rootConnectionName,
+                regionId: route.regionId,
+                startPcbPortId: route.startPcbPortId,
+                endPcbPortId: route.endPcbPortId,
+                start: route.route[0],
+                end: route.route[route.route.length - 1],
+              }),
+            ),
+          // The named guard includes its selected ordered physical fragments.
+          // Emit it once, after the actual declaration, to avoid truncating
+          // ownership evidence with a duplicate error stack.
+          rejection: errorMessage,
+        }),
+      )
+    }
+  }
+
+  expect(solver.solved).toBeTrue()
+  expect(solver.failed).toBeFalse()
+  const finalDrc = evaluateRelaxedDrc({
+    inputSrj: scenario,
+    srjWithPointPairs: solver.srjWithPointPairs!,
+    routedTraces: solver.getOutputSimplifiedPcbTraces(),
+  })
+  expect(finalDrc.errors).toEqual([])
+})

--- a/tests/features/pipeline9-srj18-sample3-terminal-ownership.test.ts
+++ b/tests/features/pipeline9-srj18-sample3-terminal-ownership.test.ts
@@ -60,9 +60,7 @@ test("Pipeline9 preserves SRJ18 sample3's child-terminal ownership and clean com
             (connection): boolean => connection.name === connectionName,
           ),
           inputFragmentOwnership: capture.input?.hdRoutes
-            .filter(
-              (route): boolean => route.connectionName === connectionName,
-            )
+            .filter((route): boolean => route.connectionName === connectionName)
             .map(
               (route): FragmentOwnership => ({
                 connectionName: route.connectionName,

--- a/tests/features/pipeline9-srj23-sample21-regional-b01-repair.test.ts
+++ b/tests/features/pipeline9-srj23-sample21-regional-b01-repair.test.ts
@@ -1,6 +1,10 @@
 import { expect, test } from "bun:test"
+import { createPipeline7HdRoutesToSimplifiedPcbTracesConverter } from "lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/convertPipeline7HdRoutesToSimplifiedPcbTraces"
 import { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/AutoroutingPipelineSolver9_PreloadedTraceGraph"
+import { preparePipeline9DrcRoutedTracesWithMetadata } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/preparePipeline9DrcRoutedTraces"
+import { RELAXED_DRC_OPTIONS } from "lib/testing/drcPresets"
 import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
+import type { HighDensityRoute } from "lib/types/high-density-types"
 import { loadScenarioBySampleNumber } from "../../scripts/benchmark/scenarios"
 
 test("Pipeline9 keeps the current SRJ23 regional repair residue bounded", async () => {
@@ -10,19 +14,100 @@ test("Pipeline9 keeps the current SRJ23 regional repair residue bounded", async 
     { cacheProvider: null, effort: 1 },
   )
 
+  while (
+    !solver.pipeline9JointDrcRepairSolver &&
+    !solver.solved &&
+    !solver.failed
+  ) {
+    solver.step()
+  }
+  const jointRepair = solver.pipeline9JointDrcRepairSolver
+  if (!jointRepair) {
+    throw new Error("Expected Pipeline9 joint repair before publication")
+  }
+  const publicationDiagnostics: Array<{
+    candidateErrors: ReturnType<typeof evaluateRelaxedDrc>["errors"]
+    accepted: boolean
+  }> = []
+  let diagnosticTimeMs = 0
+  const originalPublish =
+    jointRepair["publishValidatedOutput"].bind(jointRepair)
+  const convertNewRoutes =
+    createPipeline7HdRoutesToSimplifiedPcbTracesConverter({
+      connections: jointRepair.params.newConnections,
+      originalConnections: jointRepair.params.originalSrj.connections,
+      layerCount: jointRepair.params.layerCount,
+      obstacles: jointRepair.params.obstacles,
+      defaultViaHoleDiameter: jointRepair.params.defaultViaHoleDiameter,
+      connMap: jointRepair.params.connMap,
+    })
+  const traceClearance =
+    jointRepair.params.originalSrj.minTraceToPadEdgeClearance ??
+    RELAXED_DRC_OPTIONS.traceClearance ??
+    0.1
+  // Observe this one real proposal without changing candidate generation or
+  // acceptance. Rebuild every fixed span before the diagnostic official check.
+  jointRepair["publishValidatedOutput"] = (
+    routes: HighDensityRoute[],
+  ): void => {
+    originalPublish(routes)
+    const diagnosticStartedAt = performance.now()
+    const changedPreloadedTraceIds = new Set([
+      ...jointRepair.params.mutatedPreloadedTraceIds,
+      ...jointRepair.movablePreloadedSections.map(
+        (section) => section.originalTrace.pcb_trace_id,
+      ),
+    ])
+    const preparedCandidate = preparePipeline9DrcRoutedTracesWithMetadata({
+      originalPreloadedTraces: jointRepair.params.originalSrj.traces ?? [],
+      mutatedPreloadedTraces: jointRepair["rebuildUpdatedPreloadedTraces"](
+        routes,
+      ).filter((trace) => changedPreloadedTraceIds.has(trace.pcb_trace_id)),
+      newTraces: convertNewRoutes(
+        routes.filter(
+          (route) =>
+            !jointRepair.syntheticConnectionNames.has(route.connectionName),
+        ),
+      ),
+    })
+    const candidateDrc = evaluateRelaxedDrc({
+      inputSrj: jointRepair.params.originalSrj,
+      srjWithPointPairs: jointRepair.params.srjWithPointPairs,
+      routedTraces: preparedCandidate.routedTraces,
+      drcOptions: { traceClearance },
+    })
+    publicationDiagnostics.push({
+      candidateErrors: candidateDrc.errors,
+      accepted: jointRepair.stats.jointOutputAccepted === true,
+    })
+    diagnosticTimeMs += performance.now() - diagnosticStartedAt
+  }
+
   solver.solve()
 
   expect(solver.solved).toBeTrue()
   expect(solver.failed).toBeFalse()
-  expect(
-    solver.pipeline9JointDrcRepairSolver?.stats
-      .regionalB01RepairPreloadEligibleDrcIssueCount,
-  ).toBe(1)
   const { errors } = evaluateRelaxedDrc({
     inputSrj: scenario,
     srjWithPointPairs: solver.srjWithPointPairs!,
     routedTraces: solver.getOutputSimplifiedPcbTraces(),
   })
+  console.log(
+    JSON.stringify({
+      dataset: "srj23",
+      sample: 21,
+      finalErrors: errors,
+      publicationDiagnostics,
+      diagnosticTimeMs,
+      pipelineTimingIncludesDiagnosticOverhead: true,
+      jointRepairStats: solver.pipeline9JointDrcRepairSolver?.stats,
+    }),
+  )
+  expect(publicationDiagnostics).toHaveLength(1)
+  expect(
+    solver.pipeline9JointDrcRepairSolver?.stats
+      .regionalB01RepairPreloadEligibleDrcIssueCount,
+  ).toBe(1)
   expect(errors.length).toBeLessThanOrEqual(1)
   expect(errors.every((error) => error.type === "pcb_trace_error")).toBeTrue()
 })

--- a/tests/features/pipeline9-srj23-sample21-regional-b01-repair.test.ts
+++ b/tests/features/pipeline9-srj23-sample21-regional-b01-repair.test.ts
@@ -1,10 +1,6 @@
 import { expect, test } from "bun:test"
-import { createPipeline7HdRoutesToSimplifiedPcbTracesConverter } from "lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/convertPipeline7HdRoutesToSimplifiedPcbTraces"
 import { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/AutoroutingPipelineSolver9_PreloadedTraceGraph"
-import { preparePipeline9DrcRoutedTracesWithMetadata } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/preparePipeline9DrcRoutedTraces"
-import { RELAXED_DRC_OPTIONS } from "lib/testing/drcPresets"
 import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
-import type { HighDensityRoute } from "lib/types/high-density-types"
 import { loadScenarioBySampleNumber } from "../../scripts/benchmark/scenarios"
 
 test("Pipeline9 keeps the current SRJ23 regional repair residue bounded", async () => {
@@ -14,100 +10,19 @@ test("Pipeline9 keeps the current SRJ23 regional repair residue bounded", async 
     { cacheProvider: null, effort: 1 },
   )
 
-  while (
-    !solver.pipeline9JointDrcRepairSolver &&
-    !solver.solved &&
-    !solver.failed
-  ) {
-    solver.step()
-  }
-  const jointRepair = solver.pipeline9JointDrcRepairSolver
-  if (!jointRepair) {
-    throw new Error("Expected Pipeline9 joint repair before publication")
-  }
-  const publicationDiagnostics: Array<{
-    candidateErrors: ReturnType<typeof evaluateRelaxedDrc>["errors"]
-    accepted: boolean
-  }> = []
-  let diagnosticTimeMs = 0
-  const originalPublish =
-    jointRepair["publishValidatedOutput"].bind(jointRepair)
-  const convertNewRoutes =
-    createPipeline7HdRoutesToSimplifiedPcbTracesConverter({
-      connections: jointRepair.params.newConnections,
-      originalConnections: jointRepair.params.originalSrj.connections,
-      layerCount: jointRepair.params.layerCount,
-      obstacles: jointRepair.params.obstacles,
-      defaultViaHoleDiameter: jointRepair.params.defaultViaHoleDiameter,
-      connMap: jointRepair.params.connMap,
-    })
-  const traceClearance =
-    jointRepair.params.originalSrj.minTraceToPadEdgeClearance ??
-    RELAXED_DRC_OPTIONS.traceClearance ??
-    0.1
-  // Observe this one real proposal without changing candidate generation or
-  // acceptance. Rebuild every fixed span before the diagnostic official check.
-  jointRepair["publishValidatedOutput"] = (
-    routes: HighDensityRoute[],
-  ): void => {
-    originalPublish(routes)
-    const diagnosticStartedAt = performance.now()
-    const changedPreloadedTraceIds = new Set([
-      ...jointRepair.params.mutatedPreloadedTraceIds,
-      ...jointRepair.movablePreloadedSections.map(
-        (section) => section.originalTrace.pcb_trace_id,
-      ),
-    ])
-    const preparedCandidate = preparePipeline9DrcRoutedTracesWithMetadata({
-      originalPreloadedTraces: jointRepair.params.originalSrj.traces ?? [],
-      mutatedPreloadedTraces: jointRepair["rebuildUpdatedPreloadedTraces"](
-        routes,
-      ).filter((trace) => changedPreloadedTraceIds.has(trace.pcb_trace_id)),
-      newTraces: convertNewRoutes(
-        routes.filter(
-          (route) =>
-            !jointRepair.syntheticConnectionNames.has(route.connectionName),
-        ),
-      ),
-    })
-    const candidateDrc = evaluateRelaxedDrc({
-      inputSrj: jointRepair.params.originalSrj,
-      srjWithPointPairs: jointRepair.params.srjWithPointPairs,
-      routedTraces: preparedCandidate.routedTraces,
-      drcOptions: { traceClearance },
-    })
-    publicationDiagnostics.push({
-      candidateErrors: candidateDrc.errors,
-      accepted: jointRepair.stats.jointOutputAccepted === true,
-    })
-    diagnosticTimeMs += performance.now() - diagnosticStartedAt
-  }
-
   solver.solve()
 
   expect(solver.solved).toBeTrue()
   expect(solver.failed).toBeFalse()
+  expect(
+    solver.pipeline9JointDrcRepairSolver?.stats
+      .regionalB01RepairPreloadEligibleDrcIssueCount,
+  ).toBe(1)
   const { errors } = evaluateRelaxedDrc({
     inputSrj: scenario,
     srjWithPointPairs: solver.srjWithPointPairs!,
     routedTraces: solver.getOutputSimplifiedPcbTraces(),
   })
-  console.log(
-    JSON.stringify({
-      dataset: "srj23",
-      sample: 21,
-      finalErrors: errors,
-      publicationDiagnostics,
-      diagnosticTimeMs,
-      pipelineTimingIncludesDiagnosticOverhead: true,
-      jointRepairStats: solver.pipeline9JointDrcRepairSolver?.stats,
-    }),
-  )
-  expect(publicationDiagnostics).toHaveLength(1)
-  expect(
-    solver.pipeline9JointDrcRepairSolver?.stats
-      .regionalB01RepairPreloadEligibleDrcIssueCount,
-  ).toBe(1)
   expect(errors.length).toBeLessThanOrEqual(1)
   expect(errors.every((error) => error.type === "pcb_trace_error")).toBeTrue()
 })

--- a/tests/features/pipeline9-srj23-sample26-stitch-plated-hole.test.ts
+++ b/tests/features/pipeline9-srj23-sample26-stitch-plated-hole.test.ts
@@ -1,0 +1,254 @@
+import { expect, test } from "bun:test"
+import { convertPipeline7HdRoutesToSimplifiedPcbTraces } from "lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/convertPipeline7HdRoutesToSimplifiedPcbTraces"
+import { assignUniquePcbTraceIdsToNewTraces } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/assignUniquePcbTraceIdsToNewTraces"
+import { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/AutoroutingPipelineSolver9_PreloadedTraceGraph"
+import { preparePipeline9DrcRoutedTraces } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/preparePipeline9DrcRoutedTraces"
+import {
+  evaluateRelaxedDrc,
+  type EvaluateRelaxedDrcResult,
+} from "lib/testing/evaluate-relaxed-drc"
+import type { SimpleRouteConnection, SimplifiedPcbTrace } from "lib/types"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+import { loadScenarioBySampleNumber } from "../../scripts/benchmark/scenarios"
+
+type DrcError = EvaluateRelaxedDrcResult["errors"][number]
+type StageObservation = {
+  stage: string
+  drcCount: number
+  platedHoleContactCount: number
+  solverStageTimeMs: number
+  diagnosticTimeMs: number
+}
+
+const isPlatedHoleContact = (error: DrcError): boolean => {
+  // Match the benchmark's error-kind classification, not diagnostic ID text.
+  return (
+    error.type === "pcb_trace_error" &&
+    error.message.includes("overlaps with pcb_plated_hole") &&
+    error.message.includes("accidental contact")
+  )
+}
+
+test("Pipeline9 SRJ23 sample26 does not introduce a plated-hole contact after stitching", async (): Promise<void> => {
+  const { scenario } = await loadScenarioBySampleNumber("srj23", 26)
+  const solver = new AutoroutingPipelineSolver9_PreloadedTraceGraph(
+    structuredClone(scenario),
+    { cacheProvider: null, effort: 1 },
+  )
+  const terminalIds: string[] = ["pcb_port_76", "pcb_port_96"]
+  const observations: StageObservation[] = []
+  const originalPreloadedTraces: SimplifiedPcbTrace[] = scenario.traces ?? []
+  let solverStageTimeMs: number = 0
+  let totalSolverTimeMs: number = 0
+  let totalDiagnosticTimeMs: number = 0
+
+  const getTargetConnection = (): SimpleRouteConnection => {
+    const connection = solver.netToPointPairsSolver!.newConnections.find(
+      (candidate): boolean =>
+        terminalIds.every((terminalId): boolean =>
+          candidate.pointsToConnect.some(
+            (point): boolean =>
+              point.pcb_port_id === terminalId ||
+              point.pointId === terminalId,
+          ),
+        ),
+    )
+    if (!connection) {
+      throw new Error("Sample26 must retain the pcb_port_76/96 point pair")
+    }
+    return connection
+  }
+
+  const observeOutput = (
+    stage: string,
+    hdRoutes: HighDensityRoute[],
+    finalTraces?: SimplifiedPcbTrace[],
+  ): EvaluateRelaxedDrcResult => {
+    const diagnosticStart = performance.now()
+    const targetConnection = getTargetConnection()
+    const routedTraces =
+      finalTraces ??
+      preparePipeline9DrcRoutedTraces({
+        originalPreloadedTraces,
+        mutatedPreloadedTraces: solver.getMutatedPreloadedTraces(),
+        newTraces: assignUniquePcbTraceIdsToNewTraces(
+          convertPipeline7HdRoutesToSimplifiedPcbTraces({
+            connections: solver.netToPointPairsSolver!.newConnections,
+            originalConnections: solver.originalSrj.connections,
+            hdRoutes,
+            layerCount: solver.srj.layerCount,
+            obstacles: solver.srj.obstacles,
+            defaultViaHoleDiameter: solver.viaHoleDiameter,
+            connMap: solver.connMap,
+          }),
+          originalPreloadedTraces,
+        ),
+      })
+    const result = evaluateRelaxedDrc({
+      inputSrj: scenario,
+      srjWithPointPairs: solver.srjWithPointPairs!,
+      routedTraces,
+    })
+    const targetTraces = routedTraces.filter((trace): boolean =>
+      terminalIds.every(
+        (terminalId): boolean =>
+          trace.connectsTo?.includes(terminalId) === true,
+      ),
+    )
+    const diagnosticTraceIds = new Set<string>(
+      targetTraces.map((trace): string => trace.pcb_trace_id),
+    )
+    for (const error of result.errors) {
+      if ("pcb_trace_id" in error && typeof error.pcb_trace_id === "string") {
+        diagnosticTraceIds.add(error.pcb_trace_id)
+      }
+    }
+    const platedHoleContactCount = result.errors.filter(
+      isPlatedHoleContact,
+    ).length
+    console.info(
+      JSON.stringify({
+        diagnostic: "pipeline9-srj23-sample26-stage-drc",
+        stage,
+        context: finalTraces
+          ? "official-final-output"
+          : "public-output-reconstruction-with-current-preloads",
+        drcCount: result.errors.length,
+        platedHoleContactCount,
+        errors: result.errors,
+        errorsWithCenters: result.errorsWithCenters,
+        targetConnection,
+        targetHdRoutes: hdRoutes.filter(
+          (route): boolean => route.connectionName === targetConnection.name,
+        ),
+        targetTraces,
+        relevantCircuitElements: result.circuitJson.filter(
+          (element): boolean => {
+            if (element.type === "pcb_trace") {
+              return diagnosticTraceIds.has(element.pcb_trace_id)
+            }
+            if (element.type === "pcb_plated_hole") {
+              return element.pcb_plated_hole_id === "pcb_plated_hole_24"
+            }
+            return (
+              element.type === "pcb_smtpad" &&
+              element.pcb_smtpad_id === "pcb_smtpad_38"
+            )
+          },
+        ),
+        jointStats: solver.pipeline9JointDrcRepairSolver?.stats,
+        inheritedStats: solver.pipeline9InheritedDrcRepairSolver?.stats,
+      }),
+    )
+    const diagnosticTimeMs = performance.now() - diagnosticStart
+    totalDiagnosticTimeMs += diagnosticTimeMs
+    observations.push({
+      stage,
+      drcCount: result.errors.length,
+      platedHoleContactCount,
+      solverStageTimeMs,
+      diagnosticTimeMs,
+    })
+    return result
+  }
+
+  // Advance one real pipeline only. Diagnostic conversion/checking is outside
+  // the timed steps and never supplies geometry back to a routing stage.
+  while (!solver.solved && !solver.failed) {
+    const stage = solver.getCurrentPhase()
+    const stepStart = performance.now()
+    solver.step()
+    const stepTimeMs = performance.now() - stepStart
+    solverStageTimeMs += stepTimeMs
+    totalSolverTimeMs += stepTimeMs
+    if (solver.getCurrentPhase() === stage) continue
+
+    switch (stage) {
+      case "highDensityRepairSolver": {
+        const diagnosticStart = performance.now()
+        const targetConnection = getTargetConnection()
+        // These are unstitched fragments, not complete terminal-to-terminal
+        // traces. Do not convert each fragment into a fabricated full trace.
+        console.info(
+          JSON.stringify({
+            diagnostic: "pipeline9-srj23-sample26-pre-stitch-geometry",
+            stage,
+            targetConnection,
+            targetHdFragments: solver.highDensityRepairSolver!
+              .getOutput()
+              .filter(
+                (route): boolean =>
+                  route.connectionName === targetConnection.name,
+              ),
+            solverStageTimeMs,
+          }),
+        )
+        totalDiagnosticTimeMs += performance.now() - diagnosticStart
+        break
+      }
+      case "highDensityStitchSolver":
+        observeOutput(stage, solver.highDensityStitchSolver!.mergedHdRoutes)
+        break
+      case "traceSimplificationSolver":
+      case "mutatedPreloadedTraceSimplificationSolver":
+        observeOutput(
+          stage,
+          solver.traceSimplificationSolver!.simplifiedHdRoutes,
+        )
+        break
+      case "traceWidthSolver":
+        observeOutput(stage, solver.traceWidthSolver!.getHdRoutesWithWidths())
+        break
+      case "globalDrcForceImproveSolver":
+        observeOutput(stage, solver.globalDrcForceImproveSolver!.getOutput())
+        break
+      case "pipeline9JointDrcRepairSolver":
+        observeOutput(stage, solver.pipeline9JointDrcRepairSolver!.getOutput())
+        break
+      case "pipeline9InheritedDrcRepairSolver":
+        observeOutput(
+          stage,
+          solver.pipeline9InheritedDrcRepairSolver!.getOutput(),
+        )
+        break
+      case "lengthMatchingPostProcessingSolver":
+        observeOutput(stage, solver._getOutputHdRoutes())
+        break
+    }
+    solverStageTimeMs = 0
+  }
+
+  expect(solver.failed).toBeFalse()
+  expect(solver.solved).toBeTrue()
+  const finalResult = observeOutput(
+    "final",
+    solver._getOutputHdRoutes(),
+    solver.getOutputSimplifiedPcbTraces(),
+  )
+  console.info(
+    JSON.stringify({
+      diagnostic: "pipeline9-srj23-sample26-stage-summary",
+      observations,
+      firstOfficialCheckpointWithPlatedHoleContact: observations.find(
+        (observation): boolean => observation.platedHoleContactCount > 0,
+      )?.stage,
+      totalSolverTimeMs,
+      totalDiagnosticTimeMs,
+    }),
+  )
+  expect(observations.map((observation): string => observation.stage)).toEqual([
+    "highDensityStitchSolver",
+    "traceSimplificationSolver",
+    "mutatedPreloadedTraceSimplificationSolver",
+    "traceWidthSolver",
+    "globalDrcForceImproveSolver",
+    "pipeline9JointDrcRepairSolver",
+    "pipeline9InheritedDrcRepairSolver",
+    "lengthMatchingPostProcessingSolver",
+    "final",
+  ])
+  // The matched main benchmark has one pad-clearance error, no plated-hole
+  // contact. Keep both assertions even if the diagnostic experiment regresses.
+  expect(finalResult.errors.length).toBeLessThanOrEqual(1)
+  expect(finalResult.errors.filter(isPlatedHoleContact)).toHaveLength(0)
+})

--- a/tests/features/pipeline9-srj23-sample26-stitch-plated-hole.test.ts
+++ b/tests/features/pipeline9-srj23-sample26-stitch-plated-hole.test.ts
@@ -48,8 +48,7 @@ test("Pipeline9 SRJ23 sample26 does not introduce a plated-hole contact after st
         terminalIds.every((terminalId): boolean =>
           candidate.pointsToConnect.some(
             (point): boolean =>
-              point.pcb_port_id === terminalId ||
-              point.pointId === terminalId,
+              point.pcb_port_id === terminalId || point.pointId === terminalId,
           ),
         ),
     )
@@ -103,9 +102,8 @@ test("Pipeline9 SRJ23 sample26 does not introduce a plated-hole contact after st
         diagnosticTraceIds.add(error.pcb_trace_id)
       }
     }
-    const platedHoleContactCount = result.errors.filter(
-      isPlatedHoleContact,
-    ).length
+    const platedHoleContactCount =
+      result.errors.filter(isPlatedHoleContact).length
     console.info(
       JSON.stringify({
         diagnostic: "pipeline9-srj23-sample26-stage-drc",
@@ -174,8 +172,8 @@ test("Pipeline9 SRJ23 sample26 does not introduce a plated-hole contact after st
             diagnostic: "pipeline9-srj23-sample26-pre-stitch-geometry",
             stage,
             targetConnection,
-            targetHdFragments: solver.highDensityRepairSolver!
-              .getOutput()
+            targetHdFragments: solver
+              .highDensityRepairSolver!.getOutput()
               .filter(
                 (route): boolean =>
                   route.connectionName === targetConnection.name,

--- a/tests/features/pipeline9-srj23-sample45-stitch-completion.test.ts
+++ b/tests/features/pipeline9-srj23-sample45-stitch-completion.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/AutoroutingPipelineSolver9_PreloadedTraceGraph"
+import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
+import { loadScenarioBySampleNumber } from "../../scripts/benchmark/scenarios"
+
+test("Pipeline9 preserves SRJ23 sample45's completed DRC-clean preloaded path", async (): Promise<void> => {
+  // Main completes this benchmark ordinal with zero relaxed DRC findings.
+  const { scenario } = await loadScenarioBySampleNumber("srj23", 45)
+  const solver = new AutoroutingPipelineSolver9_PreloadedTraceGraph(
+    structuredClone(scenario),
+    { cacheProvider: null, effort: 1 },
+  )
+
+  solver.solve()
+
+  expect(solver.solved).toBeTrue()
+  expect(solver.failed).toBeFalse()
+  const finalDrc = evaluateRelaxedDrc({
+    inputSrj: scenario,
+    srjWithPointPairs: solver.srjWithPointPairs!,
+    routedTraces: solver.getOutputSimplifiedPcbTraces(),
+  })
+  expect(finalDrc.errors).toEqual([])
+})

--- a/tests/features/pipeline9-srj23-sample49-inherited-copper-repair.test.ts
+++ b/tests/features/pipeline9-srj23-sample49-inherited-copper-repair.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/AutoroutingPipelineSolver9_PreloadedTraceGraph"
+import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
+import { loadScenarioBySampleNumber } from "../../scripts/benchmark/scenarios"
+
+test("Pipeline9 reduces inherited copper DRCs on SRJ23 benchmark sample 49", async (): Promise<void> => {
+  // Use the benchmark's sorted sample ordinal, not an assumed circuit filename.
+  const { scenario } = await loadScenarioBySampleNumber("srj23", 49)
+  const baseline = evaluateRelaxedDrc({
+    inputSrj: scenario,
+    srjWithPointPairs: scenario,
+    routedTraces: [],
+  })
+  expect(baseline.errors).toHaveLength(2)
+  expect(
+    baseline.errors.every(
+      (error) => error.type === "pcb_pad_trace_clearance_error",
+    ),
+  ).toBeTrue()
+  const solver = new AutoroutingPipelineSolver9_PreloadedTraceGraph(
+    structuredClone(scenario),
+    { cacheProvider: null, effort: 1 },
+  )
+
+  solver.solve()
+
+  expect(solver.solved).toBeTrue()
+  expect(solver.failed).toBeFalse()
+  const jointRepair = solver.pipeline9JointDrcRepairSolver
+  expect(jointRepair).toBeDefined()
+  expect(Number(jointRepair?.stats.movablePreloadedTraceCount)).toBeGreaterThan(
+    0,
+  )
+  expect(jointRepair?.stats.exactRepairConfiguredMaxIterations).toBe(32)
+  expect(jointRepair?.stats.exactRepairConfiguredViaInPadMaxIterations).toBe(32)
+  expect(jointRepair?.stats.exactRepairConfiguredBroadMaxIterations).toBe(12)
+  const finalDrc = evaluateRelaxedDrc({
+    inputSrj: scenario,
+    srjWithPointPairs: solver.srjWithPointPairs!,
+    routedTraces: solver.getOutputSimplifiedPcbTraces(),
+  })
+  console.log(
+    JSON.stringify({
+      dataset: "srj23",
+      sample: 49,
+      baselineErrors: baseline.errors,
+      finalErrors: finalDrc.errors,
+      jointRepairStats: jointRepair?.stats,
+    }),
+  )
+  expect(finalDrc.errors.length).toBeLessThan(baseline.errors.length)
+})

--- a/tests/features/pipeline9-srj23-sample49-inherited-copper-repair.test.ts
+++ b/tests/features/pipeline9-srj23-sample49-inherited-copper-repair.test.ts
@@ -26,7 +26,7 @@ test("Pipeline9 reduces inherited copper DRCs on SRJ23 benchmark sample 49", asy
 
   expect(solver.solved).toBeTrue()
   expect(solver.failed).toBeFalse()
-  const jointRepair = solver.pipeline9JointDrcRepairSolver
+  const jointRepair = solver.pipeline9InheritedDrcRepairSolver
   expect(jointRepair).toBeDefined()
   expect(Number(jointRepair?.stats.movablePreloadedTraceCount)).toBeGreaterThan(
     0,

--- a/tests/fixtures/create-pipeline9-inherited-pad-clearance-fixture.ts
+++ b/tests/fixtures/create-pipeline9-inherited-pad-clearance-fixture.ts
@@ -1,4 +1,4 @@
-import { Pipeline9JointDrcRepairSolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver"
+import { Pipeline9InheritedDrcRepairSolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9InheritedDrcRepairSolver"
 import type { Obstacle, SimpleRouteJson, SimplifiedPcbTrace } from "lib/types"
 import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
 
@@ -6,7 +6,7 @@ type InheritedPadClearanceFixture = {
   srj: SimpleRouteJson
   originalSrj: SimpleRouteJson
   trace: SimplifiedPcbTrace
-  solver: Pipeline9JointDrcRepairSolver
+  solver: Pipeline9InheritedDrcRepairSolver
 }
 
 export const createPipeline9InheritedPadClearanceFixture = (
@@ -150,7 +150,7 @@ export const createPipeline9InheritedPadClearanceFixture = (
     traces: [trace],
   }
   const originalSrj = structuredClone(srj)
-  const solver = new Pipeline9JointDrcRepairSolver({
+  const solver = new Pipeline9InheritedDrcRepairSolver({
     srj,
     srjWithPointPairs: srj,
     originalSrj: srj,

--- a/tests/fixtures/create-pipeline9-inherited-pad-clearance-fixture.ts
+++ b/tests/fixtures/create-pipeline9-inherited-pad-clearance-fixture.ts
@@ -103,14 +103,19 @@ export const createPipeline9InheritedPadClearanceFixture = (
     },
   ]
   if (includeThroughObstacle) {
+    // This compound start pad contains its declared terminal and the whole
+    // protected span; a net-name-only obstacle has no physical port in DRC.
     obstacles.push({
       type: "rect",
-      center: { x: -2.5, y: routeY },
-      width: 1,
+      center: { x: -3, y: routeY },
+      width: 2.5,
       height: 0.5,
       layers: ["top"],
-      connectedTo: ["preloaded"],
-      circuitJsonMetadata: { pcb_smtpad_id: "pad_through" },
+      connectedTo: ["preloaded_start"],
+      circuitJsonMetadata: {
+        pcb_smtpad_id: "pad_through",
+        pcb_port_id: "preloaded_start",
+      },
     })
   }
   const srj: SimpleRouteJson = {

--- a/tests/fixtures/create-pipeline9-inherited-pad-clearance-fixture.ts
+++ b/tests/fixtures/create-pipeline9-inherited-pad-clearance-fixture.ts
@@ -1,0 +1,165 @@
+import { Pipeline9JointDrcRepairSolver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9JointDrcRepairSolver"
+import type { Obstacle, SimpleRouteJson, SimplifiedPcbTrace } from "lib/types"
+import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
+
+type InheritedPadClearanceFixture = {
+  srj: SimpleRouteJson
+  originalSrj: SimpleRouteJson
+  trace: SimplifiedPcbTrace
+  solver: Pipeline9JointDrcRepairSolver
+}
+
+export const createPipeline9InheritedPadClearanceFixture = (
+  includeThroughObstacle = false,
+): InheritedPadClearanceFixture => {
+  const routeY = -0.34
+  const startX = includeThroughObstacle ? -4 : -2
+  const trace: SimplifiedPcbTrace = {
+    type: "pcb_trace",
+    pcb_trace_id: "inherited_trace",
+    connection_name: "preloaded",
+    connectsTo: ["preloaded_start", "preloaded_end"],
+    route: [
+      {
+        route_type: "wire",
+        x: startX,
+        y: routeY,
+        width: 0.1,
+        layer: "top",
+        start_pcb_port_id: "preloaded_start",
+      },
+      ...(includeThroughObstacle
+        ? ([
+            {
+              route_type: "wire",
+              x: -3,
+              y: routeY,
+              width: 0.1,
+              layer: "top",
+            },
+            {
+              route_type: "through_obstacle",
+              start: { x: -3, y: routeY },
+              end: { x: -2, y: routeY },
+              from_layer: "top",
+              to_layer: "top",
+              width: 0.1,
+              circuitJsonMetadata: { pcb_smtpad_id: "pad_through" },
+            },
+            {
+              route_type: "wire",
+              x: -2,
+              y: routeY,
+              width: 0.1,
+              layer: "top",
+            },
+          ] satisfies SimplifiedPcbTrace["route"])
+        : []),
+      { route_type: "wire", x: -0.6, y: routeY, width: 0.1, layer: "top" },
+      { route_type: "wire", x: 0.6, y: routeY, width: 0.1, layer: "top" },
+      {
+        route_type: "wire",
+        x: 2,
+        y: routeY,
+        width: 0.1,
+        layer: "top",
+        end_pcb_port_id: "preloaded_end",
+      },
+    ],
+  }
+  const obstacles: Obstacle[] = [
+    {
+      type: "rect",
+      center: { x: startX, y: routeY },
+      width: 0.5,
+      height: 0.5,
+      layers: ["top"],
+      connectedTo: ["preloaded_start"],
+      circuitJsonMetadata: {
+        pcb_smtpad_id: "pad_start",
+        pcb_port_id: "preloaded_start",
+      },
+    },
+    {
+      type: "rect",
+      center: { x: 2, y: routeY },
+      width: 0.5,
+      height: 0.5,
+      layers: ["top"],
+      connectedTo: ["preloaded_end"],
+      circuitJsonMetadata: {
+        pcb_smtpad_id: "pad_end",
+        pcb_port_id: "preloaded_end",
+      },
+    },
+    {
+      type: "rect",
+      center: { x: 0, y: 0 },
+      width: 0.5,
+      height: 0.5,
+      layers: ["top"],
+      connectedTo: ["foreign_net"],
+      circuitJsonMetadata: { pcb_smtpad_id: "pad_foreign" },
+    },
+  ]
+  if (includeThroughObstacle) {
+    obstacles.push({
+      type: "rect",
+      center: { x: -2.5, y: routeY },
+      width: 1,
+      height: 0.5,
+      layers: ["top"],
+      connectedTo: ["preloaded"],
+      circuitJsonMetadata: { pcb_smtpad_id: "pad_through" },
+    })
+  }
+  const srj: SimpleRouteJson = {
+    layerCount: 2,
+    minTraceWidth: 0.1,
+    minTraceToPadEdgeClearance: 0.1,
+    minViaDiameter: 0.3,
+    minViaHoleDiameter: 0.15,
+    bounds: { minX: startX - 1, minY: -2, maxX: 3, maxY: 2 },
+    obstacles,
+    connections: [
+      {
+        name: "preloaded",
+        pointsToConnect: [
+          {
+            x: startX,
+            y: routeY,
+            layer: "top",
+            pointId: "preloaded_start",
+            pcb_port_id: "preloaded_start",
+          },
+          {
+            x: 2,
+            y: routeY,
+            layer: "top",
+            pointId: "preloaded_end",
+            pcb_port_id: "preloaded_end",
+          },
+        ],
+      },
+    ],
+    traces: [trace],
+  }
+  const originalSrj = structuredClone(srj)
+  const solver = new Pipeline9JointDrcRepairSolver({
+    srj,
+    srjWithPointPairs: srj,
+    originalSrj: srj,
+    newConnections: [],
+    newHdRoutes: [],
+    updatedPreloadedTraces: [trace],
+    mutatedPreloadedTraceIds: new Set(),
+    connMap: getConnectivityMapFromSimpleRouteJson(srj),
+    obstacles,
+    layerCount: 2,
+    defaultViaDiameter: 0.3,
+    defaultViaHoleDiameter: 0.15,
+    effort: 1,
+    colorMap: {},
+  })
+  return { srj, originalSrj, trace, solver }
+}

--- a/tests/stitch-solver/anonymous-terminal-adjacency.test.ts
+++ b/tests/stitch-solver/anonymous-terminal-adjacency.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test"
+import { MultipleHighDensityRouteStitchSolver3 } from "lib/solvers/RouteStitchingSolver/MultipleHighDensityRouteStitchSolver3"
+import type { HighDensityIntraNodeRoute } from "lib/types/high-density-types"
+
+test("a terminal claim does not force traversal of a spur beside anonymous connected copper", (): void => {
+  const points: HighDensityIntraNodeRoute["route"] = [
+    { x: 0, y: 0, z: 0 },
+    { x: 1, y: 0, z: 0 },
+    { x: 2, y: 0, z: 0 },
+    { x: 3, y: 0, z: 0 },
+  ]
+  const chain = points.slice(0, -1).map(
+    (point, index): HighDensityIntraNodeRoute => ({
+      connectionName: "terminal-adjacency-net",
+      ...(index === 2 ? { endPcbPortId: "end-port" } : {}),
+      traceThickness: 0.15,
+      viaDiameter: 0.3,
+      route: [point, points[index + 1]!],
+      vias: [],
+    }),
+  )
+  const taggedSpur: HighDensityIntraNodeRoute = {
+    connectionName: "terminal-adjacency-net",
+    startPcbPortId: "start-port",
+    traceThickness: 0.15,
+    viaDiameter: 0.3,
+    route: [points[0]!, { x: 0, y: 1, z: 0 }],
+    vias: [],
+  }
+  const hdRoutes = [taggedSpur, ...chain]
+  const inputSnapshot = structuredClone(hdRoutes)
+  const solver = new MultipleHighDensityRouteStitchSolver3({
+    connections: [
+      {
+        name: taggedSpur.connectionName,
+        pointsToConnect: [
+          { x: 0, y: 0, layer: "top", pcb_port_id: "start-port" },
+          { x: 3, y: 0, layer: "top", pcb_port_id: "end-port" },
+        ],
+      },
+    ],
+    hdRoutes,
+    layerCount: 2,
+    preserveTerminalPcbPortIds: true,
+    allowedLayerTransitionPointKeys: new Set<string>(),
+  })
+  expect(solver.unsolvedRoutes).toHaveLength(1)
+  const selected = solver.unsolvedRoutes[0]!
+  expect(selected.hdRoutes).toHaveLength(3)
+  expect(selected.hdRoutes).not.toContain(taggedSpur)
+  expect(new Set(selected.hdRoutes).size).toBe(selected.hdRoutes.length)
+  solver.solve()
+
+  expect(solver.failed).toBe(false)
+  expect(solver.solved).toBe(true)
+  expect(solver.mergedHdRoutes).toHaveLength(1)
+  const merged = solver.mergedHdRoutes[0]!
+  const startsAtStart = merged.startPcbPortId === "start-port"
+  expect(merged.endPcbPortId).toBe(startsAtStart ? "end-port" : "start-port")
+  expect(merged.route).toEqual(startsAtStart ? points : [...points].reverse())
+  expect(merged.vias).toEqual([])
+  expect(hdRoutes).toEqual(inputSnapshot)
+})

--- a/tests/stitch-solver/claimed-island-terminal-layer-guard.test.ts
+++ b/tests/stitch-solver/claimed-island-terminal-layer-guard.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test"
+import { MultipleHighDensityRouteStitchSolver3 } from "lib/solvers/RouteStitchingSolver/MultipleHighDensityRouteStitchSolver3"
+import type { HighDensityIntraNodeRoute } from "lib/types/high-density-types"
+
+test("an explicit PCB terminal claim cannot be downgraded to an anonymous opposite-layer boundary", (): void => {
+  const route: HighDensityIntraNodeRoute = {
+    connectionName: "claimed-net",
+    startPcbPortId: "start-port",
+    endPcbPortId: "end-port",
+    traceThickness: 0.15,
+    viaDiameter: 0.3,
+    route: [
+      { x: 0, y: 0, z: 1 },
+      { x: 1, y: 0, z: 1 },
+      { x: 1, y: 0, z: 0 },
+      { x: 2.4, y: 0, z: 0 },
+    ],
+    vias: [{ x: 1, y: 0 }],
+  }
+  const inputSnapshot = structuredClone(route)
+  const solver = new MultipleHighDensityRouteStitchSolver3({
+    connections: [
+      {
+        name: route.connectionName,
+        pointsToConnect: [
+          { x: 0, y: 0, layer: "bottom", pcb_port_id: "start-port" },
+          { x: 3, y: 0, layer: "bottom", pcb_port_id: "end-port" },
+        ],
+      },
+    ],
+    hdRoutes: [route],
+    layerCount: 2,
+    preserveTerminalPcbPortIds: true,
+  })
+  solver.solve()
+
+  expect(solver.solved).toBe(false)
+  expect(solver.failed).toBe(true)
+  expect(solver.error).toContain("terminal layer 1")
+  expect(solver.mergedHdRoutes).toEqual([])
+  expect(solver.activeSolver!.end).toMatchObject({
+    x: 3,
+    y: 0,
+    z: 1,
+    pcb_port_id: "end-port",
+  })
+  expect(solver.activeSolver!.mergedHdRoute.endPcbPortId).toBe("end-port")
+  expect(route).toEqual(inputSnapshot)
+})

--- a/tests/stitch-solver/clear-terminal-approach-path.test.ts
+++ b/tests/stitch-solver/clear-terminal-approach-path.test.ts
@@ -104,9 +104,7 @@ test("terminal path selection skips a blocked nearest approach for a clear exist
     expect(merged.startPcbPortId).toBe(
       startsAtStart ? "start-port" : "end-port",
     )
-    expect(merged.endPcbPortId).toBe(
-      startsAtStart ? "end-port" : "start-port",
-    )
+    expect(merged.endPcbPortId).toBe(startsAtStart ? "end-port" : "start-port")
     expect(merged.route).toEqual(
       startsAtStart ? completePoints : [...completePoints].reverse(),
     )

--- a/tests/stitch-solver/clear-terminal-approach-path.test.ts
+++ b/tests/stitch-solver/clear-terminal-approach-path.test.ts
@@ -1,0 +1,137 @@
+import { expect, test } from "bun:test"
+import { MultipleHighDensityRouteStitchSolver3 } from "lib/solvers/RouteStitchingSolver/MultipleHighDensityRouteStitchSolver3"
+import type { SimpleRouteConnection } from "lib/types"
+import type { HighDensityIntraNodeRoute } from "lib/types/high-density-types"
+
+type RoutePoint = HighDensityIntraNodeRoute["route"][number]
+
+test("terminal path selection skips a blocked nearest approach for a clear existing path", (): void => {
+  const alternatePoints: RoutePoint[] = [
+    { x: 0, y: 0.6, z: 0 },
+    { x: 0, y: 2, z: 0 },
+    { x: 4, y: 2, z: 0 },
+    { x: 4, y: 0, z: 0 },
+  ]
+  const shortRoute: HighDensityIntraNodeRoute = {
+    connectionName: "approach-net",
+    endPcbPortId: "end-port",
+    traceThickness: 0.15,
+    viaDiameter: 0.3,
+    route: [
+      { x: 0.5, y: 0, z: 0 },
+      { x: 4, y: 0, z: 0 },
+    ],
+    vias: [],
+  }
+  const alternateRoutes = alternatePoints.slice(0, -1).map(
+    (point, index): HighDensityIntraNodeRoute => ({
+      connectionName: shortRoute.connectionName,
+      ...(index === alternatePoints.length - 2
+        ? { endPcbPortId: "end-port" }
+        : {}),
+      traceThickness: shortRoute.traceThickness,
+      viaDiameter: shortRoute.viaDiameter,
+      route: [point, alternatePoints[index + 1]!],
+      vias: [],
+    }),
+  )
+  const foreignRoute: HighDensityIntraNodeRoute = {
+    connectionName: "foreign-net",
+    startPcbPortId: "foreign-start",
+    endPcbPortId: "foreign-end",
+    traceThickness: 0.05,
+    viaDiameter: 0.3,
+    route: [
+      { x: 0.25, y: -0.2, z: 0 },
+      { x: 0.25, y: 0.2, z: 0 },
+    ],
+    vias: [],
+  }
+  const connections: SimpleRouteConnection[] = [
+    {
+      name: shortRoute.connectionName,
+      pointsToConnect: [
+        { x: 0, y: 0, layer: "top", pcb_port_id: "start-port" },
+        { x: 4, y: 0, layer: "top", pcb_port_id: "end-port" },
+      ],
+    },
+    {
+      name: foreignRoute.connectionName,
+      pointsToConnect: [
+        { x: 0.25, y: -0.2, layer: "top", pcb_port_id: "foreign-start" },
+        { x: 0.25, y: 0.2, layer: "top", pcb_port_id: "foreign-end" },
+      ],
+    },
+  ]
+  const originalRoutes = [shortRoute, foreignRoute, ...alternateRoutes]
+  const inputSnapshot = structuredClone({ originalRoutes, connections })
+  const completePoints: RoutePoint[] = [
+    { x: 0, y: 0, z: 0 },
+    ...alternatePoints,
+  ]
+
+  // The closest route endpoint is half a unit from the start, but reaching
+  // it crosses foreign copper. The slightly farther vertical approach stays
+  // clear and reaches the same terminal through three existing fragments.
+  for (const reverseInput of [false, true]) {
+    const routes = reverseInput
+      ? [...originalRoutes].reverse().map(
+          (route): HighDensityIntraNodeRoute => ({
+            ...route,
+            startPcbPortId: route.endPcbPortId,
+            endPcbPortId: route.startPcbPortId,
+            route: [...route.route].reverse(),
+          }),
+        )
+      : originalRoutes
+    const routeSnapshot = structuredClone(routes)
+    const solver = new MultipleHighDensityRouteStitchSolver3({
+      connections,
+      hdRoutes: routes,
+      layerCount: 2,
+      allowedLayerTransitionPointKeys: new Set<string>(),
+      preserveTerminalPcbPortIds: true,
+    })
+    solver.solve()
+
+    expect(solver.failed).toBe(false)
+    expect(solver.solved).toBe(true)
+    expect(solver.mergedHdRoutes).toHaveLength(2)
+    const merged = solver.mergedHdRoutes.find(
+      (route): boolean => route.connectionName === shortRoute.connectionName,
+    )!
+    const startsAtStart = merged.startPcbPortId === "start-port"
+    expect(merged.startPcbPortId).toBe(
+      startsAtStart ? "start-port" : "end-port",
+    )
+    expect(merged.endPcbPortId).toBe(
+      startsAtStart ? "end-port" : "start-port",
+    )
+    expect(merged.route).toEqual(
+      startsAtStart ? completePoints : [...completePoints].reverse(),
+    )
+    expect(merged.traceThickness).toBe(shortRoute.traceThickness)
+    expect(merged.vias).toEqual([])
+
+    const foreignMerged = solver.mergedHdRoutes.find(
+      (route): boolean => route.connectionName === foreignRoute.connectionName,
+    )!
+    const foreignStartsAtStart =
+      foreignMerged.startPcbPortId === "foreign-start"
+    expect(foreignMerged.startPcbPortId).toBe(
+      foreignStartsAtStart ? "foreign-start" : "foreign-end",
+    )
+    expect(foreignMerged.endPcbPortId).toBe(
+      foreignStartsAtStart ? "foreign-end" : "foreign-start",
+    )
+    expect(foreignMerged.route).toEqual(
+      foreignStartsAtStart
+        ? foreignRoute.route
+        : [...foreignRoute.route].reverse(),
+    )
+    expect(foreignMerged.traceThickness).toBe(foreignRoute.traceThickness)
+    expect(foreignMerged.vias).toEqual([])
+    expect(routes).toEqual(routeSnapshot)
+    expect({ originalRoutes, connections }).toEqual(inputSnapshot)
+  }
+})

--- a/tests/stitch-solver/complete-path-before-nearby-via-spur.test.ts
+++ b/tests/stitch-solver/complete-path-before-nearby-via-spur.test.ts
@@ -29,9 +29,7 @@ test("an exact terminal path wins over a nearby via shortcut requiring new gaps"
     (point, index): HighDensityIntraNodeRoute => ({
       connectionName: completeRoute.connectionName,
       ...(index === 0 ? { startPcbPortId: "start-port" } : {}),
-      ...(index === chainPoints.length - 2
-        ? { endPcbPortId: "end-port" }
-        : {}),
+      ...(index === chainPoints.length - 2 ? { endPcbPortId: "end-port" } : {}),
       traceThickness: completeRoute.traceThickness,
       viaDiameter: completeRoute.viaDiameter,
       route: [point, chainPoints[index + 1]!],
@@ -118,15 +116,15 @@ test("an exact terminal path wins over a nearby via shortcut requiring new gaps"
     expect(merged.startPcbPortId).toBe(
       startsAtStart ? "start-port" : "end-port",
     )
-    expect(merged.endPcbPortId).toBe(
-      startsAtStart ? "end-port" : "start-port",
-    )
+    expect(merged.endPcbPortId).toBe(startsAtStart ? "end-port" : "start-port")
     expect(
-      merged.route.map(({ x, y, z }): RoutePoint => ({
-        x,
-        y,
-        z,
-      })),
+      merged.route.map(
+        ({ x, y, z }): RoutePoint => ({
+          x,
+          y,
+          z,
+        }),
+      ),
     ).toEqual(expectedPoints)
     expect(merged.vias).toEqual([])
     expect(merged.traceThickness).toBe(completeRoute.traceThickness)

--- a/tests/stitch-solver/complete-path-before-nearby-via-spur.test.ts
+++ b/tests/stitch-solver/complete-path-before-nearby-via-spur.test.ts
@@ -1,0 +1,167 @@
+import { expect, test } from "bun:test"
+import { MultipleHighDensityRouteStitchSolver3 } from "lib/solvers/RouteStitchingSolver/MultipleHighDensityRouteStitchSolver3"
+import { getDrcErrors } from "lib/testing/getDrcErrors"
+import { convertToCircuitJson } from "lib/testing/utils/convertToCircuitJson"
+import type { SimpleRouteJson, SimplifiedPcbTrace } from "lib/types"
+import type { HighDensityIntraNodeRoute } from "lib/types/high-density-types"
+import { convertHdRouteToSimplifiedRoute } from "lib/utils/convertHdRouteToSimplifiedRoute"
+
+type RoutePoint = HighDensityIntraNodeRoute["route"][number]
+
+test("an exact terminal path wins over a nearby via shortcut requiring new gaps", (): void => {
+  const chainPoints: HighDensityIntraNodeRoute["route"] = [
+    { x: 0, y: 0, z: 0 },
+    { x: 0, y: 3, z: 0 },
+    { x: 3, y: 3, z: 0 },
+    { x: 6, y: 3, z: 0 },
+    { x: 6, y: 0, z: 0 },
+  ]
+  const completeRoute: HighDensityIntraNodeRoute = {
+    connectionName: "complete-path-net",
+    startPcbPortId: "start-port",
+    endPcbPortId: "end-port",
+    traceThickness: 0.15,
+    viaDiameter: 0.6,
+    route: chainPoints,
+    vias: [],
+  }
+  const chainFragments = chainPoints.slice(0, -1).map(
+    (point, index): HighDensityIntraNodeRoute => ({
+      connectionName: completeRoute.connectionName,
+      ...(index === 0 ? { startPcbPortId: "start-port" } : {}),
+      ...(index === chainPoints.length - 2
+        ? { endPcbPortId: "end-port" }
+        : {}),
+      traceThickness: completeRoute.traceThickness,
+      viaDiameter: completeRoute.viaDiameter,
+      route: [point, chainPoints[index + 1]!],
+      vias: [],
+    }),
+  )
+  const nearbyViaSpur: HighDensityIntraNodeRoute = {
+    connectionName: completeRoute.connectionName,
+    traceThickness: completeRoute.traceThickness,
+    viaDiameter: completeRoute.viaDiameter,
+    route: [
+      { x: 0.5, y: 0, z: 0 },
+      { x: 0.5, y: 0, z: 1 },
+      { x: 6, y: 0.5, z: 1 },
+      { x: 6, y: 0.5, z: 0 },
+    ],
+    vias: [
+      { x: 0.5, y: 0 },
+      { x: 6, y: 0.5 },
+    ],
+  }
+  const srj: SimpleRouteJson = {
+    layerCount: 2,
+    minTraceWidth: completeRoute.traceThickness,
+    minViaDiameter: completeRoute.viaDiameter,
+    minViaHoleDiameter: 0.3,
+    bounds: { minX: -1, maxX: 7, minY: -1, maxY: 4 },
+    obstacles: [],
+    connections: [
+      {
+        name: completeRoute.connectionName,
+        pointsToConnect: [
+          { x: 0, y: 0, layer: "top", pcb_port_id: "start-port" },
+          { x: 6, y: 0, layer: "top", pcb_port_id: "end-port" },
+        ],
+      },
+    ],
+  }
+  const srjSnapshot = structuredClone(srj)
+  const originalRoutes = [nearbyViaSpur, ...chainFragments]
+  const originalSnapshot = structuredClone(originalRoutes)
+  const completeTrace: SimplifiedPcbTrace = {
+    type: "pcb_trace",
+    pcb_trace_id: "complete-path-trace",
+    connection_name: completeRoute.connectionName,
+    route: convertHdRouteToSimplifiedRoute(completeRoute, srj.layerCount),
+  }
+  const baselineCircuitJson = convertToCircuitJson(srj, [completeTrace])
+  expect(getDrcErrors(baselineCircuitJson).errors).toEqual([])
+
+  // The existing chain has four route edges. The shortcut has only three
+  // graph edges, but two are invented gaps and its middle edge adds two vias.
+  // Comparing only graph hop counts therefore selects the wrong copper.
+  expect(chainFragments).toHaveLength(4)
+  expect(nearbyViaSpur.vias).toHaveLength(2)
+  for (const reverseInput of [false, true]) {
+    const routes = reverseInput
+      ? [...originalRoutes].reverse().map(
+          (route): HighDensityIntraNodeRoute => ({
+            ...route,
+            startPcbPortId: route.endPcbPortId,
+            endPcbPortId: route.startPcbPortId,
+            route: [...route.route].reverse(),
+          }),
+        )
+      : originalRoutes
+    const inputSnapshot = structuredClone(routes)
+    const solver = new MultipleHighDensityRouteStitchSolver3({
+      connections: srj.connections,
+      hdRoutes: routes,
+      layerCount: srj.layerCount,
+      preserveTerminalPcbPortIds: true,
+    })
+    solver.solve()
+
+    expect(solver.failed).toBe(false)
+    expect(solver.solved).toBe(true)
+    expect(solver.mergedHdRoutes).toHaveLength(1)
+    const merged = solver.mergedHdRoutes[0]!
+    const startsAtStart = merged.startPcbPortId === "start-port"
+    const expectedPoints = startsAtStart
+      ? chainPoints
+      : [...chainPoints].reverse()
+    expect(merged.startPcbPortId).toBe(
+      startsAtStart ? "start-port" : "end-port",
+    )
+    expect(merged.endPcbPortId).toBe(
+      startsAtStart ? "end-port" : "start-port",
+    )
+    expect(
+      merged.route.map(({ x, y, z }): RoutePoint => ({
+        x,
+        y,
+        z,
+      })),
+    ).toEqual(expectedPoints)
+    expect(merged.vias).toEqual([])
+    expect(merged.traceThickness).toBe(completeRoute.traceThickness)
+    for (const point of merged.route) {
+      expect(point.x).toBeGreaterThanOrEqual(srj.bounds.minX)
+      expect(point.x).toBeLessThanOrEqual(srj.bounds.maxX)
+      expect(point.y).toBeGreaterThanOrEqual(srj.bounds.minY)
+      expect(point.y).toBeLessThanOrEqual(srj.bounds.maxY)
+    }
+
+    const simplifiedRoute = convertHdRouteToSimplifiedRoute(
+      merged,
+      srj.layerCount,
+    )
+    expect(simplifiedRoute[0]).toMatchObject({
+      route_type: "wire",
+      x: expectedPoints[0]!.x,
+      y: expectedPoints[0]!.y,
+      layer: "top",
+    })
+    expect(simplifiedRoute[simplifiedRoute.length - 1]).toMatchObject({
+      route_type: "wire",
+      x: expectedPoints[expectedPoints.length - 1]!.x,
+      y: expectedPoints[expectedPoints.length - 1]!.y,
+      layer: "top",
+    })
+    const circuitJson = convertToCircuitJson(srj, [
+      { ...completeTrace, route: simplifiedRoute },
+    ])
+    expect(
+      circuitJson.filter((element): boolean => element.type === "pcb_via"),
+    ).toEqual([])
+    expect(getDrcErrors(circuitJson).errors).toEqual([])
+    expect(routes).toEqual(inputSnapshot)
+    expect(originalRoutes).toEqual(originalSnapshot)
+    expect(srj).toEqual(srjSnapshot)
+  }
+})

--- a/tests/stitch-solver/declared-multilayer-terminal-copper.test.ts
+++ b/tests/stitch-solver/declared-multilayer-terminal-copper.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test"
+import { MultipleHighDensityRouteStitchSolver3 } from "lib/solvers/RouteStitchingSolver/MultipleHighDensityRouteStitchSolver3"
+import type { HighDensityIntraNodeRoute } from "lib/types/high-density-types"
+
+test("declared multilayer terminals retain legal inner-layer copper without adding vias", (): void => {
+  const route: HighDensityIntraNodeRoute = {
+    connectionName: "plated-terminal-net",
+    startPcbPortId: "start-port",
+    endPcbPortId: "end-port",
+    traceThickness: 0.15,
+    viaDiameter: 0.3,
+    route: [
+      { x: 0, y: 0, z: 1 },
+      { x: 1, y: 0, z: 1 },
+      { x: 2, y: 0, z: 1 },
+    ],
+    vias: [],
+  }
+  const inputSnapshot = structuredClone(route)
+  const solver = new MultipleHighDensityRouteStitchSolver3({
+    connections: [
+      {
+        name: route.connectionName,
+        pointsToConnect: [
+          {
+            x: 0,
+            y: 0,
+            layers: ["top", "inner1", "bottom"],
+            pcb_port_id: "start-port",
+          },
+          {
+            x: 2,
+            y: 0,
+            layers: ["top", "inner1", "bottom"],
+            pcb_port_id: "end-port",
+          },
+        ],
+      },
+    ],
+    hdRoutes: [route],
+    layerCount: 3,
+    allowedLayerTransitionPointKeys: new Set(),
+    preserveTerminalPcbPortIds: true,
+  })
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(solver.mergedHdRoutes).toHaveLength(1)
+  expect(solver.mergedHdRoutes[0]!.route).toEqual(route.route)
+  expect(solver.mergedHdRoutes[0]!.vias).toEqual([])
+  expect(solver.mergedHdRoutes[0]!.startPcbPortId).toBe("start-port")
+  expect(solver.mergedHdRoutes[0]!.endPcbPortId).toBe("end-port")
+  expect(route).toEqual(inputSnapshot)
+})

--- a/tests/stitch-solver/empty-fragment-terminal-layers.test.ts
+++ b/tests/stitch-solver/empty-fragment-terminal-layers.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test"
+import { SingleHighDensityRouteStitchSolver3 } from "lib/solvers/RouteStitchingSolver/SingleHighDensityRouteStitchSolver3"
+
+test("empty-fragment stitching uses common declared copper and never invents terminal vias", (): void => {
+  for (const shareLayer of [true, false]) {
+    const solver = new SingleHighDensityRouteStitchSolver3({
+      connectionName: "empty-net",
+      start: {
+        x: 0,
+        y: 0,
+        z: 0,
+        availableZ: shareLayer ? [0, 1] : [0],
+      },
+      end: { x: 1, y: 0, z: 1 },
+      hdRoutes: [],
+      isStitchSegmentClear: (): boolean => true,
+      stitchClearanceMode: "require_clear",
+    })
+
+    expect(solver.solved).toBe(shareLayer)
+    expect(solver.failed).toBe(!shareLayer)
+    if (shareLayer) {
+      expect(solver.mergedHdRoute.route).toEqual([
+        { x: 0, y: 0, z: 1 },
+        { x: 1, y: 0, z: 1 },
+      ])
+      expect(solver.mergedHdRoute.vias).toEqual([])
+    } else {
+      expect(solver.error).toContain("requires an existing via")
+      expect(solver.mergedHdRoute).toBeUndefined()
+    }
+  }
+})

--- a/tests/stitch-solver/endpoint-cluster-stable-claims.test.ts
+++ b/tests/stitch-solver/endpoint-cluster-stable-claims.test.ts
@@ -78,8 +78,8 @@ test("endpoint claims preserve established cluster geometry and reject conflicti
   const inputSnapshot = structuredClone({ route, conflictingRoute })
   expect(getRouteStitchEndpoint(route, "first")).toEqual(claimedC)
   expect(getRouteStitchEndpoint(route, "last")).toEqual(claimedD)
-  expect((): StitchTerminal =>
-    getRouteStitchEndpoint(conflictingRoute, "first"),
+  expect(
+    (): StitchTerminal => getRouteStitchEndpoint(conflictingRoute, "first"),
   ).toThrow("conflicting PCB terminal identities")
   expect({ route, conflictingRoute }).toEqual(inputSnapshot)
   expect(anonymousA).toEqual({ x: 0, y: 0, z: 0 })

--- a/tests/stitch-solver/endpoint-cluster-stable-claims.test.ts
+++ b/tests/stitch-solver/endpoint-cluster-stable-claims.test.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "bun:test"
+import { getRouteStitchEndpoint } from "lib/solvers/RouteStitchingSolver/getRouteStitchEndpoint"
+import type { StitchTerminal } from "lib/solvers/RouteStitchingSolver/getStitchTerminal"
+import { EndpointClusterIndex } from "lib/solvers/RouteStitchingSolver/routeStitchingEndpointHelpers"
+import type { HighDensityIntraNodeRoute } from "lib/types/high-density-types"
+
+test("endpoint claims preserve established cluster geometry and reject conflicting route metadata", (): void => {
+  const connectionName = "stable-claim-net"
+  const anonymousA: StitchTerminal = { x: 0, y: 0, z: 0 }
+  const anonymousB: StitchTerminal = { x: -0.09, y: 0, z: 0 }
+  const claimedC: StitchTerminal = {
+    x: 0.09,
+    y: 0,
+    z: 0,
+    pcb_port_id: "port-c",
+  }
+  const claimedD: StitchTerminal = {
+    x: 0,
+    y: 0,
+    z: 0,
+    pcb_port_id: "port-d",
+  }
+  const index = new EndpointClusterIndex()
+  const originalKey = index.getEndpointKey(connectionName, anonymousA)
+  expect(index.getEndpointKey(connectionName, anonymousB)).toBe(originalKey)
+  expect(index.getEndpointKey(connectionName, claimedC)).toBe(originalKey)
+  expect(index.getClusters(connectionName)).toEqual([
+    {
+      key: originalKey,
+      point: { x: 0, y: 0, z: 0, pcb_port_id: "port-c" },
+    },
+  ])
+  expect(index.getEndpointKey(connectionName, anonymousA)).toBe(originalKey)
+  expect(index.getEndpointKey(connectionName, anonymousB)).toBe(originalKey)
+
+  const distinctKey = index.getEndpointKey(connectionName, claimedD)
+  expect(distinctKey).not.toBe(originalKey)
+  expect(index.getEndpointKey(connectionName, claimedD)).toBe(distinctKey)
+  expect(index.getEndpointKey(connectionName, claimedC)).toBe(originalKey)
+  expect(index.getEndpointKey(connectionName, anonymousA)).toBe(originalKey)
+  expect(index.getEndpointKey(connectionName, anonymousB)).toBe(originalKey)
+
+  // A new claimed cluster can be geometrically closer to a previously seen
+  // anonymous boundary. Existing graph keys must not change on a later lookup.
+  const closerClaim: StitchTerminal = {
+    ...anonymousB,
+    pcb_port_id: "port-e",
+  }
+  const closerKey = index.getEndpointKey(connectionName, closerClaim)
+  expect(closerKey).not.toBe(originalKey)
+  expect(closerKey).not.toBe(distinctKey)
+  expect(index.getEndpointKey(connectionName, { ...anonymousA })).toBe(
+    originalKey,
+  )
+  expect(index.getEndpointKey(connectionName, { ...anonymousB })).toBe(
+    originalKey,
+  )
+  expect(index.getClusters(connectionName)[0]!.point).toEqual({
+    x: 0,
+    y: 0,
+    z: 0,
+    pcb_port_id: "port-c",
+  })
+
+  const route: HighDensityIntraNodeRoute = {
+    connectionName,
+    startPcbPortId: "port-c",
+    endPcbPortId: "port-d",
+    traceThickness: 0.15,
+    viaDiameter: 0.3,
+    route: [{ ...claimedC }, { ...claimedD }],
+    vias: [],
+  }
+  const conflictingRoute: HighDensityIntraNodeRoute = {
+    ...route,
+    startPcbPortId: "conflicting-port",
+  }
+  const inputSnapshot = structuredClone({ route, conflictingRoute })
+  expect(getRouteStitchEndpoint(route, "first")).toEqual(claimedC)
+  expect(getRouteStitchEndpoint(route, "last")).toEqual(claimedD)
+  expect((): StitchTerminal =>
+    getRouteStitchEndpoint(conflictingRoute, "first"),
+  ).toThrow("conflicting PCB terminal identities")
+  expect({ route, conflictingRoute }).toEqual(inputSnapshot)
+  expect(anonymousA).toEqual({ x: 0, y: 0, z: 0 })
+  expect(anonymousB).toEqual({ x: -0.09, y: 0, z: 0 })
+  expect(claimedC).toEqual({ x: 0.09, y: 0, z: 0, pcb_port_id: "port-c" })
+  expect(claimedD).toEqual({ x: 0, y: 0, z: 0, pcb_port_id: "port-d" })
+})

--- a/tests/stitch-solver/existing-terminal-via-materialization.test.ts
+++ b/tests/stitch-solver/existing-terminal-via-materialization.test.ts
@@ -87,9 +87,7 @@ test("terminal transitions reuse explicitly represented via spans and obey the a
       start: { x: 0, y: 0, z: 0, pcb_port_id: "start-port" },
       end: { x: 2, y: 0, z: 0, pcb_port_id: "end-port" },
       hdRoutes: [solverRoute],
-      allowedLayerTransitionPointKeys: new Set(
-        allowedVias.map(getXyPointKey),
-      ),
+      allowedLayerTransitionPointKeys: new Set(allowedVias.map(getXyPointKey)),
       preserveTerminalPcbPortIds: true,
       isStitchSegmentClear: (): boolean => true,
       stitchClearanceMode: "require_clear",

--- a/tests/stitch-solver/existing-terminal-via-materialization.test.ts
+++ b/tests/stitch-solver/existing-terminal-via-materialization.test.ts
@@ -1,0 +1,138 @@
+import { expect, test } from "bun:test"
+import { getXyPointKey } from "lib/autorouter-pipelines/AutoroutingPipeline8/getXyPointKey"
+import { SingleHighDensityRouteStitchSolver3 } from "lib/solvers/RouteStitchingSolver/SingleHighDensityRouteStitchSolver3"
+import { getDrcErrors } from "lib/testing/getDrcErrors"
+import { convertToCircuitJson } from "lib/testing/utils/convertToCircuitJson"
+import type { SimpleRouteJson, SimplifiedPcbTrace } from "lib/types"
+import type { HighDensityIntraNodeRoute } from "lib/types/high-density-types"
+import { convertHdRouteToSimplifiedRoute } from "lib/utils/convertHdRouteToSimplifiedRoute"
+
+test("terminal transitions reuse explicitly represented via spans and obey the allowlist", (): void => {
+  const route: HighDensityIntraNodeRoute = {
+    connectionName: "via-net",
+    startPcbPortId: "start-port",
+    endPcbPortId: "end-port",
+    traceThickness: 0.15,
+    viaDiameter: 0.6,
+    route: [
+      { x: 0, y: 0, z: 1 },
+      { x: 1, y: 0, z: 1 },
+      { x: 1, y: 0, z: 0 },
+      { x: 0, y: 0, z: 0 },
+      { x: 0, y: 0, z: 1 },
+      { x: 2, y: 0, z: 1 },
+      { x: 2, y: 0, z: 0 },
+      { x: 3, y: 0, z: 0 },
+      { x: 3, y: 0, z: 1 },
+      { x: 2, y: 0, z: 1 },
+    ],
+    vias: [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 2, y: 0 },
+      { x: 3, y: 0 },
+    ],
+  }
+  const inputSnapshot = structuredClone(route)
+  const srj: SimpleRouteJson = {
+    layerCount: 2,
+    minTraceWidth: 0.15,
+    minViaDiameter: 0.6,
+    minViaHoleDiameter: 0.3,
+    bounds: { minX: -1, maxX: 4, minY: -1, maxY: 1 },
+    obstacles: [],
+    connections: [
+      {
+        name: route.connectionName,
+        pointsToConnect: [
+          { x: 0, y: 0, layer: "top", pcb_port_id: "start-port" },
+          { x: 2, y: 0, layer: "top", pcb_port_id: "end-port" },
+        ],
+      },
+    ],
+  }
+  const originalTrace: SimplifiedPcbTrace = {
+    type: "pcb_trace",
+    pcb_trace_id: "via-trace",
+    connection_name: route.connectionName,
+    route: convertHdRouteToSimplifiedRoute(route, 2),
+  }
+  const originalCircuitJson = convertToCircuitJson(srj, [originalTrace])
+  expect(getDrcErrors(originalCircuitJson).errors).toEqual([])
+  expect(
+    originalCircuitJson.filter(
+      (element): boolean => element.type === "pcb_via",
+    ),
+  ).toHaveLength(4)
+  for (const { allowEnd, reverseInput } of [
+    { allowEnd: true, reverseInput: false },
+    { allowEnd: true, reverseInput: true },
+    { allowEnd: false, reverseInput: false },
+    { allowEnd: false, reverseInput: true },
+  ]) {
+    const solverRoute: HighDensityIntraNodeRoute = reverseInput
+      ? {
+          ...route,
+          startPcbPortId: route.endPcbPortId,
+          endPcbPortId: route.startPcbPortId,
+          route: [...route.route].reverse(),
+        }
+      : route
+    const solverInputSnapshot = structuredClone(solverRoute)
+    const allowedVias = allowEnd
+      ? route.vias
+      : route.vias.filter((via): boolean => via.x !== 2)
+    const solver = new SingleHighDensityRouteStitchSolver3({
+      connectionName: route.connectionName,
+      start: { x: 0, y: 0, z: 0, pcb_port_id: "start-port" },
+      end: { x: 2, y: 0, z: 0, pcb_port_id: "end-port" },
+      hdRoutes: [solverRoute],
+      allowedLayerTransitionPointKeys: new Set(
+        allowedVias.map(getXyPointKey),
+      ),
+      preserveTerminalPcbPortIds: true,
+      isStitchSegmentClear: (): boolean => true,
+      stitchClearanceMode: "require_clear",
+    })
+    solver.solve()
+
+    expect(solver.solved).toBe(allowEnd)
+    expect(solver.failed).toBe(!allowEnd)
+    expect(solver.mergedHdRoute.vias).toEqual(route.vias)
+    expect(route).toEqual(inputSnapshot)
+    expect(solverRoute).toEqual(solverInputSnapshot)
+    if (!allowEnd) {
+      expect(solver.error).toContain("existing allowed via")
+      continue
+    }
+    expect(solver.mergedHdRoute.route).toEqual([
+      { x: 0, y: 0, z: 0 },
+      ...route.route,
+      { x: 2, y: 0, z: 0 },
+    ])
+    const converted = convertHdRouteToSimplifiedRoute(solver.mergedHdRoute, 2)
+    expect(converted[0]).toMatchObject({
+      route_type: "wire",
+      x: 0,
+      y: 0,
+      layer: "top",
+    })
+    expect(converted[converted.length - 1]).toMatchObject({
+      route_type: "wire",
+      x: 2,
+      y: 0,
+      layer: "top",
+    })
+    const repairedCircuitJson = convertToCircuitJson(srj, [
+      { ...originalTrace, route: converted },
+    ])
+    expect(
+      repairedCircuitJson.filter(
+        (element): boolean => element.type === "pcb_via",
+      ),
+    ).toHaveLength(4)
+    expect(getDrcErrors(repairedCircuitJson).errors).toEqual([])
+    expect(solver.mergedHdRoute.startPcbPortId).toBe("start-port")
+    expect(solver.mergedHdRoute.endPcbPortId).toBe("end-port")
+  }
+})

--- a/tests/stitch-solver/mixed-width-directed-path-clearance.test.ts
+++ b/tests/stitch-solver/mixed-width-directed-path-clearance.test.ts
@@ -1,0 +1,115 @@
+import { expect, test } from "bun:test"
+import { SingleHighDensityRouteStitchSolver3 } from "lib/solvers/RouteStitchingSolver/SingleHighDensityRouteStitchSolver3"
+import type { StitchTerminal } from "lib/solvers/RouteStitchingSolver/getStitchTerminal"
+import type { StitchSegment } from "lib/solvers/RouteStitchingSolver/route-stitch-clearance-validator"
+import { selectDirectedRouteStitchPath } from "lib/solvers/RouteStitchingSolver/selectDirectedRouteStitchPath"
+import type { HighDensityIntraNodeRoute } from "lib/types/high-density-types"
+
+test("directed path clearance uses the unchanged native traversal's output width", (): void => {
+  const start: StitchTerminal = {
+    x: 0,
+    y: 0,
+    z: 0,
+    pcb_port_id: "start-port",
+  }
+  const end: StitchTerminal = {
+    x: 5,
+    y: 0,
+    z: 0,
+    pcb_port_id: "end-port",
+  }
+
+  for (const nativeOutputIsNarrow of [true, false]) {
+    const hdRoutes: HighDensityIntraNodeRoute[] = [
+      {
+        connectionName: "mixed-width-net",
+        traceThickness: nativeOutputIsNarrow ? 0.6 : 0.1,
+        viaDiameter: 0.3,
+        route: [
+          { x: 0.2, y: 0, z: 0 },
+          { x: 1, y: 0, z: 0 },
+        ],
+        vias: [],
+      },
+      {
+        connectionName: "mixed-width-net",
+        traceThickness: 0.15,
+        viaDiameter: 0.3,
+        route: [
+          { x: 1.4, y: 0, z: 0 },
+          { x: 3, y: 0, z: 0 },
+        ],
+        vias: [],
+      },
+      {
+        connectionName: "mixed-width-net",
+        endPcbPortId: "end-port",
+        traceThickness: nativeOutputIsNarrow ? 0.1 : 0.6,
+        viaDiameter: 0.3,
+        route: [
+          { x: 3, y: 0, z: 0 },
+          { x: 5, y: 0, z: 0 },
+        ],
+        vias: [],
+      },
+    ]
+    const originalInput = structuredClone(hdRoutes)
+    const isStitchSegmentClear = (segment: StitchSegment): boolean => {
+      // This clearance corridor accepts the thin output but rejects the
+      // thick output. The end-touching fragment establishes native direction,
+      // even though the requested path is returned from start to end.
+      const fitsCorridor = segment.traceThickness <= 0.2
+      return fitsCorridor
+    }
+    const orderedRoutePath = selectDirectedRouteStitchPath({
+      connectionName: "mixed-width-net",
+      hdRoutes,
+      start,
+      end,
+      isStitchSegmentClear,
+    })
+    if (!nativeOutputIsNarrow) {
+      expect(orderedRoutePath).toBeNull()
+      expect(hdRoutes).toEqual(originalInput)
+      continue
+    }
+
+    expect(orderedRoutePath).not.toBeNull()
+    expect(orderedRoutePath!.map((entry): string => entry.matchedOn)).toEqual([
+      "first",
+      "first",
+      "first",
+    ])
+    const solver = new SingleHighDensityRouteStitchSolver3({
+      connectionName: "mixed-width-net",
+      hdRoutes: orderedRoutePath!.map(
+        (entry): HighDensityIntraNodeRoute => entry.route,
+      ),
+      orderedRoutePath: orderedRoutePath!,
+      start,
+      end,
+      isStitchSegmentClear,
+      stitchClearanceMode: "require_clear",
+      allowedLayerTransitionPointKeys: new Set<string>(),
+      preserveTerminalPcbPortIds: true,
+    })
+    expect(solver.start).toEqual(end)
+    expect(solver.end).toEqual(start)
+    solver.solve()
+    expect(solver.solved).toBeTrue()
+    expect(solver.failed).toBeFalse()
+    expect(solver.mergedHdRoute.traceThickness).toBe(0.1)
+    expect(solver.mergedHdRoute.startPcbPortId).toBe("end-port")
+    expect(solver.mergedHdRoute.endPcbPortId).toBe("start-port")
+    expect(solver.mergedHdRoute.route).toEqual([
+      { x: 5, y: 0, z: 0 },
+      { x: 3, y: 0, z: 0 },
+      { x: 1.4, y: 0, z: 0 },
+      { x: 1, y: 0, z: 0 },
+      { x: 0.2, y: 0, z: 0 },
+      { x: 0, y: 0, z: 0 },
+    ])
+    expect(solver.mergedHdRoute.vias).toEqual([])
+    expect(hdRoutes).toEqual(originalInput)
+  }
+})

--- a/tests/stitch-solver/multilayer-endpoint-path-selection.test.ts
+++ b/tests/stitch-solver/multilayer-endpoint-path-selection.test.ts
@@ -33,6 +33,7 @@ test("endpoint paths retain a farther same-layer branch before a buried via", ()
     canStitchBetweenTerminals: () => true,
   })
 
-  expect(selectedRoutes).toHaveLength(3)
-  expect(selectedRoutes).toContain(sameLayerTerminalBranch)
+  expect(selectedRoutes).not.toBeNull()
+  expect(selectedRoutes!.hdRoutes).toHaveLength(3)
+  expect(selectedRoutes!.hdRoutes).toContain(sameLayerTerminalBranch)
 })

--- a/tests/stitch-solver/multilayer-endpoint-path-selection.test.ts
+++ b/tests/stitch-solver/multilayer-endpoint-path-selection.test.ts
@@ -30,6 +30,7 @@ test("endpoint paths retain a farther same-layer branch before a buried via", ()
     start: { x: 0.1, y: 0, z: 0 },
     end: { x: 3, y: 0, z: 1 },
     endpointIndex: new EndpointClusterIndex(true),
+    isStitchSegmentClear: (): boolean => true,
     canStitchBetweenTerminals: () => true,
   })
 

--- a/tests/stitch-solver/nearby-distinct-terminal-identities.test.ts
+++ b/tests/stitch-solver/nearby-distinct-terminal-identities.test.ts
@@ -71,9 +71,7 @@ test("nearby distinct PCB terminals retain their identities and exact copper pat
     expect(merged.startPcbPortId).toBe(
       startsAtStart ? "start-port" : "end-port",
     )
-    expect(merged.endPcbPortId).toBe(
-      startsAtStart ? "end-port" : "start-port",
-    )
+    expect(merged.endPcbPortId).toBe(startsAtStart ? "end-port" : "start-port")
     expect(
       merged.route.map(({ x, y, z }): RoutePoint => ({ x, y, z })),
     ).toEqual(expectedPoints)

--- a/tests/stitch-solver/nearby-distinct-terminal-identities.test.ts
+++ b/tests/stitch-solver/nearby-distinct-terminal-identities.test.ts
@@ -1,0 +1,98 @@
+import { expect, test } from "bun:test"
+import { MultipleHighDensityRouteStitchSolver3 } from "lib/solvers/RouteStitchingSolver/MultipleHighDensityRouteStitchSolver3"
+import type { SimpleRouteConnection } from "lib/types"
+import type { HighDensityIntraNodeRoute } from "lib/types/high-density-types"
+import { convertHdRouteToSimplifiedRoute } from "lib/utils/convertHdRouteToSimplifiedRoute"
+
+type RoutePoint = HighDensityIntraNodeRoute["route"][number]
+
+test("nearby distinct PCB terminals retain their identities and exact copper path", (): void => {
+  const points: RoutePoint[] = [
+    { x: 0, y: 0, z: 1 },
+    { x: 1, y: 0, z: 1 },
+    { x: 1, y: 1, z: 1 },
+    { x: 0.005, y: 0.005, z: 1 },
+  ]
+  const connections: SimpleRouteConnection[] = [
+    {
+      name: "nearby-terminal-net",
+      pointsToConnect: [
+        { x: 0, y: 0, layer: "bottom", pcb_port_id: "start-port" },
+        { x: 0.005, y: 0.005, layer: "bottom", pcb_port_id: "end-port" },
+      ],
+    },
+  ]
+  const fragments = points.slice(0, -1).map(
+    (point, index): HighDensityIntraNodeRoute => ({
+      connectionName: connections[0]!.name,
+      ...(index === 0 ? { startPcbPortId: "start-port" } : {}),
+      ...(index === points.length - 2 ? { endPcbPortId: "end-port" } : {}),
+      traceThickness: 0.15,
+      viaDiameter: 0.3,
+      route: [point, points[index + 1]!],
+      vias: [],
+    }),
+  )
+  const fragmentSnapshot = structuredClone(fragments)
+  const connectionSnapshot = structuredClone(connections)
+
+  // The terminals are within the geometric endpoint-clustering tolerance,
+  // but they are different declared ports at different physical coordinates.
+  // Three existing fragments also require endpoint-path selection to retain
+  // both terminal identities instead of collapsing the start and end keys.
+  expect(fragments).toHaveLength(3)
+  for (const reverseInput of [false, true]) {
+    const routes = reverseInput
+      ? [...fragments].reverse().map(
+          (route): HighDensityIntraNodeRoute => ({
+            ...route,
+            startPcbPortId: route.endPcbPortId,
+            endPcbPortId: route.startPcbPortId,
+            route: [...route.route].reverse(),
+          }),
+        )
+      : fragments
+    const inputSnapshot = structuredClone(routes)
+    const solver = new MultipleHighDensityRouteStitchSolver3({
+      connections,
+      hdRoutes: routes,
+      layerCount: 2,
+      allowedLayerTransitionPointKeys: new Set<string>(),
+      preserveTerminalPcbPortIds: true,
+    })
+    solver.solve()
+
+    expect(solver.failed).toBe(false)
+    expect(solver.solved).toBe(true)
+    expect(solver.mergedHdRoutes).toHaveLength(1)
+    const merged = solver.mergedHdRoutes[0]!
+    const startsAtStart = merged.startPcbPortId === "start-port"
+    const expectedPoints = startsAtStart ? points : [...points].reverse()
+    expect(merged.startPcbPortId).toBe(
+      startsAtStart ? "start-port" : "end-port",
+    )
+    expect(merged.endPcbPortId).toBe(
+      startsAtStart ? "end-port" : "start-port",
+    )
+    expect(
+      merged.route.map(({ x, y, z }): RoutePoint => ({ x, y, z })),
+    ).toEqual(expectedPoints)
+    expect(merged.vias).toEqual([])
+    expect(merged.traceThickness).toBe(0.15)
+
+    const simplifiedRoute = convertHdRouteToSimplifiedRoute(merged, 2)
+    expect(simplifiedRoute).toHaveLength(expectedPoints.length)
+    for (const [index, point] of expectedPoints.entries()) {
+      expect(simplifiedRoute[index]).toMatchObject({
+        route_type: "wire",
+        x: point.x,
+        y: point.y,
+        layer: "bottom",
+        width: 0.15,
+      })
+    }
+    expect(routes).toEqual(inputSnapshot)
+    expect(fragments).toEqual(fragmentSnapshot)
+    expect(connections).toEqual(connectionSnapshot)
+  }
+})

--- a/tests/stitch-solver/ordered-terminal-path-contract.test.ts
+++ b/tests/stitch-solver/ordered-terminal-path-contract.test.ts
@@ -1,0 +1,125 @@
+import { expect, test } from "bun:test"
+import { SingleHighDensityRouteStitchSolver3 } from "lib/solvers/RouteStitchingSolver/SingleHighDensityRouteStitchSolver3"
+import type { StitchTerminal } from "lib/solvers/RouteStitchingSolver/getStitchTerminal"
+import type { StitchSegment } from "lib/solvers/RouteStitchingSolver/route-stitch-clearance-validator"
+import type { OrderedRouteStitchEntry } from "lib/solvers/RouteStitchingSolver/routeStitchingEndpointHelpers"
+import type { HighDensityIntraNodeRoute } from "lib/types/high-density-types"
+
+test("an ordered terminal path retains its direction and rejects a blocked planned gap", (): void => {
+  const start: StitchTerminal = {
+    x: 0,
+    y: 0,
+    z: 0,
+    pcb_port_id: "start-port",
+  }
+  const end: StitchTerminal = {
+    x: 0,
+    y: 0.1,
+    z: 0,
+    pcb_port_id: "end-port",
+  }
+  const firstRoute: HighDensityIntraNodeRoute = {
+    connectionName: "ordered-path-net",
+    traceThickness: 0.15,
+    viaDiameter: 0.3,
+    route: [
+      { x: 2, y: 0, z: 0 },
+      { x: 0.5, y: 0, z: 0 },
+    ],
+    vias: [],
+  }
+  const secondRoute: HighDensityIntraNodeRoute = {
+    connectionName: firstRoute.connectionName,
+    startPcbPortId: "end-port",
+    traceThickness: firstRoute.traceThickness,
+    viaDiameter: firstRoute.viaDiameter,
+    route: [
+      { x: 0, y: 0.1, z: 0 },
+      { x: 2, y: 0, z: 0 },
+    ],
+    vias: [],
+  }
+  const hdRoutes = [secondRoute, firstRoute]
+  const orderedRoutePath: OrderedRouteStitchEntry[] = [
+    { route: firstRoute, matchedOn: "last" },
+    { route: secondRoute, matchedOn: "last" },
+  ]
+  const inputSnapshot = structuredClone({
+    hdRoutes,
+    orderedRoutePath,
+    start,
+    end,
+  })
+
+  // Without a directed plan, the fragment touching the end terminal wins
+  // over the first fragment, which needs a half-unit gap from the start.
+  const unconstrained = new SingleHighDensityRouteStitchSolver3({
+    connectionName: firstRoute.connectionName,
+    hdRoutes,
+    start,
+    end,
+    preserveTerminalPcbPortIds: true,
+    isStitchSegmentClear: (): boolean => true,
+    stitchClearanceMode: "require_clear",
+  })
+  expect(unconstrained.start.pcb_port_id).toBe("end-port")
+  expect(unconstrained.end.pcb_port_id).toBe("start-port")
+
+  for (const firstGapIsClear of [true, false]) {
+    const checkedSegments: StitchSegment[] = []
+    const solver = new SingleHighDensityRouteStitchSolver3({
+      connectionName: firstRoute.connectionName,
+      hdRoutes,
+      orderedRoutePath,
+      start,
+      end,
+      allowedLayerTransitionPointKeys: new Set<string>(),
+      preserveTerminalPcbPortIds: true,
+      isStitchSegmentClear: (segment): boolean => {
+        checkedSegments.push(structuredClone(segment))
+        const isFirstPlannedGap =
+          segment.start.x === 0 &&
+          segment.start.y === 0 &&
+          segment.end.x === 0.5 &&
+          segment.end.y === 0
+        return firstGapIsClear || !isFirstPlannedGap
+      },
+      stitchClearanceMode: "require_clear",
+    })
+    expect(solver.start).toEqual(start)
+    expect(solver.end).toEqual(end)
+    solver.solve()
+
+    expect(solver.solved).toBe(firstGapIsClear)
+    expect(solver.failed).toBe(!firstGapIsClear)
+    expect(solver.mergedHdRoute.startPcbPortId).toBe("start-port")
+    expect(solver.mergedHdRoute.endPcbPortId).toBe("end-port")
+    expect(solver.mergedHdRoute.vias).toEqual([])
+    expect(checkedSegments).toEqual([
+      {
+        connectionName: firstRoute.connectionName,
+        start: { x: 0, y: 0, z: 0 },
+        end: { x: 0.5, y: 0, z: 0 },
+        traceThickness: firstRoute.traceThickness,
+      },
+    ])
+    if (firstGapIsClear) {
+      expect(solver.mergedHdRoute.route).toEqual([
+        { x: 0, y: 0, z: 0 },
+        { x: 0.5, y: 0, z: 0 },
+        { x: 2, y: 0, z: 0 },
+        { x: 0, y: 0.1, z: 0 },
+      ])
+      expect(solver.remainingHdRoutes).toEqual([])
+    } else {
+      expect(solver.error).toContain("selected endpoint path")
+      expect(solver.mergedHdRoute.route).toEqual([{ x: 0, y: 0, z: 0 }])
+      expect(solver.remainingHdRoutes).toHaveLength(2)
+      expect(solver.remainingHdRoutes).toContain(firstRoute)
+      expect(solver.remainingHdRoutes).toContain(secondRoute)
+    }
+    expect({ hdRoutes, orderedRoutePath, start, end }).toEqual(inputSnapshot)
+    expect(orderedRoutePath[0]!.route).toBe(firstRoute)
+    expect(orderedRoutePath[1]!.route).toBe(secondRoute)
+  }
+})

--- a/tests/stitch-solver/ordered-terminal-path-contract.test.ts
+++ b/tests/stitch-solver/ordered-terminal-path-contract.test.ts
@@ -5,7 +5,7 @@ import type { StitchSegment } from "lib/solvers/RouteStitchingSolver/route-stitc
 import type { OrderedRouteStitchEntry } from "lib/solvers/RouteStitchingSolver/routeStitchingEndpointHelpers"
 import type { HighDensityIntraNodeRoute } from "lib/types/high-density-types"
 
-test("an ordered terminal path retains its direction and rejects a blocked planned gap", (): void => {
+test("an ordered path preserves legacy terminal orientation and rejects a blocked planned gap", (): void => {
   const start: StitchTerminal = {
     x: 0,
     y: 0,
@@ -35,7 +35,7 @@ test("an ordered terminal path retains its direction and rejects a blocked plann
     viaDiameter: firstRoute.viaDiameter,
     route: [
       { x: 0, y: 0.1, z: 0 },
-      { x: 2, y: 0, z: 0 },
+      { x: 2, y: 0.2, z: 0 },
     ],
     vias: [],
   }
@@ -51,8 +51,9 @@ test("an ordered terminal path retains its direction and rejects a blocked plann
     end,
   })
 
-  // Without a directed plan, the fragment touching the end terminal wins
-  // over the first fragment, which needs a half-unit gap from the start.
+  // The fragment touching the end terminal establishes the legacy global
+  // orientation. The selected plan must reverse both its entry order and
+  // each matched endpoint, without mutating the caller's start-to-end plan.
   const unconstrained = new SingleHighDensityRouteStitchSolver3({
     connectionName: firstRoute.connectionName,
     hdRoutes,
@@ -65,7 +66,7 @@ test("an ordered terminal path retains its direction and rejects a blocked plann
   expect(unconstrained.start.pcb_port_id).toBe("end-port")
   expect(unconstrained.end.pcb_port_id).toBe("start-port")
 
-  for (const firstGapIsClear of [true, false]) {
+  for (const interiorGapIsClear of [true, false]) {
     const checkedSegments: StitchSegment[] = []
     const solver = new SingleHighDensityRouteStitchSolver3({
       connectionName: firstRoute.connectionName,
@@ -77,46 +78,55 @@ test("an ordered terminal path retains its direction and rejects a blocked plann
       preserveTerminalPcbPortIds: true,
       isStitchSegmentClear: (segment): boolean => {
         checkedSegments.push(structuredClone(segment))
-        const isFirstPlannedGap =
-          segment.start.x === 0 &&
-          segment.start.y === 0 &&
-          segment.end.x === 0.5 &&
+        const isPlannedInteriorGap =
+          segment.start.x === 2 &&
+          segment.start.y === 0.2 &&
+          segment.end.x === 2 &&
           segment.end.y === 0
-        return firstGapIsClear || !isFirstPlannedGap
+        return interiorGapIsClear || !isPlannedInteriorGap
       },
       stitchClearanceMode: "require_clear",
     })
-    expect(solver.start).toEqual(start)
-    expect(solver.end).toEqual(end)
+    expect(solver.start).toEqual(end)
+    expect(solver.end).toEqual(start)
     solver.solve()
 
-    expect(solver.solved).toBe(firstGapIsClear)
-    expect(solver.failed).toBe(!firstGapIsClear)
-    expect(solver.mergedHdRoute.startPcbPortId).toBe("start-port")
-    expect(solver.mergedHdRoute.endPcbPortId).toBe("end-port")
+    expect(solver.solved).toBe(interiorGapIsClear)
+    expect(solver.failed).toBe(!interiorGapIsClear)
+    expect(solver.mergedHdRoute.startPcbPortId).toBe("end-port")
+    expect(solver.mergedHdRoute.endPcbPortId).toBe("start-port")
     expect(solver.mergedHdRoute.vias).toEqual([])
-    expect(checkedSegments).toEqual([
-      {
+    expect(checkedSegments).toHaveLength(interiorGapIsClear ? 2 : 1)
+    expect(checkedSegments[0]).toEqual({
+      connectionName: firstRoute.connectionName,
+      start: { x: 2, y: 0.2, z: 0 },
+      end: { x: 2, y: 0, z: 0 },
+      traceThickness: firstRoute.traceThickness,
+    })
+    if (interiorGapIsClear) {
+      expect(checkedSegments[1]).toEqual({
         connectionName: firstRoute.connectionName,
-        start: { x: 0, y: 0, z: 0 },
-        end: { x: 0.5, y: 0, z: 0 },
+        start: { x: 0.5, y: 0, z: 0 },
+        end: { x: 0, y: 0, z: 0 },
         traceThickness: firstRoute.traceThickness,
-      },
-    ])
-    if (firstGapIsClear) {
+      })
       expect(solver.mergedHdRoute.route).toEqual([
-        { x: 0, y: 0, z: 0 },
-        { x: 0.5, y: 0, z: 0 },
-        { x: 2, y: 0, z: 0 },
         { x: 0, y: 0.1, z: 0 },
+        { x: 2, y: 0.2, z: 0 },
+        { x: 2, y: 0, z: 0 },
+        { x: 0.5, y: 0, z: 0 },
+        { x: 0, y: 0, z: 0 },
       ])
       expect(solver.remainingHdRoutes).toEqual([])
     } else {
       expect(solver.error).toContain("selected endpoint path")
-      expect(solver.mergedHdRoute.route).toEqual([{ x: 0, y: 0, z: 0 }])
-      expect(solver.remainingHdRoutes).toHaveLength(2)
+      expect(solver.mergedHdRoute.route).toEqual([
+        { x: 0, y: 0.1, z: 0 },
+        { x: 2, y: 0.2, z: 0 },
+      ])
+      expect(solver.remainingHdRoutes).toHaveLength(1)
       expect(solver.remainingHdRoutes).toContain(firstRoute)
-      expect(solver.remainingHdRoutes).toContain(secondRoute)
+      expect(solver.remainingHdRoutes).not.toContain(secondRoute)
     }
     expect({ hdRoutes, orderedRoutePath, start, end }).toEqual(inputSnapshot)
     expect(orderedRoutePath[0]!.route).toBe(firstRoute)

--- a/tests/stitch-solver/partial-island-terminal-layer-ownership.test.ts
+++ b/tests/stitch-solver/partial-island-terminal-layer-ownership.test.ts
@@ -43,9 +43,9 @@ test("an unclaimed partial island boundary does not impersonate a nearby opposit
       { x: 2.4, y: 0, z: 0 },
     ]),
   )
-  expect(
-    [merged.startPcbPortId, merged.endPcbPortId].filter(Boolean),
-  ).toEqual(["start-port"])
+  expect([merged.startPcbPortId, merged.endPcbPortId].filter(Boolean)).toEqual([
+    "start-port",
+  ])
   expect(merged.vias).toEqual(route.vias)
   expect(merged.route).toHaveLength(route.route.length)
   expect(

--- a/tests/stitch-solver/partial-island-terminal-layer-ownership.test.ts
+++ b/tests/stitch-solver/partial-island-terminal-layer-ownership.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test"
+import { MultipleHighDensityRouteStitchSolver3 } from "lib/solvers/RouteStitchingSolver/MultipleHighDensityRouteStitchSolver3"
+import type { HighDensityIntraNodeRoute } from "lib/types/high-density-types"
+
+test("an unclaimed partial island boundary does not impersonate a nearby opposite-layer SMT terminal", (): void => {
+  const route: HighDensityIntraNodeRoute = {
+    connectionName: "partial-net",
+    startPcbPortId: "start-port",
+    traceThickness: 0.15,
+    viaDiameter: 0.3,
+    route: [
+      { x: 0, y: 0, z: 1 },
+      { x: 1, y: 0, z: 1 },
+      { x: 1, y: 0, z: 0 },
+      { x: 2.4, y: 0, z: 0 },
+    ],
+    vias: [{ x: 1, y: 0 }],
+  }
+  const inputSnapshot = structuredClone(route)
+  const solver = new MultipleHighDensityRouteStitchSolver3({
+    connections: [
+      {
+        name: route.connectionName,
+        pointsToConnect: [
+          { x: 0, y: 0, layer: "bottom", pcb_port_id: "start-port" },
+          { x: 3, y: 0, layer: "bottom", pcb_port_id: "end-port" },
+        ],
+      },
+    ],
+    hdRoutes: [route],
+    layerCount: 2,
+    preserveTerminalPcbPortIds: true,
+  })
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(solver.mergedHdRoutes).toHaveLength(1)
+  const merged = solver.mergedHdRoutes[0]!
+  expect([merged.route[0], merged.route[merged.route.length - 1]]).toEqual(
+    expect.arrayContaining([
+      { x: 0, y: 0, z: 1 },
+      { x: 2.4, y: 0, z: 0 },
+    ]),
+  )
+  expect(
+    [merged.startPcbPortId, merged.endPcbPortId].filter(Boolean),
+  ).toEqual(["start-port"])
+  expect(merged.vias).toEqual(route.vias)
+  expect(merged.route).toHaveLength(route.route.length)
+  expect(
+    merged.route.some((point): boolean => point.x === 3 && point.z === 1),
+  ).toBe(false)
+  expect(route).toEqual(inputSnapshot)
+})

--- a/tests/stitch-solver/shared-endpoint-terminal-claim.test.ts
+++ b/tests/stitch-solver/shared-endpoint-terminal-claim.test.ts
@@ -46,7 +46,7 @@ test("shared endpoint clustering preserves terminal claims and rejects conflicti
     }
     const inputSnapshot = structuredClone(routes)
     if (firstClaim === "conflicting-port") {
-      expect(createSolver).toThrow("conflicting PCB terminal claims")
+      expect(createSolver).toThrow("unknown PCB terminal")
     } else {
       const solver = createSolver()
       expect(solver.unsolvedRoutes).toHaveLength(1)

--- a/tests/stitch-solver/shared-endpoint-terminal-claim.test.ts
+++ b/tests/stitch-solver/shared-endpoint-terminal-claim.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "bun:test"
+import { MultipleHighDensityRouteStitchSolver3 } from "lib/solvers/RouteStitchingSolver/MultipleHighDensityRouteStitchSolver3"
+import type { HighDensityIntraNodeRoute } from "lib/types/high-density-types"
+
+test("shared endpoint clustering preserves terminal claims and rejects conflicting ownership", (): void => {
+  for (const firstClaim of [undefined, "start-port", "conflicting-port"]) {
+    const routes: HighDensityIntraNodeRoute[] = [
+      {
+        connectionName: "shared-net",
+        startPcbPortId: firstClaim,
+        traceThickness: 0.15,
+        viaDiameter: 0.3,
+        route: [
+          { x: 0, y: 0, z: 0 },
+          { x: 1, y: 0, z: 0 },
+        ],
+        vias: [],
+      },
+      {
+        connectionName: "shared-net",
+        startPcbPortId: "start-port",
+        traceThickness: 0.15,
+        viaDiameter: 0.3,
+        route: [
+          { x: 0, y: 0, z: 0 },
+          { x: 2, y: 0, z: 0 },
+        ],
+        vias: [],
+      },
+    ]
+    const createSolver = (): MultipleHighDensityRouteStitchSolver3 => {
+      return new MultipleHighDensityRouteStitchSolver3({
+        connections: [
+          {
+            name: "shared-net",
+            pointsToConnect: [
+              { x: 0, y: 0, layer: "bottom", pcb_port_id: "start-port" },
+              { x: 2, y: 0, layer: "top", pcb_port_id: "end-port" },
+            ],
+          },
+        ],
+        hdRoutes: routes,
+        layerCount: 2,
+        preserveTerminalPcbPortIds: true,
+      })
+    }
+    const inputSnapshot = structuredClone(routes)
+    if (firstClaim === "conflicting-port") {
+      expect(createSolver).toThrow("conflicting PCB terminal claims")
+    } else {
+      const solver = createSolver()
+      expect(solver.unsolvedRoutes).toHaveLength(1)
+      expect(solver.unsolvedRoutes[0]!.start).toMatchObject({
+        x: 0,
+        y: 0,
+        z: 1,
+        pcb_port_id: "start-port",
+      })
+    }
+    expect(routes).toEqual(inputSnapshot)
+  }
+})

--- a/tests/stitch-solver/single-layer-terminal-mismatch.test.ts
+++ b/tests/stitch-solver/single-layer-terminal-mismatch.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "bun:test"
+import { getXyPointKey } from "lib/autorouter-pipelines/AutoroutingPipeline8/getXyPointKey"
+import { SingleHighDensityRouteStitchSolver3 } from "lib/solvers/RouteStitchingSolver/SingleHighDensityRouteStitchSolver3"
+import type { HighDensityIntraNodeRoute } from "lib/types/high-density-types"
+
+test("single-layer terminals cannot be silently reassigned to fragment layers", (): void => {
+  for (const mismatch of ["start", "end"] as const) {
+    const route: HighDensityIntraNodeRoute = {
+      connectionName: "terminal-net",
+      startPcbPortId: "start-port",
+      endPcbPortId: "end-port",
+      traceThickness: 0.15,
+      viaDiameter: 0.3,
+      route:
+        mismatch === "start"
+          ? [
+              { x: 0, y: 0, z: 1 },
+              { x: 1, y: 0, z: 1 },
+              { x: 1, y: 0, z: 0 },
+              { x: 2, y: 0, z: 0 },
+            ]
+          : [
+              { x: 0, y: 0, z: 0 },
+              { x: 2, y: 0, z: 0 },
+            ],
+      vias: mismatch === "start" ? [{ x: 1, y: 0 }] : [],
+    }
+    const inputSnapshot = structuredClone(route)
+    const mismatchPoint = { x: mismatch === "start" ? 0 : 2, y: 0 }
+    for (const allowedLayerTransitionPointKeys of [
+      undefined,
+      new Set<string>(),
+      new Set([getXyPointKey(mismatchPoint)]),
+    ]) {
+      const solver = new SingleHighDensityRouteStitchSolver3({
+        connectionName: route.connectionName,
+        start: { x: 0, y: 0, z: 0, pcb_port_id: "start-port" },
+        end: {
+          x: 2,
+          y: 0,
+          z: mismatch === "end" ? 1 : 0,
+          pcb_port_id: "end-port",
+        },
+        hdRoutes: [route],
+        allowedLayerTransitionPointKeys,
+        preserveTerminalPcbPortIds: true,
+        isStitchSegmentClear: (): boolean => true,
+        stitchClearanceMode: "prefer_clear",
+      })
+      solver.solve()
+
+      expect(solver.solved).toBe(false)
+      expect(solver.failed).toBe(true)
+      expect(solver.error).toContain("existing allowed via")
+      expect(solver.mergedHdRoute.route[0]!.z).toBe(0)
+      expect(solver.mergedHdRoute.startPcbPortId).toBe("start-port")
+      expect(solver.mergedHdRoute.endPcbPortId).toBe("end-port")
+      expect(route).toEqual(inputSnapshot)
+    }
+  }
+})

--- a/tests/stitch-solver/terminal-layer-protected-span.test.ts
+++ b/tests/stitch-solver/terminal-layer-protected-span.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "bun:test"
+import { SingleHighDensityRouteStitchSolver3 } from "lib/solvers/RouteStitchingSolver/SingleHighDensityRouteStitchSolver3"
+import type { HighDensityIntraNodeRoute } from "lib/types/high-density-types"
+import { convertHdRouteToSimplifiedRoute } from "lib/utils/convertHdRouteToSimplifiedRoute"
+
+test("legal terminal layers preserve an explicit plated-hole span and its copper metadata", (): void => {
+  const route: HighDensityIntraNodeRoute = {
+    connectionName: "protected-net",
+    startPcbPortId: "start-port",
+    endPcbPortId: "end-port",
+    traceThickness: 0.15,
+    viaDiameter: 0.3,
+    route: [
+      { x: 0, y: 0, z: 0 },
+      {
+        x: 1,
+        y: 0,
+        z: 0,
+        traceThickness: 0.2,
+        toNextSegmentType: "through_obstacle",
+        toNextSegmentCircuitJsonMetadata: {
+          pcb_plated_hole_id: "protected-plated-hole",
+          pcb_port_id: "protected-port",
+        },
+      },
+      { x: 1, y: 0, z: 1, traceThickness: 0.2 },
+      { x: 2, y: 0, z: 1 },
+    ],
+    vias: [],
+  }
+  const inputSnapshot = structuredClone(route)
+  const solver = new SingleHighDensityRouteStitchSolver3({
+    connectionName: route.connectionName,
+    start: { x: 0, y: 0, z: 0, pcb_port_id: "start-port" },
+    end: { x: 2, y: 0, z: 1, pcb_port_id: "end-port" },
+    hdRoutes: [route],
+    allowedLayerTransitionPointKeys: new Set(),
+    preserveTerminalPcbPortIds: true,
+    isStitchSegmentClear: (): boolean => true,
+    stitchClearanceMode: "require_clear",
+  })
+  solver.solve()
+
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(solver.mergedHdRoute.route).toEqual(route.route)
+  expect(solver.mergedHdRoute.vias).toEqual([])
+  expect(solver.mergedHdRoute.startPcbPortId).toBe("start-port")
+  expect(solver.mergedHdRoute.endPcbPortId).toBe("end-port")
+  const converted = convertHdRouteToSimplifiedRoute(solver.mergedHdRoute, 2)
+  expect(
+    converted.filter(
+      (point): boolean => point.route_type === "through_obstacle",
+    ),
+  ).toEqual([
+    {
+      route_type: "through_obstacle",
+      start: { x: 1, y: 0 },
+      end: { x: 1, y: 0 },
+      from_layer: "top",
+      to_layer: "bottom",
+      width: 0.2,
+      circuitJsonMetadata: {
+        pcb_plated_hole_id: "protected-plated-hole",
+        pcb_port_id: "protected-port",
+      },
+    },
+  ])
+  expect(route).toEqual(inputSnapshot)
+})

--- a/tests/stitch-solver/terminal-via-layer-span-guards.test.ts
+++ b/tests/stitch-solver/terminal-via-layer-span-guards.test.ts
@@ -50,9 +50,7 @@ test("four-layer terminal stitching cannot extend blind vias or orphan via entri
       start: { x: 0, y: 0, z: 0 },
       end: { x: 2, y: 0, z: endLayer },
       hdRoutes: [route],
-      allowedLayerTransitionPointKeys: new Set([
-        getXyPointKey({ x: 2, y: 0 }),
-      ]),
+      allowedLayerTransitionPointKeys: new Set([getXyPointKey({ x: 2, y: 0 })]),
       isStitchSegmentClear: (): boolean => true,
       stitchClearanceMode: "prefer_clear",
     })

--- a/tests/stitch-solver/terminal-via-layer-span-guards.test.ts
+++ b/tests/stitch-solver/terminal-via-layer-span-guards.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "bun:test"
+import { getXyPointKey } from "lib/autorouter-pipelines/AutoroutingPipeline8/getXyPointKey"
+import { SingleHighDensityRouteStitchSolver3 } from "lib/solvers/RouteStitchingSolver/SingleHighDensityRouteStitchSolver3"
+import type { HighDensityIntraNodeRoute } from "lib/types/high-density-types"
+
+test("four-layer terminal stitching cannot extend blind vias or orphan via entries to bottom copper", (): void => {
+  for (const viaEvidence of [
+    "blind",
+    "orphan",
+    "protected",
+    "opposite",
+    "subset",
+  ] as const) {
+    const spanEndZ =
+      viaEvidence === "protected" || viaEvidence === "subset" ? 3 : 1
+    const route: HighDensityIntraNodeRoute = {
+      connectionName: "blind-via-net",
+      traceThickness: 0.15,
+      viaDiameter: 0.3,
+      route:
+        viaEvidence === "orphan"
+          ? [
+              { x: 0, y: 0, z: 0 },
+              { x: 2, y: 0, z: 0 },
+            ]
+          : [
+              { x: 0, y: 0, z: 0 },
+              {
+                x: 2,
+                y: 0,
+                z: 0,
+                ...(viaEvidence === "protected"
+                  ? { toNextSegmentType: "through_obstacle" as const }
+                  : {}),
+              },
+              { x: 2, y: 0, z: spanEndZ },
+              { x: 1.5, y: 0, z: spanEndZ },
+            ],
+      vias: [{ x: 2, y: 0 }],
+    }
+    const inputSnapshot = structuredClone(route)
+    const endLayer =
+      viaEvidence === "protected" || viaEvidence === "opposite"
+        ? 0
+        : viaEvidence === "subset"
+          ? 1
+          : 3
+    const solver = new SingleHighDensityRouteStitchSolver3({
+      connectionName: route.connectionName,
+      start: { x: 0, y: 0, z: 0 },
+      end: { x: 2, y: 0, z: endLayer },
+      hdRoutes: [route],
+      allowedLayerTransitionPointKeys: new Set([
+        getXyPointKey({ x: 2, y: 0 }),
+      ]),
+      isStitchSegmentClear: (): boolean => true,
+      stitchClearanceMode: "prefer_clear",
+    })
+    solver.solve()
+
+    expect(solver.solved).toBe(false)
+    expect(solver.failed).toBe(true)
+    expect(solver.error).toContain("existing allowed via")
+    expect(solver.mergedHdRoute.route).toEqual(route.route)
+    expect(solver.mergedHdRoute.vias).toEqual(route.vias)
+    expect(route).toEqual(inputSnapshot)
+  }
+})

--- a/tests/stitch-solver/terminal-via-planar-clearance.test.ts
+++ b/tests/stitch-solver/terminal-via-planar-clearance.test.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "bun:test"
+import { SingleHighDensityRouteStitchSolver3 } from "lib/solvers/RouteStitchingSolver/SingleHighDensityRouteStitchSolver3"
+import type { StitchSegment } from "lib/solvers/RouteStitchingSolver/route-stitch-clearance-validator"
+import type { HighDensityIntraNodeRoute } from "lib/types/high-density-types"
+
+test("reaching an existing terminal via requires a clear planar approach on the fragment layer", (): void => {
+  const route: HighDensityIntraNodeRoute = {
+    connectionName: "approach-net",
+    traceThickness: 0.15,
+    viaDiameter: 0.3,
+    route: [
+      { x: 0, y: 0, z: 0 },
+      { x: 0.5, y: 0, z: 0 },
+      { x: 0.5, y: 0, z: 1 },
+      { x: 2, y: 0, z: 1 },
+      { x: 2, y: 0, z: 0 },
+      { x: 3, y: 0, z: 0 },
+      { x: 3, y: 0, z: 1 },
+      { x: 1.5, y: 0, z: 1 },
+    ],
+    vias: [
+      { x: 0.5, y: 0 },
+      { x: 2, y: 0 },
+      { x: 3, y: 0 },
+    ],
+  }
+  const inputSnapshot = structuredClone(route)
+  for (const isClear of [true, false]) {
+    const checkedSegments: StitchSegment[] = []
+    const solver = new SingleHighDensityRouteStitchSolver3({
+      connectionName: route.connectionName,
+      start: { x: 0, y: 0, z: 0 },
+      end: { x: 2, y: 0, z: 0 },
+      hdRoutes: [route],
+      isStitchSegmentClear: (segment): boolean => {
+        checkedSegments.push(structuredClone(segment))
+        return isClear
+      },
+      stitchClearanceMode: "prefer_clear",
+    })
+    solver.solve()
+
+    expect(solver.solved).toBe(isClear)
+    expect(solver.failed).toBe(!isClear)
+    expect(checkedSegments).toEqual([
+      {
+        connectionName: route.connectionName,
+        start: { x: 1.5, y: 0, z: 1 },
+        end: { x: 2, y: 0, z: 1 },
+        traceThickness: 0.15,
+      },
+    ])
+    expect(solver.mergedHdRoute.vias).toEqual(route.vias)
+    expect(route).toEqual(inputSnapshot)
+    if (isClear) {
+      expect(solver.mergedHdRoute.route.slice(-2)).toEqual([
+        { x: 2, y: 0, z: 1 },
+        { x: 2, y: 0, z: 0 },
+      ])
+    } else {
+      expect(solver.error).toContain("violates copper clearance")
+      expect(solver.mergedHdRoute.route).toEqual(route.route)
+    }
+  }
+})


### PR DESCRIPTION
## Summary

Separate experiment requested by the user, based directly on current main `fb6c6d77c091a56c9e1d4648bbac40a7cccd0def`. This does **not** include or modify the high-density repair layer in #2413. The existing HD router and Repair03 implementation/dependency remain unchanged.

### Inherited ordinary preloaded copper

- A new `Pipeline9InheritedDrcRepairSolver` stage runs **after** the existing joint repair and before length matching. The original joint stage's baseline policy, search and acceptance behavior remain unchanged, with narrow protected hooks for reuse. Native/global Repair03 and the original HD router are untouched.
- The added layer selects and scores complete current violations, including ones already present in the original preloaded input. Baseline counts remain diagnostic in this layer, not an exemption from repair. With no eligible ordinary preloaded sections it performs no additional native search.
- Existing section ownership keeps `through_obstacle` primitives fixed. Section-boundary positions/layers and real tagged terminal positions/metadata must survive publication. Ordinary sections retain their original identities and explicit replacement metadata.
- A separate final publication gate evaluates the **actual fully reconstructed public board**, with all protected primitives reattached. It compares unfiltered official DRCs against the complete stage input, independently of the native optimizer's aggregate objective.
- Published output may not increase total error count, introduce a different copper pair, increase pair multiplicity, or worsen a measured retained clearance. Connectivity/board-edge/unknown findings require exact retention or removal. A normally rejected optimization proposal retains the **completed original joint result**, not an earlier pre-joint board, and reports rejection statistics; thrown/failed solvers still fail visibly. Speculative geometry and connectivity state must be isolated from that incumbent.
- Residual via matching uses physical owner, position and layer span, not reindexed `via_N` labels. Diagnostic IDs are opaque: participant roles must come from explicit metadata. Required clearance is part of constraint identity. Unannotated generic residuals require an unchanged complete copper context, and annotated contacts require unchanged error records and physical pairs. This deliberately conservative gate can reject useful proposals and is not a claim that every inherited error is repairable.
- Existing exact/broad budgets 32/12 and the existing precision-pass policy are unchanged. No timeout increases, feature flags, adaptive calibration, sample-specific solver logic, acceptance epsilon or new failure fallback.

### Shared terminal-layer stitching

- Preserve a single-layer terminal's required layer instead of overwriting it with the neighboring fragment's layer.
- Preserve explicitly declared multilayer-terminal eligibility without inventing a via.
- A terminal transition must reuse an existing represented via with the exact directed layer pair, existing copper dimensions, and any transition allowlist respected. A 2D via coordinate alone is not sufficient evidence. Reversed or subset-span reuse is rejected conservatively because the public converter would otherwise emit another overlapping via element.
- Unsupported layer mismatches fail visibly; the fix does not synthesize unvalidated terminal vias. Existing planar clearance checks remain, and terminal-via approaches must be clear.
- Choose a complete endpoint path by fewest newly introduced gaps before route-hop count. Preserve the selected route order and directions through stitching. A rejected path no longer silently expands to all route fragments.
- Keep nearby distinct PCB terminal identities separate while preserving stable geometric cluster assignments. Two valid overlapping same-net pads are not conflicting terminal claims.
- This shared code affects multiple pipelines and is intentionally reviewed separately from #2413. No assertion is made that the stitching defect explains all inherited errors.

## Validation

Latest pushed head `e56e773e` is a manual hosted-format correction over functional `c54ad24f`. It searches directed physical-fragment paths with actual gap/end-cap clearance checks, preserving native traversal orientation and its output width. Adds three generic path/width tests, real SRJ18sample3 constructor ownership diagnostics, and actual SRJ20sample169 DRC diagnostics. Latest GitHub Type Check, Build, Format Check and No String ID Hacks **pass**; Bun Test34063459384 is running. No snapshots, DRC/via assertions or timeout limits have been relaxed. No local solver, tests, build, typecheck, formatter or benchmarks were run.

Third benchmark wave accepted for all six datasets, all pinned to main`fb6c6d7` and PR`e56e773`, sequential same-worker comparisons with unchanged default timeouts: [01](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/34063505205), [18](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/34063506309), [19](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/34063508584), [20](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/34063510772), [21](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/34063510493), [23](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/34063510163). Results pending; these are draft experiments with known unresolved regression risks, not merge-ready evidence.

The proposed Pipeline8 pad-crossing materialization was **not included**. Safe support also needs authoritative physical-copper metadata and preservation through shared simplification/optimization stages; the current SRJ lacks typed via metadata, and later optimizers can move/drop same-layer protected spans. Provisional companion code was removed before commit. Native/global Repair03 remains unchanged; bug59's missing upstream span remains unresolved.

Previous head `18a7d54b` preserves legacy traversal direction while honoring the selected ordered path, adds failure-only physical boundary context and focused sample26/45 regressions, and corrects the intended Pipeline9 stage-count/order contract. GitHub Type Check, Build and No String ID Hacks pass. Focused tests: **42 passed, 7 failed**. All nine full-suite shards also failed; this is not merge-ready. Hosted formatting diagnostics were corrected manually in the next revision.

Sample26's hosted test now reaches main's one remaining DRC, with no plated-hole contact at any of nine complete-board checkpoints. Sample169 has32vias and1DRC in both the focused job101563269018 and full-suite shard101563269195; it is not fixed. An earlier working-note claim of0DRC in the focused run was incorrect. The next test revision adds official error details while keeping exact33vias, completion and zero-DRC assertions unchanged. Physical-gap path selection and a missing protected same-layer pad crossing are under investigation; no local solver execution.

The preceding functional head `1149b798` restored original joint behavior and added the isolated later repair layer. GitHub Type Check/Build passed. Focused tests:39pass/6fail; all inherited/generic stitching contracts and original SRJ23sample21 passed. Sample169 completesDRC-clean but34vias vs33expected; remaining board path/visual regressions are open.

### Latest measured same-machine comparison (`1149b798` vs main `fb6c6d7`)

| Dataset | Matched completed-board DRCs | Completion notes |
| --- | ---: | --- |
| [01](https://github.com/tscircuit/tscircuit-autorouter/pull/2431#issuecomment-5562252900) | 0→0 | 85/85both; already all clean |
| [18](https://github.com/tscircuit/tscircuit-autorouter/pull/2431#issuecomment-5562253056) | **31→45 (worse)** | 13/16→11/16; lostclean3 and67-DRC13;1timeout each |
| [19](https://github.com/tscircuit/tscircuit-autorouter/pull/2431#issuecomment-5562253182) | pending | running |
| [20](https://github.com/tscircuit/tscircuit-autorouter/pull/2431#issuecomment-5562252820) | pending | running |
| [21](https://github.com/tscircuit/tscircuit-autorouter/pull/2431#issuecomment-5562252959) | **2→1 (-50%)** | 10/10both; small2-error baseline |
| [23](https://github.com/tscircuit/tscircuit-autorouter/pull/2431#issuecomment-5562253187) | **22→16 (-27.3%)** | 76/76→75/76; lostclean45; sample26 worsens1→2 |

SRJ18's unmatched98→45 total is **not** a valid improvement: missing sample13 alone removes67errors. SRJ23 gains six clean boards but also loses one clean completion and adds a plated-hole contact on another board. This is not merge-ready and does not meet the requested broad30–50% reduction with completion parity. The18a7head has not been benchmarked; do not attribute1149results to it.

### Earlier trial history

All tests, type/format checks, builds and benchmarks run on GitHub only using the existing machine GitHub account; no authentication changes and no local tests, builds, solver execution, installation, formatter or benchmarks.

New focused contracts cover inherited pad repair, same-ID worsening visibility, protected spans/terminal metadata, publication rejection and a clean positive control, physical-pair quality checks, via identity/reindexing, and shared terminal-layer correctness, including official DRC after via materialization.

Hosted revision `93cc30e1` passed all 29 inherited/stitching-focused tests. SRJ23 benchmark sample 49's full-board test improved from its two original pad-clearance errors to zero, with exact/via/broad budgets still 32/32/12. Type Check, Build, Vercel Build and No String ID Hacks passed. Two mechanical formatting findings are being corrected from hosted diagnostics. No broad DRC improvement is proven yet.

The added existing Pipeline7 SRJ20 sample 169 check failed at terminal stitching; its diagnostics expose an incompatible-layer island-to-terminal boundary. The wider suite also found Pipeline9 SRJ23 sample 21 at four errors versus an existing expectation of at most one, a Pipeline4 route-shape snapshot difference, and incomplete solves in bug reports 59 and 88. These are open regression investigations, not waived assertions or reasons to update snapshots blindly. Current main's corresponding full suite passed. The PR remains a draft.

Latest functional revision `1eb8f89e`: 32 focused tests passed, including all three new island/terminal ownership contracts; the two existing Pipeline7 sample 169 / Pipeline9 sample 21 tests still fail. Sample 169's real terminal branch exists in the HD input, so layer-compatible snapping alone has not fixed the complete traversal. Sample 21's proposed 4→1 reduction replaces a pad contact with a different trace-to-trace accidental contact. The publication gate rejects that proposal; this is an actual copper-pair trade, not merely a counter being misread. These problems are not resolved.

A focused GitHub job runs the joint-repair and stitch tests alongside the existing full balanced suite, using the existing 300-second per-test timeout. No timeout override is requested for comparisons.

Request `/benchmark-all --pipeline 9 --same-machine` and `/benchmark --pipeline 9 --dataset N --same-machine` for 19/20/21/23 because the deployed benchmark-all dispatcher currently covers only 01/18. Main and PR must use identical default limits on the same worker within each pair. Report final-board DRCs on matched completed samples and any lost main completions separately; timeouts are not improvements. Benchmark results must be read alongside the open correctness regressions above, not used to call a failing revision ready for merge.

This is an unproven experiment and is not ready for merge. Dataset-wide DRC impact, completion parity and runtime overhead remain to be measured.

## Same-machine experiment status

All six runs captured current main `fb6c6d7` and functional PR revision `1eb8f89` before the subsequent test-only formatting correction. No timeout override was supplied.

- [Dataset 01](https://github.com/tscircuit/tscircuit-autorouter/pull/2431#issuecomment-5562033814): complete. Both revisions completed 85/85, all DRC-clean, no timeouts; DRCs 0→0. P50 -3.3%, P95 +2.2%.
- [SRJ18](https://github.com/tscircuit/tscircuit-autorouter/pull/2431#issuecomment-5562033924): complete. Main completed13/16, PR12/16, one timeout each. Matched completed-board DRCs **31→154 (worse)**. The bot's unmatched totals98→154 hide loss of main's67-DRC sample13. Its failure was the nearby same-net terminal identity conflict, not a timeout. Artifact9996968912.
- [SRJ19](https://github.com/tscircuit/tscircuit-autorouter/pull/2431#issuecomment-5562033330): complete. Main184/200→PR167/200; timeouts16→13, but17main completions are lost at terminal-layer stitching. Matched completed-board DRCs **569→782 (worse)**. The bot's unmatched735→782 is not a comparable-board total. Both80clean boards, but different membership; artifact9997809564. This is the older1eb8f89head, not18a7.
- [SRJ20](https://github.com/tscircuit/tscircuit-autorouter/pull/2431#issuecomment-5562033315): running.
- [SRJ21](https://github.com/tscircuit/tscircuit-autorouter/pull/2431#issuecomment-5562034502): complete. Both revisions completed 10/10 with no timeouts and 9/10 clean boards. DRCs 2→2: no improvement. P50 -5.7%, P95 -5.4%.
- [SRJ23](https://github.com/tscircuit/tscircuit-autorouter/pull/2431#issuecomment-5562033349): complete. Both revisions completed 76/76 with no timeouts. Clean boards 64→69, but total DRCs **22→24 (worse)**. P50 -0.3%, P95 +6.9%. The bot's binary clean/dirty outcome table says no regressed outcomes, but that does **not** mean no per-board DRC regressions.

SRJ23 matched-board DRC changes from raw artifact `9996837519`:

| Sample | Main DRCs | PR DRCs |
| --- | ---: | ---: |
| 17 | 1 | 0 |
| 18 | 1 | 0 |
| 21 | 1 | 4 |
| 42 | 2 | 4 |
| 43 | 1 | 0 |
| 49 | 2 | 0 |
| 72 | 1 | 4 |
| 76 | 1 | 0 |

Therefore this trial has not achieved the requested dataset-wide DRC reduction. The five clean-board gains must not obscure the three worsening still-dirty boards.

This branch isolates the inherited-copper/stitching experiment. It does not contain #2413's separate high-density repair layer, and does not claim a 30–50% improvement across datasets.
