### PR TITLE
Improve bounded repair04 results and limit expensive searches

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9Repair04Solver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9Repair04Solver.ts
@@ -50,7 +50,7 @@ type Pipeline9Repair04SolverParams = {
 /** Owns board state; the external solver receives only one cropped region. */
 export class Pipeline9Repair04Solver extends BaseSolver {
   private routes: HighDensityRoute[]
-  private readonly engine: AutoroutingDrcEngine
+  private engine: AutoroutingDrcEngine | null = null
   private localSolver: Repair04Solver | null = null
   private region: ExtractedRepairRegion | null = null
   private issues: DrcError[] | null = null
@@ -96,11 +96,6 @@ export class Pipeline9Repair04Solver extends BaseSolver {
       input.maxPathSearchNodesSinceAcceptance !== undefined ||
       input.maxPathSearchNodesPerRegion !== undefined
     this.routes = input.hdRoutes
-    this.engine = new AutoroutingDrcEngine(input.srj as any, {
-      // Local DRC uses declared SRJ net aliases. The topology connectivity map
-      // can join distinct declared nets through geometric obstacle aliases.
-      includeTraceViaOwnerMetadata: true,
-    })
     this.MAX_ITERATIONS =
       (input.maxRegions ?? 32) *
         ((input.maxCandidatesPerRegion ?? 8000) * 2 + 6) +
@@ -117,6 +112,11 @@ export class Pipeline9Repair04Solver extends BaseSolver {
   }
 
   private evaluate(routes: HighDensityRoute[]): DrcError[] {
+    this.engine ??= new AutoroutingDrcEngine(this.input.srj as any, {
+      // Local DRC uses declared SRJ net aliases. The topology connectivity map
+      // can join distinct declared nets through geometric obstacle aliases.
+      includeTraceViaOwnerMetadata: true,
+    })
     return this.engine.evaluate([
       ...(this.input.srj.traces ?? []).map((trace) =>
         normalizeRepairTrace(trace as any, this.input.srj.minTraceWidth),
@@ -197,7 +197,6 @@ export class Pipeline9Repair04Solver extends BaseSolver {
 
   override _step(): void {
     if (!this.issues) {
-      this.issues = this.evaluate(this.routes)
       this.referenceErrors = this.evaluateReference(this.routes)
       if (this.input.maxTotalCandidateAttempts !== undefined) {
         this.initialReferenceErrors = this.referenceErrors.length
@@ -215,6 +214,13 @@ export class Pipeline9Repair04Solver extends BaseSolver {
         )
         this.stats = { ...this.stats, ...this.getTotalWorkStats() }
       }
+      // A reference-clean board is returned by identity. Indexed search and
+      // fixed-copper comparisons are needed only if repair will change it.
+      if (this.referenceErrors.length === 0) {
+        this.finishRepair("clean")
+        return
+      }
+      this.issues = this.evaluate(this.routes)
       this.fixedViolations = new Map(
         getFixedObstacleViolations({
           srj: this.input.srj as any,

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9Repair04Solver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9Repair04Solver.ts
@@ -125,14 +125,14 @@ export class Pipeline9Repair04Solver extends BaseSolver {
     ] as any).errorsWithCenters
   }
 
-  /** Prioritize dense residual regions without changing any search allowance. */
+  /** Prioritize dense regions when the initial search allowance is below half. */
   private getPrioritizedErrors(): DrcError[] {
     const errors = [...this.referenceErrors!, ...this.issues!]
-    // Preserve established search order when this stage has its full allowance.
+    // Preserve established order for boards with at least half the configured budget.
     if (
       this.initialReferenceErrors === null ||
       this.input.fullEffortReferenceErrorCount === undefined ||
-      this.initialReferenceErrors <= this.input.fullEffortReferenceErrorCount
+      this.initialReferenceErrors <= 2 * this.input.fullEffortReferenceErrorCount
     )
       return errors
     const centerOf = (error: DrcError): { x: number; y: number } | null => {
@@ -267,7 +267,14 @@ export class Pipeline9Repair04Solver extends BaseSolver {
               )
         this.effectiveMaxTotalCandidateAttempts = Math.max(
           1,
-          Math.floor(this.input.maxTotalCandidateAttempts * scale),
+          Math.min(
+            Math.floor(this.input.maxTotalCandidateAttempts * scale),
+            // Boards below half the allowance share one full region's
+            // proposal budget across all accepted regions.
+            scale < 0.5
+              ? (this.input.maxCandidatesPerRegion ?? 8000)
+              : Number.MAX_SAFE_INTEGER,
+          ),
         )
         this.stats = { ...this.stats, ...this.getTotalWorkStats() }
       }

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9Repair04Solver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9Repair04Solver.ts
@@ -125,6 +125,63 @@ export class Pipeline9Repair04Solver extends BaseSolver {
     ] as any).errorsWithCenters
   }
 
+  /** Prioritize dense residual regions without changing any search allowance. */
+  private getPrioritizedErrors(): DrcError[] {
+    const errors = [...this.referenceErrors!, ...this.issues!]
+    // Preserve established search order when this stage has its full allowance.
+    if (
+      this.initialReferenceErrors === null ||
+      this.input.fullEffortReferenceErrorCount === undefined ||
+      this.initialReferenceErrors <= this.input.fullEffortReferenceErrorCount
+    )
+      return errors
+    const centerOf = (error: DrcError): { x: number; y: number } | null => {
+      const targets = (error.existingViaRepairTargets ??
+        []) as ExistingViaRepairTarget[]
+      const center = targets[0] ?? error.center ?? error.pcb_center
+      if (
+        !center ||
+        typeof center !== "object" ||
+        !("x" in center) ||
+        !("y" in center)
+      )
+        return null
+      const { x, y } = center as { x: number; y: number }
+      return Number.isFinite(x) && Number.isFinite(y) ? { x, y } : null
+    }
+    const uniqueCenters = (items: DrcError[]): { x: number; y: number }[] => {
+      const centers = new Map<string, { x: number; y: number }>()
+      for (const error of items) {
+        const center = centerOf(error)
+        if (center) centers.set(`${center.x},${center.y}`, center)
+      }
+      return [...centers.values()]
+    }
+    const referenceCenters = uniqueCenters(this.referenceErrors!)
+    const centers = referenceCenters.length
+      ? referenceCenters
+      : uniqueCenters(this.issues!)
+    return errors
+      .map(
+        (error, index): { error: DrcError; index: number; coverage: number } => {
+          const center = centerOf(error)
+          let coverage = 0
+          if (center) {
+            for (const point of centers) {
+              if (
+                Math.abs(point.x - center.x) <= 5 &&
+                Math.abs(point.y - center.y) <= 5
+              )
+                coverage++
+            }
+          }
+          return { error, index, coverage }
+        },
+      )
+      .sort((a, b): number => b.coverage - a.coverage || a.index - b.index)
+      .map(({ error }): DrcError => error)
+  }
+
   private getCandidateAttemptLimit(): number | undefined {
     if (
       this.acceptedRegionCount === 0 &&
@@ -332,9 +389,8 @@ export class Pipeline9Repair04Solver extends BaseSolver {
       this.finishRepair("unsuccessful-work-budget")
       return
     }
-    // Escalate one issue's context before moving on; a long issue list must
-    // not consume the entire region budget before any larger bounds are tried.
-    for (const error of [...this.referenceErrors!, ...this.issues]) {
+    // Retain the existing context escalation within each prioritized issue.
+    for (const error of this.getPrioritizedErrors()) {
       for (const allowLayerChanges of this.input.allowLayerChanges === true
         ? [false, true]
         : [false]) {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "high-density-repair03": "https://codeload.github.com/tscircuit/high-density-repair03/tar.gz/9d6da7d69e7a02c066cf8e962b981da3c0b4e350",
     "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d",
     "@tscircuit/high-density-b01": "git+https://github.com/tscircuit/high-density-b01.git#e651cab6c314e7aab6df31fd6067277436f67148",
-    "@tscircuit/repair04": "git+https://github.com/tscircuit/repair04.git#91644859f79c001db96f1e41fd38dfd713731a15"
+    "@tscircuit/repair04": "git+https://github.com/tscircuit/repair04.git#8ff2627b617d6e16850ffba502cc4d011b19a6b8"
   },
   "dependencies": {
     "fast-json-stable-stringify": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "high-density-repair03": "https://codeload.github.com/tscircuit/high-density-repair03/tar.gz/9d6da7d69e7a02c066cf8e962b981da3c0b4e350",
     "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d",
     "@tscircuit/high-density-b01": "git+https://github.com/tscircuit/high-density-b01.git#e651cab6c314e7aab6df31fd6067277436f67148",
-    "@tscircuit/repair04": "git+https://github.com/tscircuit/repair04.git#8ff2627b617d6e16850ffba502cc4d011b19a6b8"
+    "@tscircuit/repair04": "git+https://github.com/tscircuit/repair04.git#0b89bee14b653e2bc8832b6e1fc4682ecfbd8ea0"
   },
   "dependencies": {
     "fast-json-stable-stringify": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "high-density-repair03": "https://codeload.github.com/tscircuit/high-density-repair03/tar.gz/9d6da7d69e7a02c066cf8e962b981da3c0b4e350",
     "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d",
     "@tscircuit/high-density-b01": "git+https://github.com/tscircuit/high-density-b01.git#e651cab6c314e7aab6df31fd6067277436f67148",
-    "@tscircuit/repair04": "git+https://github.com/tscircuit/repair04.git#0b89bee14b653e2bc8832b6e1fc4682ecfbd8ea0"
+    "@tscircuit/repair04": "git+https://github.com/tscircuit/repair04.git#154c824217f08089caf7f8896d2fabe42b32b9b0"
   },
   "dependencies": {
     "fast-json-stable-stringify": "^2.1.0",

--- a/test-timings.json
+++ b/test-timings.json
@@ -6,7 +6,9 @@
     "31432202969",
     "31436492559",
     "31646368017",
-    "32252254138"
+    "32252254138",
+    "34053385564",
+    "34055995279"
   ],
   "timings": {
     "tests/auto-capacity-depth.test.ts": 0,
@@ -155,7 +157,7 @@
     "tests/features/arduino-uno-inner-pours.test.ts": 0,
     "tests/features/build-hypergraph-net-id.test.ts": 0,
     "tests/features/capacity-node-tree-spans-all-overlapped-buckets.test.ts": 0,
-    "tests/features/dataset-srj29-ddr3-bga-routing-pipeline.test.ts": 84.2,
+    "tests/features/dataset-srj29-ddr3-bga-routing-pipeline.test.ts": 275.9,
     "tests/features/fixed-topology-high-density-bottom-layer-input.test.ts": 0,
     "tests/features/fixed-topology-high-density-intra-node-solver.test.ts": 0.5,
     "tests/features/high-density-cmn159-investigation.test.ts": 0.1,
@@ -235,6 +237,8 @@
     "tests/features/pipeline9-regional-fallback-materializes-vias.test.ts": 0,
     "tests/features/pipeline9-regional-fallback-target-layers.test.ts": 0,
     "tests/features/pipeline9-splices-hypergraph-preloaded-section.test.ts": 0,
+    "tests/features/pipeline9-srj18-sample12-via-pad-stage-handoff.test.ts": 224.5,
+    "tests/features/pipeline9-srj18-sample13-bounded-post-exact-precision.test.ts": 207.7,
     "tests/features/pipeline9-srj23-sample10-regional-fallback.test.ts": 0.5,
     "tests/features/pipeline9-srj23-sample21-regional-b01-repair.test.ts": 84.2,
     "tests/features/pipeline9-srj23-sample25-terminal-metadata.test.ts": 1.7,

--- a/tests/features/pipeline9-repair04-reference-clean-fast-path.test.ts
+++ b/tests/features/pipeline9-repair04-reference-clean-fast-path.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test"
+import { Pipeline9Repair04Solver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9Repair04Solver"
+import { createPipeline9Repair04Fixture } from "../fixtures/pipeline9-repair04-fixture"
+
+test("reference-clean repair returns unchanged copper without constructing indexed search state", (): void => {
+  const fixture = createPipeline9Repair04Fixture()
+  fixture.srj.obstacles.splice(0)
+  const before = structuredClone(fixture.hdRoutes)
+  const evaluateReference = fixture.referenceDrcEvaluator
+  let referenceCalls = 0
+  const solver = new Pipeline9Repair04Solver({
+    ...fixture,
+    maxTotalCandidateAttempts: 32_768,
+    fullEffortReferenceErrorCount: 16,
+    referenceDrcEvaluator: (input): ReturnType<typeof evaluateReference> => {
+      referenceCalls++
+      return evaluateReference(input)
+    },
+  })
+  solver.solve()
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(referenceCalls).toBe(1)
+  expect(solver.getOutput()).toBe(fixture.hdRoutes)
+  expect(solver.getOutput()).toEqual(before)
+  expect(solver.stats).toMatchObject({
+    completionReason: "clean",
+    referenceErrors: 0,
+    indexedErrors: null,
+    initialReferenceErrors: 0,
+    candidateAttempts: 0,
+    regions: 0,
+  })
+  const searchState = solver as unknown as {
+    engine: unknown
+    fixedViolations: unknown
+  }
+  expect(searchState.engine).toBeNull()
+  expect(searchState.fixedViolations).toBeNull()
+})

--- a/tests/features/pipeline9-repair04-region-priority.test.ts
+++ b/tests/features/pipeline9-repair04-region-priority.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test"
+import { Pipeline9Repair04Solver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9Repair04Solver"
+import { createTotalBudgetFixture } from "../fixtures/pipeline9-repair04-total-budget-fixture"
+
+test("repair04 prioritizes a dense independent region while keeping the child and total allowances", (): void => {
+  const fixture = createTotalBudgetFixture()
+  fixture.referenceDrcEvaluator = (): any[] => [
+    { type: "pcb_trace_error", message: "isolated", center: { x: 0, y: 0 } },
+    { type: "pcb_trace_error", message: "dense first", center: { x: 0, y: 12 } },
+    { type: "pcb_trace_error", message: "dense second", center: { x: 1, y: 12 } },
+    { type: "pcb_trace_error", message: "dense third", center: { x: 2, y: 12 } },
+  ]
+  const defaultSolver = new Pipeline9Repair04Solver(fixture) as any
+  defaultSolver.step()
+  expect(defaultSolver.region.bounds).toEqual({
+    minX: -5,
+    maxX: 5,
+    minY: -5,
+    maxY: 5,
+  })
+  const fullEffortSolver = new Pipeline9Repair04Solver({
+    ...fixture,
+    maxTotalCandidateAttempts: 7,
+    fullEffortReferenceErrorCount: 4,
+  }) as any
+  fullEffortSolver.step()
+  expect(fullEffortSolver.region.bounds).toEqual(defaultSolver.region.bounds)
+  expect(fullEffortSolver.effectiveMaxTotalCandidateAttempts).toBe(7)
+  const solver = new Pipeline9Repair04Solver({
+    ...fixture,
+    maxCandidatesPerRegion: 40,
+    maxInitialCandidateAttempts: 5,
+    maxTotalCandidateAttempts: 7,
+    fullEffortReferenceErrorCount: 3,
+    maxPathSearchNodesPerRegion: 123,
+  }) as any
+  solver.step()
+  expect(solver.region.bounds).toEqual({ minX: -5, maxX: 5, minY: 7, maxY: 17 })
+  expect(solver.localSolver.input.maxCandidates).toBe(40)
+  expect(solver.localSolver.input.maxCandidateAttempts).toBe(5)
+  expect(solver.localSolver.input.maxPathSearchNodes).toBe(123)
+  expect(solver.localSolver.input.allowLayerChanges).toBe(false)
+  expect(solver.effectiveMaxTotalCandidateAttempts).toBe(5)
+  expect(solver.candidateAttempts).toBe(0)
+  expect(solver.region.routeMappings.every((mapping: any): boolean => mapping.sourceRouteIndex === 1)).toBe(true)
+})

--- a/tests/features/pipeline9-repair04-region-priority.test.ts
+++ b/tests/features/pipeline9-repair04-region-priority.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test"
 import { Pipeline9Repair04Solver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9Repair04Solver"
 import { createTotalBudgetFixture } from "../fixtures/pipeline9-repair04-total-budget-fixture"
 
-test("repair04 prioritizes a dense independent region while keeping the child and total allowances", (): void => {
+test("repair04 prioritizes dense regions only below half the total allowance", (): void => {
   const fixture = createTotalBudgetFixture()
   fixture.referenceDrcEvaluator = (): any[] => [
     { type: "pcb_trace_error", message: "isolated", center: { x: 0, y: 0 } },
@@ -26,12 +26,23 @@ test("repair04 prioritizes a dense independent region while keeping the child an
   fullEffortSolver.step()
   expect(fullEffortSolver.region.bounds).toEqual(defaultSolver.region.bounds)
   expect(fullEffortSolver.effectiveMaxTotalCandidateAttempts).toBe(7)
+  for (const threshold of [3, 2]) {
+    const moderateSolver = new Pipeline9Repair04Solver({
+      ...fixture,
+      maxTotalCandidateAttempts: 20,
+      fullEffortReferenceErrorCount: threshold,
+      maxCandidatesPerRegion: 4,
+    }) as any
+    moderateSolver.step()
+    expect(moderateSolver.region.bounds).toEqual(defaultSolver.region.bounds)
+    expect(moderateSolver.effectiveMaxTotalCandidateAttempts).toBe(5 * threshold)
+  }
   const solver = new Pipeline9Repair04Solver({
     ...fixture,
     maxCandidatesPerRegion: 40,
     maxInitialCandidateAttempts: 5,
-    maxTotalCandidateAttempts: 7,
-    fullEffortReferenceErrorCount: 3,
+    maxTotalCandidateAttempts: 20,
+    fullEffortReferenceErrorCount: 1,
     maxPathSearchNodesPerRegion: 123,
   }) as any
   solver.step()

--- a/tests/features/pipeline9-repair04-total-budget-scaling.test.ts
+++ b/tests/features/pipeline9-repair04-total-budget-scaling.test.ts
@@ -2,14 +2,21 @@ import { expect, test } from "bun:test"
 import { Pipeline9Repair04Solver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9Repair04Solver"
 import { createPipeline9Repair04Fixture } from "../fixtures/pipeline9-repair04-fixture"
 
-test("total effort scales from the initial reference count with full effort for low counts and a minimum of one attempt", (): void => {
+test("only budgets scaled below half share one region allowance", (): void => {
   const fixture = createPipeline9Repair04Fixture()
-  for (const [count, total, threshold, expected] of [
+  for (const [count, total, threshold, expected, regionAllowance] of [
     [0, 32768, 16, 32768],
     [1, 32768, 16, 32768],
     [13, 32768, 16, 32768],
     [16, 32768, 16, 32768],
     [17, 32768, 16, 30840],
+    [19, 32768, 16, 27594],
+    [32, 32768, 16, 16384],
+    [33, 32768, 16, 8000],
+    [43, 32768, 16, 8000],
+    [43, 32768, 16, 200, 200],
+    [32, 32768, 16, 16384, 200],
+    [13, 32768, 16, 32768, 200],
     [82, 32768, 16, 6393],
     [100, 1, 1, 1],
     [82, 17, undefined, 17],
@@ -17,11 +24,14 @@ test("total effort scales from the initial reference count with full effort for 
     const solver = new Pipeline9Repair04Solver({
       ...fixture,
       maxTotalCandidateAttempts: total,
+      ...(regionAllowance === undefined
+        ? {}
+        : { maxCandidatesPerRegion: regionAllowance }),
       ...(threshold === undefined
         ? {}
         : { fullEffortReferenceErrorCount: threshold }),
-      referenceDrcEvaluator: () =>
-        Array.from({ length: count }, () => ({
+      referenceDrcEvaluator: (): any[] =>
+        Array.from({ length: count }, (): any => ({
           type: "reference_constraint",
           center: { x: 0, y: 0 },
         })),


### PR DESCRIPTION
Stacked on #2420. Difficult boards can spend repair time on isolated errors before reaching denser regions. When the initial DRC count reduces the search allowance below half its configured total, prioritize regions covering more distinct DRC locations and share at most one region's proposal allowance across the stage. Boards with at least half the allowance keep their existing order and budget.

Pin the optimized repair04 core: numeric spatial/A* keys, tighter conservative obstacle bounds, reusable geometry temporaries, and cached static-clearance results for unchanged segments. Reference-clean boards skip indexed DRC construction. Every accepted repair retains the boundary, full-board DRC, fixed-copper and via-pad guards. Three measured test-time estimates improve CI shard balance. The integration diff is six files; benchmark artifacts and documentation are outside the PR.

Final same-machine comparisons use the actual PR base `83082e2` → `242bd6a`, Pipeline9, effort 1, eight workers and a 360s per-sample timeout. Dataset01 and SRJ18 ran through `/benchmark-all --same-machine`; SRJ33 ran through `/benchmark --same-machine --dataset srj33`. Each pair runs sequentially on one Blacksmith machine.

| Dataset | Clean boards before → after | DRC errors before → after (delta) | Runtime before → after (delta) |
| --- | --- | --- | --- |
| [dataset01](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/34062727365) | 85/85 → 85/85 | 0 → 0 (+0) | 345.461s → 338.923s (-1.89%) |
| [srj18](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/34062729132) | 9/16 → 9/16 | 60 → 23 (-37) | 1621.414s → 1612.516s (-0.55%) |
| [srj33](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/34062725520) | 7/37 → 7/37 | 246 → 231 (-15) | 2914.305s → 2932.914s (+0.64%) |

DRC counts use the benchmark's relaxed DRC check; runtime is summed board runtime. Both are measured over the same completed boards: 85/85, 12/16 and 34/37, respectively. Clean-board denominators include every dataset member. SRJ18 has the same two timeouts (002,006) and two failures (014,015); SRJ33 has the same three timeouts (002,045,053). There are no lost completions, clean boards, or per-board DRC-count regressions among completed boards. This PR reduces error counts; it does not add a fully DRC-clean board.

| Sample | DRC before | DRC after | DRC delta | Runtime before → after | Runtime delta |
| --- | ---: | ---: | ---: | --- | --- |
| srj18 sample013 | 51 | 14 | -37 (-72.5%) | 308.678s → 314.612s | +5.933s (+1.92%) |
| srj33 sample005 | 68 | 55 | -13 (-19.1%) | 273.375s → 295.925s | +22.550s (+8.25%) |
| srj33 sample055 | 37 | 36 | -1 (-2.7%) | 295.863s → 340.721s | +44.858s (+15.16%) |

SRJ33 sample003 stays at 5 errors and sample046 at 10. Sample055 is the Gameboy board: its remaining 15.16% runtime increase for one fewer error is a limitation.

[Final-head CI](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/34062627275) passed all nine shards: 675 tests passed, 63 skipped, zero failures. The Gameboy test took 297.421s against the unchanged 300s limit, leaving only 2.579s of margin; this is not a robust timeout fix. Local validation passed 25 pipeline tests (440 assertions), typecheck and build, plus 66 core tests and typecheck. Core/engine comparisons preserve 24,525 saved solver states, outputs and DRC statistics. No test timeout or snapshot was changed.

Dependencies: [repair04#2](https://github.com/tscircuit/repair04/pull/2), [high-density-repair03#101](https://github.com/tscircuit/high-density-repair03/pull/101).
