### PR TITLE
Improve relaxed DRC passes with bounded multi-trace repair

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9Repair04Solver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9Repair04Solver.ts
@@ -1,3 +1,4 @@
+import { getStandardDrcErrorCount } from "./getStandardDrcErrorCount"
 import type { ExistingViaRepairTarget } from "./identifyPipeline9ViaPadRepairTargets"
 import {
   Repair04Solver,
@@ -331,6 +332,8 @@ export class Pipeline9Repair04Solver extends BaseSolver {
           const candidateReferenceErrors = this.evaluateReference(candidate)
           if (
             candidateReferenceErrors.length <= this.referenceErrors!.length &&
+            getStandardDrcErrorCount(candidateReferenceErrors) <=
+              getStandardDrcErrorCount(this.referenceErrors!) &&
             (candidateIssues.length < this.issues.length ||
               candidateReferenceErrors.length < this.referenceErrors!.length)
           ) {
@@ -398,10 +401,10 @@ export class Pipeline9Repair04Solver extends BaseSolver {
     }
     // Retain the existing context escalation within each prioritized issue.
     for (const error of this.getPrioritizedErrors()) {
-      for (const allowLayerChanges of this.input.allowLayerChanges === true
-        ? [false, true]
-        : [false]) {
-        for (const size of [10, 16, 24]) {
+      for (const size of [10, 16, 24]) {
+        for (const allowLayerChanges of this.input.allowLayerChanges === true
+          ? [false, true]
+          : [false]) {
           const selectedVias =
             this.input.allowExistingViaRelocation === false || allowLayerChanges
               ? []

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9Repair04Solver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9Repair04Solver.ts
@@ -60,6 +60,7 @@ export class Pipeline9Repair04Solver extends BaseSolver {
   private attempted = new Set<string>()
   private regionCount = 0
   private acceptedRegionCount = 0
+  private referenceImproved = false
   private candidateAttempts = 0
   private pathSearchNodes = 0
   private pathSearchCalls = 0
@@ -185,7 +186,7 @@ export class Pipeline9Repair04Solver extends BaseSolver {
 
   private getCandidateAttemptLimit(): number | undefined {
     if (
-      this.acceptedRegionCount === 0 &&
+      !this.referenceImproved &&
       this.input.maxInitialCandidateAttempts !== undefined
     )
       return this.input.maxInitialCandidateAttempts
@@ -337,6 +338,8 @@ export class Pipeline9Repair04Solver extends BaseSolver {
             (candidateIssues.length < this.issues.length ||
               candidateReferenceErrors.length < this.referenceErrors!.length)
           ) {
+            const referenceImproved =
+              candidateReferenceErrors.length < this.referenceErrors!.length
             this.routes = candidate
             this.issues = candidateIssues
             this.referenceErrors = candidateReferenceErrors
@@ -347,10 +350,12 @@ export class Pipeline9Repair04Solver extends BaseSolver {
               ]),
             )
             this.acceptedRegionCount++
-            // Child-local improvements do not reset this ledger. Only the
-            // proposal retained by every full-board acceptance guard does.
-            this.attemptsSinceAcceptance = 0
-            this.nodesSinceAcceptance = 0
+            // Retain indexed-only improvements without extending the search.
+            if (referenceImproved) {
+              this.referenceImproved = true
+              this.attemptsSinceAcceptance = 0
+              this.nodesSinceAcceptance = 0
+            }
           }
         }
       }
@@ -408,7 +413,11 @@ export class Pipeline9Repair04Solver extends BaseSolver {
           const selectedVias =
             this.input.allowExistingViaRelocation === false || allowLayerChanges
               ? []
-              : this.referenceErrors!.flatMap(
+              : this.referenceErrors!.filter(
+                  (referenceError): boolean =>
+                    referenceError.type !== "pcb_via_trace_clearance_error" ||
+                    referenceError === error,
+                ).flatMap(
                   (referenceError): ExistingViaRepairTarget[] =>
                     (referenceError.existingViaRepairTargets ??
                       []) as ExistingViaRepairTarget[],
@@ -425,7 +434,15 @@ export class Pipeline9Repair04Solver extends BaseSolver {
             continue
           const { x, y } = center as { x: number; y: number }
           if (!Number.isFinite(x) || !Number.isFinite(y)) continue
-          const key = `${Math.round(x * 2)},${Math.round(y * 2)},${size},${allowLayerChanges}`
+          const typedViaKey =
+            !allowLayerChanges &&
+            this.input.allowExistingViaRelocation !== false &&
+            error.type === "pcb_via_trace_clearance_error"
+              ? errorViaTargets.map(({ routeIndex, viaIndex }): string =>
+                  `${routeIndex}:${viaIndex}`,
+                ).sort().join(";")
+              : ""
+          const key = `${Math.round(x * 2)},${Math.round(y * 2)},${size},${allowLayerChanges}${typedViaKey ? `,${typedViaKey}` : ""}`
           if (this.attempted.has(key)) continue
           this.attempted.add(key)
           // The existing-via pass cannot move anything without a reference

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/getStandardDrcErrorCount.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/getStandardDrcErrorCount.ts
@@ -1,0 +1,30 @@
+type ReferenceError = {
+  type?: unknown
+  pcb_placement_error_id?: unknown
+  pcb_pad_pad_clearance_error_id?: unknown
+}
+
+/** Recognizes only the two supplemental checker identities in getDrcErrors. */
+export const isSupplementaryViaPadError = (
+  error: ReferenceError,
+): boolean => {
+  return (
+    (error.type === "pcb_placement_error" &&
+      typeof error.pcb_placement_error_id === "string" &&
+      error.pcb_placement_error_id.startsWith("via_in_pad_")) ||
+    (error.type === "pcb_pad_pad_clearance_error" &&
+      typeof error.pcb_pad_pad_clearance_error_id === "string" &&
+      error.pcb_pad_pad_clearance_error_id.startsWith("via_pad_clearance_"))
+  )
+}
+
+/** Count unfamiliar errors conservatively; retain the expanded list unchanged. */
+export const getStandardDrcErrorCount = (
+  errors: readonly ReferenceError[],
+): number => {
+  let count = 0
+  for (const error of errors) {
+    if (!isSupplementaryViaPadError(error)) count++
+  }
+  return count
+}

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/identifyPipeline9ViaPadRepairTargets.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/identifyPipeline9ViaPadRepairTargets.ts
@@ -55,7 +55,10 @@ export const identifyPipeline9ViaPadRepairTargets = ({
       error.type === "pcb_pad_pad_clearance_error" &&
       Array.isArray(error.pcb_pad_ids)
         ? error.pcb_pad_ids
-        : []
+        : error.type === "pcb_via_trace_clearance_error" &&
+            typeof error.pcb_via_id === "string"
+          ? [error.pcb_via_id]
+          : []
     const offendingVias = vias.filter((via): boolean => {
       if (ids.includes(via.pcb_via_id)) return true
       if (

--- a/lib/testing/utils/convertToCircuitJson.ts
+++ b/lib/testing/utils/convertToCircuitJson.ts
@@ -14,6 +14,8 @@ import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivity
 import { getViaDimensions } from "lib/utils/getViaDimensions"
 import type { LayerName } from "lib/utils/mapZToLayerName"
 import { mapZToLayerName } from "lib/utils/mapZToLayerName"
+import { getTraceConnectivityIds } from "./getTraceConnectivityIds"
+import { mergeRectangularSmtPadObstacles } from "./mergeRectangularSmtPadObstacles"
 
 /**
  * Convert a simplified PCB trace from the autorouter to a circuit-json compatible PCB trace
@@ -497,13 +499,15 @@ function createSourceTraces(
     for (const trace of hdRoutes as SimplifiedPcbTrace[]) {
       const connectedSourcePortIds = [
         ...new Set(
-          (trace.connectsTo ?? []).filter((id) => declaredPcbPortIds.has(id)),
+          getTraceConnectivityIds(trace).filter((id) =>
+            declaredPcbPortIds.has(id),
+          ),
         ),
       ]
       const connectedSourcePortIdSet = new Set(connectedSourcePortIds)
       const connectedSourceNetIds = [
         ...new Set(
-          (trace.connectsTo ?? []).filter(
+          getTraceConnectivityIds(trace).filter(
             (id) => !connectedSourcePortIdSet.has(id),
           ),
         ),
@@ -520,8 +524,8 @@ function createSourceTraces(
           circuitJsonSourceTraceIdResolver,
           trace.connection_name,
         ) ??
-        trace.connectsTo
-          ?.map((connectionId) =>
+        getTraceConnectivityIds(trace)
+          .map((connectionId) =>
             resolveCircuitJsonSourceTraceId(
               circuitJsonSourceTraceIdResolver,
               connectionId,
@@ -653,7 +657,7 @@ function createPcbPadElements(srj: SimpleRouteJson): AnyCircuitElement[] {
   const portPositionMap = getPcbPortPositionMap(srj)
   const declaredPcbPortIds = getSrjDeclaredPcbPortIds(srj)
 
-  for (const obstacle of srj.obstacles) {
+  for (const obstacle of mergeRectangularSmtPadObstacles(srj.obstacles)) {
     const connectedTo = obstacle.connectedTo
     const circuitJsonMetadata = getCircuitJsonMetadata(obstacle)
     if (circuitJsonMetadata.pcb_via_id) continue
@@ -996,8 +1000,8 @@ export function convertToCircuitJson(
             routeCircuitJsonSourceTraceIdResolver,
             trace.connection_name,
           ) ??
-          trace.connectsTo
-            ?.map((connectionId) =>
+          getTraceConnectivityIds(trace)
+            .map((connectionId) =>
               resolveCircuitJsonSourceTraceId(
                 routeCircuitJsonSourceTraceIdResolver,
                 connectionId,

--- a/lib/testing/utils/getTraceConnectivityIds.ts
+++ b/lib/testing/utils/getTraceConnectivityIds.ts
@@ -1,0 +1,18 @@
+import type { SimplifiedPcbTrace } from "lib/types"
+
+type TraceWithLegacyConnectivity = SimplifiedPcbTrace & {
+  connectedTo?: SimplifiedPcbTrace["connectsTo"]
+}
+
+export function getTraceConnectivityIds(
+  trace: SimplifiedPcbTrace,
+): readonly string[] {
+  if (trace.connectsTo !== undefined) {
+    return trace.connectsTo
+  }
+  const legacyTrace = trace as TraceWithLegacyConnectivity
+  if (legacyTrace.connectedTo !== undefined) {
+    return legacyTrace.connectedTo
+  }
+  return []
+}

--- a/lib/testing/utils/mergeRectangularSmtPadObstacles.ts
+++ b/lib/testing/utils/mergeRectangularSmtPadObstacles.ts
@@ -1,0 +1,114 @@
+import type { Obstacle } from "lib/types"
+
+type RectangularPadUnion = {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+/** Only merges rectangles whose complete union is one rectangle. */
+const getExactRectangularPadUnion = (
+  pieces: readonly Obstacle[],
+): RectangularPadUnion | null => {
+  const first = pieces[0]
+  const padId = first?.circuitJsonMetadata?.pcb_smtpad_id
+  const portId = first?.circuitJsonMetadata?.pcb_port_id
+  if (pieces.length < 2 || !first || !padId || !portId) return null
+  if (
+    pieces.some(
+      (piece): boolean =>
+        piece.type !== "rect" ||
+        (piece.ccwRotationDegrees !== undefined &&
+          piece.ccwRotationDegrees !== 0) ||
+        piece.layers.length !== 1 ||
+        piece.layers[0] !== first.layers[0] ||
+        piece.circuitJsonMetadata?.pcb_smtpad_id !== padId ||
+        piece.circuitJsonMetadata?.pcb_port_id !== portId ||
+        Boolean(piece.circuitJsonMetadata?.pcb_plated_hole_id) ||
+        Boolean(piece.circuitJsonMetadata?.pcb_via_id) ||
+        ![
+          piece.center.x,
+          piece.center.y,
+          piece.width,
+          piece.height,
+        ].every(Number.isFinite) ||
+        piece.width <= 0 ||
+        piece.height <= 0,
+    )
+  ) {
+    return null
+  }
+
+  const vertical = pieces.every(
+    (piece): boolean =>
+      piece.center.x === first.center.x && piece.width === first.width,
+  )
+  const horizontal = pieces.every(
+    (piece): boolean =>
+      piece.center.y === first.center.y && piece.height === first.height,
+  )
+  if (!vertical && !horizontal) return null
+  const intervals = pieces
+    .map((piece): [number, number] => {
+      const center = vertical ? piece.center.y : piece.center.x
+      const size = vertical ? piece.height : piece.width
+      return [center - size / 2, center + size / 2]
+    })
+    .sort((a, b): number => a[0] - b[0])
+  const start = intervals[0]![0]
+  let end = intervals[0]![1]
+  for (const [lo, hi] of intervals) {
+    if (!Number.isFinite(lo) || !Number.isFinite(hi) || lo > end) return null
+    end = Math.max(end, hi)
+  }
+  if (!Number.isFinite(end - start)) return null
+  return vertical
+    ? {
+        x: first.center.x,
+        y: start + (end - start) / 2,
+        width: first.width,
+        height: end - start,
+      }
+    : {
+        x: start + (end - start) / 2,
+        y: first.center.y,
+        width: end - start,
+        height: first.height,
+      }
+}
+
+/** Preserve complete copper coverage when a pad is stored as aligned strips. */
+export const mergeRectangularSmtPadObstacles = (
+  obstacles: Obstacle[],
+): Obstacle[] => {
+  const groups = new Map<string, number[]>()
+  for (const [index, obstacle] of obstacles.entries()) {
+    const id = obstacle.circuitJsonMetadata?.pcb_smtpad_id
+    if (!id) continue
+    const group = groups.get(id)
+    if (group) group.push(index)
+    else groups.set(id, [index])
+  }
+  const replacements = new Map<number, Obstacle>()
+  const absorbed = new Set<number>()
+  for (const indices of groups.values()) {
+    const pieces = indices.map((index): Obstacle => obstacles[index]!)
+    const union = getExactRectangularPadUnion(pieces)
+    if (!union) continue
+    replacements.set(indices[0]!, {
+      ...pieces[0]!,
+      center: { x: union.x, y: union.y },
+      width: union.width,
+      height: union.height,
+      connectedTo: [
+        ...new Set(pieces.flatMap((piece): string[] => piece.connectedTo)),
+      ],
+    })
+    for (const index of indices.slice(1)) absorbed.add(index)
+  }
+  if (replacements.size === 0) return obstacles
+  return obstacles.flatMap((obstacle, index): Obstacle[] =>
+    absorbed.has(index) ? [] : [replacements.get(index) ?? obstacle],
+  )
+}

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "high-density-repair03": "https://codeload.github.com/tscircuit/high-density-repair03/tar.gz/9d6da7d69e7a02c066cf8e962b981da3c0b4e350",
     "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d",
     "@tscircuit/high-density-b01": "git+https://github.com/tscircuit/high-density-b01.git#e651cab6c314e7aab6df31fd6067277436f67148",
-    "@tscircuit/repair04": "git+https://github.com/tscircuit/repair04.git#188552c93ce842b93fb71111bb467a5808db7d2b"
+    "@tscircuit/repair04": "git+https://github.com/tscircuit/repair04.git#370ebc6b5f5438fc398edc840c4c1864d313a3b5"
   },
   "dependencies": {
     "fast-json-stable-stringify": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "high-density-repair03": "https://codeload.github.com/tscircuit/high-density-repair03/tar.gz/9d6da7d69e7a02c066cf8e962b981da3c0b4e350",
     "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d",
     "@tscircuit/high-density-b01": "git+https://github.com/tscircuit/high-density-b01.git#e651cab6c314e7aab6df31fd6067277436f67148",
-    "@tscircuit/repair04": "git+https://github.com/tscircuit/repair04.git#154c824217f08089caf7f8896d2fabe42b32b9b0"
+    "@tscircuit/repair04": "git+https://github.com/tscircuit/repair04.git#188552c93ce842b93fb71111bb467a5808db7d2b"
   },
   "dependencies": {
     "fast-json-stable-stringify": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "high-density-repair03": "https://codeload.github.com/tscircuit/high-density-repair03/tar.gz/9d6da7d69e7a02c066cf8e962b981da3c0b4e350",
     "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d",
     "@tscircuit/high-density-b01": "git+https://github.com/tscircuit/high-density-b01.git#e651cab6c314e7aab6df31fd6067277436f67148",
-    "@tscircuit/repair04": "git+https://github.com/tscircuit/repair04.git#370ebc6b5f5438fc398edc840c4c1864d313a3b5"
+    "@tscircuit/repair04": "git+https://github.com/tscircuit/repair04.git#79f794a426c32740ad89edf3624ac9e0c881bc13"
   },
   "dependencies": {
     "fast-json-stable-stringify": "^2.1.0",

--- a/tests/features/merge-rectangular-smtpad-obstacles-ineligible.test.ts
+++ b/tests/features/merge-rectangular-smtpad-obstacles-ineligible.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "bun:test"
+import type { Obstacle } from "lib/types"
+import {
+  mergeRectangularSmtPadObstacles,
+} from "lib/testing/utils/mergeRectangularSmtPadObstacles"
+
+test("retains every piece of unsupported pad unions", (): void => {
+  const pad = (): Obstacle => ({
+    type: "rect",
+    center: { x: 0, y: 0 },
+    width: 1,
+    height: 1,
+    layers: ["top"],
+    connectedTo: ["same-net"],
+    circuitJsonMetadata: { pcb_smtpad_id: "pad", pcb_port_id: "port" },
+  })
+  const changed = (update: Partial<Obstacle>): Obstacle => ({
+    ...pad(),
+    center: { x: 0, y: 0.5 },
+    ...update,
+  })
+  const cases: Obstacle[][] = [
+    [pad()],
+    [pad(), changed({ center: { x: 0, y: 1.01 } })],
+    [pad(), changed({ center: { x: 0.5, y: 0.5 } })],
+    [pad(), changed({ width: 0.75 })],
+    [pad(), changed({ ccwRotationDegrees: 45 })],
+    [pad(), changed({ layers: ["bottom"] })],
+    [pad(), changed({ layers: ["top", "bottom"] })],
+    [pad(), changed({ width: Number.NaN })],
+    [pad(), changed({ height: 0 })],
+    [pad(), changed({ circuitJsonMetadata: { pcb_smtpad_id: "other" } })],
+    [
+      pad(),
+      changed({
+        circuitJsonMetadata: { pcb_smtpad_id: "pad", pcb_port_id: "other" },
+      }),
+    ],
+    [
+      pad(),
+      changed({
+        circuitJsonMetadata: {
+          pcb_smtpad_id: "pad",
+          pcb_port_id: "port",
+          pcb_plated_hole_id: "hole",
+        },
+      }),
+    ],
+  ]
+  for (const obstacles of cases) {
+    const original = [...obstacles]
+    const result = mergeRectangularSmtPadObstacles(obstacles)
+    expect(result).toBe(obstacles)
+    expect(result).toHaveLength(original.length)
+    result.forEach((piece, index): void => {
+      expect(piece).toBe(original[index])
+    })
+  }
+})

--- a/tests/features/merge-rectangular-smtpad-obstacles.test.ts
+++ b/tests/features/merge-rectangular-smtpad-obstacles.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "bun:test"
+import type { Obstacle } from "lib/types"
+import {
+  mergeRectangularSmtPadObstacles,
+} from "lib/testing/utils/mergeRectangularSmtPadObstacles"
+
+test("merges aligned pad strips without mutating input", (): void => {
+  const pad = (
+    id: string,
+    x: number,
+    y: number,
+    alias: string,
+  ): Obstacle => ({
+    type: "rect",
+    center: { x, y },
+    width: 1,
+    height: 1,
+    layers: ["top"],
+    connectedTo: ["shared-net", alias],
+    circuitJsonMetadata: { pcb_smtpad_id: id, pcb_port_id: `${id}-port` },
+  })
+  const untouched = pad("unrelated", 8, 8, "other")
+  const obstacles = [
+    pad("vertical", 0, 0.5, "upper"),
+    untouched,
+    pad("horizontal", 3, 0, "left"),
+    pad("vertical", 0, 0, "lower"),
+    pad("horizontal", 3.5, 0, "right"),
+  ]
+  const original = structuredClone(obstacles)
+  const merged = mergeRectangularSmtPadObstacles(obstacles)
+  expect(merged).toHaveLength(3)
+  expect(merged[0]).toMatchObject({
+    center: { x: 0, y: 0.25 },
+    width: 1,
+    height: 1.5,
+    connectedTo: ["shared-net", "upper", "lower"],
+    circuitJsonMetadata: {
+      pcb_smtpad_id: "vertical",
+      pcb_port_id: "vertical-port",
+    },
+  })
+  expect(merged[1]).toBe(untouched)
+  expect(merged[2]).toMatchObject({
+    center: { x: 3.25, y: 0 },
+    width: 1.5,
+    height: 1,
+    connectedTo: ["shared-net", "left", "right"],
+  })
+  expect(obstacles).toEqual(original)
+})

--- a/tests/features/pipeline9-reference-budget-after-progress.test.ts
+++ b/tests/features/pipeline9-reference-budget-after-progress.test.ts
@@ -1,0 +1,43 @@
+import type { Repair04Solver } from "@tscircuit/repair04"
+import { expect, test } from "bun:test"
+import { Pipeline9Repair04Solver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9Repair04Solver"
+import { createTotalBudgetFixture } from "../fixtures/pipeline9-repair04-total-budget-fixture"
+
+test("indexed-only repairs after reference progress consume the graduated allowance", (): void => {
+  const fixture = createTotalBudgetFixture()
+  const solver = new Pipeline9Repair04Solver({
+    ...fixture,
+    maxRegions: 10,
+    maxInitialCandidateAttempts: 1,
+    maxCandidateAttemptsSinceAcceptance: 2,
+    referenceDrcEvaluator: (input): ReturnType<typeof fixture.referenceDrcEvaluator> => {
+      const result = fixture.referenceDrcEvaluator(input)
+      const errors = Array.isArray(result) ? result : result.errors
+      if (errors.length >= 2) return errors
+      return [
+        ...errors,
+        ...Array.from({ length: 2 - errors.length }, (_, index): { type: string; center: { x: number; y: number } } => ({
+          type: `remaining_constraint_${index}`,
+          center: { x: 0, y: -12 },
+        })),
+      ]
+    },
+  })
+  const children: Repair04Solver[] = []
+  while (!solver.solved && !solver.failed) {
+    solver.step()
+    const child = (solver as unknown as { localSolver: Repair04Solver | null }).localSolver
+    if (child && children.at(-1) !== child) children.push(child)
+  }
+  expect(solver.failed).toBe(false)
+  expect(children.map((child): number | undefined => child.getConstructorParams()[0].maxCandidateAttempts)).toEqual([1, 2, 1])
+  expect(solver.stats.acceptedRegions).toBe(3)
+  expect(solver.stats.referenceErrors).toBe(2)
+  expect(solver.stats.indexedErrors).toBe(0)
+  expect(solver.stats.candidateAttempts).toBe(3)
+  expect(solver.stats.attemptsSinceAcceptance).toBe(2)
+  expect(solver.stats.nodesSinceAcceptance).toBe(
+    children[1]!.stats.pathSearchNodes + children[2]!.stats.pathSearchNodes,
+  )
+  expect(solver.stats.completionReason).toBe("unsuccessful-work-budget")
+})

--- a/tests/features/pipeline9-reference-budget-indexed-only.test.ts
+++ b/tests/features/pipeline9-reference-budget-indexed-only.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test"
+import { Pipeline9Repair04Solver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9Repair04Solver"
+import { createPipeline9Repair04Fixture } from "../fixtures/pipeline9-repair04-fixture"
+
+test("retains indexed-only repair without replenishing work or graduating the initial allowance", (): void => {
+  const fixture = createPipeline9Repair04Fixture()
+  const solver = new Pipeline9Repair04Solver({
+    ...fixture,
+    maxRegions: 10,
+    maxInitialCandidateAttempts: 1,
+    maxCandidateAttemptsSinceAcceptance: 10,
+    maxPathSearchNodesSinceAcceptance: 100000,
+    referenceDrcEvaluator: (): ReturnType<typeof fixture.referenceDrcEvaluator> => [
+      { type: "remaining_constraint", center: { x: 0, y: 0 } },
+    ],
+  })
+  solver.solve()
+  expect(solver.failed).toBe(false)
+  expect(solver.stats.acceptedRegions).toBe(1)
+  expect(solver.stats.indexedErrors).toBe(0)
+  expect(solver.stats.referenceErrors).toBe(1)
+  expect(solver.stats.candidateAttempts).toBe(1)
+  expect(solver.stats.attemptsSinceAcceptance).toBe(1)
+  expect(solver.stats.pathSearchNodes).toBeGreaterThan(0)
+  expect(solver.stats.nodesSinceAcceptance).toBe(solver.stats.pathSearchNodes)
+  expect(solver.stats.regions).toBe(1)
+  expect(solver.stats.completionReason).toBe("unsuccessful-work-budget")
+  const routes = solver.getOutput()
+  expect(routes).not.toEqual(fixture.hdRoutes)
+  for (const [index, route] of routes.entries()) {
+    expect(route.route[0]).toEqual(fixture.hdRoutes[index]!.route[0])
+    expect(route.route.at(-1)).toEqual(fixture.hdRoutes[index]!.route.at(-1))
+    expect(route.vias).toEqual(fixture.hdRoutes[index]!.vias)
+  }
+})

--- a/tests/features/pipeline9-repair04-standard-drc-count.test.ts
+++ b/tests/features/pipeline9-repair04-standard-drc-count.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "bun:test"
+import {
+  getStandardDrcErrorCount,
+  isSupplementaryViaPadError,
+} from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/getStandardDrcErrorCount"
+
+test("only supplemental via-pad identities are excluded from standard count", (): void => {
+  const supplemental = [
+    {
+      type: "pcb_placement_error",
+      pcb_placement_error_id: "via_in_pad_opaque_via_opaque_pad",
+    },
+    {
+      type: "pcb_pad_pad_clearance_error",
+      pcb_pad_pad_clearance_error_id: "via_pad_clearance_opaque_via_pad",
+    },
+  ]
+  const standard = [
+    { type: "pcb_trace_error" },
+    { type: "pcb_via_trace_clearance_error" },
+    { type: "pcb_pad_trace_clearance_error" },
+    { type: "pcb_via_clearance_error" },
+    { type: "new_unknown_error" },
+    { type: "pcb_placement_error" },
+    {
+      type: "pcb_placement_error",
+      pcb_placement_error_id: "out_of_board_via_a",
+    },
+    {
+      type: "pcb_pad_pad_clearance_error",
+      pcb_pad_pad_clearance_error_id: "pad_pad_clearance_a_b",
+    },
+    {
+      type: "new_unknown_error",
+      pcb_placement_error_id: "via_in_pad_a_b",
+    },
+    {
+      type: "pcb_placement_error",
+      pcb_placement_error_id: 123,
+    },
+    {
+      type: "pcb_pad_pad_clearance_error",
+      pcb_pad_pad_clearance_error_id: null,
+    },
+  ]
+  const errors = [...standard, ...supplemental]
+  const before = structuredClone(errors)
+  expect(getStandardDrcErrorCount(errors)).toBe(standard.length)
+  expect(getStandardDrcErrorCount([...errors].reverse())).toBe(standard.length)
+  expect(getStandardDrcErrorCount([...errors, standard[0]!])).toBe(
+    standard.length + 1,
+  )
+  expect(getStandardDrcErrorCount([])).toBe(0)
+  for (const error of standard) {
+    expect(isSupplementaryViaPadError(error)).toBe(false)
+  }
+  for (const error of supplemental) {
+    expect(isSupplementaryViaPadError(error)).toBe(true)
+  }
+  // Expanded improvement 5→3 must not permit a standard increase 2→3.
+  const current = [standard[0]!, standard[1]!, ...supplemental, supplemental[0]!]
+  const candidate = standard.slice(0, 3)
+  expect(candidate.length).toBeLessThan(current.length)
+  expect(getStandardDrcErrorCount(candidate)).toBeGreaterThan(
+    getStandardDrcErrorCount(current),
+  )
+  expect(errors).toEqual(before)
+})

--- a/tests/features/pipeline9-repair04-typed-via-target-key.test.ts
+++ b/tests/features/pipeline9-repair04-typed-via-target-key.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "bun:test"
+import type { ExtractedRepairRegion, Repair04SolverInput } from "@tscircuit/repair04"
+import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
+import type { SimpleRouteJson } from "lib/types"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+import { Pipeline9Repair04Solver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9Repair04Solver"
+
+type Access = {
+  localSolver: { getConstructorParams(): [Repair04SolverInput] } | null
+  region: ExtractedRepairRegion | null
+}
+
+test("nearby typed-via targets receive distinct searches when their crop centers share a rounded key", (): void => {
+  const bounds = { minX: -6, maxX: 6, minY: -6, maxY: 6 }
+  const srj: SimpleRouteJson = { bounds, layerCount: 2, minTraceWidth: 0.1, obstacles: [], connections: [] }
+  const routes: HighDensityRoute[] = [0, 0.1].map((x): HighDensityRoute => ({
+    connectionName: `owner${x}`, traceThickness: 0.1, viaDiameter: 0.3,
+    vias: [{ x, y: 0 }], route: [
+      { x, y: -1, z: 0 }, { x, y: 0, z: 0 },
+      { x, y: 0, z: 1 }, { x, y: 1, z: 1 },
+    ],
+  }))
+  const errors = routes.map((route, routeIndex): {
+    type: string
+    center: { x: number; y: number }
+    existingViaRepairTargets: { routeIndex: number; viaIndex: number; x: number; y: number }[]
+  } => ({
+    type: "pcb_via_trace_clearance_error", center: route.vias[0]!,
+    existingViaRepairTargets: [{ routeIndex, viaIndex: 0, ...route.vias[0]! }],
+  }))
+  const solver = new Pipeline9Repair04Solver({
+    srj, hdRoutes: routes, connMap: getConnectivityMapFromSimpleRouteJson(srj),
+    referenceDrcEvaluator: (): typeof errors => errors,
+    allowLayerChanges: false, maxRegions: 16, maxCandidatesPerRegion: 1,
+  })
+  let previous: Access["localSolver"] = null
+  const selected: number[][] = []
+  while (!solver.solved && !solver.failed) {
+    solver.step()
+    expect(solver.iterations).toBeLessThan(200)
+    const access = solver as unknown as Access
+    if (access.localSolver && access.localSolver !== previous) {
+      previous = access.localSolver
+      const [child] = previous.getConstructorParams()
+      if (child.movableVias!.length) selected.push(child.movableVias!.map(({ routeIndex }): number =>
+        access.region!.routeMappings[routeIndex]!.sourceRouteIndex,
+      ))
+    }
+  }
+  expect(solver.failed).toBe(false)
+  expect(solver.stats.acceptedRegions).toBe(0)
+  expect(solver.getOutput()).toEqual(routes)
+  expect(selected).toEqual([[0], [0], [0], [1], [1], [1]])
+})

--- a/tests/features/pipeline9-repair04-typed-via-target-locality.test.ts
+++ b/tests/features/pipeline9-repair04-typed-via-target-locality.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test"
+import type { ExtractedRepairRegion, Repair04SolverInput } from "@tscircuit/repair04"
+import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
+import type { SimpleRouteJson } from "lib/types"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+import { Pipeline9Repair04Solver } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9Repair04Solver"
+
+type Access = {
+  localSolver: { getConstructorParams(): [Repair04SolverInput] } | null
+  region: ExtractedRepairRegion | null
+}
+
+test("a repair crop selects its own typed via-trace target while preserving legacy via-pad targets", (): void => {
+  const bounds = { minX: -6, maxX: 6, minY: -6, maxY: 6 }
+  const srj: SimpleRouteJson = { bounds, layerCount: 2, minTraceWidth: 0.1, obstacles: [], connections: [] }
+  const routes: HighDensityRoute[] = [0, 1, 2].map((x): HighDensityRoute => ({
+    connectionName: `owner${x}`, traceThickness: 0.1, viaDiameter: 0.3,
+    vias: [{ x, y: 0 }], route: [
+      { x, y: -1, z: 0 }, { x, y: 0, z: 0 },
+      { x, y: 0, z: 1 }, { x, y: 1, z: 1 },
+    ],
+  }))
+  const errors = routes.map((_, routeIndex): {
+    type: string
+    center: { x: number; y: number }
+    existingViaRepairTargets: { routeIndex: number; viaIndex: number; x: number; y: number }[]
+  } => ({
+    type: routeIndex === 2 ? "pcb_pad_pad_clearance_error" : "pcb_via_trace_clearance_error",
+    center: { x: routeIndex, y: 0 },
+    existingViaRepairTargets: [{ routeIndex, viaIndex: 0, x: routeIndex, y: 0 }],
+  }))
+  const before = structuredClone(routes)
+  for (const first of [0, 1, 2]) {
+    const ordered = [errors[first]!, ...errors.filter((_, index): boolean => index !== first)]
+    const solver = new Pipeline9Repair04Solver({
+      srj, hdRoutes: routes, connMap: getConnectivityMapFromSimpleRouteJson(srj),
+      referenceDrcEvaluator: (): typeof errors => ordered,
+      allowLayerChanges: true, maxRegions: 1, maxCandidatesPerRegion: 1,
+    })
+    solver.step()
+    const access = solver as unknown as Access
+    expect(solver.failed).toBe(false)
+    expect(access.localSolver).not.toBeNull()
+    expect(access.region).not.toBeNull()
+    const [child] = access.localSolver!.getConstructorParams()
+    expect(child.allowLayerChanges).toBe(false)
+    const selectedSources = child.movableVias!.map(({ routeIndex }): number =>
+      access.region!.routeMappings[routeIndex]!.sourceRouteIndex,
+    ).sort((a, b): number => a - b)
+    expect(selectedSources).toEqual(first === 2 ? [2] : [first, 2])
+    expect(child.bounds.minX).toBe(first - 5)
+    expect(child.bounds.maxX).toBe(first + 5)
+  }
+  expect(routes).toEqual(before)
+})

--- a/tests/features/pipeline9-repair04-via-trace-targets.test.ts
+++ b/tests/features/pipeline9-repair04-via-trace-targets.test.ts
@@ -1,0 +1,128 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+import { getDrcErrors } from "lib/testing/getDrcErrors"
+import { identifyPipeline9ViaPadRepairTargets } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/identifyPipeline9ViaPadRepairTargets"
+
+test("explicit via-trace identity selects only its owned physical span", (): void => {
+  const routes: HighDensityRoute[] = [
+    {
+      connectionName: "upper-route",
+      traceThickness: 0.1,
+      viaDiameter: 0.3,
+      vias: [{ x: 0, y: 0 }],
+      route: [
+        { x: -2, y: 0, z: 0 },
+        { x: 0, y: 0, z: 0 },
+        { x: 0, y: 0, z: 1 },
+        { x: 2, y: 0, z: 1 },
+      ],
+    },
+    {
+      connectionName: "lower-route",
+      traceThickness: 0.1,
+      viaDiameter: 0.3,
+      vias: [{ x: 0, y: 0 }],
+      route: [
+        { x: -2, y: 0, z: 2 },
+        { x: 0, y: 0, z: 2 },
+        { x: 0, y: 0, z: 3 },
+        { x: 2, y: 0, z: 3 },
+      ],
+    },
+  ]
+  const upperVia: Extract<AnyCircuitElement, { type: "pcb_via" }> = {
+    type: "pcb_via",
+    pcb_via_id: "opaque-via-alpha",
+    pcb_trace_id: "final-trace-a",
+    x: 0,
+    y: 0,
+    outer_diameter: 0.3,
+    hole_diameter: 0.15,
+    layers: ["top", "inner1"],
+  }
+  const lowerVia: Extract<AnyCircuitElement, { type: "pcb_via" }> = {
+    ...upperVia,
+    pcb_via_id: "opaque-via-beta",
+    pcb_trace_id: "final-trace-b",
+    layers: ["inner2", "bottom"],
+  }
+  const circuitJson: AnyCircuitElement[] = [
+    upperVia,
+    lowerVia,
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "foreign-trace",
+      route: [
+        { route_type: "wire", x: 0.25, y: -1, width: 0.1, layer: "top" },
+        { route_type: "wire", x: 0.25, y: 1, width: 0.1, layer: "top" },
+      ],
+    },
+  ]
+  const errors: Record<string, unknown>[] = getDrcErrors(circuitJson, {
+    traceClearance: 0.1,
+    includeTraceContinuity: false,
+  }).errorsWithCenters.filter(
+    (error): boolean => error.type === "pcb_via_trace_clearance_error",
+  ).map((error): Record<string, unknown> => ({ ...error }))
+  expect(errors).toHaveLength(1)
+  expect(errors[0]).toMatchObject({
+    pcb_via_id: upperVia.pcb_via_id,
+    pcb_trace_id: "foreign-trace",
+    center: { x: 0, y: 0 },
+  })
+  const finalTraceIdByConvertedTraceId = new Map<string, string>([
+    ["upper-route_0", "final-trace-a"],
+    ["lower-route_0", "final-trace-b"],
+  ])
+  const options = {
+    errors, circuitJson, routes, layerCount: 4,
+    finalTraceIdByConvertedTraceId,
+  }
+  const before = structuredClone({ errors, circuitJson, routes })
+  const identified = identifyPipeline9ViaPadRepairTargets(options)
+  expect(identified[0]!.existingViaRepairTargets).toEqual([
+    { routeIndex: 0, viaIndex: 0, x: 0, y: 0 },
+  ])
+  const { existingViaRepairTargets: _targets, ...unchangedPayload } =
+    identified[0]!
+  expect(unchangedPayload).toEqual(errors[0])
+
+  const unknownId = { ...errors[0], pcb_via_id: "unknown-via" }
+  const wrongType = { ...errors[0], type: "pcb_trace_error" }
+  const nonStringId = { ...errors[0], pcb_via_id: 7 }
+  for (const error of [unknownId, wrongType, nonStringId]) {
+    const result = identifyPipeline9ViaPadRepairTargets({
+      ...options, errors: [error],
+    })
+    expect(result[0]).toBe(error)
+  }
+
+  const wrongSpans: AnyCircuitElement[][] = [
+    [{ ...upperVia, layers: ["inner2", "bottom"] }, lowerVia],
+    [{ ...upperVia, outer_diameter: 0.4 }, lowerVia],
+    [{ ...upperVia, x: 0.01 }, lowerVia],
+  ]
+  for (const geometry of wrongSpans) {
+    const result = identifyPipeline9ViaPadRepairTargets({
+      ...options, circuitJson: geometry,
+    })
+    expect(result[0]).toBe(errors[0])
+  }
+
+  const unowned = { ...upperVia }
+  delete unowned.pcb_trace_id
+  const fixed = { ...upperVia, pcb_trace_id: "immutable-preloaded-trace" }
+  for (const via of [unowned, fixed]) {
+    const result = identifyPipeline9ViaPadRepairTargets({
+      ...options, circuitJson: [via, lowerVia],
+    })
+    expect(result[0]).toBe(errors[0])
+  }
+  const otherError = { type: "unrelated_error", message: "keep exact payload" }
+  const mixed = identifyPipeline9ViaPadRepairTargets({
+    ...options, errors: [...errors, otherError],
+  })
+  expect(mixed[1]).toBe(otherError)
+  expect({ errors, circuitJson, routes }).toEqual(before)
+})

--- a/tests/features/rectangular-smtpad-drc-serialization.test.ts
+++ b/tests/features/rectangular-smtpad-drc-serialization.test.ts
@@ -1,0 +1,108 @@
+import { expect, test } from "bun:test"
+import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
+import type { Obstacle, SimpleRouteJson, SimplifiedPcbTrace } from "lib/types"
+
+test("serializes pad copper while retaining real DRC failures", (): void => {
+  const srj: SimpleRouteJson = {
+    layerCount: 2,
+    minTraceWidth: 0.15,
+    bounds: { minX: -2, maxX: 6, minY: -2, maxY: 2 },
+    connections: [
+      {
+        name: "signal",
+        pointsToConnect: [
+          { x: 0, y: 0, layer: "top", pcb_port_id: "pcb_port_left" },
+          { x: 4, y: 0, layer: "top", pcb_port_id: "pcb_port_right" },
+        ],
+      },
+    ],
+    obstacles: [
+      ...[0.5, 0, -0.5].map((y): Obstacle => ({
+        type: "rect",
+        center: { x: 0, y },
+        width: 1,
+        height: 0.6,
+        layers: ["top"],
+        connectedTo: ["signal", "pcb_port_left"],
+        circuitJsonMetadata: {
+          pcb_smtpad_id: "left_pad",
+          pcb_port_id: "pcb_port_left",
+        },
+      })),
+      {
+        type: "rect",
+        center: { x: 4, y: 0 },
+        width: 1,
+        height: 1,
+        layers: ["top"],
+        connectedTo: ["signal", "pcb_port_right"],
+        circuitJsonMetadata: {
+          pcb_smtpad_id: "right_pad",
+          pcb_port_id: "pcb_port_right",
+        },
+      },
+    ],
+  }
+  const trace: SimplifiedPcbTrace = {
+    type: "pcb_trace",
+    pcb_trace_id: "routed_signal",
+    connection_name: "signal",
+    connectsTo: ["pcb_port_left", "pcb_port_right"],
+    route: [
+      { route_type: "wire", x: 0, y: 0, width: 0.15, layer: "top" },
+      { route_type: "wire", x: 4, y: 0, width: 0.15, layer: "top" },
+    ],
+  }
+  const inputBefore = structuredClone(srj)
+  const traceBefore = structuredClone(trace)
+  const evaluate = (
+    input: SimpleRouteJson,
+    traces: SimplifiedPcbTrace[],
+  ): ReturnType<typeof evaluateRelaxedDrc> =>
+    evaluateRelaxedDrc({
+      inputSrj: input,
+      srjWithPointPairs: input,
+      routedTraces: traces,
+      drcOptions: { includeViaPadChecks: true },
+    })
+  const clean = evaluate(srj, [trace])
+  expect(clean.errors).toHaveLength(0)
+  expect(srj).toEqual(inputBefore)
+  expect(trace).toEqual(traceBefore)
+
+  const foreign: SimplifiedPcbTrace = {
+    type: "pcb_trace",
+    pcb_trace_id: "foreign_trace",
+    connection_name: "foreign",
+    route: [
+      { route_type: "wire", x: -0.2, y: -0.2, width: 0.15, layer: "top" },
+      { route_type: "wire", x: 0.2, y: -0.2, width: 0.15, layer: "top" },
+    ],
+  }
+  expect(
+    evaluate(srj, [trace, foreign]).errors.some(
+      (error): boolean => error.message.includes("smtpad"),
+    ),
+  ).toBe(true)
+
+  const gap = structuredClone(srj)
+  gap.obstacles = gap.obstacles.filter(
+    (obstacle): boolean => obstacle.center.x !== 0 || obstacle.center.y !== 0,
+  )
+  expect(
+    evaluate(gap, [trace]).errors.some(
+      (error): boolean => error.message.includes("missing a connection"),
+    ),
+  ).toBe(true)
+
+  const disconnected = structuredClone(foreign)
+  disconnected.route = [
+    { route_type: "wire", x: 2, y: 1.5, width: 0.15, layer: "top" },
+    { route_type: "wire", x: 3, y: 1.5, width: 0.15, layer: "top" },
+  ]
+  expect(
+    evaluate(srj, [trace, disconnected]).errors.some(
+      (error): boolean => error.message.includes("disconnected endpoint"),
+    ),
+  ).toBe(true)
+})

--- a/tests/utils/convertToCircuitJson-legacy-trace-connectivity.test.ts
+++ b/tests/utils/convertToCircuitJson-legacy-trace-connectivity.test.ts
@@ -1,0 +1,140 @@
+import { expect, test } from "bun:test"
+import { RELAXED_DRC_OPTIONS } from "lib/testing/drcPresets"
+import { getDrcErrors } from "lib/testing/getDrcErrors"
+import { getTraceConnectivityIds } from "lib/testing/utils/getTraceConnectivityIds"
+import type { SimpleRouteJson, SimplifiedPcbTrace } from "lib/types"
+import { convertToCircuitJson } from "lib/testing/utils/convertToCircuitJson"
+
+type LegacyTrace = SimplifiedPcbTrace & { connectedTo?: string[] }
+
+test("preserves legacy fixed trace aliases without overriding canonical connectivity", (): void => {
+  const srj: SimpleRouteJson = {
+    layerCount: 2,
+    minTraceWidth: 0.1,
+    bounds: { minX: -2, minY: -2, maxX: 2, maxY: 2 },
+    connections: [],
+    obstacles: [
+      {
+        type: "rect", layers: ["top"], center: { x: -1, y: 0 },
+        width: 0.4, height: 0.4,
+        connectedTo: ["fixed-net", "port:left"],
+        circuitJsonMetadata: {
+          pcb_smtpad_id: "pad:left", pcb_port_id: "port:left",
+          source_component_name: "U1", source_port_name: "LEFT",
+        },
+      },
+      {
+        type: "rect", layers: ["top"], center: { x: 1, y: 0 },
+        width: 0.4, height: 0.4,
+        connectedTo: ["fixed-net", "port:right"],
+        circuitJsonMetadata: {
+          pcb_smtpad_id: "pad:right", pcb_port_id: "port:right",
+          source_component_name: "U1", source_port_name: "RIGHT",
+        },
+      },
+      {
+        type: "rect", layers: ["top"], center: { x: 0, y: 1 },
+        width: 0.4, height: 0.4,
+        connectedTo: ["foreign-net", "port:foreign"],
+        circuitJsonMetadata: {
+          pcb_smtpad_id: "pad:foreign", pcb_port_id: "port:foreign",
+          source_component_name: "U1", source_port_name: "FOREIGN",
+        },
+      },
+    ],
+  }
+  const trace: LegacyTrace = {
+    type: "pcb_trace", pcb_trace_id: "fixed-trace",
+    connection_name: "fixed-net",
+    connectedTo: ["fixed-net", "port:left", "port:right"],
+    route: [
+      { route_type: "wire", x: -1, y: 0, width: 0.1, layer: "top" },
+      { route_type: "wire", x: 1, y: 0, width: 0.1, layer: "top" },
+    ],
+  }
+  const inputBefore = JSON.stringify({ srj, trace })
+  const circuit = convertToCircuitJson(srj, [trace])
+  const sourceTrace = circuit.find(
+    (element): boolean => element.type === "source_trace",
+  )
+  expect(sourceTrace).toMatchObject({
+    source_trace_id: "fixed-net",
+    connected_source_port_ids: ["port:left", "port:right"],
+    connected_source_net_ids: ["fixed-net"],
+  })
+  expect(getTraceConnectivityIds(trace)).toBe(trace.connectedTo!)
+  expect(getDrcErrors(circuit, RELAXED_DRC_OPTIONS).errors).toHaveLength(0)
+
+  const foreignSrj = structuredClone(srj)
+  foreignSrj.obstacles[2].center.y = 0
+  const foreignCircuit = convertToCircuitJson(foreignSrj, [trace])
+  expect(getDrcErrors(foreignCircuit, RELAXED_DRC_OPTIONS).errors).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        error_type: "pcb_trace_error",
+        pcb_trace_error_id: "overlap_fixed-trace_pad:foreign",
+      }),
+    ]),
+  )
+  expect(foreignCircuit.find(
+    (element): boolean => element.type === "source_trace",
+  )).toEqual(sourceTrace)
+
+  const disconnectedTrace = structuredClone(trace)
+  disconnectedTrace.route[1] = {
+    route_type: "wire", x: 0, y: 0, width: 0.1, layer: "top",
+  }
+  const disconnectedCircuit = convertToCircuitJson(srj, [disconnectedTrace])
+  expect(getDrcErrors(disconnectedCircuit, RELAXED_DRC_OPTIONS).errors).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        pcb_trace_error_id: "disconnected_endpoint_fixed-trace_end",
+      }),
+    ]),
+  )
+
+  for (const canonicalIds of [["port:foreign"], []]) {
+    const canonicalTrace = { ...trace, connectsTo: canonicalIds }
+    expect(getTraceConnectivityIds(canonicalTrace)).toBe(canonicalIds)
+    const canonicalCircuit = convertToCircuitJson(srj, [canonicalTrace])
+    const withoutLegacy = { ...canonicalTrace }
+    delete withoutLegacy.connectedTo
+    expect(canonicalCircuit).toEqual(convertToCircuitJson(srj, [withoutLegacy]))
+    expect(getDrcErrors(canonicalCircuit, RELAXED_DRC_OPTIONS).errors).toHaveLength(2)
+  }
+
+  const withoutMetadata = { ...trace }
+  delete withoutMetadata.connectedTo
+  expect(getTraceConnectivityIds(withoutMetadata)).toEqual([])
+  const noMetadataCircuit = convertToCircuitJson(srj, [withoutMetadata])
+  expect(convertToCircuitJson(srj, [trace]).filter(
+    (element): boolean => element.type !== "source_trace",
+  )).toEqual(
+    noMetadataCircuit.filter(
+      (element): boolean => element.type !== "source_trace",
+    ),
+  )
+  expect(getDrcErrors(noMetadataCircuit, RELAXED_DRC_OPTIONS).errors).toHaveLength(2)
+  expect(JSON.stringify({ srj, trace })).toBe(inputBefore)
+
+  const aliasSrj = structuredClone(srj)
+  aliasSrj.connections.push({
+    name: "declared-source",
+    pointsToConnect: [
+      { x: -1, y: 0, layer: "top", pcb_port_id: "port:left" },
+      { x: 1, y: 0, layer: "top", pcb_port_id: "port:right" },
+    ],
+  })
+  const aliasTrace: LegacyTrace = {
+    ...trace, connection_name: "fixed-section",
+    connectedTo: ["declared-source", "port:left", "port:right"],
+  }
+  const aliasCircuit = convertToCircuitJson(aliasSrj, [aliasTrace])
+  expect(aliasCircuit.find(
+    (element): boolean => element.type === "pcb_trace",
+  )).toMatchObject({ source_trace_id: "declared-source" })
+  expect(aliasCircuit.filter(
+    (element): boolean => element.type === "source_trace",
+  )).toHaveLength(1)
+  expect(getDrcErrors(aliasCircuit, RELAXED_DRC_OPTIONS).errors).toHaveLength(0)
+})


### PR DESCRIPTION
Stacked on #2432. Repair neighboring trace conflicts together within the existing bounded repair04 stage. A full Pipeline9 solve of SRJ18 sample004 now passes standard relaxed and strict DRC:

| SRJ18 sample004 | Before | After | Delta |
| --- | ---: | ---: | ---: |
| Standard relaxed DRC errors | 6 | 0 | −6 |
| Expanded DRC errors, including via/pad checks | 14 | 3 | −11 |

Three supplemental via/pad clearance errors remain. The original board, DRC thresholds, endpoints and boundary constraints are preserved.

Pin [repair04#3](https://github.com/tscircuit/repair04/pull/3) at `79f794a`. Add bounded atomic crossing repairs, three-trace obstacle detours and rerouting around a permitted existing-via move. Keep the earlier tapered-trace repair and pad/connectivity conversion fixes.

Restrict explicit via-trace targets to the current repair issue, and distinguish their permissions in attempted-region keys. Retain indexed-only improvements without extending the search budget. The core reuses current-via lookup data and rejects fixed-obstacle conflicts before indexed DRC. New via-in-pad errors remain prohibited.

Full local checks preserve sample004 at 0 standard errors and sample009 at 0, restore SRJ33 sample050 from 2 to 0, and reduce SRJ18 sample013 from 37 to 6 against the preceding local revision. All 28 accepted regions pass merge, fixed-obstacle and via-pad guards. Sample009 uses 500,000 advanced search nodes instead of 1,500,000. These are correctness/work-count results, not timing measurements.

**Final same-machine benchmarks and CI are running for `ec558c3`.** The preceding measured revision reached 9/16→10/16 SRJ18 passes, but had a runtime increase and regressions addressed here. Its results are retained in [SRJ18](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/34081704166), [Dataset01](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/34081703204) and [SRJ33](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/34081701913); they are not measurements of this head.

Validation: 35 parent tests/618 assertions, typecheck and build pass. [Core CI](https://github.com/tscircuit/repair04/actions/runs/34087777586) passes; local core tests pass 91 tests/12,761 assertions. Both affected local bug tests pass functional assertions and differ only at their snapshots. [Parent CI](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/34088805606) will provide the final Linux snapshots and unchanged 300-second Game Boy check. No threshold, timeout or global-budget increase.
