### PR TITLE
test: identify and whitelist slow SRJ18 solver iterations

### DIFF
--- a/.github/workflows/srj18-iteration-timing.yml
+++ b/.github/workflows/srj18-iteration-timing.yml
@@ -52,7 +52,7 @@ jobs:
         run: bun test tests/benchmarks/srj18-iteration-timing.test.ts --timeout 600000
 
       - name: Rediscover the fastest SRJ18 sample
-        if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.discover_fastest)
+        if: github.event_name == 'workflow_dispatch' && inputs.discover_fastest
         run: bun scripts/benchmark/srj18-iteration-timing.ts --discover
 
       - name: Publish iteration timing summary

--- a/.github/workflows/srj18-iteration-timing.yml
+++ b/.github/workflows/srj18-iteration-timing.yml
@@ -1,0 +1,71 @@
+name: SRJ18 Iteration Timing
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      threshold_ms:
+        description: Warn when an iteration exceeds this duration in milliseconds
+        required: false
+        default: "1000"
+        type: string
+      discover_fastest:
+        description: Also time every SRJ18 sample serially to identify the fastest
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: srj18-iteration-timing-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  iteration-timing:
+    name: Identify slow SRJ18 solver iterations
+    runs-on: blacksmith-8vcpu-ubuntu-2404-arm
+    timeout-minutes: 60
+    env:
+      SRJ18_ITERATION_TIMING: "1"
+      SRJ18_ITERATION_REPORT_DIR: iteration-timing-results
+      SRJ18_ITERATION_THRESHOLD_MS: ${{ inputs.threshold_ms || '1000' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.8
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Time the fastest SRJ18 sample
+        run: bun test tests/benchmarks/srj18-iteration-timing.test.ts --timeout 600000
+
+      - name: Rediscover the fastest SRJ18 sample
+        if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.discover_fastest)
+        run: bun scripts/benchmark/srj18-iteration-timing.ts --discover
+
+      - name: Publish iteration timing summary
+        if: always()
+        run: |
+          if [ -f "$SRJ18_ITERATION_REPORT_DIR/summary.md" ]; then
+            cat "$SRJ18_ITERATION_REPORT_DIR/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload iteration timing reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: srj18-iteration-timing
+          path: iteration-timing-results
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -193,6 +193,7 @@ benchmark-result.txt
 benchmark-result.json
 benchmark-snapshots.html
 profile-solvers.json
+iteration-timing-results/
 result-*
 tmp
 

--- a/docs/srj18-iteration-timing.md
+++ b/docs/srj18-iteration-timing.md
@@ -103,3 +103,45 @@ Relevant source: Pipeline 7's stage definitions; the tiny-hypergraph
 constructor and `computeNodePf()`; and the corresponding solvers' constructors
 and `_step()` methods. The JSON artifacts preserve the exact active paths and
 local iterations for each observation.
+
+## Confirmation and 100ms watchlist
+
+The [confirmation run](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/34166478437)
+used the final attribution rules and matched both slow pipeline iterations to the
+three whitelist entries: iteration 9255 was **1,284.4ms**, and iteration 199986
+was **1,767.4ms**. It completed 247,488 iterations with **zero unlisted iterations
+over 1s**. The full instrumented solve took 43.53s.
+
+The following is the complete set of material contributors in its 27 retained
+pipeline iterations over 100ms. Values are attributed time, excluding separately
+reported nested calls. Comma-separated call numbers are independent observations;
+an en-dash denotes multiple synchronous calls within one pipeline iteration.
+Only the three entries explicitly marked "whitelisted" are approved at the
+initial 1s budget. The others are the starting worklist for the 100ms budget.
+
+| Deepest solver | Phase | Observed local calls | Largest attributed time | Status |
+| --- | --- | --- | ---: | --- |
+| RectDiffGridSolverPipeline | initialization | 0 | 124.3ms | Candidate |
+| TopologyMergingSolver | step | 316 | 176.1ms | Candidate |
+| DuplicateCongestedPortSolver | step | 1 | 683.7ms | Whitelisted contributor |
+| TinyHypergraphPortPointPathingSolver | initialization | 0 | 261.1ms | Whitelisted contributor |
+| SelectiveReripTinyHyperGraphSolverWithStableInitialAssignments | initialization | 0 | 100.3ms | Candidate |
+| TinyHyperGraphSectionSolver | initialization | 0 | 109.8ms | Candidate |
+| UniformPortDistributionSolver | initialization | 0 | 983.9ms | Candidate; close to 1s |
+| HighDensitySolver | initialization | 0 | 1,767.4ms | Whitelisted |
+| SingleHighDensityRouteSolver | step | 1–77, 600–699 | 153.2ms | Candidate: synchronous batches |
+| CachedIntraNodeRouteSolver | initialization | 0 | 118.7ms | Candidate |
+| CachedIntraNodeRouteSolver | step | 238–250 | 173.2ms | Candidate: synchronous batch |
+| HighDensityForceImproveSolver | step | 315 | 149.2ms | Candidate |
+| MultipleHighDensityRouteStitchSolver3 | initialization | 0 | 262.0ms | Candidate |
+| CrossingViaReductionSolver | step | 1 | 484.3ms | Candidate |
+| GlobalDrcForceImproveSolver | step | 1, 2, 22, 24, 25, 26, 27, 28, 30, 32 | 293.5ms | Candidate: repeated whole-route DRC |
+| PostProcessingSolver | initialization | 0 | 137.5ms | Candidate |
+| PowerTraceExpansionSolver | initialization | 0 | 112.0ms | Candidate |
+
+Additional candidate work: topology merging's last step finalizes and validates
+the merged regions; section-solver construction rebuilds its baseline and
+intersection summaries; high-density force improvement processes a whole node
+through multiple force/clearance passes; length-matching post-processing clones
+the input and builds a private copper model. The artifacts include full paths to
+distinguish direct DRC repair from repair inside a portfolio solver.

--- a/docs/srj18-iteration-timing.md
+++ b/docs/srj18-iteration-timing.md
@@ -1,0 +1,62 @@
+# SRJ18 iteration timing
+
+The `SRJ18 Iteration Timing` workflow runs the fastest measured successful
+dataset-srj18 sample through the exported default autorouter (Pipeline 7), with
+effort 1 and caching disabled. It runs in a separate serial Blacksmith ARM job.
+The ordinary test shards skip this benchmark unless `SRJ18_ITERATION_TIMING=1`.
+
+```sh
+SRJ18_ITERATION_TIMING=1 bun test tests/benchmarks/srj18-iteration-timing.test.ts --timeout 600000
+bun scripts/benchmark/srj18-iteration-timing.ts --discover
+SRJ18_ITERATION_THRESHOLD_MS=100 bun scripts/benchmark/srj18-iteration-timing.ts
+```
+
+The warning threshold starts at 1,000ms. The report also retains every pipeline
+iteration over the eventual 100ms target, so the whitelist can be reviewed before
+lowering the threshold. Both whitelisted and unlisted iterations over the warning
+threshold emit warnings. New slow work does not fail CI during this discovery
+phase; routing failures do fail the test.
+
+## What an iteration means
+
+An iteration is one synchronous call to the pipeline's `step()`. It can call
+several nested solvers' `step()` methods or even their entire `solve()` loops before
+returning control. Measuring the whole pipeline call detects that blocking even
+when each individual child step is fast.
+
+The opt-in profiler observes both this repository's BaseSolver and the external
+solver-utils BaseSolver, plus the step implementations of active children. It
+records the actual nested call path before completed children are cleared. Time
+spent in a child belongs to that child, rather than being counted again against
+its parents. A synchronous loop over many child steps is shown with the child's
+first and last local iteration. Separate material contributors remain visible.
+
+Initialization is iteration **0**: constructor parameters and synchronous
+construction before the new solver receives its first `step()`. Subsequent
+iterations are **1-based per solver instance**. Initialization and step 1 are
+separate whitelist entries. Solver class, phase, and local iteration (or exact
+observed range for a synchronous loop) must match. An ancestor's whitelist entry
+never authorizes a descendant.
+
+`scripts/iteration-timing/srj18IterationWhitelist.ts` contains the reviewed
+exceptions and reasons. To remove an exception, move its expensive synchronous
+work into incremental solver steps, rerun the benchmark, then remove the matching
+entry once it stays under budget.
+
+## Reports and rediscovery
+
+The workflow uploads `iterations.json` and `summary.md`; JSON includes every
+retained pipeline iteration, full solver paths, material contributors, aggregate
+solver timings, and runtime identity. Timing includes profiler overhead, so the
+numbers identify blocking work rather than serving as throughput benchmarks.
+
+Manual `discover_fastest` runs time all 16 samples serially in fresh processes,
+then repeat the three fastest successful candidates and select by median. Failed
+and timed-out samples are explicitly excluded. `discovery.json` and `discovery.md`
+retain the results. Discovery does not silently change the pinned regression
+sample or whitelist; review the result and update the constant when needed.
+
+## Initial observations
+
+Baseline measurements and solver explanations will be recorded here after the
+serial discovery and instrumented Blacksmith runs.

--- a/docs/srj18-iteration-timing.md
+++ b/docs/srj18-iteration-timing.md
@@ -58,5 +58,48 @@ sample or whitelist; review the result and update the constant when needed.
 
 ## Initial observations
 
-Baseline measurements and solver explanations will be recorded here after the
-serial discovery and instrumented Blacksmith runs.
+The [serial Blacksmith baseline](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/34165277363)
+used Bun 1.3.8 on Linux ARM64 with the dataset pinned at
+`c0aad90256a95256fcac814f9f7da81a82a2fdea`. All 16 samples were attempted; five
+completed the first pass and eleven exceeded the approximately 60s deadline.
+The three fastest completed samples were each measured three times:
+
+| Sample | Board | Median | Three trials |
+| --- | --- | ---: | --- |
+| **sample005** | **Arduino Uno** | **25.13s** | 25.13s, 25.17s, 24.97s |
+| sample003 | Arduino Micro | 30.24s | 30.38s, 30.24s, 30.03s |
+| sample001 | Arduino Leonardo | 33.67s | 33.49s, 33.67s, 34.33s |
+
+The instrumented run completed 247,488 pipeline iterations. Two exceeded the
+initial 1,000ms warning budget; their three material solver/iteration identities
+are the initial whitelist (initialization includes argument preparation):
+
+| Pipeline iteration | Wall time | Exact whitelist entries |
+| ---: | ---: | --- |
+| 9255 | 1,288.1ms | `DuplicateCongestedPortSolver` step **1** (706.4ms self), `TinyHypergraphPortPointPathingSolver` initialization **0** (259.7ms self); the remaining time includes many short nested connection solves. |
+| 199986 | 1,627.0ms | `HighDensitySolver` initialization **0** (1,626.9ms). |
+
+These measurements include profiler overhead and are observations, not fixed
+timing assertions. Later runs can reveal additional exceptions. Entries below
+1s remain visible in the report without automatically gaining whitelist status.
+
+The measured initialization interval includes parameter preparation immediately
+before `new Solver(...)`. These are the source operations associated with the
+initial hotspots; timing does not isolate individual helper functions within
+each interval.
+
+| Solver / local iteration | Synchronous work to consider splitting up |
+| --- | --- |
+| `DuplicateCongestedPortSolver` step 1 | The first setup routes every connection independently with synchronous `TinyHyperGraphSolver.solve()` calls, counts used ports, clones the graph, and duplicates congested ports. Instrumented child solve calls are reported separately. |
+| `TinyHypergraphPortPointPathingSolver` initialization 0 | Builds and serializes the hypergraph, runs the congestion duplication prepass, constructs the tiny section pipeline, and reconstructs input-node metadata. |
+| `UniformPortDistributionSolver` initialization 0 | Prepares the pathing output, finds ownership pairs for all node port points, precomputes shared edges, and sorts them. |
+| `HighDensitySolver` initialization 0 | Prepares cloned nodes and computes failure probability for each node. `computeNodePf()` repeatedly calls `getOutput()`, which rebuilds the complete region output. The constructor itself mainly assigns fields. |
+| `MultipleHighDensityRouteStitchSolver3` initialization 0 | Sorts routes, builds clearance indexes and connectivity islands, chooses endpoints and paths, and consolidates fragmented connections. |
+| `CrossingViaReductionSolver` step 1 | Runs the crossing reduction search: splits routes into sections, finds detours, builds indexes, enumerates candidates, checks clearance, and applies a reduction or completes. |
+| `GlobalDrcForceImproveSolver` later steps | Clones and materializes route geometry for several repair candidates, then runs whole-route DRC for each. This occurs both directly and inside `GlobalDrcBranchPortfolioSolver`; the deepest solver's own call number is reported in both cases. |
+
+Relevant source: Pipeline 7's stage definitions; the tiny-hypergraph
+`DuplicateCongestedPortSolver`; `TinyHypergraphPortPointPathingSolver`'s
+constructor and `computeNodePf()`; and the corresponding solvers' constructors
+and `_step()` methods. The JSON artifacts preserve the exact active paths and
+local iterations for each observation.

--- a/docs/srj18-iteration-timing.md
+++ b/docs/srj18-iteration-timing.md
@@ -70,18 +70,25 @@ The three fastest completed samples were each measured three times:
 | sample003 | Arduino Micro | 30.24s | 30.38s, 30.24s, 30.03s |
 | sample001 | Arduino Leonardo | 33.67s | 33.49s, 33.67s, 34.33s |
 
-The instrumented run completed 247,488 pipeline iterations. Two exceeded the
-initial 1,000ms warning budget; their three material solver/iteration identities
-are the initial whitelist (initialization includes argument preparation):
+The first instrumented run completed 247,488 pipeline iterations. Two exceeded
+the initial 1,000ms warning budget, identifying the first three material
+solver/iteration identities (initialization includes argument preparation):
 
 | Pipeline iteration | Wall time | Exact whitelist entries |
 | ---: | ---: | --- |
 | 9255 | 1,288.1ms | `DuplicateCongestedPortSolver` step **1** (706.4ms self), `TinyHypergraphPortPointPathingSolver` initialization **0** (259.7ms self); the remaining time includes many short nested connection solves. |
 | 199986 | 1,627.0ms | `HighDensitySolver` initialization **0** (1,626.9ms). |
 
+A [subsequent repeat](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/34166676921)
+measured **UniformPortDistributionSolver initialization 0** at **1,035.5ms** in
+pipeline iteration **199302**, after earlier measurements of 931.0ms and 983.9ms.
+This is the fourth whitelist entry. That repeat measured iterations 9255 and
+199986 at 1,751.2ms and 1,773.0ms respectively.
+
 These measurements include profiler overhead and are observations, not fixed
-timing assertions. Later runs can reveal additional exceptions. Entries below
-1s remain visible in the report without automatically gaining whitelist status.
+timing assertions. The whitelist covers all three pipeline iterations observed
+over 1s across the Blacksmith runs. Entries below 1s remain visible in the report
+without automatically gaining whitelist status.
 
 The measured initialization interval includes parameter preparation immediately
 before `new Solver(...)`. These are the source operations associated with the
@@ -116,8 +123,9 @@ The following is the complete set of material contributors in its 27 retained
 pipeline iterations over 100ms. Values are attributed time, excluding separately
 reported nested calls. Comma-separated call numbers are independent observations;
 an en-dash denotes multiple synchronous calls within one pipeline iteration.
-Only the three entries explicitly marked "whitelisted" are approved at the
-initial 1s budget. The others are the starting worklist for the 100ms budget.
+Whitelist status includes the subsequent repeat that added port distribution.
+Only the four entries explicitly marked "whitelisted" are approved at the initial
+1s budget. The others are the starting worklist for the 100ms budget.
 
 | Deepest solver | Phase | Observed local calls | Largest attributed time | Status |
 | --- | --- | --- | ---: | --- |
@@ -127,7 +135,7 @@ initial 1s budget. The others are the starting worklist for the 100ms budget.
 | TinyHypergraphPortPointPathingSolver | initialization | 0 | 261.1ms | Whitelisted contributor |
 | SelectiveReripTinyHyperGraphSolverWithStableInitialAssignments | initialization | 0 | 100.3ms | Candidate |
 | TinyHyperGraphSectionSolver | initialization | 0 | 109.8ms | Candidate |
-| UniformPortDistributionSolver | initialization | 0 | 983.9ms | Candidate; close to 1s |
+| UniformPortDistributionSolver | initialization | 0 | 983.9ms | Whitelisted after repeat reached 1,035.5ms |
 | HighDensitySolver | initialization | 0 | 1,767.4ms | Whitelisted |
 | SingleHighDensityRouteSolver | step | 1–77, 600–699 | 153.2ms | Candidate: synchronous batches |
 | CachedIntraNodeRouteSolver | initialization | 0 | 118.7ms | Candidate |
@@ -145,3 +153,17 @@ intersection summaries; high-density force improvement processes a whole node
 through multiple force/clearance passes; length-matching post-processing clones
 the input and builds a private copper model. The artifacts include full paths to
 distinguish direct DRC repair from repair inside a portfolio solver.
+
+The other setup intervals build obstacle indexes (`RectDiffGridSolverPipeline`),
+allocate graph routing/candidate storage (`SelectiveReripTinyHyperGraphSolver`),
+group route endpoints and compare their minimum spacing (`CachedIntraNodeRouteSolver`),
+or clone traces and prepare connectivity, width deficits, and obstacle indexes
+(`PowerTraceExpansionSolver`). Caching is disabled: the cached solver's name does
+not imply cache I/O caused its delay.
+
+The high-density search ranges are synchronous batches: the portfolio requests
+`MIN_SUBSTEPS = 100`, and `HyperParameterSupervisorSolver` runs those child steps
+inside one parent call. `SingleHighDensityRouteSolver` repeatedly expands search
+candidates, checks clearance, and enqueues neighbors. `CachedIntraNodeRouteSolver`
+orchestrates route searches and scans completed routes for via/trace conflicts;
+its separately timed descendants are not double-counted.

--- a/scripts/benchmark/srj18-iteration-timing.ts
+++ b/scripts/benchmark/srj18-iteration-timing.ts
@@ -20,7 +20,10 @@ export const runSrj18IterationTiming = async (
   const thresholdMs = Number(
     process.env.SRJ18_ITERATION_THRESHOLD_MS ?? SRJ18_ITERATION_THRESHOLD_MS,
   )
-  if (!Number.isFinite(thresholdMs) || thresholdMs < SRJ18_ITERATION_TARGET_MS) {
+  if (
+    !Number.isFinite(thresholdMs) ||
+    thresholdMs < SRJ18_ITERATION_TARGET_MS
+  ) {
     throw new Error("SRJ18_ITERATION_THRESHOLD_MS must be at least 100ms")
   }
   const scenarios = await loadScenarios("srj18", { effort: 1 })
@@ -62,9 +65,13 @@ if (import.meta.main) {
     const { discoverFastestSrj18Sample } = await import(
       "../iteration-timing/discoverFastestSrj18Sample"
     )
-    const outputDir = process.env.SRJ18_ITERATION_REPORT_DIR ?? "iteration-timing-results"
+    const outputDir =
+      process.env.SRJ18_ITERATION_REPORT_DIR ?? "iteration-timing-results"
     await discoverFastestSrj18Sample(outputDir)
-    appendFileSync(join(outputDir, "summary.md"), `\n${readFileSync(join(outputDir, "discovery.md"), "utf8")}`)
+    appendFileSync(
+      join(outputDir, "summary.md"),
+      `\n${readFileSync(join(outputDir, "discovery.md"), "utf8")}`,
+    )
   } else {
     const sampleIndex = process.argv.indexOf("--sample")
     const result = await runSrj18IterationTiming(

--- a/scripts/benchmark/srj18-iteration-timing.ts
+++ b/scripts/benchmark/srj18-iteration-timing.ts
@@ -1,0 +1,75 @@
+import { appendFileSync, readFileSync } from "node:fs"
+import { join } from "node:path"
+import { AutoroutingPipelineSolver7_MultiGraph } from "../../lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph"
+import {
+  classifyIteration,
+  writeIterationTimingReport,
+} from "../iteration-timing/iterationTimingReport"
+import { profileSolverIterations } from "../iteration-timing/profileSolverIterations"
+import {
+  SRJ18_FASTEST_SAMPLE,
+  SRJ18_ITERATION_TARGET_MS,
+  SRJ18_ITERATION_THRESHOLD_MS,
+  srj18IterationWhitelist,
+} from "../iteration-timing/srj18IterationWhitelist"
+import { loadScenarios } from "./scenarios"
+
+export const runSrj18IterationTiming = async (
+  sampleName = SRJ18_FASTEST_SAMPLE,
+): Promise<{ solved: boolean; failed: boolean; totalIterations: number }> => {
+  const thresholdMs = Number(
+    process.env.SRJ18_ITERATION_THRESHOLD_MS ?? SRJ18_ITERATION_THRESHOLD_MS,
+  )
+  if (!Number.isFinite(thresholdMs) || thresholdMs < SRJ18_ITERATION_TARGET_MS) {
+    throw new Error("SRJ18_ITERATION_THRESHOLD_MS must be at least 100ms")
+  }
+  const scenarios = await loadScenarios("srj18", { effort: 1 })
+  const selected = scenarios.find(([name]) => name === sampleName)
+  if (!selected) throw new Error(`Unknown SRJ18 sample: ${sampleName}`)
+  const solver = new AutoroutingPipelineSolver7_MultiGraph(
+    structuredClone(selected[1]),
+    { effort: 1, cacheProvider: null },
+  )
+  const profile = profileSolverIterations(solver, {
+    thresholdMs: SRJ18_ITERATION_TARGET_MS,
+  })
+  const report = {
+    ...profile,
+    sampleName,
+    thresholdMs,
+    iterations: profile.iterations.map((iteration) =>
+      classifyIteration(iteration, srj18IterationWhitelist),
+    ),
+    solved: solver.solved,
+    failed: solver.failed,
+    error: solver.error,
+    runtime: {
+      bun: Bun.version,
+      platform: process.platform,
+      arch: process.arch,
+      commit: process.env.GITHUB_SHA ?? "local",
+    },
+  }
+  writeIterationTimingReport(
+    process.env.SRJ18_ITERATION_REPORT_DIR ?? "iteration-timing-results",
+    report,
+  )
+  return report
+}
+
+if (import.meta.main) {
+  if (process.argv.includes("--discover")) {
+    const { discoverFastestSrj18Sample } = await import(
+      "../iteration-timing/discoverFastestSrj18Sample"
+    )
+    const outputDir = process.env.SRJ18_ITERATION_REPORT_DIR ?? "iteration-timing-results"
+    await discoverFastestSrj18Sample(outputDir)
+    appendFileSync(join(outputDir, "summary.md"), `\n${readFileSync(join(outputDir, "discovery.md"), "utf8")}`)
+  } else {
+    const sampleIndex = process.argv.indexOf("--sample")
+    const result = await runSrj18IterationTiming(
+      sampleIndex === -1 ? SRJ18_FASTEST_SAMPLE : process.argv[sampleIndex + 1],
+    )
+    if (!result.solved || result.failed) process.exitCode = 1
+  }
+}

--- a/scripts/iteration-timing/discoverFastestSrj18Sample.ts
+++ b/scripts/iteration-timing/discoverFastestSrj18Sample.ts
@@ -1,5 +1,11 @@
 import { spawn } from "node:child_process"
-import { closeSync, mkdirSync, openSync, readFileSync, writeFileSync } from "node:fs"
+import {
+  closeSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs"
 import { arch, cpus, platform } from "node:os"
 import { join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
@@ -65,7 +71,9 @@ export function getSrj18DiscoveryRankings(
   const sampleNames = [...new Set(trials.map((trial) => trial.sampleName))]
   const rankings: Srj18DiscoveryRanking[] = []
   for (const sampleName of sampleNames) {
-    const sampleTrials = trials.filter((trial) => trial.sampleName === sampleName)
+    const sampleTrials = trials.filter(
+      (trial) => trial.sampleName === sampleName,
+    )
     if (
       sampleTrials.length !== requiredTrials ||
       sampleTrials.some((trial) => trial.status !== "solved")
@@ -88,7 +96,8 @@ export function getSrj18DiscoveryRankings(
   }
   return rankings.sort(
     (a, b) =>
-      a.medianTimeMs - b.medianTimeMs || a.sampleName.localeCompare(b.sampleName),
+      a.medianTimeMs - b.medianTimeMs ||
+      a.sampleName.localeCompare(b.sampleName),
   )
 }
 
@@ -132,7 +141,8 @@ async function runChildSample(
       status: "failed",
       elapsedTimeMs: performance.now() - startedAt,
       iterations: 0,
-      error: error instanceof Error ? error.stack || error.message : String(error),
+      error:
+        error instanceof Error ? error.stack || error.message : String(error),
     }
   }
   writeFileSync(outputPath, `${JSON.stringify(result, null, 2)}\n`)
@@ -171,7 +181,11 @@ async function runDiscoveryTrial(
     }, timeoutMs)
     child.once("error", (error) => {
       clearTimeout(timer)
-      resolveOutcome({ exitCode: null, signal: null, spawnError: error.message })
+      resolveOutcome({
+        exitCode: null,
+        signal: null,
+        spawnError: error.message,
+      })
     })
     child.once("close", (exitCode, signal) => {
       clearTimeout(timer)

--- a/scripts/iteration-timing/discoverFastestSrj18Sample.ts
+++ b/scripts/iteration-timing/discoverFastestSrj18Sample.ts
@@ -1,0 +1,372 @@
+import { spawn } from "node:child_process"
+import { closeSync, mkdirSync, openSync, readFileSync, writeFileSync } from "node:fs"
+import { arch, cpus, platform } from "node:os"
+import { join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { loadScenarios } from "../benchmark/scenarios"
+
+type TrialIdentity = {
+  sampleName: string
+  trialNumber: number
+  wallTimeMs: number
+  logPath: string
+  resultPath: string
+}
+
+export type Srj18DiscoveryTrial = TrialIdentity &
+  (
+    | { status: "solved"; elapsedTimeMs: number; iterations: number }
+    | { status: "failed"; elapsedTimeMs: number | null; error: string }
+    | { status: "timed_out"; timeoutMs: number }
+  )
+
+type ChildResult = {
+  sampleName: string
+  elapsedTimeMs: number
+  iterations: number
+} & ({ status: "solved" } | { status: "failed"; error: string })
+
+export type Srj18DiscoveryRanking = {
+  sampleName: string
+  medianTimeMs: number
+  elapsedTimesMs: number[]
+}
+
+export type Srj18DiscoveryReport = {
+  version: 1
+  dataset: "srj18"
+  pipeline: "AutoroutingPipelineSolver7_MultiGraph"
+  effort: 1
+  cacheProvider: null
+  selectedSample: string | null
+  generatedAt: string
+  timeoutMs: number
+  measurement: string
+  selection: string
+  runtime: {
+    bunVersion: string
+    platform: string
+    architecture: string
+    cpuModel: string
+    runnerName: string | null
+    commitSha: string | null
+  }
+  firstPassRankings: Srj18DiscoveryRanking[]
+  rankings: Srj18DiscoveryRanking[]
+  trials: Srj18DiscoveryTrial[]
+}
+
+const childTimeoutMs = 90_000
+
+export function getSrj18DiscoveryRankings(
+  trials: Srj18DiscoveryTrial[],
+  requiredTrials: number,
+): Srj18DiscoveryRanking[] {
+  const sampleNames = [...new Set(trials.map((trial) => trial.sampleName))]
+  const rankings: Srj18DiscoveryRanking[] = []
+  for (const sampleName of sampleNames) {
+    const sampleTrials = trials.filter((trial) => trial.sampleName === sampleName)
+    if (
+      sampleTrials.length !== requiredTrials ||
+      sampleTrials.some((trial) => trial.status !== "solved")
+    ) {
+      continue
+    }
+    const elapsedTimesMs = sampleTrials.map((trial) => {
+      if (trial.status !== "solved") {
+        throw new Error(`Cannot rank incomplete trial for ${sampleName}`)
+      }
+      return trial.elapsedTimeMs
+    })
+    const sortedTimes = [...elapsedTimesMs].sort((a, b) => a - b)
+    const middle = Math.floor(sortedTimes.length / 2)
+    const medianTimeMs =
+      sortedTimes.length % 2 === 1
+        ? sortedTimes[middle]!
+        : (sortedTimes[middle - 1]! + sortedTimes[middle]!) / 2
+    rankings.push({ sampleName, medianTimeMs, elapsedTimesMs })
+  }
+  return rankings.sort(
+    (a, b) =>
+      a.medianTimeMs - b.medianTimeMs || a.sampleName.localeCompare(b.sampleName),
+  )
+}
+
+async function runChildSample(
+  sampleName: string,
+  outputPath: string,
+): Promise<void> {
+  const scenarios = await loadScenarios("srj18", { effort: 1 })
+  const scenario = scenarios.find(([name]) => name === sampleName)
+  if (!scenario) throw new Error(`Unknown SRJ18 sample: ${sampleName}`)
+  const { AutoroutingPipelineSolver7_MultiGraph } = await import(
+    "../../lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph"
+  )
+  const startedAt = performance.now()
+  let result: ChildResult
+  try {
+    const solver = new AutoroutingPipelineSolver7_MultiGraph(scenario[1], {
+      effort: 1,
+      cacheProvider: null,
+    })
+    solver.solve()
+    const elapsedTimeMs = performance.now() - startedAt
+    result =
+      solver.solved && !solver.failed
+        ? {
+            sampleName,
+            status: "solved",
+            elapsedTimeMs,
+            iterations: solver.iterations,
+          }
+        : {
+            sampleName,
+            status: "failed",
+            elapsedTimeMs,
+            iterations: solver.iterations,
+            error: solver.error || "Pipeline finished without a solved result",
+          }
+  } catch (error) {
+    result = {
+      sampleName,
+      status: "failed",
+      elapsedTimeMs: performance.now() - startedAt,
+      iterations: 0,
+      error: error instanceof Error ? error.stack || error.message : String(error),
+    }
+  }
+  writeFileSync(outputPath, `${JSON.stringify(result, null, 2)}\n`)
+}
+
+async function runDiscoveryTrial(
+  outputDir: string,
+  sampleName: string,
+  trialNumber: number,
+  timeoutMs: number,
+): Promise<Srj18DiscoveryTrial> {
+  const logPath = join("trials", `${sampleName}-${trialNumber}.log`)
+  const resultPath = join("trials", `${sampleName}-${trialNumber}.json`)
+  const logFd = openSync(join(outputDir, logPath), "w")
+  const startedAt = performance.now()
+  const child = spawn(
+    process.execPath,
+    [
+      fileURLToPath(import.meta.url),
+      "--child",
+      sampleName,
+      join(outputDir, resultPath),
+    ],
+    { stdio: ["ignore", logFd, logFd] },
+  )
+  closeSync(logFd)
+  let timedOut = false
+  const outcome = await new Promise<{
+    exitCode: number | null
+    signal: string | null
+    spawnError: string | null
+  }>((resolveOutcome) => {
+    const timer = setTimeout(() => {
+      timedOut = true
+      child.kill("SIGKILL")
+    }, timeoutMs)
+    child.once("error", (error) => {
+      clearTimeout(timer)
+      resolveOutcome({ exitCode: null, signal: null, spawnError: error.message })
+    })
+    child.once("close", (exitCode, signal) => {
+      clearTimeout(timer)
+      resolveOutcome({ exitCode, signal, spawnError: null })
+    })
+  })
+  const identity: TrialIdentity = {
+    sampleName,
+    trialNumber,
+    wallTimeMs: performance.now() - startedAt,
+    logPath,
+    resultPath,
+  }
+  if (timedOut) {
+    return { ...identity, status: "timed_out", timeoutMs }
+  }
+  if (outcome.spawnError || outcome.exitCode !== 0) {
+    return {
+      ...identity,
+      status: "failed",
+      elapsedTimeMs: null,
+      error:
+        outcome.spawnError ||
+        `Child exited with code ${outcome.exitCode}, signal ${outcome.signal}; see ${logPath}`,
+    }
+  }
+  let result: ChildResult
+  try {
+    result = JSON.parse(readFileSync(join(outputDir, resultPath), "utf8"))
+  } catch (error) {
+    return {
+      ...identity,
+      status: "failed",
+      elapsedTimeMs: null,
+      error: `Could not read child result: ${String(error)}; see ${logPath}`,
+    }
+  }
+  if (
+    result.sampleName !== sampleName ||
+    !Number.isFinite(result.elapsedTimeMs) ||
+    result.elapsedTimeMs < 0 ||
+    (result.status !== "solved" && result.status !== "failed")
+  ) {
+    throw new Error(`Invalid discovery child result: ${resultPath}`)
+  }
+  return { ...identity, ...result }
+}
+
+function writeDiscoveryReport(
+  outputDir: string,
+  report: Srj18DiscoveryReport,
+): void {
+  writeFileSync(
+    join(outputDir, "discovery.json"),
+    `${JSON.stringify(report, null, 2)}\n`,
+  )
+  const lines = [
+    "# SRJ18 fastest sample discovery",
+    "",
+    `Selected sample: **${report.selectedSample || "none"}**.`,
+    "",
+    report.measurement,
+    "",
+    report.selection,
+    "",
+    `Pipeline: \`${report.pipeline}\`; effort: 1; cache provider: null.`,
+    `Runtime: Bun ${report.runtime.bunVersion}, ${report.runtime.platform}/${report.runtime.architecture}, ${report.runtime.cpuModel}.`,
+    `Runner: ${report.runtime.runnerName || "local"}; commit: ${report.runtime.commitSha || "not provided"}.`,
+    "",
+    "## Repeated candidate rankings",
+    "",
+    "| Sample | Median solve time | Trial times |",
+    "| --- | ---: | --- |",
+    ...report.rankings.map(
+      (ranking) =>
+        `| ${ranking.sampleName} | ${ranking.medianTimeMs.toFixed(1)} ms | ${ranking.elapsedTimesMs.map((time) => `${time.toFixed(1)} ms`).join(", ")} |`,
+    ),
+    "",
+    "## All trials",
+    "",
+    "Timeouts include startup/import time and exclude the sample from selection; failed solves are also excluded. Measured solve time excludes imports.",
+    "",
+    "| Sample | Trial | Status | Construction + solve | Child wall time | Details |",
+    "| --- | ---: | --- | ---: | ---: | --- |",
+    ...report.trials.map((trial) => {
+      const elapsed =
+        trial.status !== "timed_out" && trial.elapsedTimeMs !== null
+          ? `${trial.elapsedTimeMs.toFixed(1)} ms`
+          : "—"
+      const details =
+        trial.status === "failed"
+          ? trial.error.replaceAll("|", "\\|").replaceAll("\n", " ")
+          : trial.status === "timed_out"
+            ? `Killed at ${trial.timeoutMs / 1000}s wall deadline`
+            : `${trial.iterations} pipeline iterations`
+      return `| ${trial.sampleName} | ${trial.trialNumber} | ${trial.status} | ${elapsed} | ${trial.wallTimeMs.toFixed(1)} ms | ${details}; [log](${trial.logPath}) |`
+    }),
+    "",
+  ]
+  writeFileSync(join(outputDir, "discovery.md"), lines.join("\n"))
+}
+
+export async function discoverFastestSrj18Sample(
+  outputDir: string,
+): Promise<Srj18DiscoveryReport & { selectedSample: string }> {
+  const absoluteOutputDir = resolve(outputDir)
+  mkdirSync(join(absoluteOutputDir, "trials"), { recursive: true })
+  const scenarios = await loadScenarios("srj18", { effort: 1 })
+  const sampleNames = scenarios
+    .map(([sampleName]) => sampleName)
+    .sort(
+      (a, b) =>
+        Number(b === "sample005") - Number(a === "sample005") ||
+        a.localeCompare(b),
+    )
+  const report: Srj18DiscoveryReport = {
+    version: 1,
+    dataset: "srj18",
+    pipeline: "AutoroutingPipelineSolver7_MultiGraph",
+    effort: 1,
+    cacheProvider: null,
+    selectedSample: null,
+    generatedAt: new Date().toISOString(),
+    timeoutMs: childTimeoutMs,
+    measurement:
+      "Every trial uses a fresh Bun child process, run serially. Timing covers pipeline construction and solve(), after module imports and dataset loading, without iteration instrumentation.",
+    selection:
+      "Run every SRJ18 sample once, starting with sample005 (the fastest sample in main run 34137610765). Repeat the three fastest completed samples twice more, then select the lowest median across three successful trials. Each child has at most a 90-second wall deadline, reduced after a successful solve to twice the fastest measured time plus a 10-second startup margin. Timed-out samples are excluded rather than claimed to have completed.",
+    runtime: {
+      bunVersion: Bun.version,
+      platform: platform(),
+      architecture: arch(),
+      cpuModel: cpus()[0]?.model || "unknown",
+      runnerName: process.env.RUNNER_NAME || null,
+      commitSha: process.env.GITHUB_SHA || null,
+    },
+    firstPassRankings: [],
+    rankings: [],
+    trials: [],
+  }
+  let fastestTimeMs = Number.POSITIVE_INFINITY
+  for (const [sampleIndex, sampleName] of sampleNames.entries()) {
+    const timeoutMs = Math.min(childTimeoutMs, fastestTimeMs * 2 + 10_000)
+    console.log(
+      `[discovery] ${sampleName}, sample ${sampleIndex + 1}/${sampleNames.length}, trial 1 (deadline ${Math.round(timeoutMs)}ms)`,
+    )
+    const trial = await runDiscoveryTrial(
+      absoluteOutputDir,
+      sampleName,
+      1,
+      timeoutMs,
+    )
+    report.trials.push(trial)
+    if (trial.status === "solved") {
+      fastestTimeMs = Math.min(fastestTimeMs, trial.elapsedTimeMs)
+    }
+    console.log(
+      `[discovery] ${sampleName}: ${trial.status}, ${Math.round(trial.wallTimeMs)}ms wall`,
+    )
+    writeDiscoveryReport(absoluteOutputDir, report)
+  }
+  report.firstPassRankings = getSrj18DiscoveryRankings(report.trials, 1)
+  const candidates = report.firstPassRankings.slice(0, 3)
+  for (const trialNumber of [2, 3]) {
+    for (const candidate of candidates) {
+      console.log(`[discovery] ${candidate.sampleName}, trial ${trialNumber}/3`)
+      const trial = await runDiscoveryTrial(
+        absoluteOutputDir,
+        candidate.sampleName,
+        trialNumber,
+        Math.min(childTimeoutMs, fastestTimeMs * 2 + 10_000),
+      )
+      report.trials.push(trial)
+      console.log(
+        `[discovery] ${candidate.sampleName}: ${trial.status}, ${Math.round(trial.wallTimeMs)}ms wall`,
+      )
+      writeDiscoveryReport(absoluteOutputDir, report)
+    }
+  }
+  report.rankings = getSrj18DiscoveryRankings(report.trials, 3)
+  const selectedSample = report.rankings[0]?.sampleName
+  report.selectedSample = selectedSample || null
+  writeDiscoveryReport(absoluteOutputDir, report)
+  if (!selectedSample) {
+    throw new Error("No SRJ18 sample completed all three discovery trials")
+  }
+  return { ...report, selectedSample }
+}
+
+if (import.meta.main) {
+  const [mode, sampleName, outputPath] = process.argv.slice(2)
+  if (mode !== "--child" || !sampleName || !outputPath) {
+    throw new Error(
+      "This utility is imported by the iteration timing workflow; child usage: --child sampleName outputPath",
+    )
+  }
+  await runChildSample(sampleName, outputPath)
+}

--- a/scripts/iteration-timing/iterationTimingReport.ts
+++ b/scripts/iteration-timing/iterationTimingReport.ts
@@ -1,0 +1,114 @@
+import { mkdirSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import type {
+  SolverIterationAttribution,
+  SolverIterationTiming,
+} from "./profileSolverIterations"
+import {
+  SRJ18_ITERATION_TARGET_MS,
+  type IterationWhitelistEntry,
+} from "./srj18IterationWhitelist"
+
+export type ClassifiedIteration = SolverIterationTiming & {
+  whitelisted: boolean
+  unlistedAttributions: SolverIterationAttribution[]
+}
+
+export const classifyIteration = (
+  iteration: SolverIterationTiming,
+  whitelist: readonly IterationWhitelistEntry[],
+): ClassifiedIteration => {
+  // Inspect every material contributor, not just the largest one: a known
+  // parent must never grant permission to an unknown descendant.
+  const material = iteration.attributions.filter(
+    (entry) => entry.elapsedMs > SRJ18_ITERATION_TARGET_MS,
+  )
+  const contributors = material.length > 0 ? material : iteration.attributions
+  const unlistedAttributions = contributors.filter(
+    (entry) =>
+      !whitelist.some(
+        (allowed) =>
+          allowed.solverName === entry.solverName &&
+          allowed.phase === entry.phase &&
+          allowed.localIteration === entry.localIteration &&
+          (allowed.iterationEnd ?? allowed.localIteration) ===
+            (entry.iterationEnd ?? entry.localIteration),
+      ),
+  )
+  return {
+    ...iteration,
+    whitelisted: contributors.length > 0 && unlistedAttributions.length === 0,
+    unlistedAttributions,
+  }
+}
+
+export const describeAttribution = (
+  entry: SolverIterationAttribution,
+): string => {
+  const iteration = entry.iterationEnd
+    ? `${entry.localIteration}–${entry.iterationEnd}`
+    : String(entry.localIteration)
+  return `${entry.solverName} ${entry.phase} ${iteration} (${entry.elapsedMs.toFixed(1)}ms)`
+}
+
+export const writeIterationTimingReport = (
+  outputDir: string,
+  report: {
+    sampleName: string
+    thresholdMs: number
+    elapsedMs: number
+    totalIterations: number
+    maxIterationMs: number
+    iterations: ClassifiedIteration[]
+    solverTimings: unknown[]
+    solved: boolean
+    failed: boolean
+    error: string | null
+    runtime: { bun: string; platform: string; arch: string; commit: string }
+  },
+): void => {
+  mkdirSync(outputDir, { recursive: true })
+  writeFileSync(join(outputDir, "iterations.json"), JSON.stringify(report, null, 2))
+  const warnings = report.iterations.filter(
+    (iteration) => iteration.elapsedMs > report.thresholdMs,
+  )
+  const summary = [
+    "# SRJ18 iteration timing",
+    "",
+    `Sample: **${report.sampleName}**, Pipeline 7, effort 1, cache disabled.`,
+    `Runtime: Bun ${report.runtime.bun}, ${report.runtime.platform}/${report.runtime.arch}, commit ${report.runtime.commit}.`,
+    `Solved: ${report.solved}; failed: ${report.failed}${report.error ? `; error: ${report.error}` : ""}.`,
+    `Completed ${report.totalIterations.toLocaleString("en-US")} pipeline iterations in ${(report.elapsedMs / 1_000).toFixed(2)}s; maximum iteration ${report.maxIterationMs.toFixed(1)}ms.`,
+    `Warning threshold: ${report.thresholdMs}ms. ${warnings.length} slow iterations, ${warnings.filter((entry) => !entry.whitelisted).length} with unlisted contributors.`,
+    "",
+    "Every pipeline step is timed. The table retains steps over 100ms so the future budget can be reviewed now. Attribution follows nested step calls, including synchronous solve loops and children that finish or are created inside the call. Initialization is numbered 0; step iterations are 1-based per solver instance. A range means several child steps ran synchronously inside one pipeline iteration.",
+    "",
+    "| Pipeline iteration | Duration (ms) | Deepest solver / local iteration | Status |",
+    "| ---: | ---: | --- | --- |",
+    ...report.iterations.map((entry) => {
+      const status = entry.elapsedMs > report.thresholdMs
+        ? entry.whitelisted ? "Whitelisted slow iteration" : "WARNING: unlisted"
+        : entry.whitelisted ? "Whitelisted >100ms candidate" : ">100ms candidate"
+      const contributors = entry.attributions
+        .filter((part) => part.elapsedMs > SRJ18_ITERATION_TARGET_MS)
+        .map(describeAttribution)
+      return `| ${entry.rootIteration} | ${entry.elapsedMs.toFixed(1)} | ${contributors.length > 0 ? contributors.join("; ") : `${entry.solverName} ${entry.phase} ${entry.localIteration}`} | ${status} |`
+    }),
+    "",
+    "See iterations.json for full active solver paths, all contributors, and aggregate timings. Known slow iterations remain visible; new slow iterations emit warnings without failing this discovery-stage benchmark. Routing failure still fails the test.",
+    "",
+  ].join("\n")
+  writeFileSync(join(outputDir, "summary.md"), summary)
+  for (const iteration of warnings) {
+    const status = iteration.whitelisted ? "whitelisted" : "UNLISTED"
+    const detail = iteration.attributions
+      .filter((entry) => entry.elapsedMs > SRJ18_ITERATION_TARGET_MS)
+      .map(describeAttribution)
+      .join("; ")
+    const message = `${report.sampleName} pipeline iteration ${iteration.rootIteration}: ${iteration.elapsedMs.toFixed(1)}ms > ${report.thresholdMs}ms [${status}]; ${detail || `${iteration.solverName} ${iteration.phase} ${iteration.localIteration}`}`
+    console.warn(process.env.GITHUB_ACTIONS === "true"
+      ? `::warning title=Slow SRJ18 iteration::${message.replaceAll("%", "%25").replaceAll("\r", "%0D").replaceAll("\n", "%0A")}`
+      : `WARNING: ${message}`)
+  }
+  console.log(summary)
+}

--- a/scripts/iteration-timing/iterationTimingReport.ts
+++ b/scripts/iteration-timing/iterationTimingReport.ts
@@ -68,7 +68,10 @@ export const writeIterationTimingReport = (
   },
 ): void => {
   mkdirSync(outputDir, { recursive: true })
-  writeFileSync(join(outputDir, "iterations.json"), JSON.stringify(report, null, 2))
+  writeFileSync(
+    join(outputDir, "iterations.json"),
+    JSON.stringify(report, null, 2),
+  )
   const warnings = report.iterations.filter(
     (iteration) => iteration.elapsedMs > report.thresholdMs,
   )
@@ -86,9 +89,14 @@ export const writeIterationTimingReport = (
     "| Pipeline iteration | Duration (ms) | Deepest solver / local iteration | Status |",
     "| ---: | ---: | --- | --- |",
     ...report.iterations.map((entry) => {
-      const status = entry.elapsedMs > report.thresholdMs
-        ? entry.whitelisted ? "Whitelisted slow iteration" : "WARNING: unlisted"
-        : entry.whitelisted ? "Whitelisted >100ms candidate" : ">100ms candidate"
+      const status =
+        entry.elapsedMs > report.thresholdMs
+          ? entry.whitelisted
+            ? "Whitelisted slow iteration"
+            : "WARNING: unlisted"
+          : entry.whitelisted
+            ? "Whitelisted >100ms candidate"
+            : ">100ms candidate"
       const contributors = entry.attributions
         .filter((part) => part.elapsedMs > SRJ18_ITERATION_TARGET_MS)
         .map(describeAttribution)
@@ -106,9 +114,11 @@ export const writeIterationTimingReport = (
       .map(describeAttribution)
       .join("; ")
     const message = `${report.sampleName} pipeline iteration ${iteration.rootIteration}: ${iteration.elapsedMs.toFixed(1)}ms > ${report.thresholdMs}ms [${status}]; ${detail || `${iteration.solverName} ${iteration.phase} ${iteration.localIteration}`}`
-    console.warn(process.env.GITHUB_ACTIONS === "true"
-      ? `::warning title=Slow SRJ18 iteration::${message.replaceAll("%", "%25").replaceAll("\r", "%0D").replaceAll("\n", "%0A")}`
-      : `WARNING: ${message}`)
+    console.warn(
+      process.env.GITHUB_ACTIONS === "true"
+        ? `::warning title=Slow SRJ18 iteration::${message.replaceAll("%", "%25").replaceAll("\r", "%0D").replaceAll("\n", "%0A")}`
+        : `WARNING: ${message}`,
+    )
   }
   console.log(summary)
 }

--- a/scripts/iteration-timing/profileSolverIterations.ts
+++ b/scripts/iteration-timing/profileSolverIterations.ts
@@ -1,0 +1,348 @@
+import { BaseSolver as ExternalBaseSolver } from "@tscircuit/solver-utils"
+import { BaseSolver } from "../../lib/solvers/BaseSolver"
+
+export type ProfiledSolver = {
+  iterations: number
+  solved: boolean
+  failed: boolean
+  activeSubSolver?: ProfiledSolver | null
+  step(): unknown
+  getSolverName?(): string
+}
+
+export type SolverIterationAttribution = {
+  solverName: string
+  localIteration: number
+  /** Present when several synchronous calls to this solver blocked one root step. */
+  iterationEnd?: number
+  phase: "step" | "initialization"
+  path: string[]
+  /** Exclusive time: nested solver calls are attributed separately. */
+  elapsedMs: number
+}
+
+export type SolverIterationTiming = SolverIterationAttribution & {
+  rootIteration: number
+  /** Wall time of the complete root step, including its nested calls. */
+  elapsedMs: number
+  attributions: SolverIterationAttribution[]
+}
+
+export type SolverTimingSummary = {
+  solverName: string
+  phase: SolverIterationAttribution["phase"]
+  iterations: number
+  totalMs: number
+  maxMs: number
+}
+
+export type SolverIterationProfile = {
+  iterations: SolverIterationTiming[]
+  totalIterations: number
+  maxIterationMs: number
+  elapsedMs: number
+  solverTimings: SolverTimingSummary[]
+}
+
+type ProfileOptions = {
+  /** Retain root iterations above this duration, independently of warning policy. */
+  thresholdMs?: number
+  now?: () => number
+  additionalSolverPrototypes?: object[]
+}
+
+type Frame = {
+  solver: ProfiledSolver
+  iteration: number
+  path: string[]
+  lastTime: number
+  pendingSelfMs: number
+  activeAtStart: ProfiledSolver[]
+}
+
+type PropertyRestore = {
+  target: object
+  property: string
+  descriptor: PropertyDescriptor | undefined
+  getCurrentValue?: () => unknown
+}
+
+let profiling = false
+
+/**
+ * Profiles synchronous step() calls without changing production solver code.
+ * Run in an isolated process: the two BaseSolver prototypes are patched only for
+ * this synchronous call and are restored even when a solver throws. The external
+ * base also covers tiny-hypergraph, pcb-poly-hyper-graph and high-density-repair03.
+ */
+export function profileSolverIterations(
+  root: ProfiledSolver,
+  options: ProfileOptions = {},
+): SolverIterationProfile {
+  if (profiling) throw new Error("A solver iteration profile is already running")
+  const thresholdMs = options.thresholdMs ?? 100
+  if (!Number.isFinite(thresholdMs) || thresholdMs < 0) {
+    throw new Error("thresholdMs must be a finite non-negative number")
+  }
+  const now = options.now ?? (() => performance.now())
+  const restores: PropertyRestore[] = []
+  const patchedPrototypes = new Set<object>()
+  const observedSolvers = new WeakSet<object>()
+  const assignedSolvers = new WeakSet<object>()
+  const solverNames = new WeakMap<object, string>()
+  const frames: Frame[] = []
+  const summaries = new Map<string, SolverTimingSummary>()
+  const summaryIterations = new WeakMap<
+    ProfiledSolver,
+    Map<string, { iteration: number; elapsedMs: number }>
+  >()
+  let attributions = new Map<ProfiledSolver, Map<string, SolverIterationAttribution>>()
+  const result: SolverIterationProfile = {
+    iterations: [],
+    totalIterations: 0,
+    maxIterationMs: 0,
+    elapsedMs: 0,
+    solverTimings: [],
+  }
+
+  function solverName(solver: ProfiledSolver): string {
+    let name = solverNames.get(solver)
+    if (name === undefined) {
+      name = solver.getSolverName?.() ?? solver.constructor.name
+      solverNames.set(solver, name)
+    }
+    return name
+  }
+
+  function record(
+    solver: ProfiledSolver,
+    phase: SolverIterationAttribution["phase"],
+    iteration: number,
+    path: string[],
+    elapsedMs: number,
+  ): void {
+    if (elapsedMs <= 0) return
+    let byPhase = attributions.get(solver)
+    if (!byPhase) {
+      byPhase = new Map()
+      attributions.set(solver, byPhase)
+    }
+    const existing = byPhase.get(phase)
+    if (existing) {
+      existing.elapsedMs += elapsedMs
+      if (iteration !== existing.localIteration) {
+        existing.iterationEnd = Math.max(existing.iterationEnd ?? 0, iteration)
+        existing.localIteration = Math.min(existing.localIteration, iteration)
+      }
+    } else {
+      byPhase.set(phase, {
+        solverName: solverName(solver),
+        phase,
+        localIteration: iteration,
+        path,
+        elapsedMs,
+      })
+    }
+    const key = `${solverName(solver)}:${phase}`
+    let previousIterations = summaryIterations.get(solver)
+    if (!previousIterations) {
+      previousIterations = new Map()
+      summaryIterations.set(solver, previousIterations)
+    }
+    const previous = previousIterations.get(phase)
+    const sameIteration = previous?.iteration === iteration
+    const iterationMs = elapsedMs + (sameIteration ? previous.elapsedMs : 0)
+    previousIterations.set(phase, { iteration, elapsedMs: iterationMs })
+    const summary = summaries.get(key)
+    if (summary) {
+      if (!sameIteration) summary.iterations++
+      summary.totalMs += elapsedMs
+      summary.maxMs = Math.max(summary.maxMs, iterationMs)
+    } else {
+      summaries.set(key, {
+        solverName: solverName(solver),
+        phase,
+        iterations: 1,
+        totalMs: elapsedMs,
+        maxMs: elapsedMs,
+      })
+    }
+  }
+
+  function observeSolver(solver: ProfiledSolver): void {
+    if (observedSolvers.has(solver)) return
+    observedSolvers.add(solver)
+    patchStepPrototype(solver)
+    const descriptor = Object.getOwnPropertyDescriptor(solver, "activeSubSolver")
+    if (descriptor && (!descriptor.configurable || descriptor.get || descriptor.set)) {
+      throw new Error(`Cannot observe ${solverName(solver)}.activeSubSolver`)
+    }
+    let active = solver.activeSubSolver
+    restores.push({
+      target: solver,
+      property: "activeSubSolver",
+      descriptor,
+      getCurrentValue: (): unknown => active,
+    })
+    Object.defineProperty(solver, "activeSubSolver", {
+      configurable: true,
+      enumerable: descriptor?.enumerable ?? true,
+      get: (): ProfiledSolver | null | undefined => active,
+      set: (next: ProfiledSolver | null | undefined): void => {
+        const firstAssignment = next && !assignedSolvers.has(next)
+        active = next
+        if (next) {
+          assignedSolvers.add(next)
+          observeSolver(next)
+        }
+        if (!firstAssignment || !next) return
+        const frame = frames.findLast((item) => item.solver === solver)
+        if (!frame) return
+        const assignedAt = now()
+        frame.pendingSelfMs += assignedAt - frame.lastTime
+        frame.lastTime = assignedAt
+        const activeChain = getActiveChain(next)
+        const deepest = activeChain.at(-1) ?? next
+        const path = [...frame.path, solverName(next), ...activeChain.map(solverName)]
+        // This includes constructor parameters and synchronous construction.
+        // Nested step()/solve() work has already been subtracted from self time.
+        record(deepest, "initialization", 0, path, frame.pendingSelfMs)
+        frame.pendingSelfMs = 0
+      },
+    })
+    if (active) {
+      assignedSolvers.add(active)
+      observeSolver(active)
+    }
+  }
+
+  function getActiveChain(solver: ProfiledSolver): ProfiledSolver[] {
+    const chain: ProfiledSolver[] = []
+    const visited = new Set<ProfiledSolver>([solver])
+    let child = solver.activeSubSolver
+    while (child && !visited.has(child)) {
+      visited.add(child)
+      chain.push(child)
+      child = child.activeSubSolver
+    }
+    if (child) throw new Error("Cycle in the active subsolver chain")
+    return chain
+  }
+
+  function patchStepPrototype(target: object): void {
+    let owner: object | null = target
+    while (owner && !Object.hasOwn(owner, "step")) {
+      owner = Object.getPrototypeOf(owner)
+    }
+    if (!owner || patchedPrototypes.has(owner)) return
+    const descriptor = Object.getOwnPropertyDescriptor(owner, "step")!
+    if (typeof descriptor.value !== "function") {
+      throw new Error("Solver step must be a method")
+    }
+    const original = descriptor.value as (this: ProfiledSolver) => unknown
+    patchedPrototypes.add(owner)
+    restores.push({ target: owner, property: "step", descriptor })
+    Object.defineProperty(owner, "step", {
+      ...descriptor,
+      value: function (this: ProfiledSolver): unknown {
+        if (this.solved || this.failed) return original.call(this)
+        // An override may call super.step(); that is the same solver iteration.
+        if (frames.at(-1)?.solver === this) return original.call(this)
+        const startedAt = now()
+        const parent = frames.at(-1)
+        if (parent) {
+          parent.pendingSelfMs += startedAt - parent.lastTime
+        }
+        observeSolver(this)
+        const frame: Frame = {
+          solver: this,
+          iteration: this.iterations + 1,
+          path: [...(parent?.path ?? []), solverName(this)],
+          lastTime: startedAt,
+          pendingSelfMs: 0,
+          activeAtStart: getActiveChain(this),
+        }
+        frames.push(frame)
+        try {
+          return original.call(this)
+        } finally {
+          const endedAt = now()
+          frame.pendingSelfMs += endedAt - frame.lastTime
+          const activeChain = frame.activeAtStart
+          const deepest = activeChain.at(-1) ?? this
+          record(
+            deepest,
+            "step",
+            deepest === this ? frame.iteration : Math.max(1, deepest.iterations),
+            [...frame.path, ...activeChain.map(solverName)],
+            frame.pendingSelfMs,
+          )
+          frames.pop()
+          if (parent) parent.lastTime = endedAt
+        }
+      },
+    })
+  }
+
+  profiling = true
+  try {
+    for (const prototype of [
+      BaseSolver.prototype,
+      ExternalBaseSolver.prototype,
+      ...(options.additionalSolverPrototypes ?? []),
+    ]) {
+      patchStepPrototype(prototype)
+    }
+    observeSolver(root)
+    const startedAt = now()
+    while (!root.solved && !root.failed) {
+      attributions = new Map()
+      const iterationStartedAt = now()
+      root.step()
+      const elapsedMs = now() - iterationStartedAt
+      result.totalIterations++
+      result.maxIterationMs = Math.max(result.maxIterationMs, elapsedMs)
+      if (elapsedMs <= thresholdMs) continue
+      const entries = [...attributions.values()]
+        .flatMap((byPhase) => [...byPhase.values()])
+        .sort((a, b) => b.elapsedMs - a.elapsedMs)
+      if (entries.length === 0) {
+        throw new Error("A slow root iteration had no solver attribution")
+      }
+      result.iterations.push({
+        ...entries[0],
+        rootIteration: root.iterations,
+        elapsedMs,
+        attributions: entries,
+      })
+    }
+    result.elapsedMs = now() - startedAt
+    result.solverTimings = [...summaries.values()].sort((a, b) => b.maxMs - a.maxMs)
+    return result
+  } finally {
+    for (const restore of restores.reverse()) {
+      if (restore.getCurrentValue) {
+        const value = restore.getCurrentValue()
+        if (restore.descriptor) {
+          Object.defineProperty(restore.target, restore.property, {
+            ...restore.descriptor,
+            value,
+          })
+        } else {
+          delete (restore.target as Record<string, unknown>)[restore.property]
+          if (value !== undefined) {
+            Object.defineProperty(restore.target, restore.property, {
+              configurable: true,
+              enumerable: true,
+              writable: true,
+              value,
+            })
+          }
+        }
+      } else {
+        Object.defineProperty(restore.target, restore.property, restore.descriptor!)
+      }
+    }
+    profiling = false
+  }
+}

--- a/scripts/iteration-timing/profileSolverIterations.ts
+++ b/scripts/iteration-timing/profileSolverIterations.ts
@@ -209,7 +209,8 @@ export function profileSolverIterations(
         if (next === active) return
         const firstAssignment = next && !assignedSolvers.has(next)
         const affectedFrames = frames.filter(
-          (frame) => frame.solver === solver || frame.activeChain.includes(solver),
+          (frame) =>
+            frame.solver === solver || frame.activeChain.includes(solver),
         )
         const assignedAt = now()
         for (const frame of affectedFrames) {

--- a/scripts/iteration-timing/profileSolverIterations.ts
+++ b/scripts/iteration-timing/profileSolverIterations.ts
@@ -1,4 +1,6 @@
 import { BaseSolver as ExternalBaseSolver } from "@tscircuit/solver-utils"
+import { PowerTraceExpanderSolver } from "@tscircuit/power-trace-expander"
+import { ConvexRegionsSolver } from "pcb-poly-hyper-graph"
 import { BaseSolver } from "../../lib/solvers/BaseSolver"
 
 export type ProfiledSolver = {
@@ -12,6 +14,7 @@ export type ProfiledSolver = {
 
 export type SolverIterationAttribution = {
   solverName: string
+  /** Observed step calls per instance; initialization is 0. */
   localIteration: number
   /** Present when several synchronous calls to this solver blocked one root step. */
   iterationEnd?: number
@@ -57,7 +60,8 @@ type Frame = {
   path: string[]
   lastTime: number
   pendingSelfMs: number
-  activeAtStart: ProfiledSolver[]
+  activeChain: ProfiledSolver[]
+  canAttributeInitialization: boolean
 }
 
 type PropertyRestore = {
@@ -71,15 +75,17 @@ let profiling = false
 
 /**
  * Profiles synchronous step() calls without changing production solver code.
- * Run in an isolated process: the two BaseSolver prototypes are patched only for
+ * Run in an isolated process: solver prototypes are patched only for
  * this synchronous call and are restored even when a solver throws. The external
- * base also covers tiny-hypergraph, pcb-poly-hyper-graph and high-density-repair03.
+ * base covers tiny-hypergraph and high-density-repair03; exported solvers also
+ * locate the separate solver-utils versions used by polygon and power routing.
  */
 export function profileSolverIterations(
   root: ProfiledSolver,
   options: ProfileOptions = {},
 ): SolverIterationProfile {
-  if (profiling) throw new Error("A solver iteration profile is already running")
+  if (profiling)
+    throw new Error("A solver iteration profile is already running")
   const thresholdMs = options.thresholdMs ?? 100
   if (!Number.isFinite(thresholdMs) || thresholdMs < 0) {
     throw new Error("thresholdMs must be a finite non-negative number")
@@ -90,13 +96,17 @@ export function profileSolverIterations(
   const observedSolvers = new WeakSet<object>()
   const assignedSolvers = new WeakSet<object>()
   const solverNames = new WeakMap<object, string>()
+  const stepCounts = new WeakMap<ProfiledSolver, number>()
   const frames: Frame[] = []
   const summaries = new Map<string, SolverTimingSummary>()
   const summaryIterations = new WeakMap<
     ProfiledSolver,
     Map<string, { iteration: number; elapsedMs: number }>
   >()
-  let attributions = new Map<ProfiledSolver, Map<string, SolverIterationAttribution>>()
+  let attributions = new Map<
+    ProfiledSolver,
+    Map<string, SolverIterationAttribution>
+  >()
   const result: SolverIterationProfile = {
     iterations: [],
     totalIterations: 0,
@@ -173,8 +183,14 @@ export function profileSolverIterations(
     if (observedSolvers.has(solver)) return
     observedSolvers.add(solver)
     patchStepPrototype(solver)
-    const descriptor = Object.getOwnPropertyDescriptor(solver, "activeSubSolver")
-    if (descriptor && (!descriptor.configurable || descriptor.get || descriptor.set)) {
+    const descriptor = Object.getOwnPropertyDescriptor(
+      solver,
+      "activeSubSolver",
+    )
+    if (
+      descriptor &&
+      (!descriptor.configurable || descriptor.get || descriptor.set)
+    ) {
       throw new Error(`Cannot observe ${solverName(solver)}.activeSubSolver`)
     }
     let active = solver.activeSubSolver
@@ -189,25 +205,52 @@ export function profileSolverIterations(
       enumerable: descriptor?.enumerable ?? true,
       get: (): ProfiledSolver | null | undefined => active,
       set: (next: ProfiledSolver | null | undefined): void => {
+        // Reaffirming the active child does not end its current time interval.
+        if (next === active) return
         const firstAssignment = next && !assignedSolvers.has(next)
+        const affectedFrames = frames.filter(
+          (frame) => frame.solver === solver || frame.activeChain.includes(solver),
+        )
+        const assignedAt = now()
+        for (const frame of affectedFrames) {
+          // Ancestors are paused inside the current call: their pending self
+          // time excludes that nested call and must not be charged twice.
+          if (frame === frames.at(-1)) {
+            frame.pendingSelfMs += assignedAt - frame.lastTime
+            frame.lastTime = assignedAt
+          }
+          if (
+            frame.solver === solver &&
+            frame.canAttributeInitialization &&
+            firstAssignment &&
+            next
+          ) {
+            const activeChain = getActiveChain(next)
+            const deepest = activeChain.at(-1) ?? next
+            const path = [
+              ...frame.path,
+              solverName(next),
+              ...activeChain.map(solverName),
+            ]
+            // A construction-only transition includes parameter preparation.
+            // After a clear/replacement, retain parent work under the parent:
+            // a child's initialization whitelist must not cover teardown.
+            record(deepest, "initialization", 0, path, frame.pendingSelfMs)
+            frame.pendingSelfMs = 0
+          } else {
+            const isReplacement = frame.solver === solver && firstAssignment
+            recordPendingSelf(frame, Boolean(isReplacement))
+          }
+          frame.canAttributeInitialization = false
+        }
         active = next
         if (next) {
           assignedSolvers.add(next)
           observeSolver(next)
         }
-        if (!firstAssignment || !next) return
-        const frame = frames.findLast((item) => item.solver === solver)
-        if (!frame) return
-        const assignedAt = now()
-        frame.pendingSelfMs += assignedAt - frame.lastTime
-        frame.lastTime = assignedAt
-        const activeChain = getActiveChain(next)
-        const deepest = activeChain.at(-1) ?? next
-        const path = [...frame.path, solverName(next), ...activeChain.map(solverName)]
-        // This includes constructor parameters and synchronous construction.
-        // Nested step()/solve() work has already been subtracted from self time.
-        record(deepest, "initialization", 0, path, frame.pendingSelfMs)
-        frame.pendingSelfMs = 0
+        for (const frame of affectedFrames) {
+          frame.activeChain = getActiveChain(frame.solver)
+        }
       },
     })
     if (active) {
@@ -227,6 +270,23 @@ export function profileSolverIterations(
     }
     if (child) throw new Error("Cycle in the active subsolver chain")
     return chain
+  }
+
+  function recordPendingSelf(frame: Frame, forceParent = false): void {
+    const activeChain = forceParent ? [] : frame.activeChain
+    const deepest = activeChain.at(-1) ?? frame.solver
+    const iteration =
+      deepest === frame.solver
+        ? frame.iteration
+        : (stepCounts.get(deepest) ?? deepest.iterations)
+    record(
+      deepest,
+      iteration === 0 ? "initialization" : "step",
+      iteration,
+      [...frame.path, ...activeChain.map(solverName)],
+      frame.pendingSelfMs,
+    )
+    frame.pendingSelfMs = 0
   }
 
   function patchStepPrototype(target: object): void {
@@ -254,13 +314,19 @@ export function profileSolverIterations(
           parent.pendingSelfMs += startedAt - parent.lastTime
         }
         observeSolver(this)
+        // Some external overrides never increment this.iterations, so whitelist
+        // identity must follow observed calls rather than that mutable field.
+        const iteration = (stepCounts.get(this) ?? this.iterations) + 1
+        stepCounts.set(this, iteration)
+        const activeChain = getActiveChain(this)
         const frame: Frame = {
           solver: this,
-          iteration: this.iterations + 1,
+          iteration,
           path: [...(parent?.path ?? []), solverName(this)],
           lastTime: startedAt,
           pendingSelfMs: 0,
-          activeAtStart: getActiveChain(this),
+          activeChain,
+          canAttributeInitialization: activeChain.length === 0,
         }
         frames.push(frame)
         try {
@@ -268,15 +334,7 @@ export function profileSolverIterations(
         } finally {
           const endedAt = now()
           frame.pendingSelfMs += endedAt - frame.lastTime
-          const activeChain = frame.activeAtStart
-          const deepest = activeChain.at(-1) ?? this
-          record(
-            deepest,
-            "step",
-            deepest === this ? frame.iteration : Math.max(1, deepest.iterations),
-            [...frame.path, ...activeChain.map(solverName)],
-            frame.pendingSelfMs,
-          )
+          recordPendingSelf(frame)
           frames.pop()
           if (parent) parent.lastTime = endedAt
         }
@@ -289,6 +347,8 @@ export function profileSolverIterations(
     for (const prototype of [
       BaseSolver.prototype,
       ExternalBaseSolver.prototype,
+      ConvexRegionsSolver.prototype,
+      PowerTraceExpanderSolver.prototype,
       ...(options.additionalSolverPrototypes ?? []),
     ]) {
       patchStepPrototype(prototype)
@@ -311,13 +371,15 @@ export function profileSolverIterations(
       }
       result.iterations.push({
         ...entries[0],
-        rootIteration: root.iterations,
+        rootIteration: stepCounts.get(root)!,
         elapsedMs,
         attributions: entries,
       })
     }
     result.elapsedMs = now() - startedAt
-    result.solverTimings = [...summaries.values()].sort((a, b) => b.maxMs - a.maxMs)
+    result.solverTimings = [...summaries.values()].sort(
+      (a, b) => b.maxMs - a.maxMs,
+    )
     return result
   } finally {
     for (const restore of restores.reverse()) {
@@ -340,7 +402,11 @@ export function profileSolverIterations(
           }
         }
       } else {
-        Object.defineProperty(restore.target, restore.property, restore.descriptor!)
+        Object.defineProperty(
+          restore.target,
+          restore.property,
+          restore.descriptor!,
+        )
       }
     }
     profiling = false

--- a/scripts/iteration-timing/srj18IterationWhitelist.ts
+++ b/scripts/iteration-timing/srj18IterationWhitelist.ts
@@ -13,4 +13,26 @@ export const SRJ18_ITERATION_TARGET_MS = 100
 
 // Exact deepest-solver iterations only. Ancestor names and solver-wide wildcards
 // would hide new blocking work in their descendants.
-export const srj18IterationWhitelist: IterationWhitelistEntry[] = []
+export const srj18IterationWhitelist: IterationWhitelistEntry[] = [
+  {
+    solverName: "DuplicateCongestedPortSolver",
+    phase: "step",
+    localIteration: 1,
+    reason:
+      "Congestion setup routes connections synchronously and duplicates the graph; a material contributor to pipeline iteration 9255 (1.29s on Blacksmith).",
+  },
+  {
+    solverName: "TinyHypergraphPortPointPathingSolver",
+    phase: "initialization",
+    localIteration: 0,
+    reason:
+      "Hypergraph construction, serialization and input-node preparation share pipeline iteration 9255 with the separately attributed congestion prepass.",
+  },
+  {
+    solverName: "HighDensitySolver",
+    phase: "initialization",
+    localIteration: 0,
+    reason:
+      "Preparing nodes calls computeNodePf for every node, repeatedly rebuilding pathing output; pipeline iteration 199986 took 1.63s on Blacksmith.",
+  },
+]

--- a/scripts/iteration-timing/srj18IterationWhitelist.ts
+++ b/scripts/iteration-timing/srj18IterationWhitelist.ts
@@ -29,6 +29,13 @@ export const srj18IterationWhitelist: IterationWhitelistEntry[] = [
       "Hypergraph construction, serialization and input-node preparation share pipeline iteration 9255 with the separately attributed congestion prepass.",
   },
   {
+    solverName: "UniformPortDistributionSolver",
+    phase: "initialization",
+    localIteration: 0,
+    reason:
+      "Preparing pathing output, ownership pairs and shared edges took 1.04s in pipeline iteration 199302 on a repeated Blacksmith run.",
+  },
+  {
     solverName: "HighDensitySolver",
     phase: "initialization",
     localIteration: 0,

--- a/scripts/iteration-timing/srj18IterationWhitelist.ts
+++ b/scripts/iteration-timing/srj18IterationWhitelist.ts
@@ -1,0 +1,16 @@
+export type IterationWhitelistEntry = {
+  solverName: string
+  phase: "step" | "initialization"
+  localIteration: number
+  iterationEnd?: number
+  reason: string
+}
+
+// Selected by serial discovery; see docs/srj18-iteration-timing.md.
+export const SRJ18_FASTEST_SAMPLE = "sample005"
+export const SRJ18_ITERATION_THRESHOLD_MS = 1_000
+export const SRJ18_ITERATION_TARGET_MS = 100
+
+// Exact deepest-solver iterations only. Ancestor names and solver-wide wildcards
+// would hide new blocking work in their descendants.
+export const srj18IterationWhitelist: IterationWhitelistEntry[] = []

--- a/tests/benchmarks/srj18-iteration-timing.test.ts
+++ b/tests/benchmarks/srj18-iteration-timing.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "bun:test"
+import { runSrj18IterationTiming } from "../../scripts/benchmark/srj18-iteration-timing"
+
+// This performance test gets a dedicated serial Blacksmith job. Keep ordinary
+// parallel test shards from producing noisy wall-clock warnings and duplicate work.
+test.skipIf(process.env.SRJ18_ITERATION_TIMING !== "1")(
+  "the fastest SRJ18 sample reports slow iterations by deepest active solver",
+  async (): Promise<void> => {
+    const result = await runSrj18IterationTiming()
+    expect(result.failed).toBe(false)
+    expect(result.solved).toBe(true)
+    expect(result.totalIterations).toBeGreaterThan(0)
+  },
+)

--- a/tests/iteration-timing-warning-report.test.ts
+++ b/tests/iteration-timing-warning-report.test.ts
@@ -1,0 +1,105 @@
+import { expect, spyOn, test } from "bun:test"
+import { mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import {
+  classifyIteration,
+  type ClassifiedIteration,
+  writeIterationTimingReport,
+} from "../scripts/iteration-timing/iterationTimingReport"
+import type { SolverIterationAttribution } from "../scripts/iteration-timing/profileSolverIterations"
+import type { IterationWhitelistEntry } from "../scripts/iteration-timing/srj18IterationWhitelist"
+
+test("reports warn for known and unlisted steps strictly over 1s and retain 100ms candidates", (): void => {
+  const outputDir = mkdtempSync(join(tmpdir(), "srj18-iteration-report-"))
+  const warn = spyOn(console, "warn").mockImplementation((): void => {})
+  const log = spyOn(console, "log").mockImplementation((): void => {})
+  const previousGitHubActions = process.env.GITHUB_ACTIONS
+  process.env.GITHUB_ACTIONS = "true"
+
+  try {
+    const whitelist: IterationWhitelistEntry[] = [
+      {
+        solverName: "KnownSolver",
+        phase: "step",
+        localIteration: 1,
+        reason: "Known first step",
+      },
+    ]
+    const examples = [
+      { solverName: "KnownSolver", elapsedMs: 1_200 },
+      { solverName: "UnknownSolver", elapsedMs: 1_100 },
+      { solverName: "KnownSolver", elapsedMs: 300 },
+      { solverName: "UnknownSolver", elapsedMs: 400 },
+      { solverName: "BoundarySolver", elapsedMs: 1_000 },
+    ]
+    const iterations = examples.map((example, index): ClassifiedIteration => {
+      const attribution: SolverIterationAttribution = {
+        ...example,
+        phase: "step",
+        localIteration: 1,
+        path: ["Pipeline", example.solverName],
+      }
+      return classifyIteration(
+        {
+          ...attribution,
+          rootIteration: index + 1,
+          attributions: [attribution],
+        },
+        whitelist,
+      )
+    })
+    writeIterationTimingReport(outputDir, {
+      sampleName: "fixture-sample",
+      thresholdMs: 1_000,
+      elapsedMs: 4_000,
+      totalIterations: 5,
+      maxIterationMs: 1_200,
+      iterations,
+      solverTimings: [],
+      solved: true,
+      failed: false,
+      error: null,
+      runtime: { bun: "test", platform: "test", arch: "test", commit: "test" },
+    })
+
+    expect(warn).toHaveBeenCalledTimes(2)
+    expect(warn.mock.calls[0]?.[0]).toBe(
+      "::warning title=Slow SRJ18 iteration::fixture-sample pipeline iteration 1: 1200.0ms > 1000ms [whitelisted]; KnownSolver step 1 (1200.0ms)",
+    )
+    expect(warn.mock.calls[1]?.[0]).toBe(
+      "::warning title=Slow SRJ18 iteration::fixture-sample pipeline iteration 2: 1100.0ms > 1000ms [UNLISTED]; UnknownSolver step 1 (1100.0ms)",
+    )
+    const summary = readFileSync(join(outputDir, "summary.md"), "utf8")
+    expect(summary).toContain("2 slow iterations, 1 with unlisted contributors")
+    expect(summary).toContain(
+      "| 1 | 1200.0 | KnownSolver step 1 (1200.0ms) | Whitelisted slow iteration |",
+    )
+    expect(summary).toContain(
+      "| 2 | 1100.0 | UnknownSolver step 1 (1100.0ms) | WARNING: unlisted |",
+    )
+    expect(summary).toContain(
+      "| 3 | 300.0 | KnownSolver step 1 (300.0ms) | Whitelisted >100ms candidate |",
+    )
+    expect(summary).toContain(
+      "| 4 | 400.0 | UnknownSolver step 1 (400.0ms) | >100ms candidate |",
+    )
+    expect(summary).toContain(
+      "| 5 | 1000.0 | BoundarySolver step 1 (1000.0ms) | >100ms candidate |",
+    )
+    const saved = JSON.parse(
+      readFileSync(join(outputDir, "iterations.json"), "utf8"),
+    )
+    expect(saved.iterations).toEqual(iterations)
+    expect(saved.thresholdMs).toBe(1_000)
+  } finally {
+    warn.mockRestore()
+    log.mockRestore()
+    if (previousGitHubActions === undefined) {
+      delete process.env.GITHUB_ACTIONS
+    } else {
+      process.env.GITHUB_ACTIONS = previousGitHubActions
+    }
+    rmSync(outputDir, { recursive: true, force: true })
+  }
+})

--- a/tests/iteration-timing-whitelist-cumulative.test.ts
+++ b/tests/iteration-timing-whitelist-cumulative.test.ts
@@ -48,6 +48,7 @@ test("a cumulatively slow step requires all contributors when none exceeds 100ms
     unlistedAttributions: [],
   })
   expect(
-    classifyIteration({ ...iteration, attributions: [] }, whitelist).whitelisted,
+    classifyIteration({ ...iteration, attributions: [] }, whitelist)
+      .whitelisted,
   ).toBeFalse()
 })

--- a/tests/iteration-timing-whitelist-cumulative.test.ts
+++ b/tests/iteration-timing-whitelist-cumulative.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "bun:test"
+import { classifyIteration } from "../scripts/iteration-timing/iterationTimingReport"
+import type { SolverIterationAttribution } from "../scripts/iteration-timing/profileSolverIterations"
+import type { IterationWhitelistEntry } from "../scripts/iteration-timing/srj18IterationWhitelist"
+
+test("a cumulatively slow step requires all contributors when none exceeds 100ms", (): void => {
+  const first: SolverIterationAttribution = {
+    solverName: "FirstSolver",
+    phase: "step",
+    localIteration: 1,
+    path: ["Pipeline", "FirstSolver"],
+    elapsedMs: 80,
+  }
+  const second: SolverIterationAttribution = {
+    solverName: "SecondSolver",
+    phase: "initialization",
+    localIteration: 0,
+    path: ["Pipeline", "SecondSolver"],
+    elapsedMs: 90,
+  }
+  const iteration = {
+    ...second,
+    rootIteration: 42,
+    elapsedMs: 170,
+    attributions: [second, first],
+  }
+  const whitelist: IterationWhitelistEntry[] = [
+    {
+      solverName: second.solverName,
+      phase: second.phase,
+      localIteration: second.localIteration,
+      reason: "Known initialization",
+    },
+  ]
+
+  expect(classifyIteration(iteration, whitelist)).toMatchObject({
+    whitelisted: false,
+    unlistedAttributions: [first],
+  })
+  whitelist.push({
+    solverName: first.solverName,
+    phase: first.phase,
+    localIteration: first.localIteration,
+    reason: "Known first step",
+  })
+  expect(classifyIteration(iteration, whitelist)).toMatchObject({
+    whitelisted: true,
+    unlistedAttributions: [],
+  })
+  expect(
+    classifyIteration({ ...iteration, attributions: [] }, whitelist).whitelisted,
+  ).toBeFalse()
+})

--- a/tests/iteration-timing-whitelist-deepest.test.ts
+++ b/tests/iteration-timing-whitelist-deepest.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "bun:test"
+import { classifyIteration } from "../scripts/iteration-timing/iterationTimingReport"
+import type { SolverIterationAttribution } from "../scripts/iteration-timing/profileSolverIterations"
+import type { IterationWhitelistEntry } from "../scripts/iteration-timing/srj18IterationWhitelist"
+
+test("every material deepest contributor needs its own whitelist entry", (): void => {
+  const parent: SolverIterationAttribution = {
+    solverName: "ParentSolver",
+    phase: "step",
+    localIteration: 1,
+    path: ["Pipeline", "ParentSolver"],
+    elapsedMs: 1_200,
+  }
+  const child: SolverIterationAttribution = {
+    solverName: "DeepestSolver",
+    phase: "step",
+    localIteration: 1,
+    path: ["Pipeline", "ParentSolver", "DeepestSolver"],
+    elapsedMs: 1_100,
+  }
+  const bookkeeping: SolverIterationAttribution = {
+    solverName: "Pipeline",
+    phase: "step",
+    localIteration: 42,
+    path: ["Pipeline"],
+    elapsedMs: 100,
+  }
+  const iteration = {
+    ...parent,
+    rootIteration: 42,
+    elapsedMs: 2_400,
+    attributions: [parent, child, bookkeeping],
+  }
+  const whitelist: IterationWhitelistEntry[] = [
+    {
+      solverName: parent.solverName,
+      phase: parent.phase,
+      localIteration: parent.localIteration,
+      reason: "Known parent work",
+    },
+  ]
+
+  expect(classifyIteration(iteration, whitelist)).toMatchObject({
+    whitelisted: false,
+    unlistedAttributions: [child],
+  })
+  whitelist.push({
+    solverName: child.solverName,
+    phase: child.phase,
+    localIteration: child.localIteration,
+    reason: "Known deepest child work",
+  })
+  expect(classifyIteration(iteration, whitelist)).toMatchObject({
+    whitelisted: true,
+    unlistedAttributions: [],
+  })
+  expect(classifyIteration(iteration, whitelist.slice(1))).toMatchObject({
+    whitelisted: false,
+    unlistedAttributions: [parent],
+  })
+})

--- a/tests/iteration-timing-whitelist-exact.test.ts
+++ b/tests/iteration-timing-whitelist-exact.test.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "bun:test"
+import { classifyIteration } from "../scripts/iteration-timing/iterationTimingReport"
+import type { SolverIterationAttribution } from "../scripts/iteration-timing/profileSolverIterations"
+import type { IterationWhitelistEntry } from "../scripts/iteration-timing/srj18IterationWhitelist"
+
+test("whitelist matching requires the exact solver, phase, and iteration range", (): void => {
+  const attribution: SolverIterationAttribution = {
+    solverName: "RouteSolver",
+    phase: "step",
+    localIteration: 1,
+    path: ["Pipeline", "RouteSolver"],
+    elapsedMs: 1_200,
+  }
+  const allowed: IterationWhitelistEntry = {
+    solverName: attribution.solverName,
+    phase: attribution.phase,
+    localIteration: attribution.localIteration,
+    reason: "Known first step",
+  }
+  const cases: {
+    attribution: SolverIterationAttribution
+    whitelist: IterationWhitelistEntry
+    expected: boolean
+  }[] = [
+    { attribution, whitelist: allowed, expected: true },
+    {
+      attribution: { ...attribution, solverName: "AnotherRouteSolver" },
+      whitelist: allowed,
+      expected: false,
+    },
+    {
+      attribution: { ...attribution, phase: "initialization" },
+      whitelist: allowed,
+      expected: false,
+    },
+    {
+      attribution: { ...attribution, localIteration: 2 },
+      whitelist: allowed,
+      expected: false,
+    },
+    {
+      attribution: { ...attribution, iterationEnd: 2 },
+      whitelist: allowed,
+      expected: false,
+    },
+    {
+      attribution: { ...attribution, iterationEnd: 2 },
+      whitelist: { ...allowed, iterationEnd: 2 },
+      expected: true,
+    },
+    {
+      attribution,
+      whitelist: { ...allowed, iterationEnd: 2 },
+      expected: false,
+    },
+    {
+      attribution: { ...attribution, iterationEnd: 1 },
+      whitelist: allowed,
+      expected: true,
+    },
+    {
+      attribution: {
+        ...attribution,
+        phase: "initialization",
+        localIteration: 0,
+      },
+      whitelist: { ...allowed, phase: "initialization", localIteration: 0 },
+      expected: true,
+    },
+  ]
+
+  for (const entry of cases) {
+    const classified = classifyIteration(
+      {
+        ...entry.attribution,
+        rootIteration: 42,
+        attributions: [entry.attribution],
+      },
+      [entry.whitelist],
+    )
+    expect(classified.whitelisted).toBe(entry.expected)
+    expect(classified.unlistedAttributions).toEqual(
+      entry.expected ? [] : [entry.attribution],
+    )
+  }
+})

--- a/tests/iteration-timing/profile-cleared-subsolver.test.ts
+++ b/tests/iteration-timing/profile-cleared-subsolver.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "bun:test"
+import { BaseSolver } from "../../lib/solvers/BaseSolver"
+import { profileSolverIterations } from "../../scripts/iteration-timing/profileSolverIterations"
+
+test("attributes a completed and cleared subsolver to its own iteration", (): void => {
+  let time = 0
+  class LeafSolver extends BaseSolver {
+    override _step(): void {
+      time += 1_200
+      this.solved = true
+    }
+  }
+  class ParentSolver extends BaseSolver {
+    constructor() {
+      super()
+      this.activeSubSolver = new LeafSolver()
+    }
+
+    override _step(): void {
+      this.activeSubSolver!.step()
+      this.activeSubSolver = null
+      this.solved = true
+    }
+  }
+  const originalStep = BaseSolver.prototype.step
+  const solver = new ParentSolver()
+  const profile = profileSolverIterations(solver, { now: () => time })
+  expect(profile.totalIterations).toBe(1)
+  expect(profile.iterations).toHaveLength(1)
+  expect(profile.iterations[0]).toMatchObject({
+    rootIteration: 1,
+    solverName: "LeafSolver",
+    localIteration: 1,
+    phase: "step",
+    elapsedMs: 1_200,
+    path: ["ParentSolver", "LeafSolver"],
+  })
+  expect(solver.activeSubSolver).toBeNull()
+  expect(BaseSolver.prototype.step).toBe(originalStep)
+  expect(Object.getOwnPropertyDescriptor(solver, "activeSubSolver")?.get).toBeUndefined()
+})

--- a/tests/iteration-timing/profile-cleared-subsolver.test.ts
+++ b/tests/iteration-timing/profile-cleared-subsolver.test.ts
@@ -37,5 +37,7 @@ test("attributes a completed and cleared subsolver to its own iteration", (): vo
   })
   expect(solver.activeSubSolver).toBeNull()
   expect(BaseSolver.prototype.step).toBe(originalStep)
-  expect(Object.getOwnPropertyDescriptor(solver, "activeSubSolver")?.get).toBeUndefined()
+  expect(
+    Object.getOwnPropertyDescriptor(solver, "activeSubSolver")?.get,
+  ).toBeUndefined()
 })

--- a/tests/iteration-timing/profile-deep-initialization.test.ts
+++ b/tests/iteration-timing/profile-deep-initialization.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "bun:test"
+import { BaseSolver } from "../../lib/solvers/BaseSolver"
+import { profileSolverIterations } from "../../scripts/iteration-timing/profileSolverIterations"
+
+test("assigns construction to the deepest newly active solver and keeps first step distinct", (): void => {
+  let time = 0
+  class DeepLeafSolver extends BaseSolver {
+    constructor() {
+      super()
+      time += 200
+    }
+
+    override _step(): void {
+      time += 150
+      this.solved = true
+    }
+  }
+  class IntermediateSolver extends BaseSolver {
+    constructor() {
+      super()
+      this.activeSubSolver = new DeepLeafSolver()
+    }
+
+    override _step(): void {
+      this.activeSubSolver!.step()
+      this.activeSubSolver = null
+      this.solved = true
+    }
+  }
+  class RootSolver extends BaseSolver {
+    override _step(): void {
+      if (!this.activeSubSolver) {
+        this.activeSubSolver = new IntermediateSolver()
+        return
+      }
+      this.activeSubSolver.step()
+      this.solved = true
+    }
+  }
+  const profile = profileSolverIterations(new RootSolver(), { now: () => time })
+  expect(profile.iterations).toMatchObject([
+    {
+      rootIteration: 1,
+      solverName: "DeepLeafSolver",
+      localIteration: 0,
+      phase: "initialization",
+      path: ["RootSolver", "IntermediateSolver", "DeepLeafSolver"],
+    },
+    {
+      rootIteration: 2,
+      solverName: "DeepLeafSolver",
+      localIteration: 1,
+      phase: "step",
+      path: ["RootSolver", "IntermediateSolver", "DeepLeafSolver"],
+    },
+  ])
+})

--- a/tests/iteration-timing/profile-initialization.test.ts
+++ b/tests/iteration-timing/profile-initialization.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "bun:test"
+import { BaseSolver as ExternalBaseSolver } from "@tscircuit/solver-utils"
+import { BaseSolver } from "../../lib/solvers/BaseSolver"
+import { profileSolverIterations } from "../../scripts/iteration-timing/profileSolverIterations"
+
+test("separates initialization from external nested solve calls in a constructor", (): void => {
+  let time = 0
+  class ExternalLeafSolver extends ExternalBaseSolver {
+    override _step(): void {
+      time += 300
+      this.solved = this.iterations === 2
+    }
+  }
+  class NewStageSolver extends BaseSolver {
+    constructor() {
+      super()
+      time += 400
+      new ExternalLeafSolver().solve()
+      this.solved = true
+    }
+  }
+  class RootSolver extends BaseSolver {
+    override _step(): void {
+      this.activeSubSolver = new NewStageSolver()
+      this.activeSubSolver = null
+      this.solved = true
+    }
+  }
+  const externalStep = ExternalBaseSolver.prototype.step
+  const profile = profileSolverIterations(new RootSolver(), { now: () => time })
+  expect(profile.iterations[0]?.elapsedMs).toBe(1_000)
+  expect(profile.iterations[0]?.attributions).toEqual([
+    {
+      solverName: "ExternalLeafSolver",
+      phase: "step",
+      localIteration: 1,
+      iterationEnd: 2,
+      path: ["RootSolver", "ExternalLeafSolver"],
+      elapsedMs: 600,
+    },
+    {
+      solverName: "NewStageSolver",
+      phase: "initialization",
+      localIteration: 0,
+      path: ["RootSolver", "NewStageSolver"],
+      elapsedMs: 400,
+    },
+  ])
+  expect(ExternalBaseSolver.prototype.step).toBe(externalStep)
+})

--- a/tests/iteration-timing/profile-nested-clear.test.ts
+++ b/tests/iteration-timing/profile-nested-clear.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test"
+import { BaseSolver } from "../../lib/solvers/BaseSolver"
+import { profileSolverIterations } from "../../scripts/iteration-timing/profileSolverIterations"
+
+test("refreshes paused ancestors when a nested active leaf is cleared", (): void => {
+  let time = 0
+  class LeafSolver extends BaseSolver {
+    override _step(): void {
+      time += 10
+      this.solved = true
+    }
+  }
+  class IntermediateSolver extends BaseSolver {
+    constructor() {
+      super()
+      this.activeSubSolver = new LeafSolver()
+    }
+
+    override _step(): void {
+      this.activeSubSolver!.step()
+      this.activeSubSolver = null
+      time += 1_200
+      this.solved = true
+    }
+  }
+  class RootSolver extends BaseSolver {
+    constructor() {
+      super()
+      this.activeSubSolver = new IntermediateSolver()
+    }
+
+    override _step(): void {
+      this.activeSubSolver!.step()
+      time += 100
+      this.solved = true
+    }
+  }
+  const profile = profileSolverIterations(new RootSolver(), { now: () => time })
+  expect(profile.iterations[0]?.elapsedMs).toBe(1_310)
+  expect(profile.iterations[0]?.attributions).toEqual([
+    {
+      solverName: "IntermediateSolver",
+      phase: "step",
+      localIteration: 1,
+      path: ["RootSolver", "IntermediateSolver"],
+      elapsedMs: 1_300,
+    },
+    {
+      solverName: "LeafSolver",
+      phase: "step",
+      localIteration: 1,
+      path: ["RootSolver", "IntermediateSolver", "LeafSolver"],
+      elapsedMs: 10,
+    },
+  ])
+})

--- a/tests/iteration-timing/profile-nonincrementing-step.test.ts
+++ b/tests/iteration-timing/profile-nonincrementing-step.test.ts
@@ -29,8 +29,12 @@ test("counts actual root and child calls when step overrides never increment ite
   expect(solver.iterations).toBe(0)
   expect(solver.activeSubSolver!.iterations).toBe(0)
   expect(profile.totalIterations).toBe(3)
-  expect(profile.iterations.map((item) => item.rootIteration)).toEqual([1, 2, 3])
-  expect(profile.iterations.map((item) => item.localIteration)).toEqual([1, 2, 3])
+  expect(profile.iterations.map((item) => item.rootIteration)).toEqual([
+    1, 2, 3,
+  ])
+  expect(profile.iterations.map((item) => item.localIteration)).toEqual([
+    1, 2, 3,
+  ])
   expect(profile.solverTimings[0]).toMatchObject({
     solverName: "LeafSolver",
     iterations: 3,

--- a/tests/iteration-timing/profile-nonincrementing-step.test.ts
+++ b/tests/iteration-timing/profile-nonincrementing-step.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test"
+import { BaseSolver } from "../../lib/solvers/BaseSolver"
+import { profileSolverIterations } from "../../scripts/iteration-timing/profileSolverIterations"
+
+test("counts actual root and child calls when step overrides never increment iterations", (): void => {
+  let time = 0
+  class LeafSolver extends BaseSolver {
+    calls = 0
+
+    override step(): void {
+      time += 1_200
+      this.calls++
+      this.solved = this.calls === 3
+    }
+  }
+  class RootSolver extends BaseSolver {
+    constructor() {
+      super()
+      this.activeSubSolver = new LeafSolver()
+    }
+
+    override step(): void {
+      this.activeSubSolver!.step()
+      this.solved = this.activeSubSolver!.solved
+    }
+  }
+  const solver = new RootSolver()
+  const profile = profileSolverIterations(solver, { now: () => time })
+  expect(solver.iterations).toBe(0)
+  expect(solver.activeSubSolver!.iterations).toBe(0)
+  expect(profile.totalIterations).toBe(3)
+  expect(profile.iterations.map((item) => item.rootIteration)).toEqual([1, 2, 3])
+  expect(profile.iterations.map((item) => item.localIteration)).toEqual([1, 2, 3])
+  expect(profile.solverTimings[0]).toMatchObject({
+    solverName: "LeafSolver",
+    iterations: 3,
+    totalMs: 3_600,
+    maxMs: 1_200,
+  })
+})

--- a/tests/iteration-timing/profile-post-clear-work.test.ts
+++ b/tests/iteration-timing/profile-post-clear-work.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "bun:test"
+import { BaseSolver } from "../../lib/solvers/BaseSolver"
+import { classifyIteration } from "../../scripts/iteration-timing/iterationTimingReport"
+import { profileSolverIterations } from "../../scripts/iteration-timing/profileSolverIterations"
+
+test("a leaf whitelist cannot cover root work after clearing that leaf", (): void => {
+  let time = 0
+  class LeafSolver extends BaseSolver {
+    override _step(): void {
+      time += 10
+      this.solved = true
+    }
+  }
+  class RootSolver extends BaseSolver {
+    constructor() {
+      super()
+      this.activeSubSolver = new LeafSolver()
+    }
+
+    override _step(): void {
+      this.activeSubSolver!.step()
+      this.activeSubSolver = null
+      time += 1_200
+      this.solved = true
+    }
+  }
+  const profile = profileSolverIterations(new RootSolver(), { now: () => time })
+  const iteration = profile.iterations[0]!
+  expect(iteration.attributions).toEqual([
+    {
+      solverName: "RootSolver",
+      phase: "step",
+      localIteration: 1,
+      path: ["RootSolver"],
+      elapsedMs: 1_200,
+    },
+    {
+      solverName: "LeafSolver",
+      phase: "step",
+      localIteration: 1,
+      path: ["RootSolver", "LeafSolver"],
+      elapsedMs: 10,
+    },
+  ])
+  expect(
+    classifyIteration(iteration, [
+      {
+        solverName: "LeafSolver",
+        phase: "step",
+        localIteration: 1,
+        reason: "A known leaf must not exempt later root work",
+      },
+    ]),
+  ).toMatchObject({
+    whitelisted: false,
+    unlistedAttributions: [iteration.attributions[0]],
+  })
+})

--- a/tests/iteration-timing/profile-reaffirmed-subsolver.test.ts
+++ b/tests/iteration-timing/profile-reaffirmed-subsolver.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "bun:test"
+import { BaseSolver } from "../../lib/solvers/BaseSolver"
+import { profileSolverIterations } from "../../scripts/iteration-timing/profileSolverIterations"
+
+test("reaffirming the active child does not create false iteration ranges", (): void => {
+  let time = 0
+  class LeafSolver extends BaseSolver {
+    override _step(): void {
+      time += 1_200
+      this.solved = this.iterations === 3
+    }
+  }
+  class RootSolver extends BaseSolver {
+    leaf = new LeafSolver()
+
+    constructor() {
+      super()
+      this.activeSubSolver = this.leaf
+    }
+
+    override _step(): void {
+      time += 200
+      this.activeSubSolver = this.leaf
+      this.leaf.step()
+      this.solved = this.leaf.solved
+    }
+  }
+  const profile = profileSolverIterations(new RootSolver(), { now: () => time })
+  expect(profile.iterations).toHaveLength(3)
+  for (const [index, iteration] of profile.iterations.entries()) {
+    expect(iteration.attributions).toEqual([
+      {
+        solverName: "LeafSolver",
+        phase: "step",
+        localIteration: index + 1,
+        path: ["RootSolver", "LeafSolver"],
+        elapsedMs: 1_400,
+      },
+    ])
+    expect(iteration.iterationEnd).toBeUndefined()
+  }
+  expect(profile.solverTimings).toEqual([
+    {
+      solverName: "LeafSolver",
+      phase: "step",
+      iterations: 3,
+      totalMs: 4_200,
+      maxMs: 1_400,
+    },
+  ])
+})

--- a/tests/iteration-timing/profile-replaced-subsolver.test.ts
+++ b/tests/iteration-timing/profile-replaced-subsolver.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test"
+import { BaseSolver } from "../../lib/solvers/BaseSolver"
+import { profileSolverIterations } from "../../scripts/iteration-timing/profileSolverIterations"
+
+test("replacement initialization cannot absorb parent teardown after a clear", (): void => {
+  let time = 0
+  class LeafSolver extends BaseSolver {
+    override _step(): void {
+      time += 10
+      this.solved = true
+    }
+  }
+  class ReplacementSolver extends BaseSolver {
+    constructor() {
+      super()
+      time += 500
+    }
+
+    override _step(): void {
+      time += 30
+      this.solved = true
+    }
+  }
+  class RootSolver extends BaseSolver {
+    constructor() {
+      super()
+      this.activeSubSolver = new LeafSolver()
+    }
+
+    override _step(): void {
+      this.activeSubSolver!.step()
+      this.activeSubSolver = null
+      time += 700
+      this.activeSubSolver = new ReplacementSolver()
+      this.activeSubSolver.step()
+      this.solved = true
+    }
+  }
+  const profile = profileSolverIterations(new RootSolver(), { now: () => time })
+  expect(profile.iterations[0]?.attributions).toEqual([
+    {
+      solverName: "RootSolver",
+      phase: "step",
+      localIteration: 1,
+      path: ["RootSolver"],
+      elapsedMs: 1_200,
+    },
+    {
+      solverName: "ReplacementSolver",
+      phase: "step",
+      localIteration: 1,
+      path: ["RootSolver", "ReplacementSolver"],
+      elapsedMs: 30,
+    },
+    {
+      solverName: "LeafSolver",
+      phase: "step",
+      localIteration: 1,
+      path: ["RootSolver", "LeafSolver"],
+      elapsedMs: 10,
+    },
+  ])
+})

--- a/tests/iteration-timing/profile-restore-on-error.test.ts
+++ b/tests/iteration-timing/profile-restore-on-error.test.ts
@@ -19,5 +19,7 @@ test("restores profiling hooks and permits another run after a solver throws", (
   expect(() => profileSolverIterations(new ThrowingSolver())).toThrow(failure)
   expect(BaseSolver.prototype.step).toBe(originalStep)
   expect(ThrowingSolver.prototype.step).toBe(originalThrowingStep)
-  expect(profileSolverIterations(new SuccessfulSolver()).totalIterations).toBe(1)
+  expect(profileSolverIterations(new SuccessfulSolver()).totalIterations).toBe(
+    1,
+  )
 })

--- a/tests/iteration-timing/profile-restore-on-error.test.ts
+++ b/tests/iteration-timing/profile-restore-on-error.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test"
+import { BaseSolver } from "../../lib/solvers/BaseSolver"
+import { profileSolverIterations } from "../../scripts/iteration-timing/profileSolverIterations"
+
+test("restores profiling hooks and permits another run after a solver throws", (): void => {
+  const failure = new Error("solver invariant failed")
+  class ThrowingSolver extends BaseSolver {
+    override step(): void {
+      throw failure
+    }
+  }
+  class SuccessfulSolver extends BaseSolver {
+    override _step(): void {
+      this.solved = true
+    }
+  }
+  const originalStep = BaseSolver.prototype.step
+  const originalThrowingStep = ThrowingSolver.prototype.step
+  expect(() => profileSolverIterations(new ThrowingSolver())).toThrow(failure)
+  expect(BaseSolver.prototype.step).toBe(originalStep)
+  expect(ThrowingSolver.prototype.step).toBe(originalThrowingStep)
+  expect(profileSolverIterations(new SuccessfulSolver()).totalIterations).toBe(1)
+})

--- a/tests/iteration-timing/profile-synchronous-loop.test.ts
+++ b/tests/iteration-timing/profile-synchronous-loop.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test"
+import { BaseSolver } from "../../lib/solvers/BaseSolver"
+import { profileSolverIterations } from "../../scripts/iteration-timing/profileSolverIterations"
+
+test("retains blocking root steps made of individually short deepest solver calls", (): void => {
+  let time = 0
+  class RepeatedLeafSolver extends BaseSolver {
+    override _step(): void {
+      time += 20
+      this.solved = this.iterations === 60
+    }
+  }
+  class RootSolver extends BaseSolver {
+    override _step(): void {
+      new RepeatedLeafSolver().solve()
+      this.solved = true
+    }
+  }
+  const profile = profileSolverIterations(new RootSolver(), {
+    thresholdMs: 1_000,
+    now: () => time,
+  })
+  expect(profile.maxIterationMs).toBe(1_200)
+  expect(profile.iterations[0]).toMatchObject({
+    solverName: "RepeatedLeafSolver",
+    localIteration: 1,
+    iterationEnd: 60,
+    elapsedMs: 1_200,
+  })
+  expect(profile.solverTimings).toEqual([
+    {
+      solverName: "RepeatedLeafSolver",
+      phase: "step",
+      iterations: 60,
+      totalMs: 1_200,
+      maxMs: 20,
+    },
+  ])
+})

--- a/tests/srj18-fastest-discovery-ranking.test.ts
+++ b/tests/srj18-fastest-discovery-ranking.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "bun:test"
+import {
+  getSrj18DiscoveryRankings,
+  type Srj18DiscoveryTrial,
+} from "../scripts/iteration-timing/discoverFastestSrj18Sample"
+
+test("SRJ18 discovery ranks successful repeated trials by median and excludes incomplete samples", () => {
+  const trials: Srj18DiscoveryTrial[] = []
+  for (const [sampleName, times] of [
+    ["sample001", [1, 40, 50]],
+    ["sample003", [20, 21, 22]],
+    ["sample005", [5]],
+  ] as const) {
+    times.forEach((elapsedTimeMs, index) => {
+      trials.push({
+        sampleName,
+        trialNumber: index + 1,
+        wallTimeMs: elapsedTimeMs + 10,
+        logPath: "test.log",
+        resultPath: "test.json",
+        status: "solved",
+        elapsedTimeMs,
+        iterations: 1,
+      })
+    })
+  }
+  trials.push(
+    {
+      sampleName: "sample005",
+      trialNumber: 2,
+      wallTimeMs: 90_000,
+      logPath: "test.log",
+      resultPath: "test.json",
+      status: "timed_out",
+      timeoutMs: 90_000,
+    },
+    {
+      sampleName: "sample005",
+      trialNumber: 3,
+      wallTimeMs: 50,
+      logPath: "test.log",
+      resultPath: "test.json",
+      status: "failed",
+      elapsedTimeMs: 40,
+      error: "Routing failed",
+    },
+  )
+  expect(getSrj18DiscoveryRankings(trials, 3)).toEqual([
+    { sampleName: "sample003", medianTimeMs: 21, elapsedTimesMs: [20, 21, 22] },
+    { sampleName: "sample001", medianTimeMs: 40, elapsedTimesMs: [1, 40, 50] },
+  ])
+  expect(
+    getSrj18DiscoveryRankings(
+      trials.filter((trial) => trial.trialNumber === 1),
+      1,
+    ).map((ranking) => ranking.sampleName),
+  ).toEqual(["sample001", "sample005", "sample003"])
+})


### PR DESCRIPTION
Adds a serial benchmark for the fastest measured successful SRJ18 sample: `sample005` (Arduino Uno), using the exported default Pipeline 7, effort 1, and caching disabled. All 16 samples were attempted; repeated median times were 25.13s for sample005, 30.24s for sample003, and 33.67s for sample001.

Every synchronous pipeline `step()` is timed. Calls over 1,000ms emit warnings, including known exceptions; reports also retain every step over the eventual 100ms target. Attribution follows the deepest active solver and actual per-instance step-call numbers, including initialization, cleared/replaced children, and synchronous nested solve loops. Exact solver/phase/iteration matching prevents ancestor exceptions from approving new descendant work. Routing failures fail the test; timing warnings remain non-failing during discovery.

The initial whitelist contains all four identities observed in three blocking pipeline iterations across repeated Blacksmith runs:

| Pipeline iteration | Observed wall time | Exact whitelist entries / synchronous work |
| ---: | ---: | --- |
| 9255 | 1.28–1.75s | `DuplicateCongestedPortSolver` step **1** and `TinyHypergraphPortPointPathingSolver` initialization **0**: congestion prepass plus hypergraph construction/serialization. |
| 199302 | 0.93–1.04s | `UniformPortDistributionSolver` initialization **0**: prepares pathing output, ownership pairs, and shared edges. Added when the repeated run crossed 1s. |
| 199986 | 1.63–1.77s | `HighDensitySolver` initialization **0**: input-node preparation repeatedly calls `computeNodePf()`/`getOutput()` before construction. |

Initialization 0 is distinct from step 1. There are no solver-wide wildcards. The docs include the complete 17 solver/phase entries from the 27 retained calls in the confirmation run, with exact local call numbers and explanations. Additional 100ms candidates include ordinary DRC repair iterations and synchronous batches of 100 high-density search steps.

The dedicated workflow runs the pinned sample on PRs/main and offers optional manual fastest-sample rediscovery. It publishes JSON/Markdown artifacts and a job summary. Production solver code is unchanged.

Validation: 15 focused tests (73 assertions), repeated local sample005 integration, serial Blacksmith discovery plus repeated profiling, TypeScript check, build, and a completed full nine-shard CI test run. Final-head Blacksmith timing passed after adding the port-distribution exception; all observed calls over 1s were whitelisted. Type and formatting checks also pass; the final full test shards are still running.

[Final whitelist validation](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/34166841112) · [Serial discovery](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/34165277363) · [Attribution confirmation](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/34166478437) · [Repeat identifying port distribution](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/34166676921) · [Full findings and reproduction commands](https://github.com/tscircuit/tscircuit-autorouter/blob/test/srj18-slow-iterations/docs/srj18-iteration-timing.md)
