### PR TITLE
Reduce Pipeline9 preprocessing latency

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/AutoroutingPipelineSolver9_PreloadedTraceGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/AutoroutingPipelineSolver9_PreloadedTraceGraph.ts
@@ -36,6 +36,7 @@ import {
   type TraceColorMode,
 } from "lib/utils/convertSrjToGraphicsObject"
 import { createSrjWithBoardValidObstacleLayers } from "lib/utils/create-srj-with-board-valid-obstacle-layers"
+import { createSrjWithUniqueObstacleConnections } from "lib/utils/createSrjWithUniqueObstacleConnections"
 import { createObstacleLabelFormatter } from "lib/utils/formatObstacleLabel"
 import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
 import { getInitiallyConnectedMapFromSimpleRouteJson } from "lib/utils/get-initially-connected-map-from-simple-route-json"
@@ -971,7 +972,9 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
   ) {
     super()
     const srjWithBoardValidObstacleLayers =
-      createSrjWithBoardValidObstacleLayers(srj)
+      createSrjWithBoardValidObstacleLayers(
+        createSrjWithUniqueObstacleConnections(srj),
+      )
     this.originalSrj = srjWithBoardValidObstacleLayers
     this.opts = { ...opts }
     const mutableOpts = this.opts
@@ -1041,11 +1044,11 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
     if (this.activeSubSolver) {
       this.activeSubSolver.step()
       if (this.activeSubSolver.solved) {
+        pipelineStepDef.onSolved?.(this)
         this.endTimeOfPhase[pipelineStepDef.solverName] = performance.now()
         this.timeSpentOnPhase[pipelineStepDef.solverName] =
           this.endTimeOfPhase[pipelineStepDef.solverName] -
           this.startTimeOfPhase[pipelineStepDef.solverName]
-        pipelineStepDef.onSolved?.(this)
         this.activeSubSolver = null
         this.currentPipelineStepIndex++
       } else if (this.activeSubSolver.failed) {
@@ -1056,6 +1059,8 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
       return
     }
 
+    this.timeSpentOnPhase[pipelineStepDef.solverName] = 0
+    this.startTimeOfPhase[pipelineStepDef.solverName] = performance.now()
     const constructorParams = pipelineStepDef.getConstructorParams(this)
     // @ts-ignore
     this.activeSubSolver = new pipelineStepDef.solverClass(...constructorParams)
@@ -1068,8 +1073,6 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
         this.iterations + this.activeSubSolver.MAX_ITERATIONS + 1,
       )
     ;(this as any)[pipelineStepDef.solverName] = this.activeSubSolver
-    this.timeSpentOnPhase[pipelineStepDef.solverName] = 0
-    this.startTimeOfPhase[pipelineStepDef.solverName] = performance.now()
   }
 
   solveUntilPhase(phase: string) {

--- a/lib/solvers/CapacityMeshSolver/CapacityMeshEdgeSolver.ts
+++ b/lib/solvers/CapacityMeshSolver/CapacityMeshEdgeSolver.ts
@@ -61,6 +61,34 @@ export class CapacityMeshEdgeSolver extends BaseSolver {
     const nodeById = new Map(
       this.nodes.map((node) => [node.capacityMeshNodeId, node]),
     )
+    // Target regions may overlap many other targets. Scanning every existing
+    // edge for each candidate pair makes this pass dominate large boards.
+    // Build this index from the current edges because subclasses create them
+    // incrementally before calling handleTargetNodes().
+    const neighborsByNodeId = new Map<
+      CapacityMeshNodeId,
+      Set<CapacityMeshNodeId>
+    >()
+    const indexEdge = (
+      nodeAId: CapacityMeshNodeId,
+      nodeBId: CapacityMeshNodeId,
+    ): void => {
+      let neighborsA = neighborsByNodeId.get(nodeAId)
+      if (!neighborsA) {
+        neighborsA = new Set()
+        neighborsByNodeId.set(nodeAId, neighborsA)
+      }
+      neighborsA.add(nodeBId)
+      let neighborsB = neighborsByNodeId.get(nodeBId)
+      if (!neighborsB) {
+        neighborsB = new Set()
+        neighborsByNodeId.set(nodeBId, neighborsB)
+      }
+      neighborsB.add(nodeAId)
+    }
+    for (const edge of this.edges) {
+      indexEdge(edge.nodeIds[0], edge.nodeIds[1])
+    }
 
     for (let i = 0; i < targetNodes.length; i++) {
       for (let j = i + 1; j < targetNodes.length; j++) {
@@ -68,12 +96,18 @@ export class CapacityMeshEdgeSolver extends BaseSolver {
         const nodeB = targetNodes[j]!
         if (!this.doNodesHaveSharedLayer(nodeA, nodeB)) continue
         if (!this.doNodesTouchOrOverlap(nodeA, nodeB)) continue
-        if (this.hasEdgeBetween(nodeA, nodeB)) continue
+        if (
+          neighborsByNodeId
+            .get(nodeA.capacityMeshNodeId)
+            ?.has(nodeB.capacityMeshNodeId)
+        )
+          continue
 
         this.edges.push({
           capacityMeshEdgeId: this.getNextCapacityMeshEdgeId(),
           nodeIds: [nodeA.capacityMeshNodeId, nodeB.capacityMeshNodeId],
         })
+        indexEdge(nodeA.capacityMeshNodeId, nodeB.capacityMeshNodeId)
       }
     }
 
@@ -82,12 +116,9 @@ export class CapacityMeshEdgeSolver extends BaseSolver {
         continue
       }
 
-      const hasRoutingEdge = this.edges.some((edge) => {
-        if (!edge.nodeIds.includes(targetNode.capacityMeshNodeId)) return false
-        const otherNodeId =
-          edge.nodeIds[0] === targetNode.capacityMeshNodeId
-            ? edge.nodeIds[1]
-            : edge.nodeIds[0]
+      const hasRoutingEdge = Array.from(
+        neighborsByNodeId.get(targetNode.capacityMeshNodeId) ?? [],
+      ).some((otherNodeId) => {
         const otherNode = nodeById.get(otherNodeId)
         if (!otherNode) return false
 

--- a/lib/solvers/PortPointPathingSolver/hgportpointpathingsolver/buildHyperGraph.ts
+++ b/lib/solvers/PortPointPathingSolver/hgportpointpathingsolver/buildHyperGraph.ts
@@ -187,14 +187,18 @@ export function buildHyperGraph(params: {
     })
   }
 
+  const regionsById = new Map<string, RegionHg>()
+  for (const region of graph.regions) {
+    // Preserve the first matching region, as the previous Array.find did.
+    if (!regionsById.has(region.regionId)) {
+      regionsById.set(region.regionId, region)
+    }
+  }
+
   for (const spp of params.segmentPortPoints) {
     const [region1Id, region2Id] = spp.nodeIds
-    const region1 = graph.regions.find(
-      (region) => region.regionId === region1Id,
-    )
-    const region2 = graph.regions.find(
-      (region) => region.regionId === region2Id,
-    )
+    const region1 = regionsById.get(region1Id)
+    const region2 = regionsById.get(region2Id)
 
     assertDefined(
       region1,

--- a/lib/utils/createSrjWithUniqueObstacleConnections.ts
+++ b/lib/utils/createSrjWithUniqueObstacleConnections.ts
@@ -1,0 +1,52 @@
+import type { Obstacle, SimpleRouteJson } from "lib/types"
+
+function createObstaclesWithUniqueConnections(
+  obstacles: Obstacle[],
+  connectionsByInput: Map<string[], string[]>,
+): Obstacle[] {
+  let result = obstacles
+  for (const [index, obstacle] of obstacles.entries()) {
+    let uniqueConnections = connectionsByInput.get(obstacle.connectedTo)
+    if (!uniqueConnections) {
+      const distinctIds = new Set(obstacle.connectedTo)
+      uniqueConnections = distinctIds.size === obstacle.connectedTo.length
+        ? obstacle.connectedTo
+        : [...distinctIds]
+      connectionsByInput.set(obstacle.connectedTo, uniqueConnections)
+    }
+    if (uniqueConnections === obstacle.connectedTo) continue
+
+    if (result === obstacles) result = [...obstacles]
+    result[index] = {
+      ...obstacle,
+      connectedTo: uniqueConnections,
+    }
+  }
+  return result
+}
+
+/**
+ * Repeated memberships add no routing connectivity. Preserve first-occurrence
+ * order and every distinct alias: some consumers use the first ID or compare
+ * exact route names. Circuit JSON provenance must remain in its metadata field.
+ */
+export function createSrjWithUniqueObstacleConnections(
+  srj: SimpleRouteJson,
+): SimpleRouteJson {
+  // Plane approximations can share the same large membership array across
+  // hundreds of obstacles. Normalize it once and preserve that sharing.
+  const connectionsByInput = new Map<string[], string[]>()
+  const obstacles = createObstaclesWithUniqueConnections(srj.obstacles, connectionsByInput)
+  let jumpers = srj.jumpers
+  if (srj.jumpers) {
+    for (const [index, jumper] of srj.jumpers.entries()) {
+      const pads = createObstaclesWithUniqueConnections(jumper.pads, connectionsByInput)
+      if (pads === jumper.pads) continue
+
+      if (jumpers === srj.jumpers) jumpers = [...srj.jumpers]
+      jumpers![index] = { ...jumper, pads }
+    }
+  }
+  if (obstacles === srj.obstacles && jumpers === srj.jumpers) return srj
+  return { ...srj, obstacles, ...(jumpers ? { jumpers } : {}) }
+}


### PR DESCRIPTION
Pipeline 9 spent minutes preparing the Allwinner T113 bugreport106 input before global path search. This removes repeated work by:

- normalizing duplicate obstacle connectivity once per shared input array;
- indexing target-node adjacency instead of rescanning all edges;
- indexing graph regions by ID instead of rescanning all regions;
- including parameter preparation, construction, and output callbacks in phase timings.

No routing constraints or effort settings change. This PR contains only implementation fixes; the repro and skipped snapshot test are in #2451.

Validation: `bun run build`; 8 existing targeted tests (52 assertions).
