### PR TITLE
fix: handle undefined effort in getEffortScale and HgPortPointPathingSolver

### DIFF
--- a/lib/solvers/PortPointPathingSolver/hgportpointpathingsolver/HgPortPointPathingSolverClass.ts
+++ b/lib/solvers/PortPointPathingSolver/hgportpointpathingsolver/HgPortPointPathingSolverClass.ts
@@ -56,7 +56,7 @@ export class HgPortPointPathingSolver extends HyperGraphSolver<
     this.totalRipCount = 0
     if (params.weights.MAX_ITERATIONS_PER_PATH > 0) {
       this.MAX_ITERATIONS =
-        params.weights.MAX_ITERATIONS_PER_PATH * params.effort
+        params.weights.MAX_ITERATIONS_PER_PATH * (params.effort ?? 1)
     }
   }
 

--- a/lib/solvers/PortPointPathingSolver/hgportpointpathingsolver/types.ts
+++ b/lib/solvers/PortPointPathingSolver/hgportpointpathingsolver/types.ts
@@ -95,7 +95,7 @@ export interface HgPortPointPathingSolverParams {
   colorMap?: Record<string, string>
   inputSolvedRoutes?: SolvedRoutesHg[]
   layerCount: number
-  effort: number
+  effort?: number
   preserveTerminalPcbPortIds?: boolean
   minViaPadDiameter?: number
   flags: {

--- a/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
+++ b/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
@@ -256,7 +256,8 @@ const DUPLICATE_PORT_TRAVERSAL_PENALTY = 150
 const DEFAULT_CRAMPED_PORT_TRAVERSAL_PENALTY = 150
 const MAX_CONNECTIONS_FOR_DUPLICATE_CONGESTED_PORT_PREPASS = 180
 
-const getEffortScale = (effort: number) => Math.max(effort, 1e-2)
+export const getEffortScale = (effort?: number) =>
+  Math.max(Number.isFinite(effort) ? (effort as number) : 1, 1e-2)
 
 const getTinyViaSizeOptions = (
   minViaPadDiameter?: number,
@@ -266,7 +267,7 @@ const getTinyViaSizeOptions = (
     : {}
 
 const getTinyHyperGraphSolveGraphOptions = (
-  effort: number,
+  effort?: number,
   minViaPadDiameter?: number,
 ): TinyHyperGraphSolverOptions => {
   const effortScale = getEffortScale(effort)
@@ -280,7 +281,7 @@ const getTinyHyperGraphSolveGraphOptions = (
 }
 
 const getTinyHyperGraphSectionSolverOptions = (
-  effort: number,
+  effort?: number,
   minViaPadDiameter?: number,
 ): TinyHyperGraphSectionSolverOptions => {
   const effortScale = getEffortScale(effort)
@@ -295,7 +296,7 @@ const getTinyHyperGraphSectionSolverOptions = (
 
 const getTinyHyperGraphPipelineInput = (
   serializedHyperGraph: SerializedHyperGraph,
-  effort: number,
+  effort?: number,
   minViaPadDiameter?: number,
   enablePartialRip = true,
   partialRipEligibilityCount?: number,

--- a/tests/get-effort-scale.test.ts
+++ b/tests/get-effort-scale.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "bun:test"
+import { getEffortScale } from "../lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver"
+
+test("getEffortScale handles undefined and numeric values correctly", () => {
+  // undefined should fallback to 1
+  expect(getEffortScale(undefined)).toBe(1)
+  // NaN should fallback to 1
+  expect(getEffortScale(Number.NaN)).toBe(1)
+  // Normal effort value
+  expect(getEffortScale(2)).toBe(2)
+  // Fractional effort value above minimum
+  expect(getEffortScale(0.5)).toBe(0.5)
+  // Very small effort should be floored at 0.01 (1e-2)
+  expect(getEffortScale(0.001)).toBe(0.01)
+})


### PR DESCRIPTION
## Summary
- Ensure `getEffortScale` in `TinyHypergraphPortPointPathingSolver` falls back to `1` when `effort` is `undefined` or non-finite, avoiding `NaN` iterations and premature failure on low-connection boards.
- Fall back to `1` for `params.effort` when computing `MAX_ITERATIONS` in `HgPortPointPathingSolver`.
- Make `effort` optional in `HgPortPointPathingSolverParams` and downstream helper parameter signatures.
- Add unit tests in `tests/get-effort-scale.test.ts` covering `undefined`, `NaN`, normal, fractional, and minimum effort bounds.

Fixes #1525

## Validation
- `bun test tests/get-effort-scale.test.ts` (1 pass, 0 fail, 5 assertions)
- `bun test tests/autorouting-pipeline4-via-dimensions.test.ts` (2 pass, 0 fail)
- `bunx tsc --noEmit` (clean, 0 errors)
- `bun run build` (successful compilation of bundle and dts)
- `bun run format:check` (1501 files checked, 0 errors)