### PR TITLE
fix: keep the widest nominalTraceWidth when merging connections

### DIFF
--- a/lib/solvers/NetToPointPairsSolver/mergeConnections.ts
+++ b/lib/solvers/NetToPointPairsSolver/mergeConnections.ts
@@ -125,13 +125,18 @@ export function mergeConnections(
         mergedNetConnectionNames.add(simpleRouteConnection.__netConnectionName)
       }
 
-      // Take the nominalTraceWidth from the first connection for now
-      // A more robust solution might average or pick the max/min based on context
-      if (
-        nominalTraceWidth === undefined &&
-        simpleRouteConnection.nominalTraceWidth !== undefined
-      ) {
-        nominalTraceWidth = simpleRouteConnection.nominalTraceWidth
+      // Keep the widest requested nominalTraceWidth across the merged group.
+      // These widths are minimum requirements (e.g. a 1mm motor output), so
+      // taking the first one found would silently drop a wider requirement
+      // whenever it merged with a thinner branch on the same net.
+      if (simpleRouteConnection.nominalTraceWidth !== undefined) {
+        nominalTraceWidth =
+          nominalTraceWidth === undefined
+            ? simpleRouteConnection.nominalTraceWidth
+            : Math.max(
+                nominalTraceWidth,
+                simpleRouteConnection.nominalTraceWidth,
+              )
       }
     })
 
@@ -152,7 +157,7 @@ export function mergeConnections(
           ? Array.from(mergedNetConnectionNames).join("__") // Combine unique net connection names
           : undefined,
       __rootConnectionNames: Array.from(mergedRootConnectionNames),
-      nominalTraceWidth: nominalTraceWidth, // Keep the first found nominalTraceWidth
+      nominalTraceWidth: nominalTraceWidth,
     }
 
     mergedSimpleRouteConnections.push(newSimpleRouteConnection)

--- a/tests/solvers/merge-connections-nominal-trace-width.test.ts
+++ b/tests/solvers/merge-connections-nominal-trace-width.test.ts
@@ -1,0 +1,122 @@
+import { expect, test } from "bun:test"
+import { mergeConnections } from "lib/solvers/NetToPointPairsSolver/mergeConnections"
+
+test("merging keeps the widest requested nominalTraceWidth", () => {
+  const connections = mergeConnections([
+    {
+      name: "thin_branch",
+      nominalTraceWidth: 0.15,
+      pointsToConnect: [
+        { x: 0, y: 0, layer: "top" },
+        { x: 1, y: 0, layer: "top" },
+      ],
+    },
+    {
+      name: "motor_output",
+      nominalTraceWidth: 1,
+      pointsToConnect: [
+        { x: 1, y: 0, layer: "top" },
+        { x: 2, y: 0, layer: "top" },
+      ],
+    },
+  ])
+
+  expect(connections).toHaveLength(1)
+  expect(connections[0]?.nominalTraceWidth).toBe(1)
+})
+
+test("widest width does not depend on which connection is listed first", () => {
+  const connections = mergeConnections([
+    {
+      name: "motor_output",
+      nominalTraceWidth: 1,
+      pointsToConnect: [
+        { x: 1, y: 0, layer: "top" },
+        { x: 2, y: 0, layer: "top" },
+      ],
+    },
+    {
+      name: "thin_branch",
+      nominalTraceWidth: 0.15,
+      pointsToConnect: [
+        { x: 0, y: 0, layer: "top" },
+        { x: 1, y: 0, layer: "top" },
+      ],
+    },
+  ])
+
+  expect(connections).toHaveLength(1)
+  expect(connections[0]?.nominalTraceWidth).toBe(1)
+})
+
+test("connections without a requested width stay undefined", () => {
+  const connections = mergeConnections([
+    {
+      name: "a",
+      pointsToConnect: [
+        { x: 0, y: 0, layer: "top" },
+        { x: 1, y: 0, layer: "top" },
+      ],
+    },
+    {
+      name: "b",
+      pointsToConnect: [
+        { x: 1, y: 0, layer: "top" },
+        { x: 2, y: 0, layer: "top" },
+      ],
+    },
+  ])
+
+  expect(connections).toHaveLength(1)
+  expect(connections[0]?.nominalTraceWidth).toBeUndefined()
+})
+
+test("a requested width survives merging with unspecified branches", () => {
+  const connections = mergeConnections([
+    {
+      name: "unspecified",
+      pointsToConnect: [
+        { x: 0, y: 0, layer: "top" },
+        { x: 1, y: 0, layer: "top" },
+      ],
+    },
+    {
+      name: "power",
+      nominalTraceWidth: 0.8,
+      pointsToConnect: [
+        { x: 1, y: 0, layer: "top" },
+        { x: 2, y: 0, layer: "top" },
+      ],
+    },
+  ])
+
+  expect(connections).toHaveLength(1)
+  expect(connections[0]?.nominalTraceWidth).toBe(0.8)
+})
+
+test("separate nets keep their own widths", () => {
+  const connections = mergeConnections([
+    {
+      name: "motor",
+      nominalTraceWidth: 1,
+      pointsToConnect: [
+        { x: 0, y: 0, layer: "top" },
+        { x: 1, y: 0, layer: "top" },
+      ],
+    },
+    {
+      name: "signal",
+      nominalTraceWidth: 0.15,
+      pointsToConnect: [
+        { x: 5, y: 5, layer: "top" },
+        { x: 6, y: 5, layer: "top" },
+      ],
+    },
+  ])
+
+  expect(connections).toHaveLength(2)
+  expect(connections.find((c) => c.name === "motor")?.nominalTraceWidth).toBe(1)
+  expect(connections.find((c) => c.name === "signal")?.nominalTraceWidth).toBe(
+    0.15,
+  )
+})


### PR DESCRIPTION
## Summary

`mergeConnections` unions every `SimpleRouteConnection` that shares a point, but it kept only the **first** `nominalTraceWidth` it encountered. Those widths are minimum requirements, so a 1 mm motor output that merges with a thinner same-net branch silently loses its width whenever the thin branch is visited first.

That is the order-dependent part of #1721 (1.0 mm DRV8833 motor traces emitted at 0.15 mm).

## Change

Take `Math.max` across the merged group. Connections with no requested width still stay `undefined`. Result does not depend on input order.

## Tests

`tests/solvers/merge-connections-nominal-trace-width.test.ts` covers:

- thin-then-wide merge keeps 1 mm
- wide-then-thin merge keeps 1 mm
- unspecified widths stay undefined
- a requested width survives unspecified siblings
- separate nets keep their own widths

```
bun test tests/solvers/merge-connections-nominal-trace-width.test.ts
```

A previous attempt at this same `mergeConnections` root cause (#1773) was closed by stalebot without a review. The silent `minTraceWidth` fallback on pinched geometry (D1 in #1721) is still a separate design call and is not in this PR.

Related to #1721