### PR TITLE
feat: validate autorouter output vias against pad obstacles

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -112,3 +112,13 @@ export type {
   SingleLayerConnectionPoint,
   TerminalViaHint,
 } from "./types/srj-types"
+export {
+  validateSimpleRouteJsonOutput,
+  getSimpleRouteJsonOutputValidationFailure,
+  DEFAULT_VIA_TO_PAD_CLEARANCE,
+} from "./utils/validateSimpleRouteJsonOutput"
+export type {
+  AutorouterOutputViolation,
+  AutorouterOutputViolationType,
+  ValidateSimpleRouteJsonOutputOptions,
+} from "./utils/validateSimpleRouteJsonOutput"

--- a/lib/utils/validateSimpleRouteJsonOutput.ts
+++ b/lib/utils/validateSimpleRouteJsonOutput.ts
@@ -1,0 +1,249 @@
+import type { Obstacle, SimpleRouteJson, SimplifiedPcbTrace } from "lib/types"
+import { getViaDimensions } from "lib/utils/getViaDimensions"
+import { mapLayerNameToZ } from "lib/utils/mapLayerNameToZ"
+import { mapZToLayerName } from "lib/utils/mapZToLayerName"
+
+export const DEFAULT_VIA_TO_PAD_CLEARANCE = 0.1
+
+export type AutorouterOutputViolationType =
+  | "via_overlaps_unrelated_pad"
+  | "via_in_connected_pad"
+
+export type AutorouterOutputViolation = {
+  type: AutorouterOutputViolationType
+  connectionName: string
+  pcbTraceId: string
+  via: { x: number; y: number; diameter: number; layers: string[] }
+  pad: {
+    center: { x: number; y: number }
+    width: number
+    height: number
+    layers: string[]
+    connectedTo: string[]
+  }
+  gap: number
+  minClearance: number
+}
+
+export type ValidateSimpleRouteJsonOutputOptions = {
+  minClearance?: number
+}
+
+type ViaPad = {
+  x: number
+  y: number
+  diameter: number
+  layers: string[]
+  pcbTraceId: string
+  connectionName: string
+  connectsTo: string[]
+}
+
+const layersOccupiedByVia = (
+  fromLayer: string,
+  toLayer: string,
+  layerCount: number,
+): string[] => {
+  const fromZ = mapLayerNameToZ(fromLayer, layerCount)
+  const toZ = mapLayerNameToZ(toLayer, layerCount)
+  if (!Number.isFinite(fromZ) || !Number.isFinite(toZ)) {
+    return Array.from(new Set([fromLayer, toLayer]))
+  }
+  const lo = Math.min(fromZ, toZ)
+  const hi = Math.max(fromZ, toZ)
+  const layers: string[] = []
+  for (let z = lo; z <= hi; z++) {
+    layers.push(mapZToLayerName(z, layerCount))
+  }
+  return layers
+}
+
+const sharedLayer = (
+  viaLayers: string[],
+  padLayers: string[],
+): string | null => {
+  for (const layer of viaLayers) {
+    if (padLayers.includes(layer)) return layer
+  }
+  return null
+}
+
+/**
+ * Signed gap from a circle to an axis-aligned rectangle: negative means overlap.
+ */
+export const signedGapCircleToAabb = ({
+  cx,
+  cy,
+  radius,
+  center,
+  width,
+  height,
+}: {
+  cx: number
+  cy: number
+  radius: number
+  center: { x: number; y: number }
+  width: number
+  height: number
+}): number => {
+  const halfW = width / 2
+  const halfH = height / 2
+  const dx = Math.abs(cx - center.x)
+  const dy = Math.abs(cy - center.y)
+  const insideX = dx <= halfW
+  const insideY = dy <= halfH
+  if (insideX && insideY) {
+    return -radius
+  }
+  const outsideX = Math.max(dx - halfW, 0)
+  const outsideY = Math.max(dy - halfH, 0)
+  return Math.hypot(outsideX, outsideY) - radius
+}
+
+const viaIds = (via: ViaPad): Set<string> =>
+  new Set(
+    [via.connectionName, via.pcbTraceId, ...via.connectsTo].filter(Boolean),
+  )
+
+const isConnectedPad = (via: ViaPad, pad: Obstacle): boolean => {
+  const ids = viaIds(via)
+  return pad.connectedTo.some((id) => ids.has(id))
+}
+
+const collectVias = (
+  traces: SimplifiedPcbTrace[],
+  layerCount: number,
+  defaultViaDiameter: number,
+): ViaPad[] => {
+  const vias: ViaPad[] = []
+  for (const trace of traces) {
+    for (const point of trace.route) {
+      if (point.route_type !== "via") continue
+      vias.push({
+        x: point.x,
+        y: point.y,
+        diameter: point.via_diameter ?? defaultViaDiameter,
+        layers: layersOccupiedByVia(
+          point.from_layer,
+          point.to_layer,
+          layerCount,
+        ),
+        pcbTraceId: trace.pcb_trace_id,
+        connectionName: trace.connection_name,
+        connectsTo: trace.connectsTo ?? [],
+      })
+    }
+  }
+  return vias
+}
+
+/**
+ * Validate autorouter output (including traces mutated after solve) against
+ * pad obstacles. Callers can run this after custom post-processing.
+ *
+ * - Unrelated pads: via copper must stay at least `minClearance` (default 0.1 mm)
+ *   away, matching typical DRC.
+ * - Connected pads: flagged only when `allowViaInPad` is not true and the via
+ *   center is inside the pad.
+ */
+export function validateSimpleRouteJsonOutput(
+  srj: SimpleRouteJson,
+  opts: ValidateSimpleRouteJsonOutputOptions = {},
+): AutorouterOutputViolation[] {
+  const traces = srj.traces ?? []
+  if (traces.length === 0) return []
+
+  const minClearance =
+    opts.minClearance ??
+    srj.minViaEdgeToPadEdgeClearance ??
+    DEFAULT_VIA_TO_PAD_CLEARANCE
+  const defaultViaDiameter = getViaDimensions(srj).padDiameter
+  const vias = collectVias(traces, srj.layerCount, defaultViaDiameter)
+  const pads = srj.obstacles.filter(
+    (obstacle) => obstacle.type === "rect" && !obstacle.isCopperPour,
+  )
+
+  const violations: AutorouterOutputViolation[] = []
+  const allowViaInPad = srj.allowViaInPad === true
+
+  for (const via of vias) {
+    const radius = via.diameter / 2
+    for (const pad of pads) {
+      if (!sharedLayer(via.layers, pad.layers)) continue
+      const gap = signedGapCircleToAabb({
+        cx: via.x,
+        cy: via.y,
+        radius,
+        center: pad.center,
+        width: pad.width,
+        height: pad.height,
+      })
+      const connected = isConnectedPad(via, pad)
+
+      if (connected) {
+        if (allowViaInPad) continue
+        if (gap > -radius + 1e-9) continue
+        violations.push({
+          type: "via_in_connected_pad",
+          connectionName: via.connectionName,
+          pcbTraceId: via.pcbTraceId,
+          via: {
+            x: via.x,
+            y: via.y,
+            diameter: via.diameter,
+            layers: via.layers,
+          },
+          pad: {
+            center: pad.center,
+            width: pad.width,
+            height: pad.height,
+            layers: pad.layers,
+            connectedTo: pad.connectedTo,
+          },
+          gap,
+          minClearance: 0,
+        })
+        continue
+      }
+
+      if (gap + 1e-9 >= minClearance) continue
+      violations.push({
+        type: "via_overlaps_unrelated_pad",
+        connectionName: via.connectionName,
+        pcbTraceId: via.pcbTraceId,
+        via: {
+          x: via.x,
+          y: via.y,
+          diameter: via.diameter,
+          layers: via.layers,
+        },
+        pad: {
+          center: pad.center,
+          width: pad.width,
+          height: pad.height,
+          layers: pad.layers,
+          connectedTo: pad.connectedTo,
+        },
+        gap,
+        minClearance,
+      })
+    }
+  }
+
+  return violations
+}
+
+export function getSimpleRouteJsonOutputValidationFailure(
+  srj: SimpleRouteJson,
+  opts: ValidateSimpleRouteJsonOutputOptions = {},
+): string | null {
+  const violations = validateSimpleRouteJsonOutput(srj, opts)
+  if (violations.length === 0) return null
+  const first = violations[0]!
+  const extra =
+    violations.length > 1 ? ` (${violations.length} violations)` : ""
+  return (
+    `${first.type} on ${first.connectionName} via=(${first.via.x.toFixed(3)}, ${first.via.y.toFixed(3)}) ` +
+    `gap=${first.gap.toFixed(3)} min=${first.minClearance.toFixed(3)}${extra}`
+  )
+}

--- a/tests/utils/validate-simple-route-json-output.test.ts
+++ b/tests/utils/validate-simple-route-json-output.test.ts
@@ -1,0 +1,186 @@
+import { expect, test } from "bun:test"
+import type { SimpleRouteJson } from "lib/types"
+import {
+  getSimpleRouteJsonOutputValidationFailure,
+  signedGapCircleToAabb,
+  validateSimpleRouteJsonOutput,
+} from "lib/utils/validateSimpleRouteJsonOutput"
+
+const gpio5Pad = {
+  type: "rect" as const,
+  layers: ["top"],
+  center: { x: -2.99999, y: 5.975102 },
+  width: 0.6500114,
+  height: 0.1500124,
+  connectedTo: ["source_trace_33", "U_MCU.pin5"],
+}
+
+const gpio6Pad = {
+  type: "rect" as const,
+  layers: ["top"],
+  center: { x: -2.99999, y: 5.62509 },
+  width: 0.6500114,
+  height: 0.1500124,
+  connectedTo: ["source_trace_34", "U_MCU.pin6"],
+}
+
+const makeSrj = (
+  traces: SimpleRouteJson["traces"],
+  extra?: Partial<SimpleRouteJson>,
+): SimpleRouteJson => ({
+  layerCount: 2,
+  minTraceWidth: 0.15,
+  minViaDiameter: 0.6,
+  allowViaInPad: false,
+  obstacles: [gpio5Pad, gpio6Pad],
+  connections: [
+    { name: "source_trace_33", pointsToConnect: [] },
+    { name: "source_trace_34", pointsToConnect: [] },
+  ],
+  bounds: { minX: -5, maxX: 5, minY: 4, maxY: 8 },
+  traces,
+  ...extra,
+})
+
+test("signedGapCircleToAabb is negative when the circle overlaps the rect", () => {
+  expect(
+    signedGapCircleToAabb({
+      cx: -2.8,
+      cy: 5.8,
+      radius: 0.3,
+      center: gpio5Pad.center,
+      width: gpio5Pad.width,
+      height: gpio5Pad.height,
+    }),
+  ).toBeLessThan(0)
+})
+
+test("flags a post-processed via that overlaps a neighboring pad (#2058)", () => {
+  const srj = makeSrj([
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "pcb_via_119_trace",
+      connection_name: "source_trace_34",
+      connectsTo: ["source_trace_34", "U_MCU.pin6"],
+      route: [
+        {
+          route_type: "via",
+          x: -2.8,
+          y: 5.8,
+          from_layer: "top",
+          to_layer: "bottom",
+          via_diameter: 0.6,
+        },
+      ],
+    },
+  ])
+
+  const violations = validateSimpleRouteJsonOutput(srj)
+  expect(violations.length).toBeGreaterThan(0)
+  expect(violations[0]).toMatchObject({
+    type: "via_overlaps_unrelated_pad",
+    connectionName: "source_trace_34",
+  })
+  expect(violations[0]!.pad.connectedTo).toContain("U_MCU.pin5")
+  expect(violations.some((v) => v.pad.connectedTo.includes("U_MCU.pin6"))).toBe(
+    false,
+  )
+
+  const message = getSimpleRouteJsonOutputValidationFailure(srj)
+  expect(message).toContain("via_overlaps_unrelated_pad")
+  expect(message).toContain("source_trace_34")
+})
+
+test("does not flag a via that stays clear of unrelated pads", () => {
+  const srj = makeSrj([
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "far_via",
+      connection_name: "source_trace_34",
+      connectsTo: ["source_trace_34", "U_MCU.pin6"],
+      route: [
+        {
+          route_type: "via",
+          x: 0,
+          y: 0,
+          from_layer: "top",
+          to_layer: "bottom",
+          via_diameter: 0.6,
+        },
+      ],
+    },
+  ])
+
+  expect(validateSimpleRouteJsonOutput(srj)).toEqual([])
+  expect(getSimpleRouteJsonOutputValidationFailure(srj)).toBeNull()
+})
+
+test("flags via-in-pad on a connected pad when allowViaInPad is false", () => {
+  const ownPad = {
+    type: "rect" as const,
+    layers: ["top"],
+    center: { x: 10, y: 10 },
+    width: 0.8,
+    height: 0.8,
+    connectedTo: ["source_trace_34", "U_MCU.pin6"],
+  }
+  const srj = makeSrj(
+    [
+      {
+        type: "pcb_trace",
+        pcb_trace_id: "via_in_pad",
+        connection_name: "source_trace_34",
+        connectsTo: ["source_trace_34", "U_MCU.pin6"],
+        route: [
+          {
+            route_type: "via",
+            x: ownPad.center.x,
+            y: ownPad.center.y,
+            from_layer: "top",
+            to_layer: "bottom",
+            via_diameter: 0.6,
+          },
+        ],
+      },
+    ],
+    { allowViaInPad: false, obstacles: [ownPad] },
+  )
+
+  const violations = validateSimpleRouteJsonOutput(srj)
+  expect(violations).toHaveLength(1)
+  expect(violations[0]!.type).toBe("via_in_connected_pad")
+})
+
+test("allows via-in-pad when allowViaInPad is true", () => {
+  const ownPad = {
+    type: "rect" as const,
+    layers: ["top"],
+    center: { x: 10, y: 10 },
+    width: 0.8,
+    height: 0.8,
+    connectedTo: ["source_trace_34", "U_MCU.pin6"],
+  }
+  const srj = makeSrj(
+    [
+      {
+        type: "pcb_trace",
+        pcb_trace_id: "via_in_pad",
+        connection_name: "source_trace_34",
+        connectsTo: ["source_trace_34", "U_MCU.pin6"],
+        route: [
+          {
+            route_type: "via",
+            x: ownPad.center.x,
+            y: ownPad.center.y,
+            from_layer: "top",
+            to_layer: "bottom",
+            via_diameter: 0.6,
+          },
+        ],
+      },
+    ],
+    { allowViaInPad: true, obstacles: [ownPad] },
+  )
+
+  expect(validateSimpleRouteJsonOutput(srj)).toEqual([])
+})


### PR DESCRIPTION
## Summary

On boards that post-process \`solver.getOutputSimpleRouteJson().traces\` (see \`normalizeToPlatedThroughVias\` on \`spi-display-webcam-interceptor\`), a via can be shifted into a neighboring pad after the solver has already returned. The solver cannot see that mutation, and there was no shared helper to diagnose it at the custom-autorouter boundary.

This exports \`validateSimpleRouteJsonOutput(srj)\` for callers to run on the traces they are about to accept:

- **via_overlaps_unrelated_pad** — via copper closer than 0.1 mm (or \`minViaEdgeToPadEdgeClearance\`) to a pad on another net/connection
- **via_in_connected_pad** — via center inside a same-net pad when \`allowViaInPad\` is not true

The helper is intentionally side-effect free so custom \`algorithmFn\` post-processing can keep its own geometry and still get a targeted error that names the connection and via.

## Tests

\`tests/utils/validate-simple-route-json-output.test.ts\`

- GPIO5/GPIO6 coordinates from #2058: a 0.6 mm via at \`(-2.8, 5.8)\` flags the neighboring pin 5 pad and not the same-net pin 6 pad
- a far-away via is clean
- via-in-pad is flagged when \`allowViaInPad\` is false and allowed when true

Fixes #2058