### PR TITLE
test: fix formatting after stacked Pipeline9 merges

### DIFF
--- a/tests/features/pipeline9-copper-geometry-through-obstacle.test.ts
+++ b/tests/features/pipeline9-copper-geometry-through-obstacle.test.ts
@@ -40,10 +40,7 @@ test("Pipeline9 endpoint resolution leaves through-obstacle copper unchanged", (
   for (const explicitVia of [false, true]) {
     const colocatedRoute: HighDensityRoute = {
       ...hdRoute,
-      route: [
-        hdRoute.route[0]!,
-        { x: 0, y: 0, z: 2, traceThickness: 0.7 },
-      ],
+      route: [hdRoute.route[0]!, { x: 0, y: 0, z: 2, traceThickness: 0.7 }],
       vias: explicitVia ? [{ x: 0, y: 0 }] : [],
     }
     expect(getPipeline9RouteCopperGeometry(colocatedRoute)).toEqual({

--- a/tests/features/pipeline9-copper-geometry-via-endpoints.test.ts
+++ b/tests/features/pipeline9-copper-geometry-via-endpoints.test.ts
@@ -37,7 +37,9 @@ test("Pipeline9 copper geometry follows either explicit transition endpoint", ()
         },
       ])
       const materializedRoute = materializePipeline9HdRouteVias([hdRoute])[0]!
-      expect(getPipeline9RouteCopperGeometry(materializedRoute)).toEqual(geometry)
+      expect(getPipeline9RouteCopperGeometry(materializedRoute)).toEqual(
+        geometry,
+      )
       expect(hdRoute).toEqual(originalRoute)
     }
   }


### PR DESCRIPTION
## Summary

- apply Biome's required formatting to the two Pipeline 9 copper-geometry tests added by the stacked #2453/#2455 work
- restore the `format-check` that the stacked branch merge bypassed
- keep the change limited to formatting; solver behavior and assertions are unchanged

## Verification

- `bun run format:check`
- `bunx tsc --noEmit`
- `bun run build`
- `bun test tests/features/pipeline9-copper-geometry-through-obstacle.test.ts tests/features/pipeline9-copper-geometry-via-endpoints.test.ts tests/repro/pipeline9-t113-boot-fanout.test.ts --timeout 9999999` (3 passing)