### PR TITLE
fix: emit full-stack vias when allowBlindAndBuriedVias is false

### DIFF
--- a/lib/autorouter-pipelines/AssignableAutoroutingPipeline1/AssignableAutoroutingPipeline1Solver.ts
+++ b/lib/autorouter-pipelines/AssignableAutoroutingPipeline1/AssignableAutoroutingPipeline1Solver.ts
@@ -47,6 +47,7 @@ import { HyperAssignableViaCapacityPathingSolver } from "./HyperAssignableViaCap
 import { AssignableViaCapacityPathingSolver_DirectiveSubOptimal } from "./AssignableViaCapacityPathing/AssignableViaCapacityPathingSolver_DirectiveSubOptimal"
 import { OffboardCapacityNodeSolver } from "./OffboardCapacityNodeSolver"
 import { OffboardPathFragmentSolver } from "./OffboardPathFragmentSolver"
+import { materializeAndValidateGeneratedThroughVias } from "lib/utils/materializeAndValidateGeneratedThroughVias"
 
 interface CapacityMeshSolverOptions {
   capacityDepth?: number
@@ -739,14 +740,19 @@ export class AssignableAutoroutingPipeline1Solver extends BaseSolver {
           pcb_trace_id: `${connection.name}_${i}`,
           connection_name:
             netConnectionName ?? rootConnectionName ?? connection.name,
-          route: convertHdRouteToSimplifiedRoute(hdRoute, this.srj.layerCount),
+          route: convertHdRouteToSimplifiedRoute(hdRoute, this.srj.layerCount, {
+            allowBlindAndBuriedVias: this.srj.allowBlindAndBuriedVias,
+          }),
         }
 
         traces.push(simplifiedPcbTrace)
       }
     }
 
-    return traces
+    return materializeAndValidateGeneratedThroughVias({
+      srj: this.srj,
+      outputTraces: traces,
+    })
   }
 
   getOutputSimpleRouteJson(): SimpleRouteJson {

--- a/lib/autorouter-pipelines/AssignableAutoroutingPipeline2/AssignableAutoroutingPipeline2.ts
+++ b/lib/autorouter-pipelines/AssignableAutoroutingPipeline2/AssignableAutoroutingPipeline2.ts
@@ -61,6 +61,7 @@ import { PortPointOffboardPathFragmentSolver } from "./PortPointOffboardPathFrag
 import { RelateNodesToOffBoardConnectionsSolver } from "./RelateNodesToOffBoardConnectionsSolver"
 import { SimpleHighDensitySolver } from "./SimpleHighDensitySolver"
 import { updateConnMapWithOffboardObstacleConnections } from "./updateConnMapWithOffboardObstacleConnections"
+import { materializeAndValidateGeneratedThroughVias } from "lib/utils/materializeAndValidateGeneratedThroughVias"
 
 interface CapacityMeshSolverOptions {
   capacityDepth?: number
@@ -748,14 +749,19 @@ export class AssignableAutoroutingPipeline2 extends BaseSolver {
             netConnectionName ??
             connection.__rootConnectionNames?.[0] ??
             connection.name,
-          route: convertHdRouteToSimplifiedRoute(hdRoute, this.srj.layerCount),
+          route: convertHdRouteToSimplifiedRoute(hdRoute, this.srj.layerCount, {
+            allowBlindAndBuriedVias: this.srj.allowBlindAndBuriedVias,
+          }),
         }
 
         traces.push(simplifiedPcbTrace)
       }
     }
 
-    return traces
+    return materializeAndValidateGeneratedThroughVias({
+      srj: this.srj,
+      outputTraces: traces,
+    })
   }
 
   getOutputSimpleRouteJson(): SimpleRouteJson {

--- a/lib/autorouter-pipelines/AssignableAutoroutingPipeline3/AssignableAutoroutingPipeline3.ts
+++ b/lib/autorouter-pipelines/AssignableAutoroutingPipeline3/AssignableAutoroutingPipeline3.ts
@@ -69,6 +69,7 @@ import { PortPointOffboardPathFragmentSolver } from "../AssignableAutoroutingPip
 import { RelateNodesToOffBoardConnectionsSolver } from "../AssignableAutoroutingPipeline2/RelateNodesToOffBoardConnectionsSolver"
 import { SimpleHighDensitySolver } from "../AssignableAutoroutingPipeline2/SimpleHighDensitySolver"
 import { updateConnMapWithOffboardObstacleConnections } from "../AssignableAutoroutingPipeline2/updateConnMapWithOffboardObstacleConnections"
+import { materializeAndValidateGeneratedThroughVias } from "lib/utils/materializeAndValidateGeneratedThroughVias"
 
 interface CapacityMeshSolverOptions {
   capacityDepth?: number
@@ -798,14 +799,19 @@ export class AssignableAutoroutingPipeline3 extends BaseSolver {
             netConnectionName ??
             connection.__rootConnectionNames?.[0] ??
             connection.name,
-          route: convertHdRouteToSimplifiedRoute(hdRoute, this.srj.layerCount),
+          route: convertHdRouteToSimplifiedRoute(hdRoute, this.srj.layerCount, {
+            allowBlindAndBuriedVias: this.srj.allowBlindAndBuriedVias,
+          }),
         }
 
         traces.push(simplifiedPcbTrace)
       }
     }
 
-    return traces
+    return materializeAndValidateGeneratedThroughVias({
+      srj: this.srj,
+      outputTraces: traces,
+    })
   }
 
   /**

--- a/lib/autorouter-pipelines/AutoroutingPipeline11_Simplification/ApplyTraceSimplificationSolver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline11_Simplification/ApplyTraceSimplificationSolver.ts
@@ -100,6 +100,8 @@ export class ApplyTraceSimplificationSolver extends BaseSolver {
         defaultViaHoleDiameter: preparedTrace.viaHoleDiameter,
         obstacles: this.inputProblem.preparedInput.srj.obstacles,
         connMap: this.inputProblem.preparedInput.connMap,
+        allowBlindAndBuriedVias:
+          this.inputProblem.preparedInput.srj.allowBlindAndBuriedVias,
       },
     )
     const jumpers = convertedRoute.filter(

--- a/lib/autorouter-pipelines/AutoroutingPipeline11_Simplification/AutoroutingPipelineSolver11_Simplification.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline11_Simplification/AutoroutingPipelineSolver11_Simplification.ts
@@ -7,6 +7,7 @@ import type { BaseSolver } from "@tscircuit/solver-utils"
 import type { GraphicsObject } from "graphics-debug"
 import type { SimpleRouteJson, SimplifiedPcbTraces } from "lib/types"
 import { convertSrjToGraphicsObject } from "lib/utils/convertSrjToGraphicsObject"
+import { materializeAndValidateGeneratedThroughVias } from "lib/utils/materializeAndValidateGeneratedThroughVias"
 import {
   ApplyTraceSimplificationSolver,
   type ApplyTraceSimplificationSolverInput,
@@ -121,7 +122,14 @@ export class AutoroutingPipelineSolver11_Simplification extends BasePipelineSolv
     if (!this.validateTraceSimplificationSolver?.solved) {
       throw new Error("Pipeline 11 simplification has not solved yet")
     }
-    return this.validateTraceSimplificationSolver.getOutput()
+    const output = this.validateTraceSimplificationSolver.getOutput()
+    return {
+      ...output,
+      traces: materializeAndValidateGeneratedThroughVias({
+        srj: this.inputProblem.inputSrj,
+        outputTraces: output.traces ?? [],
+      }),
+    }
   }
 
   getOutputSimpleRouteJson(): SimpleRouteJson {

--- a/lib/autorouter-pipelines/AutoroutingPipeline1_OriginalUnravel/AutoroutingPipeline1_OriginalUnravel.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline1_OriginalUnravel/AutoroutingPipeline1_OriginalUnravel.ts
@@ -61,6 +61,7 @@ import { getViaDimensions } from "lib/utils/getViaDimensions"
 import { calculateOptimalCapacityDepth } from "lib/utils/getTunedTotalCapacity1"
 import { mapLayerNameToZ } from "lib/utils/mapLayerNameToZ"
 import { mergeRouteSegments } from "lib/utils/mergeRouteSegments"
+import { materializeAndValidateGeneratedThroughVias } from "lib/utils/materializeAndValidateGeneratedThroughVias"
 
 interface CapacityMeshSolverOptions {
   capacityDepth?: number
@@ -647,14 +648,19 @@ export class AutoroutingPipeline1_OriginalUnravel extends BaseSolver {
             netConnectionName ??
             connection.__rootConnectionNames?.[0] ??
             connection.name,
-          route: convertHdRouteToSimplifiedRoute(hdRoute, this.srj.layerCount),
+          route: convertHdRouteToSimplifiedRoute(hdRoute, this.srj.layerCount, {
+            allowBlindAndBuriedVias: this.srj.allowBlindAndBuriedVias,
+          }),
         }
 
         traces.push(simplifiedPcbTrace)
       }
     }
 
-    return traces
+    return materializeAndValidateGeneratedThroughVias({
+      srj: this.srj,
+      outputTraces: traces,
+    })
   }
 
   getOutputSimpleRouteJson(): SimpleRouteJson {

--- a/lib/autorouter-pipelines/AutoroutingPipeline2_PortPointPathing/AutoroutingPipelineSolver2_PortPointPathing.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline2_PortPointPathing/AutoroutingPipelineSolver2_PortPointPathing.ts
@@ -56,6 +56,7 @@ import type {
 } from "../../types"
 import { combineVisualizations } from "../../utils/combineVisualizations"
 import { calculateOptimalCapacityDepth } from "../../utils/getTunedTotalCapacity1"
+import { materializeAndValidateGeneratedThroughVias } from "lib/utils/materializeAndValidateGeneratedThroughVias"
 
 interface CapacityMeshSolverOptions {
   capacityDepth?: number
@@ -696,14 +697,19 @@ export class AutoroutingPipelineSolver2_PortPointPathing extends BaseSolver {
             netConnectionName ??
             connection.__rootConnectionNames?.[0] ??
             connection.name,
-          route: convertHdRouteToSimplifiedRoute(hdRoute, this.srj.layerCount),
+          route: convertHdRouteToSimplifiedRoute(hdRoute, this.srj.layerCount, {
+            allowBlindAndBuriedVias: this.srj.allowBlindAndBuriedVias,
+          }),
         }
 
         traces.push(simplifiedPcbTrace)
       }
     }
 
-    return traces
+    return materializeAndValidateGeneratedThroughVias({
+      srj: this.srj,
+      outputTraces: traces,
+    })
   }
 
   getOutputSimpleRouteJson(): SimpleRouteJson {

--- a/lib/autorouter-pipelines/AutoroutingPipeline3_HgPortPointPathing/AutoroutingPipelineSolver3_HgPortPointPathing.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline3_HgPortPointPathing/AutoroutingPipelineSolver3_HgPortPointPathing.ts
@@ -47,6 +47,7 @@ import { SingleLayerNodeMergerSolver } from "../../solvers/SingleLayerNodeMerger
 import { StrawSolver } from "../../solvers/StrawSolver/StrawSolver"
 import { TraceSimplificationSolver } from "../../solvers/TraceSimplificationSolver/TraceSimplificationSolver"
 import { TraceWidthSolver } from "../../solvers/TraceWidthSolver/TraceWidthSolver"
+import { materializeAndValidateGeneratedThroughVias } from "lib/utils/materializeAndValidateGeneratedThroughVias"
 
 interface CapacityMeshSolverOptions {
   capacityDepth?: number
@@ -623,14 +624,19 @@ export class AutoroutingPipelineSolver3_HgPortPointPathing extends BaseSolver {
             netConnectionName ??
             connection.__rootConnectionNames?.[0] ??
             connection.name,
-          route: convertHdRouteToSimplifiedRoute(hdRoute, this.srj.layerCount),
+          route: convertHdRouteToSimplifiedRoute(hdRoute, this.srj.layerCount, {
+            allowBlindAndBuriedVias: this.srj.allowBlindAndBuriedVias,
+          }),
         }
 
         traces.push(simplifiedPcbTrace)
       }
     }
 
-    return traces
+    return materializeAndValidateGeneratedThroughVias({
+      srj: this.srj,
+      outputTraces: traces,
+    })
   }
 
   getOutputSimpleRouteJson(): SimpleRouteJson {

--- a/lib/autorouter-pipelines/AutoroutingPipeline4_TinyHypergraph/AutoroutingPipelineSolver4_TinyHypergraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline4_TinyHypergraph/AutoroutingPipelineSolver4_TinyHypergraph.ts
@@ -55,6 +55,7 @@ import { StrawSolver } from "../../solvers/StrawSolver/StrawSolver"
 import { TraceSimplificationSolver } from "../../solvers/TraceSimplificationSolver/TraceSimplificationSolver"
 import { TraceWidthSolver } from "../../solvers/TraceWidthSolver/TraceWidthSolver"
 import { PreprocessSimpleRouteJsonSolver } from "./PreprocessSimpleRouteJsonSolver"
+import { materializeAndValidateGeneratedThroughVias } from "lib/utils/materializeAndValidateGeneratedThroughVias"
 
 interface CapacityMeshSolverOptions {
   capacityDepth?: number
@@ -769,6 +770,7 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
             defaultViaHoleDiameter: this.viaHoleDiameter,
             obstacles: this.srj.obstacles,
             connMap: this.connMap,
+            allowBlindAndBuriedVias: this.srj.allowBlindAndBuriedVias,
           }),
         }
 
@@ -776,7 +778,10 @@ export class AutoroutingPipelineSolver4_TinyHypergraph extends BaseSolver {
       }
     }
 
-    return traces
+    return materializeAndValidateGeneratedThroughVias({
+      srj: this.originalSrj,
+      outputTraces: traces,
+    })
   }
 
   getOutputSimpleRouteJson(): SimpleRouteJson {

--- a/lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/AutoroutingPipelineSolver6_PolyHypergraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/AutoroutingPipelineSolver6_PolyHypergraph.ts
@@ -36,6 +36,7 @@ import { PolyHypergraphPortPointPathingSolver } from "./PolyHypergraphPortPointP
 import { PreprocessSimpleRouteJsonSolver } from "./PreprocessSimpleRouteJsonSolver"
 import { ProjectHighDensityToPolygonSolver } from "./ProjectHighDensityToPolygonSolver"
 import type { PolyNodeWithPortPoints } from "./types"
+import { materializeAndValidateGeneratedThroughVias } from "lib/utils/materializeAndValidateGeneratedThroughVias"
 
 interface CapacityMeshSolverOptions {
   capacityDepth?: number
@@ -629,6 +630,7 @@ export class AutoroutingPipelineSolver6_PolyHypergraph extends BaseSolver {
           route: convertHdRouteToSimplifiedRoute(hdRoute, this.srj.layerCount, {
             connectionPoints: connection.pointsToConnect,
             defaultViaHoleDiameter: this.viaHoleDiameter,
+            allowBlindAndBuriedVias: this.srj.allowBlindAndBuriedVias,
           }),
         }
 
@@ -636,7 +638,10 @@ export class AutoroutingPipelineSolver6_PolyHypergraph extends BaseSolver {
       }
     }
 
-    return traces
+    return materializeAndValidateGeneratedThroughVias({
+      srj: this.originalSrj,
+      outputTraces: traces,
+    })
   }
 
   getOutputSimpleRouteJson(): SimpleRouteJson {

--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph.ts
@@ -75,6 +75,7 @@ import { createPipeline7AutoroutingDrcEvaluator } from "./create-pipeline7-autor
 import { getPowerTraceExpansionConnectionNames } from "./getPowerTraceExpansionConnectionNames"
 import { lockHdRouteTerminals } from "./lock-hd-route-terminals"
 import { preparePipeline7PowerTraceExpansionInput } from "./prepare-pipeline7-power-trace-expansion-input"
+import { materializeAndValidateGeneratedThroughVias } from "lib/utils/materializeAndValidateGeneratedThroughVias"
 
 interface CapacityMeshSolverOptions {
   capacityDepth?: number
@@ -677,6 +678,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
           obstacles: cms.srj.obstacles,
           defaultViaHoleDiameter: cms.viaHoleDiameter,
           connMap: cms.connMap,
+          allowBlindAndBuriedVias: cms.srj.allowBlindAndBuriedVias,
           srjWithPointPairs: cms.srjWithPointPairs!,
           originalSrj: cms.originalSrj,
         })
@@ -1187,11 +1189,13 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
       throw new Error("Cannot get output before solving is complete")
     }
 
-    if (this.powerTraceExpansionSolver) {
-      return this.powerTraceExpansionSolver.getOutput()
-    }
-
-    return this.getPrePowerTraceOutputSimplifiedPcbTraces()
+    const traces = this.powerTraceExpansionSolver
+      ? this.powerTraceExpansionSolver.getOutput()
+      : this.getPrePowerTraceOutputSimplifiedPcbTraces()
+    return materializeAndValidateGeneratedThroughVias({
+      srj: this.originalSrj,
+      outputTraces: traces,
+    })
   }
 
   getPrePowerTraceOutputSimplifiedPcbTraces(): SimplifiedPcbTraces {
@@ -1203,6 +1207,7 @@ export class AutoroutingPipelineSolver7_MultiGraph extends BaseSolver {
       obstacles: this.srj.obstacles,
       defaultViaHoleDiameter: this.viaHoleDiameter,
       connMap: this.connMap,
+      allowBlindAndBuriedVias: this.srj.allowBlindAndBuriedVias,
     })
   }
 

--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/PowerTraceExpansionSolver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/PowerTraceExpansionSolver.ts
@@ -6,6 +6,7 @@ import {
 import type { GraphicsObject } from "graphics-debug"
 import type { SimpleRouteJson, SimplifiedPcbTraces } from "lib/types"
 import { convertSrjToGraphicsObject } from "lib/utils/convertSrjToGraphicsObject"
+import { materializeAndValidateGeneratedThroughVias } from "lib/utils/materializeAndValidateGeneratedThroughVias"
 import { BaseSolver } from "../../solvers/BaseSolver"
 
 export class PowerTraceExpansionSolver extends BaseSolver {
@@ -58,7 +59,11 @@ export class PowerTraceExpansionSolver extends BaseSolver {
       throw new Error("Cannot get power trace expansion output before solving")
     }
 
-    return this.powerTraceExpanderSolver.getOutput() as SimplifiedPcbTraces
+    return materializeAndValidateGeneratedThroughVias({
+      srj: this.inputSrj,
+      outputTraces:
+        this.powerTraceExpanderSolver.getOutput() as SimplifiedPcbTraces,
+    })
   }
 
   override visualize(): GraphicsObject {

--- a/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/convertPipeline7HdRoutesToSimplifiedPcbTraces.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/convertPipeline7HdRoutesToSimplifiedPcbTraces.ts
@@ -16,6 +16,7 @@ export interface ConvertPipeline7HdRoutesOptions {
   obstacles: Obstacle[]
   defaultViaHoleDiameter: number
   connMap: ConnectivityMap
+  allowBlindAndBuriedVias?: boolean
 }
 
 type StaticConvertPipeline7HdRoutesOptions = Omit<
@@ -36,6 +37,7 @@ export const createPipeline7HdRoutesToSimplifiedPcbTracesConverter = ({
   obstacles,
   defaultViaHoleDiameter,
   connMap,
+  allowBlindAndBuriedVias,
 }: StaticConvertPipeline7HdRoutesOptions) => {
   const netConnectionNameByOriginalConnectionName = new Map<
     string,
@@ -134,6 +136,7 @@ export const createPipeline7HdRoutesToSimplifiedPcbTracesConverter = ({
             connectedMultilayerObstacles:
               getConnectedMultilayerObstacles(hdRoute),
             connMap,
+            allowBlindAndBuriedVias,
           }),
         })
       }
@@ -152,6 +155,7 @@ export const convertPipeline7HdRoutesToSimplifiedPcbTraces = ({
   obstacles,
   defaultViaHoleDiameter,
   connMap,
+  allowBlindAndBuriedVias,
 }: ConvertPipeline7HdRoutesOptions): SimplifiedPcbTraces =>
   createPipeline7HdRoutesToSimplifiedPcbTracesConverter({
     connections,
@@ -160,4 +164,5 @@ export const convertPipeline7HdRoutesToSimplifiedPcbTraces = ({
     obstacles,
     defaultViaHoleDiameter,
     connMap,
+    allowBlindAndBuriedVias,
   })(hdRoutes)

--- a/lib/autorouter-pipelines/AutoroutingPipeline8/AutoroutingPipelineSolver8.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline8/AutoroutingPipelineSolver8.ts
@@ -59,6 +59,7 @@ import { TraceSimplificationSolver } from "../../solvers/TraceSimplificationSolv
 import { TraceWidthSolver } from "../../solvers/TraceWidthSolver/TraceWidthSolver"
 import { PreprocessSimpleRouteJsonSolver } from "../AutoroutingPipeline4_TinyHypergraph/PreprocessSimpleRouteJsonSolver"
 import { SplitNodesIntoSingleLayerNodeSolver } from "./SplitNodesIntoSingleLayerNodeSolver"
+import { materializeAndValidateGeneratedThroughVias } from "lib/utils/materializeAndValidateGeneratedThroughVias"
 
 interface CapacityMeshSolverOptions {
   capacityDepth?: number
@@ -892,6 +893,7 @@ export class AutoroutingPipelineSolver8 extends BaseSolver {
             defaultViaHoleDiameter: this.viaHoleDiameter,
             obstacles: this.srj.obstacles,
             connMap: this.connMap,
+            allowBlindAndBuriedVias: this.srj.allowBlindAndBuriedVias,
           }),
         }
 
@@ -899,7 +901,10 @@ export class AutoroutingPipelineSolver8 extends BaseSolver {
       }
     }
 
-    return traces
+    return materializeAndValidateGeneratedThroughVias({
+      srj: this.originalSrj,
+      outputTraces: traces,
+    })
   }
 
   getOutputSimpleRouteJson(): SimpleRouteJson {

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/AutoroutingPipelineSolver9_PreloadedTraceGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/AutoroutingPipelineSolver9_PreloadedTraceGraph.ts
@@ -38,6 +38,7 @@ import {
 import { createSrjWithBoardValidObstacleLayers } from "lib/utils/create-srj-with-board-valid-obstacle-layers"
 import { createObstacleLabelFormatter } from "lib/utils/formatObstacleLabel"
 import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
+import { materializeAndValidateGeneratedThroughVias } from "lib/utils/materializeAndValidateGeneratedThroughVias"
 import { getInitiallyConnectedMapFromSimpleRouteJson } from "lib/utils/get-initially-connected-map-from-simple-route-json"
 import {
   getGraphicsLayerForConnectionPoint,
@@ -1444,6 +1445,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
       defaultViaHoleDiameter: this.viaHoleDiameter,
       obstacles: this.originalSrj.obstacles,
       connMap: this.connMap,
+      allowBlindAndBuriedVias: this.originalSrj.allowBlindAndBuriedVias,
     })
   }
 
@@ -1482,6 +1484,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
       obstacles: this.srj.obstacles,
       defaultViaHoleDiameter: this.viaHoleDiameter,
       connMap: this.connMap,
+      allowBlindAndBuriedVias: this.srj.allowBlindAndBuriedVias,
     })
     return assignUniquePcbTraceIdsToNewTraces(
       routedTraces,
@@ -1510,12 +1513,15 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
         "Pipeline9 invariant violated: solved pipeline is missing the unconditional power-trace expansion solver",
       )
     }
-    return [
-      ...this.getPowerTraceExpansionFixedTraces().filter(
-        (trace) => trace.__replaces_pcb_trace_id !== undefined,
-      ),
-      ...this.powerTraceExpansionSolver.getOutput(),
-    ]
+    return materializeAndValidateGeneratedThroughVias({
+      srj: this.originalSrj,
+      outputTraces: [
+        ...this.getPowerTraceExpansionFixedTraces().filter(
+          (trace) => trace.__replaces_pcb_trace_id !== undefined,
+        ),
+        ...this.powerTraceExpansionSolver.getOutput(),
+      ],
+    })
   }
 
   getOutputSimpleRouteJson(): SimpleRouteJson {
@@ -1527,10 +1533,13 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
         "Pipeline9 invariant violated: solved pipeline is missing the unconditional power-trace expansion solver",
       )
     }
-    const traces = [
-      ...this.getPowerTraceExpansionFixedTraces(),
-      ...this.powerTraceExpansionSolver.getOutput(),
-    ]
+    const traces = materializeAndValidateGeneratedThroughVias({
+      srj: this.originalSrj,
+      outputTraces: [
+        ...this.getPowerTraceExpansionFixedTraces(),
+        ...this.powerTraceExpansionSolver.getOutput(),
+      ],
+    })
     return {
       ...this.originalSrj,
       traces,

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/applyFixedRouteReplacementsToPreloadedTraces.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/applyFixedRouteReplacementsToPreloadedTraces.ts
@@ -14,6 +14,7 @@ type ApplyFixedRouteReplacementsParams = {
   defaultViaHoleDiameter: number
   obstacles: Obstacle[]
   connMap: ConnectivityMap
+  allowBlindAndBuriedVias?: boolean
 }
 
 type ApplyFixedRouteReplacementsResult = {
@@ -33,6 +34,7 @@ type ConvertUpdatedTraceRoutesParams = {
   defaultViaHoleDiameter: number
   obstacles: Obstacle[]
   connMap: ConnectivityMap
+  allowBlindAndBuriedVias?: boolean
 }
 
 type RebuildThroughObstacleTraceParams = ConvertUpdatedTraceRoutesParams & {
@@ -109,6 +111,7 @@ const convertUpdatedTraceRoutes = ({
   defaultViaHoleDiameter,
   obstacles,
   connMap,
+  allowBlindAndBuriedVias,
 }: ConvertUpdatedTraceRoutesParams): SimplifiedPcbTrace["route"] => {
   if (updatedTraceRoutes.length === 0) {
     throw new Error(
@@ -146,6 +149,7 @@ const convertUpdatedTraceRoutes = ({
     defaultViaHoleDiameter,
     obstacles,
     connMap,
+    allowBlindAndBuriedVias,
   })
 }
 
@@ -207,6 +211,7 @@ const rebuildThroughObstacleTrace = ({
   defaultViaHoleDiameter,
   obstacles,
   connMap,
+  allowBlindAndBuriedVias,
 }: RebuildThroughObstacleTraceParams): SimplifiedPcbTrace["route"] => {
   if (updatedTraceRoutes.length === 0) {
     throw new Error(
@@ -258,6 +263,7 @@ const rebuildThroughObstacleTrace = ({
             defaultViaHoleDiameter,
             obstacles,
             connMap,
+            allowBlindAndBuriedVias,
           })
         : trace.route.slice(
             section.routePositionStart,
@@ -283,6 +289,7 @@ export const applyFixedRouteReplacementsToPreloadedTraces = ({
   defaultViaHoleDiameter,
   obstacles,
   connMap,
+  allowBlindAndBuriedVias,
 }: ApplyFixedRouteReplacementsParams): ApplyFixedRouteReplacementsResult => {
   const originalFixedRoutesByTraceIndex = new Map<
     number,
@@ -343,6 +350,7 @@ export const applyFixedRouteReplacementsToPreloadedTraces = ({
             defaultViaHoleDiameter,
             obstacles,
             connMap,
+            allowBlindAndBuriedVias,
           })
         : convertUpdatedTraceRoutes({
             trace,
@@ -351,6 +359,7 @@ export const applyFixedRouteReplacementsToPreloadedTraces = ({
             defaultViaHoleDiameter,
             obstacles,
             connMap,
+            allowBlindAndBuriedVias,
           }),
     }
     mutatedPreloadedTraces.push(mutatedTrace)

--- a/lib/types/srj-types.ts
+++ b/lib/types/srj-types.ts
@@ -61,6 +61,11 @@ export interface SimpleRouteJson {
   minViaPadDiameter?: number
   min_via_hole_diameter?: number
   min_via_pad_diameter?: number
+  /**
+   * Allows generated vias to use partial layer spans. Omission preserves the
+   * legacy standalone-SRJ behavior; set false for full-stack through vias.
+   */
+  allowBlindAndBuriedVias?: boolean
   defaultObstacleMargin?: number
   minTraceToPadEdgeClearance?: number
   minBoardEdgeClearance?: number

--- a/lib/utils/convertHdRouteToSimplifiedRoute.ts
+++ b/lib/utils/convertHdRouteToSimplifiedRoute.ts
@@ -9,6 +9,7 @@ import {
   isSingleLayerConnectionPoint,
 } from "lib/types"
 import { HighDensityIntraNodeRoute, Jumper } from "lib/types/high-density-types"
+import { shouldUseThroughVias } from "./materializeGeneratedThroughVias"
 import { mapZToLayerName } from "./mapZToLayerName"
 
 type Point = {
@@ -30,6 +31,27 @@ export interface ConvertHdRouteToSimplifiedRouteOptions {
   obstacles?: ReadonlyArray<Obstacle>
   connectedMultilayerObstacles?: ReadonlyArray<Obstacle>
   connMap?: ConnectivityMap
+  allowBlindAndBuriedVias?: boolean
+}
+
+const getOutputViaSpan = ({
+  fromLayer,
+  toLayer,
+  layerCount,
+  allowBlindAndBuriedVias,
+}: {
+  fromLayer: string
+  toLayer: string
+  layerCount: number
+  allowBlindAndBuriedVias: boolean | undefined
+}): { from_layer: string; to_layer: string } => {
+  if (!shouldUseThroughVias(allowBlindAndBuriedVias)) {
+    return { from_layer: fromLayer, to_layer: toLayer }
+  }
+  return {
+    from_layer: mapZToLayerName(0, layerCount),
+    to_layer: mapZToLayerName(layerCount - 1, layerCount),
+  }
 }
 
 /**
@@ -123,6 +145,7 @@ const attachTerminalViasToSimplifiedRoute = ({
   connectionPoints = [],
   tolerance = DEFAULT_TERMINAL_VIA_ATTACH_TOLERANCE,
   defaultViaHoleDiameter,
+  allowBlindAndBuriedVias,
 }: {
   route: SimplifiedPcbTraces[number]["route"]
   hdRoute: HdRouteWithOptionalJumpers
@@ -130,6 +153,7 @@ const attachTerminalViasToSimplifiedRoute = ({
   connectionPoints?: ReadonlyArray<ConnectionPoint>
   tolerance?: number
   defaultViaHoleDiameter?: number
+  allowBlindAndBuriedVias?: boolean
 }): SimplifiedPcbTraces[number]["route"] => {
   if (
     route.length === 0 ||
@@ -187,8 +211,12 @@ const attachTerminalViasToSimplifiedRoute = ({
       route_type: "via",
       x: startTerminalViaPoint.x,
       y: startTerminalViaPoint.y,
-      from_layer: startTerminalViaPoint.layer,
-      to_layer: startTerminalViaPoint.terminalVia.toLayer,
+      ...getOutputViaSpan({
+        fromLayer: startTerminalViaPoint.layer,
+        toLayer: startTerminalViaPoint.terminalVia.toLayer,
+        layerCount,
+        allowBlindAndBuriedVias,
+      }),
       via_diameter:
         startTerminalViaPoint.terminalVia.viaDiameter ?? hdRoute.viaDiameter,
       ...(defaultViaHoleDiameter !== undefined
@@ -234,8 +262,12 @@ const attachTerminalViasToSimplifiedRoute = ({
       route_type: "via",
       x: endTerminalViaPoint.x,
       y: endTerminalViaPoint.y,
-      from_layer: endTerminalViaPoint.layer,
-      to_layer: endTerminalViaPoint.terminalVia.toLayer,
+      ...getOutputViaSpan({
+        fromLayer: endTerminalViaPoint.layer,
+        toLayer: endTerminalViaPoint.terminalVia.toLayer,
+        layerCount,
+        allowBlindAndBuriedVias,
+      }),
       via_diameter:
         endTerminalViaPoint.terminalVia.viaDiameter ?? hdRoute.viaDiameter,
       ...(defaultViaHoleDiameter !== undefined
@@ -311,8 +343,12 @@ export const convertHdRouteToSimplifiedRoute = (
             route_type: "via",
             x: point.x,
             y: point.y,
-            from_layer: layerName,
-            to_layer: nextLayerName,
+            ...getOutputViaSpan({
+              fromLayer: layerName,
+              toLayer: nextLayerName,
+              layerCount,
+              allowBlindAndBuriedVias: opts.allowBlindAndBuriedVias,
+            }),
             via_diameter: hdRoute.viaDiameter,
             ...(opts.defaultViaHoleDiameter !== undefined
               ? { via_hole_diameter: opts.defaultViaHoleDiameter }
@@ -373,5 +409,6 @@ export const convertHdRouteToSimplifiedRoute = (
     connectionPoints: opts.connectionPoints,
     tolerance: opts.terminalViaAttachTolerance,
     defaultViaHoleDiameter: opts.defaultViaHoleDiameter,
+    allowBlindAndBuriedVias: opts.allowBlindAndBuriedVias,
   })
 }

--- a/lib/utils/getGeneratedThroughViaCollision.ts
+++ b/lib/utils/getGeneratedThroughViaCollision.ts
@@ -1,0 +1,269 @@
+import { pointToSegmentDistance } from "@tscircuit/math-utils"
+import type {
+  Obstacle,
+  SimpleRouteJson,
+  SimplifiedPcbTrace,
+  SimplifiedPcbTraces,
+} from "lib/types"
+import { getConnectivityMapFromSimpleRouteJson } from "lib/utils/getConnectivityMapFromSimpleRouteJson"
+import {
+  getGeneratedViaRefs,
+  shouldUseThroughVias,
+} from "lib/utils/materializeGeneratedThroughVias"
+import { getViaDimensions } from "lib/utils/getViaDimensions"
+import { JUMPER_DIMENSIONS } from "lib/utils/jumperSizes"
+import { mapLayerNameToZ } from "lib/utils/mapLayerNameToZ"
+import { mapZToLayerName } from "lib/utils/mapZToLayerName"
+
+type TraceSegment = {
+  trace: SimplifiedPcbTrace
+  start: { x: number; y: number }
+  end: { x: number; y: number }
+  width: number
+  layers: string[]
+}
+
+type JumperPad = {
+  trace: SimplifiedPcbTrace
+  center: { x: number; y: number }
+  width: number
+  height: number
+  layer: string
+}
+
+const pointToRotatedRectDistance = (
+  point: { x: number; y: number },
+  rect: {
+    center: { x: number; y: number }
+    width: number
+    height: number
+    ccwRotationDegrees?: number
+  },
+): number => {
+  const angle = -((rect.ccwRotationDegrees ?? 0) * Math.PI) / 180
+  const dx = point.x - rect.center.x
+  const dy = point.y - rect.center.y
+  const localX = dx * Math.cos(angle) - dy * Math.sin(angle)
+  const localY = dx * Math.sin(angle) + dy * Math.cos(angle)
+  const outsideX = Math.max(Math.abs(localX) - rect.width / 2, 0)
+  const outsideY = Math.max(Math.abs(localY) - rect.height / 2, 0)
+  return Math.hypot(outsideX, outsideY)
+}
+
+const getLayersBetween = (
+  fromLayer: string,
+  toLayer: string,
+  layerCount: number,
+): string[] => {
+  const fromZ = mapLayerNameToZ(fromLayer, layerCount)
+  const toZ = mapLayerNameToZ(toLayer, layerCount)
+  const minZ = Math.min(fromZ, toZ)
+  const maxZ = Math.max(fromZ, toZ)
+
+  return Array.from({ length: maxZ - minZ + 1 }, (_, index) =>
+    mapZToLayerName(minZ + index, layerCount),
+  )
+}
+
+const getTraceIds = (trace: SimplifiedPcbTrace): string[] =>
+  [
+    trace.pcb_trace_id,
+    trace.__replaces_pcb_trace_id,
+    trace.connection_name,
+    ...(trace.connectsTo ?? []),
+  ].filter((id): id is string => id !== undefined)
+
+const getTraceSegments = (
+  traces: ReadonlyArray<SimplifiedPcbTrace>,
+  layerCount: number,
+): TraceSegment[] => {
+  const segments: TraceSegment[] = []
+  for (const trace of traces) {
+    for (let routeIndex = 0; routeIndex < trace.route.length; routeIndex++) {
+      const routePoint = trace.route[routeIndex]!
+      const nextRoutePoint = trace.route[routeIndex + 1]
+      if (
+        routePoint.route_type === "wire" &&
+        nextRoutePoint?.route_type === "wire" &&
+        routePoint.layer === nextRoutePoint.layer
+      ) {
+        segments.push({
+          trace,
+          start: routePoint,
+          end: nextRoutePoint,
+          width: Math.max(routePoint.width, nextRoutePoint.width),
+          layers: [routePoint.layer],
+        })
+      } else if (routePoint.route_type === "through_obstacle") {
+        segments.push({
+          trace,
+          start: routePoint.start,
+          end: routePoint.end,
+          width: routePoint.width,
+          layers: getLayersBetween(
+            routePoint.from_layer,
+            routePoint.to_layer,
+            layerCount,
+          ),
+        })
+      }
+    }
+  }
+  return segments
+}
+
+const getJumperPads = (
+  traces: ReadonlyArray<SimplifiedPcbTrace>,
+): JumperPad[] =>
+  traces.flatMap((trace) =>
+    trace.route.flatMap((routePoint) => {
+      if (routePoint.route_type !== "jumper") return []
+      const dimensions = JUMPER_DIMENSIONS[routePoint.footprint]
+      const isHorizontal =
+        Math.abs(routePoint.end.x - routePoint.start.x) >
+        Math.abs(routePoint.end.y - routePoint.start.y)
+      const width = isHorizontal ? dimensions.padLength : dimensions.padWidth
+      const height = isHorizontal ? dimensions.padWidth : dimensions.padLength
+      return [routePoint.start, routePoint.end].map((center) => ({
+        trace,
+        center,
+        width,
+        height,
+        layer: routePoint.layer,
+      }))
+    }),
+  )
+
+const layersOverlap = (
+  firstLayers: ReadonlyArray<string>,
+  secondLayers: ReadonlyArray<string>,
+): boolean => {
+  const firstLayerSet = new Set(firstLayers)
+  return secondLayers.some((layer) => firstLayerSet.has(layer))
+}
+
+export const getGeneratedThroughViaCollision = ({
+  srj,
+  preservedInputTraces,
+  outputTraces,
+  collisionTraces = outputTraces,
+}: {
+  srj: SimpleRouteJson
+  preservedInputTraces: ReadonlyArray<SimplifiedPcbTrace>
+  outputTraces: SimplifiedPcbTraces
+  collisionTraces?: SimplifiedPcbTraces
+}): string | null => {
+  if (!shouldUseThroughVias(srj.allowBlindAndBuriedVias)) return null
+
+  const viaDimensions = getViaDimensions(srj)
+  const combinedSrj = { ...srj, traces: collisionTraces }
+  const connMap = getConnectivityMapFromSimpleRouteJson(combinedSrj)
+  const generatedVias = getGeneratedViaRefs({
+    inputTraces: preservedInputTraces,
+    outputTraces,
+  })
+  const traceSegments = getTraceSegments(collisionTraces, srj.layerCount)
+  const jumperPads = getJumperPads(collisionTraces)
+  const allVias = collisionTraces.flatMap((trace) =>
+    trace.route.flatMap((routePoint, routeIndex) =>
+      routePoint.route_type === "via"
+        ? [{ trace, routeIndex, via: routePoint }]
+        : [],
+    ),
+  )
+  const obstacleClearance =
+    srj.minViaEdgeToPadEdgeClearance ?? srj.defaultObstacleMargin ?? 0
+  const traceClearance = srj.defaultObstacleMargin ?? 0
+  const staticObstacles = [
+    ...srj.obstacles,
+    ...(srj.jumpers ?? []).flatMap((jumper) => jumper.pads),
+  ]
+
+  const tracesAreConnected = (
+    firstTrace: SimplifiedPcbTrace,
+    secondTrace: SimplifiedPcbTrace,
+  ): boolean =>
+    getTraceIds(firstTrace).some((firstId) =>
+      getTraceIds(secondTrace).some(
+        (secondId) =>
+          firstId === secondId || connMap.areIdsConnected(firstId, secondId),
+      ),
+    )
+  const obstacleIsConnected = (
+    trace: SimplifiedPcbTrace,
+    obstacle: Obstacle,
+  ): boolean =>
+    getTraceIds(trace).some((traceId) =>
+      obstacle.connectedTo.some(
+        (obstacleId) =>
+          traceId === obstacleId ||
+          connMap.areIdsConnected(traceId, obstacleId),
+      ),
+    )
+
+  for (const generatedVia of generatedVias) {
+    const { trace, routeIndex, via } = generatedVia
+    const viaLayers = getLayersBetween(
+      via.from_layer,
+      via.to_layer,
+      srj.layerCount,
+    )
+    const viaRadius = (via.via_diameter ?? viaDimensions.padDiameter) / 2
+
+    for (const obstacle of staticObstacles) {
+      if (obstacle.isCopperPour) continue
+      if (!layersOverlap(viaLayers, obstacle.layers)) continue
+      if (obstacleIsConnected(trace, obstacle)) continue
+      if (
+        pointToRotatedRectDistance(via, obstacle) <
+        viaRadius + obstacleClearance
+      ) {
+        return `Generated through via for ${trace.connection_name} at (${via.x}, ${via.y}) collides with obstacle ${obstacle.obstacleId ?? "without an id"} on ${obstacle.layers.join(", ")}`
+      }
+    }
+
+    for (const jumperPad of jumperPads) {
+      if (!viaLayers.includes(jumperPad.layer)) continue
+      if (tracesAreConnected(trace, jumperPad.trace)) continue
+      if (
+        pointToRotatedRectDistance(via, jumperPad) <
+        viaRadius + obstacleClearance
+      ) {
+        return `Generated through via for ${trace.connection_name} at (${via.x}, ${via.y}) collides with jumper pad on trace ${jumperPad.trace.pcb_trace_id} on ${jumperPad.layer}`
+      }
+    }
+
+    for (const segment of traceSegments) {
+      if (!layersOverlap(viaLayers, segment.layers)) continue
+      if (tracesAreConnected(trace, segment.trace)) continue
+      if (
+        pointToSegmentDistance(via, segment.start, segment.end) <
+        viaRadius + segment.width / 2 + traceClearance
+      ) {
+        return `Generated through via for ${trace.connection_name} at (${via.x}, ${via.y}) collides with trace ${segment.trace.pcb_trace_id} on ${segment.layers.join(", ")}`
+      }
+    }
+
+    for (const otherVia of allVias) {
+      if (otherVia.trace === trace && otherVia.routeIndex === routeIndex)
+        continue
+      if (tracesAreConnected(trace, otherVia.trace)) continue
+      const otherViaLayers = getLayersBetween(
+        otherVia.via.from_layer,
+        otherVia.via.to_layer,
+        srj.layerCount,
+      )
+      if (!layersOverlap(viaLayers, otherViaLayers)) continue
+      const otherRadius =
+        (otherVia.via.via_diameter ?? viaDimensions.padDiameter) / 2
+      if (
+        Math.hypot(via.x - otherVia.via.x, via.y - otherVia.via.y) <
+        viaRadius + otherRadius + traceClearance
+      ) {
+        return `Generated through via for ${trace.connection_name} at (${via.x}, ${via.y}) collides with via on trace ${otherVia.trace.pcb_trace_id}`
+      }
+    }
+  }
+
+  return null
+}

--- a/lib/utils/materializeAndValidateGeneratedThroughVias.ts
+++ b/lib/utils/materializeAndValidateGeneratedThroughVias.ts
@@ -1,0 +1,37 @@
+import type { SimpleRouteJson, SimplifiedPcbTraces } from "lib/types"
+import { getGeneratedThroughViaCollision } from "lib/utils/getGeneratedThroughViaCollision"
+import { materializeGeneratedThroughVias } from "lib/utils/materializeGeneratedThroughVias"
+
+export const materializeAndValidateGeneratedThroughVias = ({
+  srj,
+  outputTraces,
+}: {
+  srj: SimpleRouteJson
+  outputTraces: SimplifiedPcbTraces
+}): SimplifiedPcbTraces => {
+  const preservedInputTraces = srj.traces ?? []
+  const materializedTraces = materializeGeneratedThroughVias({
+    inputTraces: preservedInputTraces,
+    outputTraces,
+    layerCount: srj.layerCount,
+    allowBlindAndBuriedVias: srj.allowBlindAndBuriedVias,
+  })
+  const supersededTraceIds = new Set(
+    materializedTraces.flatMap((trace) => [
+      trace.pcb_trace_id,
+      ...(trace.__replaces_pcb_trace_id ? [trace.__replaces_pcb_trace_id] : []),
+    ]),
+  )
+  const preservedGeometry = preservedInputTraces.filter(
+    (trace) => !supersededTraceIds.has(trace.pcb_trace_id),
+  )
+  const collisionTraces = [...preservedGeometry, ...materializedTraces]
+  const collision = getGeneratedThroughViaCollision({
+    srj: { ...srj, traces: collisionTraces },
+    preservedInputTraces,
+    outputTraces: materializedTraces,
+    collisionTraces,
+  })
+  if (collision) throw new Error(collision)
+  return materializedTraces
+}

--- a/lib/utils/materializeGeneratedThroughVias.ts
+++ b/lib/utils/materializeGeneratedThroughVias.ts
@@ -1,0 +1,134 @@
+import type { SimplifiedPcbTrace, SimplifiedPcbTraces } from "lib/types"
+import { mapZToLayerName } from "lib/utils/mapZToLayerName"
+
+type RoutePoint = SimplifiedPcbTrace["route"][number]
+export type ViaRoutePoint = Extract<RoutePoint, { route_type: "via" }>
+
+export type GeneratedViaRef = {
+  trace: SimplifiedPcbTrace
+  routeIndex: number
+  via: ViaRoutePoint
+}
+
+export const shouldUseThroughVias = (
+  allowBlindAndBuriedVias: boolean | undefined,
+): boolean => {
+  if (allowBlindAndBuriedVias === undefined) return false
+  if (allowBlindAndBuriedVias === true) return false
+  if (allowBlindAndBuriedVias === false) return true
+  throw new Error("allowBlindAndBuriedVias must be a boolean when provided")
+}
+
+const getViaIdentity = (via: ViaRoutePoint): string =>
+  JSON.stringify([
+    via.x,
+    via.y,
+    via.from_layer,
+    via.to_layer,
+    via.via_diameter ?? null,
+    via.via_hole_diameter ?? null,
+  ])
+
+const getInputViaCountsByTraceId = (
+  inputTraces: ReadonlyArray<SimplifiedPcbTrace>,
+): Map<string, Map<string, number>> => {
+  const countsByTraceId = new Map<string, Map<string, number>>()
+  for (const trace of inputTraces) {
+    const counts = countsByTraceId.get(trace.pcb_trace_id) ?? new Map()
+    for (const routePoint of trace.route) {
+      if (routePoint.route_type !== "via") continue
+      const identity = getViaIdentity(routePoint)
+      counts.set(identity, (counts.get(identity) ?? 0) + 1)
+    }
+    countsByTraceId.set(trace.pcb_trace_id, counts)
+  }
+  return countsByTraceId
+}
+
+const consumeMatchingInputVia = ({
+  trace,
+  via,
+  inputViaCountsByTraceId,
+}: {
+  trace: SimplifiedPcbTrace
+  via: ViaRoutePoint
+  inputViaCountsByTraceId: Map<string, Map<string, number>>
+}): boolean => {
+  const identity = getViaIdentity(via)
+  const candidateTraceIds = [
+    trace.pcb_trace_id,
+    trace.__replaces_pcb_trace_id,
+  ].filter((traceId): traceId is string => traceId !== undefined)
+
+  for (const traceId of candidateTraceIds) {
+    const counts = inputViaCountsByTraceId.get(traceId)
+    const count = counts?.get(identity) ?? 0
+    if (count === 0) continue
+    counts!.set(identity, count - 1)
+    return true
+  }
+  return false
+}
+
+export const getGeneratedViaRefs = ({
+  inputTraces,
+  outputTraces,
+}: {
+  inputTraces: ReadonlyArray<SimplifiedPcbTrace>
+  outputTraces: ReadonlyArray<SimplifiedPcbTrace>
+}): GeneratedViaRef[] => {
+  const inputViaCountsByTraceId = getInputViaCountsByTraceId(inputTraces)
+  const generatedVias: GeneratedViaRef[] = []
+  for (const trace of outputTraces) {
+    for (const [routeIndex, routePoint] of trace.route.entries()) {
+      if (routePoint.route_type !== "via") continue
+      if (
+        consumeMatchingInputVia({
+          trace,
+          via: routePoint,
+          inputViaCountsByTraceId,
+        })
+      ) {
+        continue
+      }
+      generatedVias.push({ trace, routeIndex, via: routePoint })
+    }
+  }
+  return generatedVias
+}
+
+export const materializeGeneratedThroughVias = ({
+  inputTraces,
+  outputTraces,
+  layerCount,
+  allowBlindAndBuriedVias,
+}: {
+  inputTraces: ReadonlyArray<SimplifiedPcbTrace>
+  outputTraces: SimplifiedPcbTraces
+  layerCount: number
+  allowBlindAndBuriedVias: boolean | undefined
+}): SimplifiedPcbTraces => {
+  if (!shouldUseThroughVias(allowBlindAndBuriedVias)) return outputTraces
+
+  const generatedViaIndexesByTrace = new Map<SimplifiedPcbTrace, Set<number>>()
+  for (const { trace, routeIndex } of getGeneratedViaRefs({
+    inputTraces,
+    outputTraces,
+  })) {
+    const routeIndexes = generatedViaIndexesByTrace.get(trace) ?? new Set()
+    routeIndexes.add(routeIndex)
+    generatedViaIndexesByTrace.set(trace, routeIndexes)
+  }
+  const fromLayer = mapZToLayerName(0, layerCount)
+  const toLayer = mapZToLayerName(layerCount - 1, layerCount)
+
+  return outputTraces.map((trace) => ({
+    ...trace,
+    route: trace.route.map((routePoint, routeIndex) =>
+      routePoint.route_type === "via" &&
+      generatedViaIndexesByTrace.get(trace)?.has(routeIndex)
+        ? { ...routePoint, from_layer: fromLayer, to_layer: toLayer }
+        : routePoint,
+    ),
+  }))
+}

--- a/tests/features/allow-blind-and-buried-vias.test.ts
+++ b/tests/features/allow-blind-and-buried-vias.test.ts
@@ -1,0 +1,109 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { convertPipeline7HdRoutesToSimplifiedPcbTraces } from "lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/convertPipeline7HdRoutesToSimplifiedPcbTraces"
+import type { SimplifiedPcbTraces } from "lib/types"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+import { convertHdRouteToSimplifiedRoute } from "lib/utils/convertHdRouteToSimplifiedRoute"
+import { getObstaclesFromSrjTraces } from "lib/utils/convertSrjTracesToObstacles"
+
+test("four-layer output allows partial spans unless blind and buried vias are disabled", () => {
+  const highDensityRoute: HighDensityRoute = {
+    connectionName: "SIGNAL",
+    traceThickness: 0.15,
+    viaDiameter: 0.45,
+    route: [
+      { x: -3, y: 0, z: 0 },
+      { x: -1, y: 0, z: 0 },
+      { x: -1, y: 0, z: 1 },
+      { x: 1, y: 0, z: 1 },
+      { x: 1, y: 0, z: 2 },
+      { x: 3, y: 0, z: 2 },
+    ],
+    vias: [
+      { x: -1, y: 0 },
+      { x: 1, y: 0 },
+    ],
+  }
+  const getPipelineOutput = (
+    allowBlindAndBuriedVias?: boolean,
+  ): {
+    traces: SimplifiedPcbTraces
+    viaSpans: Array<[string, string]>
+  } => {
+    const traces = convertPipeline7HdRoutesToSimplifiedPcbTraces({
+      connections: [
+        {
+          name: "SIGNAL",
+          pointsToConnect: [
+            { x: -3, y: 0, layer: "top" },
+            { x: 3, y: 0, layer: "inner2" },
+          ],
+        },
+      ],
+      originalConnections: [],
+      hdRoutes: [highDensityRoute],
+      layerCount: 4,
+      obstacles: [],
+      defaultViaHoleDiameter: 0.3,
+      connMap: new ConnectivityMap({}),
+      allowBlindAndBuriedVias,
+    })
+    const viaSpans = traces[0]!.route.flatMap((segment) =>
+      segment.route_type === "via"
+        ? [[segment.from_layer, segment.to_layer] as [string, string]]
+        : [],
+    )
+
+    return { traces, viaSpans }
+  }
+
+  const legacySpans: Array<[string, string]> = [
+    ["top", "inner1"],
+    ["inner1", "inner2"],
+  ]
+  const legacyOutput = getPipelineOutput()
+  expect(legacyOutput.viaSpans).toEqual(legacySpans)
+  expect(getPipelineOutput(true)).toEqual(legacyOutput)
+  const throughViaOutput = getPipelineOutput(false)
+  expect(throughViaOutput.viaSpans).toEqual([
+    ["top", "bottom"],
+    ["top", "bottom"],
+  ])
+  const viaObstacle = getObstaclesFromSrjTraces({
+    layerCount: 4,
+    minTraceWidth: 0.15,
+    obstacles: [],
+    connections: [],
+    bounds: { minX: -4, maxX: 4, minY: -1, maxY: 1 },
+    traces: throughViaOutput.traces,
+  }).find((obstacle) => obstacle.obstacleId?.endsWith("_via"))
+  expect(viaObstacle?.layers).toEqual(["top", "inner1", "inner2", "bottom"])
+
+  const terminalRoute = convertHdRouteToSimplifiedRoute(
+    {
+      connectionName: "TERMINAL_SIGNAL",
+      traceThickness: 0.15,
+      viaDiameter: 0.45,
+      route: [
+        { x: -3, y: -1, z: 1 },
+        { x: 3, y: -1, z: 1 },
+      ],
+      vias: [],
+    },
+    4,
+    {
+      connectionPoints: [
+        {
+          x: -3,
+          y: -1,
+          layer: "inner1",
+          terminalVia: { toLayer: "top" },
+        },
+      ],
+      allowBlindAndBuriedVias: false,
+    },
+  )
+  expect(
+    terminalRoute.find((segment) => segment.route_type === "via"),
+  ).toMatchObject({ from_layer: "top", to_layer: "bottom" })
+})

--- a/tests/features/disallow-blind-buried-vias-all-native-output-paths.test.ts
+++ b/tests/features/disallow-blind-buried-vias-all-native-output-paths.test.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "bun:test"
+import { AssignableAutoroutingPipeline1Solver } from "lib/autorouter-pipelines/AssignableAutoroutingPipeline1/AssignableAutoroutingPipeline1Solver"
+import { AssignableAutoroutingPipeline2 } from "lib/autorouter-pipelines/AssignableAutoroutingPipeline2/AssignableAutoroutingPipeline2"
+import { AssignableAutoroutingPipeline3 } from "lib/autorouter-pipelines/AssignableAutoroutingPipeline3/AssignableAutoroutingPipeline3"
+import { AutoroutingPipeline1_OriginalUnravel } from "lib/autorouter-pipelines/AutoroutingPipeline1_OriginalUnravel/AutoroutingPipeline1_OriginalUnravel"
+import { AutoroutingPipelineSolver2_PortPointPathing } from "lib/autorouter-pipelines/AutoroutingPipeline2_PortPointPathing/AutoroutingPipelineSolver2_PortPointPathing"
+import { AutoroutingPipelineSolver3_HgPortPointPathing } from "lib/autorouter-pipelines/AutoroutingPipeline3_HgPortPointPathing/AutoroutingPipelineSolver3_HgPortPointPathing"
+import { AutoroutingPipelineSolver4_TinyHypergraph } from "lib/autorouter-pipelines/AutoroutingPipeline4_TinyHypergraph/AutoroutingPipelineSolver4_TinyHypergraph"
+import { AutoroutingPipelineSolver6_PolyHypergraph } from "lib/autorouter-pipelines/AutoroutingPipeline6_PolyHypergraph/AutoroutingPipelineSolver6_PolyHypergraph"
+import { AutoroutingPipelineSolver7_MultiGraph } from "lib/autorouter-pipelines/AutoroutingPipeline7_MultiGraph/AutoroutingPipelineSolver7_MultiGraph"
+import { AutoroutingPipelineSolver8 } from "lib/autorouter-pipelines/AutoroutingPipeline8/AutoroutingPipelineSolver8"
+import type { BaseSolver } from "lib/solvers/BaseSolver"
+import type { SimpleRouteJson } from "lib/types"
+import type { HighDensityRoute } from "lib/types/high-density-types"
+
+type PipelineConstructor = new (
+  srj: SimpleRouteJson,
+  options: { cacheProvider: null },
+) => BaseSolver
+
+test("every native output path rejects a generated through via crossing inner copper", () => {
+  const input: SimpleRouteJson = {
+    layerCount: 4,
+    allowBlindAndBuriedVias: false,
+    bounds: { minX: -1, maxX: 4, minY: -1, maxY: 1 },
+    minTraceWidth: 0.15,
+    minViaDiameter: 0.5,
+    obstacles: [
+      {
+        type: "rect",
+        layers: ["inner2"],
+        center: { x: 1.5, y: 0 },
+        width: 0.8,
+        height: 0.8,
+        connectedTo: [],
+        obstacleId: "inner2-blocker",
+      },
+    ],
+    connections: [
+      {
+        name: "SIG",
+        pointsToConnect: [
+          { x: 0, y: 0, layer: "top" },
+          { x: 3, y: 0, layer: "inner1" },
+        ],
+      },
+    ],
+  }
+  const generatedRoute: HighDensityRoute = {
+    connectionName: "SIG",
+    traceThickness: 0.15,
+    viaDiameter: 0.5,
+    route: [
+      { x: 0, y: 0, z: 0 },
+      { x: 1.5, y: 0, z: 0 },
+      { x: 1.5, y: 0, z: 1 },
+      { x: 3, y: 0, z: 1 },
+    ],
+    vias: [{ x: 1.5, y: 0 }],
+  }
+  const pipelineConstructors: Array<[string, PipelineConstructor]> = [
+    ["Assignable 1", AssignableAutoroutingPipeline1Solver],
+    ["Assignable 2", AssignableAutoroutingPipeline2],
+    ["Assignable 3", AssignableAutoroutingPipeline3],
+    ["Pipeline 1", AutoroutingPipeline1_OriginalUnravel],
+    ["Pipeline 2", AutoroutingPipelineSolver2_PortPointPathing],
+    ["Pipeline 3", AutoroutingPipelineSolver3_HgPortPointPathing],
+    ["Pipeline 4", AutoroutingPipelineSolver4_TinyHypergraph],
+    ["Pipeline 6", AutoroutingPipelineSolver6_PolyHypergraph],
+    ["Pipeline 7", AutoroutingPipelineSolver7_MultiGraph],
+    ["Pipeline 8", AutoroutingPipelineSolver8],
+  ]
+
+  for (const [name, Pipeline] of pipelineConstructors) {
+    const pipeline = new Pipeline(structuredClone(input), {
+      cacheProvider: null,
+    }) as BaseSolver & {
+      highDensityRouteSolver: object
+      netToPointPairsSolver: object
+      srjWithPointPairs: object
+      _getOutputHdRoutes: () => HighDensityRoute[]
+      getOutputSimplifiedPcbTraces: () => unknown
+    }
+    pipeline.solved = true
+    pipeline.highDensityRouteSolver = {}
+    pipeline.netToPointPairsSolver = {
+      newConnections: structuredClone(input.connections),
+    }
+    pipeline.srjWithPointPairs = {
+      connections: structuredClone(input.connections),
+    }
+    pipeline._getOutputHdRoutes = () => [generatedRoute]
+
+    expect(
+      () => pipeline.getOutputSimplifiedPcbTraces(),
+      `${name} emitted an unsafe physical through via`,
+    ).toThrow("collides with obstacle inner2-blocker on inner2")
+  }
+})

--- a/tests/utils/materialize-generated-through-vias.test.ts
+++ b/tests/utils/materialize-generated-through-vias.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "bun:test"
+import type { SimplifiedPcbTraces } from "lib/types"
+import {
+  materializeGeneratedThroughVias,
+  shouldUseThroughVias,
+} from "lib/utils/materializeGeneratedThroughVias"
+
+test("omitted or true allowBlindAndBuriedVias keeps generated partial spans", () => {
+  expect(shouldUseThroughVias(undefined)).toBe(false)
+  expect(shouldUseThroughVias(true)).toBe(false)
+  expect(shouldUseThroughVias(false)).toBe(true)
+  expect(() => shouldUseThroughVias("yes" as unknown as boolean)).toThrow(
+    "allowBlindAndBuriedVias must be a boolean when provided",
+  )
+})
+
+test("false rewrites generated vias to the full board stack and preserves authored spans", () => {
+  const authored: SimplifiedPcbTraces = [
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "authored",
+      connection_name: "SIG",
+      route: [
+        {
+          route_type: "via",
+          x: 0,
+          y: 0,
+          from_layer: "top",
+          to_layer: "inner1",
+        },
+      ],
+    },
+  ]
+  const output: SimplifiedPcbTraces = [
+    ...authored,
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "generated",
+      connection_name: "SIG",
+      route: [
+        {
+          route_type: "via",
+          x: 2,
+          y: 0,
+          from_layer: "top",
+          to_layer: "inner1",
+        },
+      ],
+    },
+  ]
+
+  const materialized = materializeGeneratedThroughVias({
+    inputTraces: authored,
+    outputTraces: output,
+    layerCount: 4,
+    allowBlindAndBuriedVias: false,
+  })
+
+  expect(materialized[0]!.route[0]).toMatchObject({
+    from_layer: "top",
+    to_layer: "inner1",
+  })
+  expect(materialized[1]!.route[0]).toMatchObject({
+    from_layer: "top",
+    to_layer: "bottom",
+  })
+})


### PR DESCRIPTION
## Summary

Fixes https://github.com/tscircuit/tscircuit-autorouter/issues/2156.

Ordinary `<board layers={4}>` routing was emitting F.Cu–In1 / In1–B.Cu style vias even when the board never opted into blind/buried fabrication. Core already sends `allowBlindAndBuriedVias: false` on Simple Route JSON; this repo ignored the field.

- Add `allowBlindAndBuriedVias?: boolean` to Simple Route JSON. Omission or `true` keeps standalone legacy partial-span behavior.
- Explicit `false` materializes **generated** vias as `top`↔`bottom` PTH barrels (authored input vias are left unchanged).
- Fail closed if a generated through via would collide with unrelated copper, jumper pads, or other vias.
- Wire the policy through HD-route conversion, Pipeline 7 (the default), other native/Assignable output paths, Pipeline 9 replacements, power-trace expansion, and Pipeline 11 simplification.

This is the remaining autorouter half of the board-facing default described on #2156. The earlier implementation in #2200 was closed before landing; this ports the output-boundary behavior onto current main.

## Test plan

- [x] `bun test tests/utils/materialize-generated-through-vias.test.ts`
- [x] `bun test tests/features/allow-blind-and-buried-vias.test.ts`
- [x] `bun test tests/features/disallow-blind-buried-vias-all-native-output-paths.test.ts`
- [x] `bun test tests/utils/convertHdRouteToSimplifiedRoute.test.ts tests/via-span-reference-drc.test.ts`