### PR TITLE
Compute Pipeline9 node probabilities from one pathing output

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/AutoroutingPipelineSolver9_PreloadedTraceGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/AutoroutingPipelineSolver9_PreloadedTraceGraph.ts
@@ -622,12 +622,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
             viaToPadClearance: cms.srj.minViaEdgeToPadEdgeClearance,
             effort: cms.effort,
             includeBoardObstacles: true,
-            nodePfById: new Map(
-              portPointPathingOutput.inputNodeWithPortPoints.map((node) => [
-                node.capacityMeshNodeId,
-                portPointPathingSolver.computeNodePf(node),
-              ]),
-            ),
+            nodePfById: portPointPathingSolver.computeNodePfMap(),
             preserveTerminalPcbPortIds: true,
           },
         ]

--- a/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
+++ b/lib/solvers/PortPointPathingSolver/tinyhypergraph/TinyHypergraphPortPointPathingSolver.ts
@@ -1722,7 +1722,32 @@ export class TinyHypergraphPortPointPathingSolver extends BaseSolver {
     const solvedNode = this.getOutput().nodesWithPortPoints.find(
       (candidate) => candidate.capacityMeshNodeId === node.capacityMeshNodeId,
     )
-    const originalRegion = this.originalRegionById.get(node.capacityMeshNodeId)
+    return this.computeSolvedNodePf(node.capacityMeshNodeId, solvedNode)
+  }
+
+  computeNodePfMap(): Map<string, number | null> {
+    const solvedNodeById = new Map(
+      this.getOutput().nodesWithPortPoints.map((node) => [
+        node.capacityMeshNodeId,
+        node,
+      ]),
+    )
+    return new Map(
+      this.inputNodeWithPortPoints.map((node) => [
+        node.capacityMeshNodeId,
+        this.computeSolvedNodePf(
+          node.capacityMeshNodeId,
+          solvedNodeById.get(node.capacityMeshNodeId),
+        ),
+      ]),
+    )
+  }
+
+  private computeSolvedNodePf(
+    capacityMeshNodeId: string,
+    solvedNode: NodeWithPortPoints | undefined,
+  ): number | null {
+    const originalRegion = this.originalRegionById.get(capacityMeshNodeId)
 
     if (!solvedNode || !originalRegion) {
       return null

--- a/tests/features/pipeline9-node-probabilities-reuse-pathing-output.test.ts
+++ b/tests/features/pipeline9-node-probabilities-reuse-pathing-output.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/AutoroutingPipelineSolver9_PreloadedTraceGraph"
+
+test("Pipeline9 computes every node probability from one pathing output", (): void => {
+  const solver = new AutoroutingPipelineSolver9_PreloadedTraceGraph({
+    layerCount: 2,
+    minTraceWidth: 0.1,
+    bounds: { minX: -5, minY: -5, maxX: 5, maxY: 5 },
+    obstacles: [
+      {
+        type: "rect",
+        center: { x: 0, y: 0 },
+        width: 1,
+        height: 1,
+        layers: ["top", "bottom"],
+        connectedTo: [],
+      },
+    ],
+    connections: [
+      {
+        name: "horizontal",
+        pointsToConnect: [
+          { x: -4, y: 0, layer: "top" },
+          { x: 4, y: 0, layer: "top" },
+        ],
+      },
+      {
+        name: "vertical",
+        pointsToConnect: [
+          { x: 0, y: -4, layer: "top" },
+          { x: 0, y: 4, layer: "top" },
+        ],
+      },
+    ],
+  })
+  solver.solveUntilPhase("highDensityRouteSolver")
+  expect(solver.failed).toBe(false)
+  const pathingSolver = solver.portPointPathingSolver!
+  expect(pathingSolver.solved).toBe(true)
+  const inputNodes = pathingSolver.getOutput().inputNodeWithPortPoints
+  const expected = new Map(
+    inputNodes.map((node) => [
+      node.capacityMeshNodeId,
+      pathingSolver.computeNodePf(node),
+    ]),
+  )
+  expect(expected.size).toBeGreaterThan(1)
+  expect([...expected.values()].some((value) => value !== null)).toBe(true)
+
+  const getOutput = pathingSolver.getOutput.bind(pathingSolver)
+  let outputConversions = 0
+  pathingSolver.getOutput = (): ReturnType<typeof getOutput> => {
+    outputConversions += 1
+    return getOutput()
+  }
+  const probabilities = pathingSolver.computeNodePfMap()
+  expect(probabilities).toEqual(expected)
+  expect(outputConversions).toBe(1)
+})


### PR DESCRIPTION
Pipeline9 calculates each high-density node's failure probability by rebuilding the complete pathing output for every input node. Large boards repeatedly pay for identical route conversion and lookup work before high-density routing starts.

Build the solved-node lookup once and calculate every probability from that output. This distills one performance improvement from #2447 into three files. Probability formulas, pipeline stages, dependency versions, clearances, and search budgets are unchanged.

The [same-machine SRJ18 comparison](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/34308681211) runs `/benchmark --same-machine --dataset 18` on main `207c4191` and this PR's `c4d639eb` sequentially on one runner:

| Measurement | Main | PR |
| --- | ---: | ---: |
| DRC passing | 9/16 (56.3%) | 10/16 (62.5%) |
| Completion | 11/16 (68.8%) | 12/16 (75.0%) |
| Timeouts | 3 | 2 |
| Total sample time | 3034.1s | 2732.0s (-10.0%) |
| P50 time | 143.3s | 128.8s (-10.1%) |
| P80 time | 348.8s | 300.6s (-13.8%) |
| P95 time | 360.0s | 360.0s |

Sample 12 changes from a 360-second timeout to DRC passing in 346.5s. There are no regressed outcomes. All 11 samples that complete on both revisions retain identical DRC messages and via counts. These rates describe this paired run; the quality gain comes from completing an existing route within the unchanged deadline.

Validation: all CI checks pass, including the full test suite, TypeScript, and production build. The generic regression verifies identical node probabilities with one output conversion. A separate full native sample 6 comparison preserves every route, reference DRC result, and non-timing solver statistic while reducing runtime from 300.9s to 265.0s (-11.9%).
