### PR TITLE
Avoid duplicate net lookups during DRC repair

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "zdwiel-dataset": "git+https://github.com/dwiel/tscircuit-benchmark.git#be36518b5bf51755dae92c230061ab3cf4e3e063",
     "high-density-repair01": "git+https://github.com/tscircuit/high-density-repair01.git#01f9fe901ac6f691c325bb25d993f52d916a98a1",
     "high-density-repair02": "https://codeload.github.com/tscircuit/high-density-repair02/tar.gz/eba02dae55f156990e23fac0108a620c8021f47b",
-    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#37d2b7af008c3a79c1a794e2ca307583a0f19c98",
+    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#fd77be86b949a8de03d529b1e21aaf58a540350a",
     "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d",
     "@tscircuit/high-density-b01": "git+https://github.com/tscircuit/high-density-b01.git#e651cab6c314e7aab6df31fd6067277436f67148"
   },


### PR DESCRIPTION
## Summary

Avoid duplicate net lookups during DRC repair by pinning `high-density-repair03` to `fd77be86b949a8de03d529b1e21aaf58a540350a`.

The pinned commit is the existing dependency revision `37d2b7af008c3a79c1a794e2ca307583a0f19c98` plus one focused change: fetch each net ID once in `sharesNet`. Existing repair behavior and fixes are preserved; no routing-policy, search-budget, or DRC-rule changes.

Only one dependency line changes. No solver files, tests, or benchmark tooling are added.

## Validation

- Installed the exact published Git pin in an isolated local validation directory and verified its complete `lib` source against the integration commit. Other consumer dependencies were reused locally; this is not a fresh full install.
- Five focused connectivity and Pipeline9 DRC tests pass.
- Production build, including TypeScript declaration generation, passes.
- Diff whitespace check passes. Local formatting was not run, following repository instructions.

## Performance evidence

An earlier same-machine Pipeline9 comparison on autorouter main `d1e664f2`, using the same repair03 source change, measured SRJ18 **sample 8 only**, three runs per version:

| Median | Main | With change | Reduction |
| --- | ---: | ---: | ---: |
| Pipeline solve | 62.780 s | 56.753 s | 9.60% |
| Joint repair | 24.484 s | 19.703 s | 19.53% |

All six runs completed with identical routing output, 0 DRC errors, and 315 vias. These are prior local measurements, not full-suite results for the dependency pin. Full SRJ18 regression and performance validation remains pending.
