### PR TITLE
Isolate native A11 integration in the solver portfolio

### DIFF
--- a/lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver/GrowShrinkHighDensityIntraNodeSolver.ts
+++ b/lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver/GrowShrinkHighDensityIntraNodeSolver.ts
@@ -16,6 +16,15 @@ type PortfolioSingleIntraNodeSolverParams = ConstructorParameters<
   typeof PortfolioSingleIntraNodeSolver
 >[0]
 
+// Scaled retries keep the existing coarse portfolio; A11 is native-only.
+class ScaledPortfolioSingleIntraNodeSolver extends PortfolioSingleIntraNodeSolver {
+  override getCombinationDefs(): string[][] {
+    return super
+      .getCombinationDefs()
+      .filter((combination) => !combination.includes("highDensityA11"))
+  }
+}
+
 export const DEFAULT_MAX_GROWTH_ATTEMPTS = 3
 
 export type GrowShrinkHighDensityIntraNodeSolverParams =
@@ -152,7 +161,11 @@ export class GrowShrinkHighDensityIntraNodeSolver extends BaseSolver {
   private createActiveSubSolver() {
     const { growShrinkSolutionValidator: _, ...portfolioParams } =
       this.constructorParams
-    this.activeSubSolver = new PortfolioSingleIntraNodeSolver({
+    const PortfolioSolver =
+      this.scaleFactor === 1
+        ? PortfolioSingleIntraNodeSolver
+        : ScaledPortfolioSingleIntraNodeSolver
+    this.activeSubSolver = new PortfolioSolver({
       ...portfolioParams,
       nodeWithPortPoints: scaleNodeWithPortPoints(
         this.nodeWithPortPoints,

--- a/lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver.ts
+++ b/lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver.ts
@@ -1,6 +1,8 @@
 import {
   HighDensitySolverA03 as HighDensityA03Solver,
   HighDensitySolverA01,
+  HighDensitySolverA11,
+  getRouteGeometryViolationError,
 } from "@tscircuit/high-density-a01"
 import { ConnectivityMap } from "circuit-json-to-connectivity-map"
 import {
@@ -20,24 +22,44 @@ import {
   HyperParameterSupervisorSolver,
   SupervisedSolver,
 } from "../HyperParameterSupervisorSolver"
-import { repairDisconnectedSameRootPortPoints } from "./repairDisconnectedSameRootPortPoints"
+import {
+  doRoutesCoverNodePortPointPairsExactlyOnce,
+  repairDisconnectedSameRootPortPoints,
+} from "./repairDisconnectedSameRootPortPoints"
 
 // Match the existing six-ordering portfolio used by the other intra-node
 // solver. The first ordering remains in the normal portfolio; the remaining
 // orderings are introduced only after that portfolio spends its dynamically
 // derived exploration budget or exhausts all of its candidates.
 const ORDERING_SHUFFLE_SEEDS = Array.from({ length: 6 }, (_, seed) => seed)
+const NATIVE_GRID_BOUNDS_TOLERANCE_MM = 1e-9
 
-/** Coordinates a fitness-scheduled portfolio of intra-node routing solvers. */
-export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolver<
+type ExternalGridSolver =
+  | HighDensitySolverA01
+  | HighDensityA03Solver
+  | HighDensitySolverA11
+
+type PortfolioCandidateSolver =
   | IntraNodeRouteSolver
   | TwoCrossingRoutesHighDensitySolver
   | SingleTransitionCrossingRouteSolver
   | SingleTransitionIntraNodeSolver
   | SingleTransitionThroughObstacleIntraNodeSolver
   | SingleLayerNoDifferentRootIntersectionsIntraNodeSolver
-  | HighDensityA03Solver
-> {
+  | MultiHeadPolyLineIntraNodeSolver3
+  | ExternalGridSolver
+
+function isExternalGridSolver(
+  solver: PortfolioCandidateSolver,
+): solver is ExternalGridSolver {
+  return (
+    solver instanceof HighDensitySolverA01 ||
+    solver instanceof HighDensityA03Solver
+  )
+}
+
+/** Coordinates a fitness-scheduled portfolio of intra-node routing solvers. */
+export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolver<PortfolioCandidateSolver> {
   override getSolverName(): string {
     return "PortfolioSingleIntraNodeSolver"
   }
@@ -49,12 +71,14 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
   effort: number
   adaptiveSearchExpanded = false
 
-  private getSolvedSegmentCount(solver: unknown): number | null {
-    const solvedConnectionsMap = (solver as any).solvedConnectionsMap
-    if (!(solvedConnectionsMap instanceof Map)) return null
+  private getSolvedSegmentCount(
+    solver: PortfolioCandidateSolver,
+  ): number | null {
+    if (!isExternalGridSolver(solver)) return null
+    if (!solver._setupDone) return null
 
     let solvedSegmentCount = 0
-    for (const routes of solvedConnectionsMap.values()) {
+    for (const routes of solver.solvedConnectionsMap.values()) {
       if (Array.isArray(routes)) solvedSegmentCount += routes.length
     }
     return solvedSegmentCount
@@ -72,7 +96,10 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
     )
   }
 
-  private getCandidateProgress(solver: { progress: number }): number {
+  private getCandidateProgress(solver: PortfolioCandidateSolver): number {
+    // Setup can reject an ineligible candidate before allocating route state.
+    // Failed candidates have no usable progress and are excluded by scheduling.
+    if (solver.failed) return 0
     const solvedSegmentCount = this.getSolvedSegmentCount(solver)
     if (solvedSegmentCount !== null) {
       return Math.min(1, solvedSegmentCount / this.getNodeSegmentCount())
@@ -94,9 +121,9 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
     // to fail or introducing a wall-clock iteration constant.
     return Math.max(
       1,
-      ...(this.supervisedSolvers ?? []).map(
-        ({ solver }) => solver.MAX_ITERATIONS,
-      ),
+      ...(this.supervisedSolvers ?? [])
+        .filter(({ solver }) => !solver.failed)
+        .map(({ solver }) => solver.MAX_ITERATIONS),
     )
   }
 
@@ -128,6 +155,7 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
       // ["closedFormTwoTrace"],
       ["highDensityA01"],
       ["highDensityA03"],
+      ["highDensityA11"],
     ]
   }
 
@@ -266,6 +294,15 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
           },
         ],
       },
+      {
+        name: "highDensityA11",
+        possibleValues: [
+          {
+            HIGH_DENSITY_A11: true,
+            SHUFFLE_SEED: ORDERING_SHUFFLE_SEEDS[0],
+          },
+        ],
+      },
     ]
   }
 
@@ -274,9 +311,8 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
    * their natural iteration budget from the problem. Running setup here does
    * not advance the solver or give it preference in the portfolio.
    */
-  private initializeCandidateBudget(solver: unknown) {
-    const setup = (solver as any).setup
-    if (typeof setup === "function") setup.call(solver)
+  private initializeCandidateBudget(solver: PortfolioCandidateSolver) {
+    if (isExternalGridSolver(solver)) solver.setup()
   }
 
   private refreshDynamicIterationLimit() {
@@ -372,17 +408,17 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
     }
   }
 
-  computeG(solver: IntraNodeRouteSolver) {
+  computeG(solver: PortfolioCandidateSolver) {
     if (
-      (solver as any) instanceof HighDensitySolverA01 ||
-      (solver as any) instanceof HighDensityA03Solver
+      solver instanceof HighDensitySolverA01 ||
+      solver instanceof HighDensityA03Solver
     ) {
-      return (solver as any).iterations / 1_000_000
+      return solver.iterations / 1_000_000
     }
-    if (solver?.hyperParameters?.MULTI_HEAD_POLYLINE_SOLVER) {
+    if (solver instanceof MultiHeadPolyLineIntraNodeSolver2) {
       return (
         1000 +
-        ((solver.hyperParameters?.ITERATION_PENALTY ?? 0) + solver.iterations) /
+        ((solver.hyperParameters.ITERATION_PENALTY ?? 0) + solver.iterations) /
           10_000 +
         10_000 * (solver.hyperParameters.SEGMENTS_PER_POLYLINE! - 3)
       )
@@ -392,14 +428,14 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
     )
   }
 
-  computeH(solver: IntraNodeRouteSolver) {
+  computeH(solver: PortfolioCandidateSolver) {
     if (this.adaptiveSearchExpanded) {
       return 1 - this.getCandidateProgress(solver)
     }
     return 1 - (solver.progress || 0)
   }
 
-  generateSolver(hyperParameters: any): IntraNodeRouteSolver {
+  generateSolver(hyperParameters: any): PortfolioCandidateSolver {
     if (hyperParameters.SINGLE_LAYER_NO_DIFFERENT_ROOT_INTERSECTIONS) {
       if (
         !SingleLayerNoDifferentRootIntersectionsIntraNodeSolver.isApplicable(
@@ -416,14 +452,14 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
         ineligibleSolver.failed = true
         ineligibleSolver.error =
           "Single-layer no-different-root-intersection solver not applicable"
-        return ineligibleSolver as any
+        return ineligibleSolver
       }
 
       return new SingleLayerNoDifferentRootIntersectionsIntraNodeSolver({
         nodeWithPortPoints: this.nodeWithPortPoints,
         traceWidth: this.constructorParams.traceWidth,
         viaDiameter: this.constructorParams.viaDiameter,
-      }) as any
+      })
     }
 
     if (hyperParameters.HIGH_DENSITY_A01) {
@@ -439,7 +475,7 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
           shuffleSeed: hyperParameters.SHUFFLE_SEED ?? 0,
         },
       })
-      return solver as any
+      return solver
     }
     if (hyperParameters.HIGH_DENSITY_A03) {
       const solver = new HighDensityA03Solver({
@@ -458,25 +494,39 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
         effort: this.effort,
         hyperParameters,
       })
-      return solver as any
+      return solver
+    }
+    if (hyperParameters.HIGH_DENSITY_A11) {
+      const solver = new HighDensitySolverA11({
+        nodeWithPortPoints: this.nodeWithPortPoints,
+        viaDiameter: this.constructorParams.viaDiameter ?? 0.3,
+        viaMinDistFromBorder: (this.constructorParams.viaDiameter ?? 0.3) / 2,
+        traceMargin: 0.1,
+        traceThickness: this.constructorParams.traceWidth ?? 0.15,
+        effort: this.effort,
+        hyperParameters: {
+          shuffleSeed: hyperParameters.SHUFFLE_SEED ?? 0,
+        },
+      })
+      return solver
     }
     if (hyperParameters.CLOSED_FORM_TWO_TRACE_SAME_LAYER) {
       return new TwoCrossingRoutesHighDensitySolver({
         nodeWithPortPoints: this.nodeWithPortPoints,
         viaDiameter: this.constructorParams.viaDiameter,
-      }) as any
+      })
     }
     if (hyperParameters.CLOSED_FORM_TWO_TRACE_TRANSITION_CROSSING) {
       return new SingleTransitionCrossingRouteSolver({
         nodeWithPortPoints: this.nodeWithPortPoints,
         viaDiameter: this.constructorParams.viaDiameter,
-      }) as any
+      })
     }
     if (hyperParameters.CLOSED_FORM_SINGLE_TRANSITION) {
       return new SingleTransitionIntraNodeSolver({
         nodeWithPortPoints: this.nodeWithPortPoints,
         viaDiameter: this.constructorParams.viaDiameter,
-      }) as any
+      })
     }
     if (hyperParameters.THROUGH_OBSTACLE) {
       return new SingleTransitionThroughObstacleIntraNodeSolver({
@@ -486,7 +536,7 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
         layerCount: this.constructorParams.layerCount,
         viaDiameter: this.constructorParams.viaDiameter,
         traceThickness: this.constructorParams.traceWidth,
-      }) as any
+      })
     }
     if (hyperParameters.MULTI_HEAD_POLYLINE_SOLVER) {
       return new MultiHeadPolyLineIntraNodeSolver3({
@@ -494,7 +544,7 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
         connMap: this.connMap,
         hyperParameters: hyperParameters,
         viaDiameter: this.constructorParams.viaDiameter,
-      }) as any
+      })
     }
     return new CachedIntraNodeRouteSolver({
       ...this.constructorParams,
@@ -502,15 +552,50 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
     })
   }
 
-  onSolve(solver: SupervisedSolver<IntraNodeRouteSolver>) {
+  onSolve(solver: SupervisedSolver<PortfolioCandidateSolver>) {
     let routes: HighDensityIntraNodeRoute[]
-    if (
-      (solver.solver as any) instanceof HighDensitySolverA01 ||
-      (solver.solver as any) instanceof HighDensityA03Solver
-    ) {
-      routes = (solver.solver as any).getOutput()
+    if (isExternalGridSolver(solver.solver)) {
+      routes = solver.solver.getOutput()
     } else {
       routes = solver.solver.solvedRoutes
+    }
+    if (solver.solver instanceof HighDensitySolverA11) {
+      // Validate native output before legacy metadata or alias repair can
+      // conceal a wrong net or duplicate a unique physical pair.
+      const { center, width, height } = this.nodeWithPortPoints
+      const availableZ = solver.solver.availableZ
+      for (const route of routes) {
+        for (const point of route.route) {
+          if (
+            !Number.isFinite(point.x) ||
+            !Number.isFinite(point.y) ||
+            !Number.isInteger(point.z) ||
+            point.z < 0 ||
+            !availableZ.includes(point.z) ||
+            Math.abs(point.x - center.x) >
+              width / 2 + NATIVE_GRID_BOUNDS_TOLERANCE_MM ||
+            Math.abs(point.y - center.y) >
+              height / 2 + NATIVE_GRID_BOUNDS_TOLERANCE_MM
+          ) {
+            throw new Error(
+              `${solver.solver.getSolverName()} output rejected: non-finite, out-of-bounds, or unavailable-layer route point in ${this.nodeWithPortPoints.capacityMeshNodeId}: ${JSON.stringify(point)}; node center ${JSON.stringify(center)}, width ${width}, height ${height}, layers ${availableZ.join(",")}`,
+            )
+          }
+        }
+      }
+      const geometryError = getRouteGeometryViolationError(routes)
+      const physicalPairCoverageIsValid =
+        doRoutesCoverNodePortPointPairsExactlyOnce(
+          routes,
+          this.nodeWithPortPoints,
+        )
+      if (geometryError || !physicalPairCoverageIsValid) {
+        throw new Error(
+          `${solver.solver.getSolverName()} output rejected: ${geometryError ?? "physical port-point pairs are not covered exactly once"}`,
+        )
+      }
+      this.solvedRoutes = routes
+      return
     }
     const routesWithRootConnectionNames = routes.map((route) => {
       const matchingPortPoint = this.nodeWithPortPoints.portPoints.find(

--- a/lib/solvers/HyperHighDensitySolver/repairDisconnectedSameRootPortPoints.ts
+++ b/lib/solvers/HyperHighDensitySolver/repairDisconnectedSameRootPortPoints.ts
@@ -5,6 +5,9 @@ import type {
 } from "lib/types/high-density-types"
 import { getConnectionPortPointPairs } from "lib/utils/getConnectionPortPointPairs"
 
+type PhysicalPairKey = string & { readonly __brand: "PhysicalPairKey" }
+type ConnectionName = PortPoint["connectionName"]
+
 const pointKey = (point: { x: number; y: number; z: number }) =>
   `${point.x.toFixed(6)},${point.y.toFixed(6)},${point.z}`
 
@@ -12,6 +15,78 @@ const routeEndpoints = (route: HighDensityIntraNodeRoute) => [
   route.route[0],
   route.route[route.route.length - 1],
 ]
+
+const getPhysicalPairKey = (
+  pair: readonly [
+    { x: number; y: number; z: number },
+    { x: number; y: number; z: number },
+  ],
+  rootConnectionName: string,
+): PhysicalPairKey => {
+  const endpointKeys = pair
+    .map((point) => JSON.stringify([point.x, point.y, point.z]))
+    .sort()
+  return JSON.stringify([rootConnectionName, endpointKeys]) as PhysicalPairKey
+}
+
+const getExpectedPhysicalPortPointPairs = (
+  nodeWithPortPoints: NodeWithPortPoints,
+): Array<[PortPoint, PortPoint]> => {
+  const explicitPairs = nodeWithPortPoints.portPointsInPairs ?? []
+  if (explicitPairs.length > 0) return explicitPairs
+
+  const connectionNames = new Set(
+    nodeWithPortPoints.portPoints.map((portPoint) => portPoint.connectionName),
+  )
+  return [...connectionNames].flatMap((connectionName) =>
+    getConnectionPortPointPairs(
+      nodeWithPortPoints.portPoints.filter(
+        (portPoint) => portPoint.connectionName === connectionName,
+      ),
+    ),
+  )
+}
+
+export const doRoutesCoverNodePortPointPairsExactlyOnce = (
+  routes: HighDensityIntraNodeRoute[],
+  nodeWithPortPoints: NodeWithPortPoints,
+): boolean => {
+  const remainingPairs = new Map<PhysicalPairKey, Set<ConnectionName>>()
+  for (const pair of getExpectedPhysicalPortPointPairs(nodeWithPortPoints)) {
+    const [start, end] = pair
+    const rootConnectionName = start.rootConnectionName ?? start.connectionName
+    if (
+      start.connectionName !== end.connectionName ||
+      rootConnectionName !== (end.rootConnectionName ?? end.connectionName) ||
+      pair.some((point) => ![point.x, point.y, point.z].every(Number.isFinite))
+    ) {
+      return false
+    }
+    const pairKey = getPhysicalPairKey(pair, rootConnectionName)
+    const connectionNames =
+      remainingPairs.get(pairKey) ?? new Set<ConnectionName>()
+    connectionNames.add(start.connectionName)
+    remainingPairs.set(pairKey, connectionNames)
+  }
+
+  for (const route of routes) {
+    const [start, end] = routeEndpoints(route)
+    if (!start || !end) return false
+    if (
+      ![start.x, start.y, start.z, end.x, end.y, end.z].every(Number.isFinite)
+    ) {
+      return false
+    }
+    const pairKey = getPhysicalPairKey(
+      [start, end],
+      route.rootConnectionName ?? route.connectionName,
+    )
+    if (!remainingPairs.get(pairKey)?.has(route.connectionName)) return false
+    remainingPairs.delete(pairKey)
+  }
+
+  return remainingPairs.size === 0
+}
 
 const getConnectedPointKeysForConnection = (
   routes: HighDensityIntraNodeRoute[],

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "high-density-repair01": "git+https://github.com/tscircuit/high-density-repair01.git#01f9fe901ac6f691c325bb25d993f52d916a98a1",
     "high-density-repair02": "https://codeload.github.com/tscircuit/high-density-repair02/tar.gz/eba02dae55f156990e23fac0108a620c8021f47b",
     "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#37d2b7af008c3a79c1a794e2ca307583a0f19c98",
-    "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d",
+    "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#7d0c1c55aa791bd16358e556c6cf94fa631f704e",
     "@tscircuit/high-density-b01": "git+https://github.com/tscircuit/high-density-b01.git#e651cab6c314e7aab6df31fd6067277436f67148"
   },
   "dependencies": {

--- a/tests/features/high-density-native-a11-portfolio.test.ts
+++ b/tests/features/high-density-native-a11-portfolio.test.ts
@@ -1,0 +1,132 @@
+import { expect, spyOn, test } from "bun:test"
+import {
+  HighDensitySolverA11,
+  getRouteGeometryViolationError,
+} from "@tscircuit/high-density-a01"
+import { GrowShrinkHighDensityIntraNodeSolver } from "lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver"
+import { PortfolioSingleIntraNodeSolver } from "lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver"
+import { doRoutesCoverNodePortPointPairsExactlyOnce } from "lib/solvers/HyperHighDensitySolver/repairDisconnectedSameRootPortPoints"
+import { makeNode } from "./never-fail-growth-high-density/test-helpers"
+
+test("A11 uses the native portfolio budget and preserves exact physical pairs", (): void => {
+  const nodeWithPortPoints = makeNode()
+  nodeWithPortPoints.portPoints = ["a", "alias"].flatMap((connectionName) =>
+    nodeWithPortPoints.portPoints.map((point) => ({
+      ...point,
+      connectionName,
+      rootConnectionName: "net",
+    })),
+  )
+  const solverParams = {
+    nodeWithPortPoints,
+    viaDiameter: 0.3,
+    traceWidth: 0.15,
+    obstacleMargin: 0.15,
+    effort: 1,
+    obstacles: [],
+    layerCount: 2,
+  }
+  const portfolio = new PortfolioSingleIntraNodeSolver(solverParams)
+  portfolio.initializeSolvers()
+  const candidates = portfolio.supervisedSolvers!
+  const a11Candidate = candidates.find(
+    ({ solver }) => solver instanceof HighDensitySolverA11,
+  )!
+  const a11 = a11Candidate.solver
+  if (!(a11 instanceof HighDensitySolverA11)) {
+    throw new Error("The native portfolio must contain A11")
+  }
+  const a01Candidate = candidates.find(
+    ({ hyperParameters }) => hyperParameters.HIGH_DENSITY_A01,
+  )!
+  expect(a11Candidate.f).toBe(a01Candidate.f)
+  expect(
+    candidates.filter(({ solver }) => solver instanceof HighDensitySolverA11),
+  ).toHaveLength(1)
+  expect(
+    candidates.some(
+      ({ solver }) => solver.getSolverName() === "HighDensitySolverA12",
+    ),
+  ).toBe(false)
+  const standalone = new HighDensitySolverA11({
+    nodeWithPortPoints,
+    viaDiameter: 0.3,
+    viaMinDistFromBorder: 0.15,
+    traceThickness: 0.15,
+    traceMargin: 0.1,
+    effort: 1,
+    hyperParameters: { shuffleSeed: 0 },
+  })
+  standalone.setup()
+  expect(a11.MAX_ITERATIONS).toBe(standalone.MAX_ITERATIONS)
+  expect(Number.isFinite(a11.MAX_ITERATIONS)).toBe(true)
+  expect(a11.MAX_ITERATIONS).toBeGreaterThan(0)
+  expect(a11.iterations).toBe(0)
+  a11.solve()
+  expect(a11.solved).toBe(true)
+  expect(a11.failed).toBe(false)
+  portfolio.onSolve(a11Candidate)
+  const routes = portfolio.solvedRoutes
+  expect(routes).toHaveLength(1)
+  expect(getRouteGeometryViolationError(routes)).toBeNull()
+  expect(
+    doRoutesCoverNodePortPointPairsExactlyOnce(routes, nodeWithPortPoints),
+  ).toBe(true)
+
+  const duplicateOutput = spyOn(a11, "getOutput").mockReturnValueOnce([
+    ...routes,
+    routes[0]!,
+  ])
+  expect(() => portfolio.onSolve(a11Candidate)).toThrow("exactly once")
+  duplicateOutput.mockRestore()
+  expect(
+    doRoutesCoverNodePortPointPairsExactlyOnce([], nodeWithPortPoints),
+  ).toBe(false)
+  const invalidOutput = spyOn(a11, "getOutput").mockReturnValueOnce([
+    {
+      ...routes[0]!,
+      route: [{ ...routes[0]!.route[0]!, x: Number.NaN }],
+    },
+  ])
+  expect(() => portfolio.onSolve(a11Candidate)).toThrow("non-finite")
+  invalidOutput.mockRestore()
+
+  // Existing alias repair remains in place for A01/A03.
+  a01Candidate.solver.solve()
+  expect(a01Candidate.solver.solved).toBe(true)
+  portfolio.onSolve(a01Candidate)
+  expect(
+    new Set(portfolio.solvedRoutes.map((route) => route.connectionName)),
+  ).toEqual(new Set(["a", "alias"]))
+
+  const grown = new GrowShrinkHighDensityIntraNodeSolver(solverParams)
+  grown.scaleFactor = 2
+  grown.step()
+  const scaledPortfolio = grown.activeSubSolver ?? grown.winningSolver
+  expect(scaledPortfolio).toBeDefined()
+  expect(scaledPortfolio!.getCombinationDefs()).toEqual(
+    portfolio
+      .getCombinationDefs()
+      .filter((combination) => !combination.includes("highDensityA11")),
+  )
+  expect(
+    scaledPortfolio!.supervisedSolvers!.some(
+      ({ solver }) => solver instanceof HighDensitySolverA11,
+    ),
+  ).toBe(false)
+
+  // A candidate rejected during setup must not access unallocated route state.
+  const invalidNode = makeNode()
+  invalidNode.portPoints[0]!.x -= invalidNode.width
+  const ineligiblePortfolio = new PortfolioSingleIntraNodeSolver({
+    ...solverParams,
+    nodeWithPortPoints: invalidNode,
+  })
+  ineligiblePortfolio.initializeSolvers()
+  const rejected = ineligiblePortfolio.supervisedSolvers!.find(
+    ({ solver }) => solver instanceof HighDensitySolverA11,
+  )!.solver
+  expect(rejected.failed).toBe(true)
+  ineligiblePortfolio.adaptiveSearchExpanded = true
+  expect(ineligiblePortfolio.computeH(rejected)).toBe(1)
+})


### PR DESCRIPTION
## Summary

Isolates A11's native-size portfolio integration from #2441 on main `d1e664f2`.

- Five files: package pin, existing portfolio integration/validation, native-only exclusion from scaled attempts, and one focused test.
- A01/A03 stay in the portfolio. Existing scheduling and problem-derived budgets are retained; no new public flags, custom caps, or retries.
- No stitching, repair04/repair01, benchmark reporting, or snapshot changes.

## Validation

16 focused tests pass (386 assertions); typecheck and build pass. Full local suite not run.

Full local SRJ18: **12/16 completed, 9/16 DRC-clean, zero timeouts**. P50 **48.0s**, P95 **339.7s**. These are candidate-only local timings, not a paired speedup claim.

Samples **4/12 fail with duplicate PCB terminals during stitching**; sample **6 has 123 DRC errors**, samples **8/16 have two each**. Samples 14/15 exhaust upstream pathing iterations.

**Benchmark experiment, not merge-ready.** Uses the same A11 evaluation pin `7d0c1c55aa791bd16358e556c6cf94fa631f704e` from [high-density-a01 #102](https://github.com/tscircuit/high-density-a01/pull/102) as #2441. A merged-main package pin and passing regression checks are required before landing.

[GitHub SRJ18 same-machine benchmark](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/34355097414) dispatched using `/benchmark --pipeline 9 --dataset srj18 --same-machine`.