### PR TITLE
Show pipeline stage timings in benchmark comments

### DIFF
--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     # Balanced plans target roughly ten minutes of test work; leave room for
     # checkout, dependency installation, and runner variance.
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -59,7 +59,24 @@ jobs:
           fi
 
           echo "Running ${#test_files[@]} test files from $test_plan"
-          bun test "${test_files[@]}" --timeout 300000
+          # This full-board regression takes just over five minutes even on
+          # successful main runs. Keep its assertions, but allow runner variance.
+          slow_test="tests/features/pipeline9-srj18-sample2-bounded-regional-drc.test.ts"
+          regular_tests=()
+          has_slow_test=false
+          for test_file in "${test_files[@]}"; do
+            if [ "$test_file" = "$slow_test" ]; then
+              has_slow_test=true
+            else
+              regular_tests+=("$test_file")
+            fi
+          done
+          if [ "${#regular_tests[@]}" -gt 0 ]; then
+            bun test "${regular_tests[@]}" --timeout 300000
+          fi
+          if [ "$has_slow_test" = true ]; then
+            bun test "$slow_test" --timeout 600000
+          fi
 
       - name: Upload diff PNG and SVG snapshot artifacts
         if: failure()

--- a/scripts/benchmark/benchmark-comment-comparison.js
+++ b/scripts/benchmark/benchmark-comment-comparison.js
@@ -1,3 +1,5 @@
+import { renderBenchmarkStageTimings } from "./renderBenchmarkStageTimings.js"
+
 const formatTime = (timeMs) => {
   if (typeof timeMs !== "number" || !Number.isFinite(timeMs)) {
     return "n/a"
@@ -186,10 +188,10 @@ export const renderBenchmarkComparison = ({
       fallbackText.length > maxLength
         ? `${fallbackText.slice(0, maxLength)}\n\n...truncated...`
         : fallbackText
-    return ["```", truncated, "```"]
+    return ["```", truncated, "```", ...renderBenchmarkStageTimings(prReport, "PR")]
   }
   if (isNetworkedColdHotReport(prReport)) {
-    return renderNetworkedColdHotComparison(prReport)
+    return [...renderNetworkedColdHotComparison(prReport), ...renderBenchmarkStageTimings(prReport, "Cold/hot")]
   }
 
   const mainSummaries = new Map(
@@ -242,5 +244,7 @@ export const renderBenchmarkComparison = ({
     ...rows,
     "",
     "_DRC issues are totaled across solved samples. Timing percentiles include solved and timed-out samples; negative timing changes are faster._",
+    ...renderBenchmarkStageTimings(mainReport, "Main"),
+    ...renderBenchmarkStageTimings(prReport, "PR"),
   ]
 }

--- a/scripts/benchmark/benchmark-comment-comparison.js
+++ b/scripts/benchmark/benchmark-comment-comparison.js
@@ -188,10 +188,18 @@ export const renderBenchmarkComparison = ({
       fallbackText.length > maxLength
         ? `${fallbackText.slice(0, maxLength)}\n\n...truncated...`
         : fallbackText
-    return ["```", truncated, "```", ...renderBenchmarkStageTimings(prReport, "PR")]
+    return [
+      "```",
+      truncated,
+      "```",
+      ...renderBenchmarkStageTimings(prReport, "PR"),
+    ]
   }
   if (isNetworkedColdHotReport(prReport)) {
-    return [...renderNetworkedColdHotComparison(prReport), ...renderBenchmarkStageTimings(prReport, "Cold/hot")]
+    return [
+      ...renderNetworkedColdHotComparison(prReport),
+      ...renderBenchmarkStageTimings(prReport, "Cold/hot"),
+    ]
   }
 
   const mainSummaries = new Map(

--- a/scripts/benchmark/renderBenchmarkStageTimings.d.ts
+++ b/scripts/benchmark/renderBenchmarkStageTimings.d.ts
@@ -1,0 +1,6 @@
+import type { BenchmarkReport } from "./benchmark-types"
+
+export declare function renderBenchmarkStageTimings(
+  report: BenchmarkReport | null | undefined,
+  label: string,
+): string[]

--- a/scripts/benchmark/renderBenchmarkStageTimings.js
+++ b/scripts/benchmark/renderBenchmarkStageTimings.js
@@ -1,0 +1,49 @@
+/**
+ * @param {import("./benchmark-types").BenchmarkReport | null | undefined} report
+ * @param {string} label
+ * @returns {string[]}
+ */
+export function renderBenchmarkStageTimings(report, label) {
+  const lines = ["", "<details>", `<summary>${label} pipeline stage timings</summary>`, ""]
+  const solverNames = new Set((report?.tests ?? []).map((test) => test.solverName))
+  if (solverNames.size === 0) lines.push("Stage timings unavailable for this report.", "")
+  for (const solverName of solverNames) {
+    const tests = report.tests.filter((test) => test.solverName === solverName)
+    const timedTests = tests.filter((test) => test.stageTiming !== undefined)
+    const totals = new Map()
+    let partialCount = 0
+    for (const test of timedTests) {
+      if (test.stageTiming.status === "partial") partialCount++
+      for (const stage of test.stageTiming.stages) {
+        totals.set(stage.stageName, (totals.get(stage.stageName) ?? 0) + stage.elapsedTimeMs)
+      }
+    }
+    const totalMs = [...totals.values()].reduce((sum, value) => sum + value, 0)
+    // Escape report-provided names before placing them in Markdown or HTML.
+    const escapedSolver = solverName.replace(/[&<>|\r\n]/g, (character) => ({
+      "&": "&amp;", "<": "&lt;", ">": "&gt;", "|": "&#124;", "\r": " ", "\n": " ",
+    })[character])
+    lines.push(`**${escapedSolver}**`, "")
+    if (timedTests.length === 0) {
+      lines.push("Stage timings unavailable for this report.", "")
+      continue
+    }
+    lines.push(
+      `Recorded timings: ${timedTests.length}/${tests.length} samples (${partialCount} partial, including failed or timed-out samples).`,
+      "Times are summed across samples; percentages use the total recorded stage time for this solver.",
+      "",
+      "| Stage | Total time | % of stage time |",
+      "| --- | ---: | ---: |",
+    )
+    for (const [stageName, elapsedTimeMs] of totals) {
+      const escapedStage = stageName.replace(/[&<>|\r\n]/g, (character) => ({
+        "&": "&amp;", "<": "&lt;", ">": "&gt;", "|": "&#124;", "\r": " ", "\n": " ",
+      })[character])
+      const percent = totalMs > 0 ? `${(elapsedTimeMs / totalMs * 100).toFixed(1)}%` : "n/a"
+      lines.push(`| ${escapedStage} | ${(elapsedTimeMs / 1000).toFixed(3)}s | ${percent} |`)
+    }
+    lines.push(`| **Total** | **${(totalMs / 1000).toFixed(3)}s** | **${totalMs > 0 ? "100.0%" : "n/a"}** |`, "")
+  }
+  lines.push("</details>")
+  return lines
+}

--- a/scripts/benchmark/renderBenchmarkStageTimings.js
+++ b/scripts/benchmark/renderBenchmarkStageTimings.js
@@ -4,9 +4,17 @@
  * @returns {string[]}
  */
 export function renderBenchmarkStageTimings(report, label) {
-  const lines = ["", "<details>", `<summary>${label} pipeline stage timings</summary>`, ""]
-  const solverNames = new Set((report?.tests ?? []).map((test) => test.solverName))
-  if (solverNames.size === 0) lines.push("Stage timings unavailable for this report.", "")
+  const lines = [
+    "",
+    "<details>",
+    `<summary>${label} pipeline stage timings</summary>`,
+    "",
+  ]
+  const solverNames = new Set(
+    (report?.tests ?? []).map((test) => test.solverName),
+  )
+  if (solverNames.size === 0)
+    lines.push("Stage timings unavailable for this report.", "")
   for (const solverName of solverNames) {
     const tests = report.tests.filter((test) => test.solverName === solverName)
     const timedTests = tests.filter((test) => test.stageTiming !== undefined)
@@ -15,14 +23,26 @@ export function renderBenchmarkStageTimings(report, label) {
     for (const test of timedTests) {
       if (test.stageTiming.status === "partial") partialCount++
       for (const stage of test.stageTiming.stages) {
-        totals.set(stage.stageName, (totals.get(stage.stageName) ?? 0) + stage.elapsedTimeMs)
+        totals.set(
+          stage.stageName,
+          (totals.get(stage.stageName) ?? 0) + stage.elapsedTimeMs,
+        )
       }
     }
     const totalMs = [...totals.values()].reduce((sum, value) => sum + value, 0)
     // Escape report-provided names before placing them in Markdown or HTML.
-    const escapedSolver = solverName.replace(/[&<>|\r\n]/g, (character) => ({
-      "&": "&amp;", "<": "&lt;", ">": "&gt;", "|": "&#124;", "\r": " ", "\n": " ",
-    })[character])
+    const escapedSolver = solverName.replace(
+      /[&<>|\r\n]/g,
+      (character) =>
+        ({
+          "&": "&amp;",
+          "<": "&lt;",
+          ">": "&gt;",
+          "|": "&#124;",
+          "\r": " ",
+          "\n": " ",
+        })[character],
+    )
     lines.push(`**${escapedSolver}**`, "")
     if (timedTests.length === 0) {
       lines.push("Stage timings unavailable for this report.", "")
@@ -36,13 +56,28 @@ export function renderBenchmarkStageTimings(report, label) {
       "| --- | ---: | ---: |",
     )
     for (const [stageName, elapsedTimeMs] of totals) {
-      const escapedStage = stageName.replace(/[&<>|\r\n]/g, (character) => ({
-        "&": "&amp;", "<": "&lt;", ">": "&gt;", "|": "&#124;", "\r": " ", "\n": " ",
-      })[character])
-      const percent = totalMs > 0 ? `${(elapsedTimeMs / totalMs * 100).toFixed(1)}%` : "n/a"
-      lines.push(`| ${escapedStage} | ${(elapsedTimeMs / 1000).toFixed(3)}s | ${percent} |`)
+      const escapedStage = stageName.replace(
+        /[&<>|\r\n]/g,
+        (character) =>
+          ({
+            "&": "&amp;",
+            "<": "&lt;",
+            ">": "&gt;",
+            "|": "&#124;",
+            "\r": " ",
+            "\n": " ",
+          })[character],
+      )
+      const percent =
+        totalMs > 0 ? `${((elapsedTimeMs / totalMs) * 100).toFixed(1)}%` : "n/a"
+      lines.push(
+        `| ${escapedStage} | ${(elapsedTimeMs / 1000).toFixed(3)}s | ${percent} |`,
+      )
     }
-    lines.push(`| **Total** | **${(totalMs / 1000).toFixed(3)}s** | **${totalMs > 0 ? "100.0%" : "n/a"}** |`, "")
+    lines.push(
+      `| **Total** | **${(totalMs / 1000).toFixed(3)}s** | **${totalMs > 0 ? "100.0%" : "n/a"}** |`,
+      "",
+    )
   }
   lines.push("</details>")
   return lines

--- a/scripts/benchmark/same-machine-results.ts
+++ b/scripts/benchmark/same-machine-results.ts
@@ -1,3 +1,4 @@
+import { renderBenchmarkStageTimings } from "./renderBenchmarkStageTimings.js"
 import { readFile, writeFile } from "node:fs/promises"
 import type { BenchmarkReport, WorkerResult } from "./benchmark-types"
 
@@ -229,6 +230,11 @@ export const renderSameMachineBenchmarkResults = ({
   lines.push(
     "",
     `Outcome changes: **${improvementCount} improved**, **${regressionCount} regressed**. DRC issues are totaled across solved samples. Timing percentiles include solved and timed-out samples; negative timing deltas are faster.`,
+  )
+
+  lines.push(
+    ...renderBenchmarkStageTimings(mainReport, "Main"),
+    ...renderBenchmarkStageTimings(prReport, "PR"),
   )
 
   if (changedOutcomes.length > 0) {

--- a/tests/benchmark-comment-comparison.test.ts
+++ b/tests/benchmark-comment-comparison.test.ts
@@ -83,7 +83,7 @@ test("PR benchmark comments render one main-versus-PR comparison table", () => {
 
   expect(
     renderBenchmarkComparison({ mainReport, prReport }).join("\n"),
-  ).toBe(`Dataset: srj18 · Scenarios: 2 · Effort: 1x effort
+  ).toContain(`Dataset: srj18 · Scenarios: 2 · Effort: 1x effort
 
 | Solver | Metric | Main | PR | Change |
 | --- | --- | ---: | ---: | ---: |

--- a/tests/benchmark-comment-stage-timings.test.ts
+++ b/tests/benchmark-comment-stage-timings.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "bun:test"
+import type { BenchmarkReport, WorkerResult } from "../scripts/benchmark/benchmark-types"
+import { renderBenchmarkStageTimings } from "../scripts/benchmark/renderBenchmarkStageTimings.js"
+import { renderBenchmarkComparison } from "../scripts/benchmark/benchmark-comment-comparison.js"
+import { renderSameMachineBenchmarkResults } from "../scripts/benchmark/same-machine-results"
+
+test("benchmark comments total stage timings by solver and report, including partial samples", () => {
+  const makeSample = (solverName: string, status: "complete" | "partial", times: number[]): WorkerResult => ({
+    solverName, scenarioName: "sample", sampleNumber: 1,
+    elapsedTimeMs: 10_000, didSolve: status === "complete",
+    didTimeout: status === "partial", relaxedDrcPassed: false,
+    stageTiming: { status, stages: times.map((elapsedTimeMs, index) => ({
+      stageName: ["fanout", "routing"][index]!, elapsedTimeMs,
+    })) },
+  })
+  const report: BenchmarkReport = {
+    version: 1, datasetName: "srj18", scenarioCount: 3, effortLabel: "1x effort",
+    summary: [{ solverName: "Pipeline9", completedRateLabel: "50%", relaxedDrcRateLabel: "0%", timedOutLabel: "1/2", p50TimeMs: 10_000, p95TimeMs: 10_000, avgVia: 0 }],
+    solverFailureSummary: [], timeoutSummary: [], failureSummary: [], snapshots: [],
+    tests: [makeSample("Pipeline9", "complete", [1000, 2000]), makeSample("Pipeline9", "partial", [500, 2500])],
+  }
+  report.tests.push({ ...makeSample("Pipeline9", "complete", []), stageTiming: undefined })
+  const details = renderBenchmarkStageTimings(report, "PR").join("\n")
+  expect(details).toContain("<details>\n<summary>PR pipeline stage timings</summary>\n\n")
+  expect(details).toContain("2/3 samples (1 partial")
+  expect(details).toContain("| fanout | 1.500s | 25.0% |")
+  expect(details).toContain("| routing | 4.500s | 75.0% |")
+  expect(details).toContain("| **Total** | **6.000s** | **100.0%** |")
+  expect(details).toEndWith("\n\n</details>")
+  const mainReport = { ...report, tests: [makeSample("Pipeline9", "complete", [100, 900])] }
+  for (const markdown of [
+    renderBenchmarkComparison({ mainReport, prReport: report }).join("\n"),
+    renderSameMachineBenchmarkResults({ mainReport, prReport: report, mainSha: "a", prSha: "b", repository: "tscircuit/tscircuit-autorouter", runnerName: "test" }),
+  ]) {
+    expect(markdown).toContain("<summary>Main pipeline stage timings</summary>")
+    expect(markdown).toContain("| fanout | 0.100s | 10.0% |")
+    expect(markdown).toContain(details)
+  }
+  const coldHotReport = { ...report, summary: [
+    { ...report.summary[0]!, solverName: "Pipeline9_Networked Cold" },
+    { ...report.summary[0]!, solverName: "Pipeline9_Networked Hot" },
+  ], tests: [makeSample("Pipeline9_Networked Cold", "complete", [1000, 3000]), makeSample("Pipeline9_Networked Hot", "complete", [1000, 1000])] }
+  const coldHot = renderBenchmarkComparison({ mainReport: null, prReport: coldHotReport }).join("\n")
+  expect(coldHot).toContain("<summary>Cold/hot pipeline stage timings</summary>")
+  expect(coldHot).toContain("| fanout | 1.000s | 25.0% |")
+  expect(coldHot).toContain("| fanout | 1.000s | 50.0% |")
+  const zero = renderBenchmarkStageTimings({ ...report, tests: [makeSample("<Pipeline|9>", "complete", [0, 0])] }, "PR").join("\n")
+  expect(zero).toContain("&lt;Pipeline&#124;9&gt;")
+  expect(zero).toContain("| fanout | 0.000s | n/a |")
+  expect(zero).not.toMatch(/NaN|Infinity/)
+  expect(renderBenchmarkStageTimings(null, "Main").join("\n")).toContain("Stage timings unavailable")
+  expect(renderBenchmarkStageTimings({ ...report, tests: [report.tests[2]!] }, "PR").join("\n")).toContain("Stage timings unavailable")
+})

--- a/tests/benchmark-comment-stage-timings.test.ts
+++ b/tests/benchmark-comment-stage-timings.test.ts
@@ -1,53 +1,124 @@
 import { expect, test } from "bun:test"
-import type { BenchmarkReport, WorkerResult } from "../scripts/benchmark/benchmark-types"
+import type {
+  BenchmarkReport,
+  WorkerResult,
+} from "../scripts/benchmark/benchmark-types"
 import { renderBenchmarkStageTimings } from "../scripts/benchmark/renderBenchmarkStageTimings.js"
 import { renderBenchmarkComparison } from "../scripts/benchmark/benchmark-comment-comparison.js"
 import { renderSameMachineBenchmarkResults } from "../scripts/benchmark/same-machine-results"
 
 test("benchmark comments total stage timings by solver and report, including partial samples", () => {
-  const makeSample = (solverName: string, status: "complete" | "partial", times: number[]): WorkerResult => ({
-    solverName, scenarioName: "sample", sampleNumber: 1,
-    elapsedTimeMs: 10_000, didSolve: status === "complete",
-    didTimeout: status === "partial", relaxedDrcPassed: false,
-    stageTiming: { status, stages: times.map((elapsedTimeMs, index) => ({
-      stageName: ["fanout", "routing"][index]!, elapsedTimeMs,
-    })) },
+  const makeSample = (
+    solverName: string,
+    status: "complete" | "partial",
+    times: number[],
+  ): WorkerResult => ({
+    solverName,
+    scenarioName: "sample",
+    sampleNumber: 1,
+    elapsedTimeMs: 10_000,
+    didSolve: status === "complete",
+    didTimeout: status === "partial",
+    relaxedDrcPassed: false,
+    stageTiming: {
+      status,
+      stages: times.map((elapsedTimeMs, index) => ({
+        stageName: ["fanout", "routing"][index]!,
+        elapsedTimeMs,
+      })),
+    },
   })
   const report: BenchmarkReport = {
-    version: 1, datasetName: "srj18", scenarioCount: 3, effortLabel: "1x effort",
-    summary: [{ solverName: "Pipeline9", completedRateLabel: "50%", relaxedDrcRateLabel: "0%", timedOutLabel: "1/2", p50TimeMs: 10_000, p95TimeMs: 10_000, avgVia: 0 }],
-    solverFailureSummary: [], timeoutSummary: [], failureSummary: [], snapshots: [],
-    tests: [makeSample("Pipeline9", "complete", [1000, 2000]), makeSample("Pipeline9", "partial", [500, 2500])],
+    version: 1,
+    datasetName: "srj18",
+    scenarioCount: 3,
+    effortLabel: "1x effort",
+    summary: [
+      {
+        solverName: "Pipeline9",
+        completedRateLabel: "50%",
+        relaxedDrcRateLabel: "0%",
+        timedOutLabel: "1/2",
+        p50TimeMs: 10_000,
+        p95TimeMs: 10_000,
+        avgVia: 0,
+      },
+    ],
+    solverFailureSummary: [],
+    timeoutSummary: [],
+    failureSummary: [],
+    snapshots: [],
+    tests: [
+      makeSample("Pipeline9", "complete", [1000, 2000]),
+      makeSample("Pipeline9", "partial", [500, 2500]),
+    ],
   }
-  report.tests.push({ ...makeSample("Pipeline9", "complete", []), stageTiming: undefined })
+  report.tests.push({
+    ...makeSample("Pipeline9", "complete", []),
+    stageTiming: undefined,
+  })
   const details = renderBenchmarkStageTimings(report, "PR").join("\n")
-  expect(details).toContain("<details>\n<summary>PR pipeline stage timings</summary>\n\n")
+  expect(details).toContain(
+    "<details>\n<summary>PR pipeline stage timings</summary>\n\n",
+  )
   expect(details).toContain("2/3 samples (1 partial")
   expect(details).toContain("| fanout | 1.500s | 25.0% |")
   expect(details).toContain("| routing | 4.500s | 75.0% |")
   expect(details).toContain("| **Total** | **6.000s** | **100.0%** |")
   expect(details).toEndWith("\n\n</details>")
-  const mainReport = { ...report, tests: [makeSample("Pipeline9", "complete", [100, 900])] }
+  const mainReport = {
+    ...report,
+    tests: [makeSample("Pipeline9", "complete", [100, 900])],
+  }
   for (const markdown of [
     renderBenchmarkComparison({ mainReport, prReport: report }).join("\n"),
-    renderSameMachineBenchmarkResults({ mainReport, prReport: report, mainSha: "a", prSha: "b", repository: "tscircuit/tscircuit-autorouter", runnerName: "test" }),
+    renderSameMachineBenchmarkResults({
+      mainReport,
+      prReport: report,
+      mainSha: "a",
+      prSha: "b",
+      repository: "tscircuit/tscircuit-autorouter",
+      runnerName: "test",
+    }),
   ]) {
     expect(markdown).toContain("<summary>Main pipeline stage timings</summary>")
     expect(markdown).toContain("| fanout | 0.100s | 10.0% |")
     expect(markdown).toContain(details)
   }
-  const coldHotReport = { ...report, summary: [
-    { ...report.summary[0]!, solverName: "Pipeline9_Networked Cold" },
-    { ...report.summary[0]!, solverName: "Pipeline9_Networked Hot" },
-  ], tests: [makeSample("Pipeline9_Networked Cold", "complete", [1000, 3000]), makeSample("Pipeline9_Networked Hot", "complete", [1000, 1000])] }
-  const coldHot = renderBenchmarkComparison({ mainReport: null, prReport: coldHotReport }).join("\n")
-  expect(coldHot).toContain("<summary>Cold/hot pipeline stage timings</summary>")
+  const coldHotReport = {
+    ...report,
+    summary: [
+      { ...report.summary[0]!, solverName: "Pipeline9_Networked Cold" },
+      { ...report.summary[0]!, solverName: "Pipeline9_Networked Hot" },
+    ],
+    tests: [
+      makeSample("Pipeline9_Networked Cold", "complete", [1000, 3000]),
+      makeSample("Pipeline9_Networked Hot", "complete", [1000, 1000]),
+    ],
+  }
+  const coldHot = renderBenchmarkComparison({
+    mainReport: null,
+    prReport: coldHotReport,
+  }).join("\n")
+  expect(coldHot).toContain(
+    "<summary>Cold/hot pipeline stage timings</summary>",
+  )
   expect(coldHot).toContain("| fanout | 1.000s | 25.0% |")
   expect(coldHot).toContain("| fanout | 1.000s | 50.0% |")
-  const zero = renderBenchmarkStageTimings({ ...report, tests: [makeSample("<Pipeline|9>", "complete", [0, 0])] }, "PR").join("\n")
+  const zero = renderBenchmarkStageTimings(
+    { ...report, tests: [makeSample("<Pipeline|9>", "complete", [0, 0])] },
+    "PR",
+  ).join("\n")
   expect(zero).toContain("&lt;Pipeline&#124;9&gt;")
   expect(zero).toContain("| fanout | 0.000s | n/a |")
   expect(zero).not.toMatch(/NaN|Infinity/)
-  expect(renderBenchmarkStageTimings(null, "Main").join("\n")).toContain("Stage timings unavailable")
-  expect(renderBenchmarkStageTimings({ ...report, tests: [report.tests[2]!] }, "PR").join("\n")).toContain("Stage timings unavailable")
+  expect(renderBenchmarkStageTimings(null, "Main").join("\n")).toContain(
+    "Stage timings unavailable",
+  )
+  expect(
+    renderBenchmarkStageTimings(
+      { ...report, tests: [report.tests[2]!] },
+      "PR",
+    ).join("\n"),
+  ).toContain("Stage timings unavailable")
 })


### PR DESCRIPTION
Benchmark result comments now include collapsible pipeline stage timing tables for Main and PR, including same-machine comparisons and networked cold/hot runs. Each table shows total seconds per stage, its percentage of the solver’s summed recorded stage time, and the overall total.

Timings are aggregated across samples, including partial failed or timed-out samples. Coverage and partial-sample counts are shown; older reports without timings explicitly show that timings are unavailable.

Validation: five focused tests passed (43 assertions), covering both comment renderers, cold/hot runs, aggregation, partial timings, missing data, and zero totals. Tests ran in an isolated harness using the unchanged source and test files because the checkout lacks the `graphics-debug/matcher` dependency required by the repository’s global test preload. The full suite was not run. `git diff --cached --check` passed before commit.


CI also runs the existing SRJ18 sample 2 regional DRC regression separately with a ten-minute timeout, keeping the five-minute limit for other tests and allowing twenty minutes for the shard. This test timed out twice on the PR and took 307 seconds in the latest successful main run, exceeding the old 300-second limit. Its routing and work-budget assertions are unchanged. Verified shell command selection for regular-only, slow-only, and mixed shards; all nine test shards passed in CI run https://github.com/tscircuit/tscircuit-autorouter/actions/runs/34403149458.
