### PR TITLE
update tiny-hypergraph for blocker-search benchmarking

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "recharts": "^2.15.1",
     "tailwind-merge": "^3.2.0",
     "terser": "^5.43.1",
-    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#c1043b3043ddf0c4d841fe5a6d9a515165960911",
+    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#4e23015d63f168957c0964d7761db1dea6ed844f",
     "tiny-hypergraph-poly": "git+https://github.com/tscircuit/tiny-hypergraph.git#7b93b4c",
     "tsup": "^8.3.6",
     "tscircuit-for-pipeline9-fixtures": "npm:tscircuit@0.0.2467",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "recharts": "^2.15.1",
     "tailwind-merge": "^3.2.0",
     "terser": "^5.43.1",
-    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#06cf0b365292b2c06ee4a28591628076d92beeeb",
+    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#c65ce89f793da764552734f4fbef0cb57dd9afc4",
     "tiny-hypergraph-poly": "git+https://github.com/tscircuit/tiny-hypergraph.git#7b93b4c",
     "tsup": "^8.3.6",
     "tscircuit-for-pipeline9-fixtures": "npm:tscircuit@0.0.2467",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "recharts": "^2.15.1",
     "tailwind-merge": "^3.2.0",
     "terser": "^5.43.1",
-    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#4e23015d63f168957c0964d7761db1dea6ed844f",
+    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#06cf0b365292b2c06ee4a28591628076d92beeeb",
     "tiny-hypergraph-poly": "git+https://github.com/tscircuit/tiny-hypergraph.git#7b93b4c",
     "tsup": "^8.3.6",
     "tscircuit-for-pipeline9-fixtures": "npm:tscircuit@0.0.2467",


### PR DESCRIPTION
### Motivation
- Benchmark the blocker-search optimization on srj18 using the same machine.

### Before
- Autorouter uses the existing tiny-hypergraph revision without this optimization.

### After
- Pins the [updated fix revision](https://github.com/tscircuit/tiny-hypergraph/commit/c65ce89f793da764552734f4fbef0cb57dd9afc4), including [#180's repro and before snapshot](https://github.com/tscircuit/tiny-hypergraph/pull/180) and [#181's optimization and refreshed snapshot](https://github.com/tscircuit/tiny-hypergraph/pull/181), while preserving existing dependency changes.
- Graph routing completed on this baseline; full PCB routing reached repair and timed out. Run srj18 by commenting `/benchmark --dataset 18 --pipeline 9 --same-machine`.
