### PR TITLE
Build autorouter after release version bump

### DIFF
--- a/.github/workflows/bun-pver-release.yml
+++ b/.github/workflows/bun-pver-release.yml
@@ -32,7 +32,7 @@ jobs:
           package-manager-cache: false
       - run: npm install -g pver
       - run: bun install --frozen-lockfile
-      - run: bun run build
+      # npm prepublishOnly builds after pver has written the release version.
       - run: pver release --no-push-main
         env:
           GITHUB_TOKEN: ${{ secrets.TSCIRCUIT_BOT_GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dist"
   ],
   "scripts": {
+    "prepublishOnly": "bun run build && bun scripts/check-published-autorouter-version.ts",
     "start": "cosmos",
     "build": "tsup ./lib/index.ts --minify terser --external @tscircuit/core --external circuit-to-svg --format esm --dts --sourcemap",
     "bench": "bun test tests/spatial-index-bench.test.ts",

--- a/scripts/check-published-autorouter-version.ts
+++ b/scripts/check-published-autorouter-version.ts
@@ -2,7 +2,7 @@ import packageJson from "../package.json" with { type: "json" }
 
 // Resolve the built artifact at runtime so source typechecks need no dist folder.
 const { AUTOROUTER_VERSION } = await import(
-  new URL("../dist/index.js", import.meta.url).href,
+  new URL("../dist/index.js", import.meta.url).href
 )
 
 if (AUTOROUTER_VERSION !== packageJson.version) {

--- a/scripts/check-published-autorouter-version.ts
+++ b/scripts/check-published-autorouter-version.ts
@@ -2,7 +2,7 @@ import packageJson from "../package.json" with { type: "json" }
 
 // Resolve the built artifact at runtime so source typechecks need no dist folder.
 const { AUTOROUTER_VERSION } = await import(
-  new URL("../dist/index.js", import.meta.url).href
+  new URL("../dist/index.js", import.meta.url).href,
 )
 
 if (AUTOROUTER_VERSION !== packageJson.version) {

--- a/scripts/check-published-autorouter-version.ts
+++ b/scripts/check-published-autorouter-version.ts
@@ -1,0 +1,9 @@
+import { AUTOROUTER_VERSION } from "../dist/index.js"
+import packageJson from "../package.json" with { type: "json" }
+
+if (AUTOROUTER_VERSION !== packageJson.version) {
+  throw new Error(
+    `Built autorouter version ${AUTOROUTER_VERSION} does not match package version ${packageJson.version}. Rebuild after bumping the version.`,
+  )
+}
+console.log(`Verified published autorouter version ${AUTOROUTER_VERSION}`)

--- a/scripts/check-published-autorouter-version.ts
+++ b/scripts/check-published-autorouter-version.ts
@@ -1,5 +1,9 @@
-import { AUTOROUTER_VERSION } from "../dist/index.js"
 import packageJson from "../package.json" with { type: "json" }
+
+// Resolve the built artifact at runtime so source typechecks need no dist folder.
+const { AUTOROUTER_VERSION } = await import(
+  new URL("../dist/index.js", import.meta.url).href
+)
 
 if (AUTOROUTER_VERSION !== packageJson.version) {
   throw new Error(


### PR DESCRIPTION
Fix the npm release ordering so Pipeline9 Networked sends the version of the package actually installed. Published `@tscircuit/capacity-autorouter@0.0.892` currently exports `AUTOROUTER_VERSION = "0.0.891"`: the workflow builds before `pver release` updates package.json.

Move the release build into npm's `prepublishOnly` lifecycle, which pver invokes after staging the version bump. Add a post-build guard that refuses publication when the bundled version differs from package.json.

Validation: `bun run prepublishOnly` (ESM/declaration build and version guard); checked the guard rejects a copied bundle paired with a bumped manifest and accepts its matching manifest.

Required before enabling the companion core cloud-routing change. hd-cache2 will reject incorrectly versioned historical packages instead of caching their output under another release's identity.
