### PR TITLE
Update SRJ18 dataset with corrected pad geometry

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "circuit-to-svg": "^0.0.220",
     "clsx": "^2.1.1",
     "dataset-srj11-45-degree": "git+https://github.com/tscircuit/dataset-srj11-45-degree.git#c49dd43c38f85fa2777c7d67393df413ca8d5a75",
-    "dataset-srj18": "git+https://github.com/tscircuit/dataset-srj18.git#c0aad90256a95256fcac814f9f7da81a82a2fdea",
+    "dataset-srj18": "git+https://github.com/tscircuit/dataset-srj18.git#100e8957ce789b5b288e14c476dc83f4efc5214b",
     "flatbush": "^4.4.0",
     "format-si-unit": "0.0.12",
     "graphics-debug": "0.0.99",


### PR DESCRIPTION
Update `dataset-srj18` from `c0aad902` to `100e8957`, incorporating the regenerated inputs from https://github.com/tscircuit/dataset-srj18/pull/18.

The update corrects rotated trapezoid pad geometry in sample 16, including the C43 pad that previously covered the neighboring TP5 endpoint, and custom polygon pad geometry in samples 12 and 16. The other 14 routing inputs, all connections, and board bounds are unchanged.

Validation on autorouter main `826b99f` with the updated pin:

- `bun run build` passes.
- Pipeline 9, SRJ18 sample 16, effort 1 completes successfully with **0 relaxed DRC errors** (`bun scripts/run-sample.ts --pipeline 9 --dataset srj18 --sample 16 --effort 1`).
- `bun test tests/features/pipeline9-srj18-sample12-via-pad-stage-handoff.test.ts --timeout 9999999` passes (1 test, 3 assertions), including zero relaxed DRC errors for sample 12.
