### PR TITLE
Integrate A13 negotiated congestion into the high-density portfolio

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9HighDensitySolver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9HighDensitySolver.ts
@@ -361,6 +361,7 @@ export const createPipeline9RegularNodeSolver = ({
     obstacles,
     layerCount,
     useGrowShrinkHighDensityIntraNodeSolver: true,
+    enableNegotiatedSearch: true,
     preserveTerminalPcbPortIds: false,
     growShrinkFallbackToInvalidGeometryOnFailure: false,
     captureSearchDebug: false,

--- a/lib/solvers/HighDensitySolver/HighDensitySolver.ts
+++ b/lib/solvers/HighDensitySolver/HighDensitySolver.ts
@@ -58,6 +58,7 @@ export class HighDensitySolver extends BaseSolver {
   obstacles: Obstacle[]
   layerCount: number
   useGrowShrinkHighDensityIntraNodeSolver: boolean
+  enableNegotiatedSearch: boolean
   preserveTerminalPcbPortIds: boolean
   growShrinkMaxInnerIterationsPerGrowthAttempt?: number
   growShrinkFallbackToInvalidGeometryOnFailure: boolean
@@ -93,6 +94,7 @@ export class HighDensitySolver extends BaseSolver {
     obstacles,
     layerCount,
     useGrowShrinkHighDensityIntraNodeSolver,
+    enableNegotiatedSearch = false,
     preserveTerminalPcbPortIds,
     growShrinkMaxInnerIterationsPerGrowthAttempt,
     growShrinkFallbackToInvalidGeometryOnFailure,
@@ -109,6 +111,7 @@ export class HighDensitySolver extends BaseSolver {
     obstacles?: Obstacle[]
     layerCount?: number
     useGrowShrinkHighDensityIntraNodeSolver?: boolean
+    enableNegotiatedSearch?: boolean
     preserveTerminalPcbPortIds?: boolean
     growShrinkMaxInnerIterationsPerGrowthAttempt?: number
     growShrinkFallbackToInvalidGeometryOnFailure?: boolean
@@ -132,6 +135,7 @@ export class HighDensitySolver extends BaseSolver {
     this.obstacleMargin = obstacleMargin ?? 0.15
     this.obstacles = obstacles ?? []
     this.layerCount = layerCount ?? 2
+    this.enableNegotiatedSearch = enableNegotiatedSearch
     this.useGrowShrinkHighDensityIntraNodeSolver =
       useGrowShrinkHighDensityIntraNodeSolver ?? false
     this.preserveTerminalPcbPortIds = preserveTerminalPcbPortIds ?? false
@@ -373,6 +377,7 @@ export class HighDensitySolver extends BaseSolver {
 
     const intraNodeSolverParams = {
       nodeWithPortPoints: node,
+      enableNegotiatedSearch: this.enableNegotiatedSearch,
       colorMap: this.colorMap,
       connMap: this.connMap,
       viaDiameter: this.viaDiameter,

--- a/lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver/GrowShrinkHighDensityIntraNodeSolver.ts
+++ b/lib/solvers/HyperHighDensitySolver/GrowShrinkHighDensityIntraNodeSolver/GrowShrinkHighDensityIntraNodeSolver.ts
@@ -154,6 +154,9 @@ export class GrowShrinkHighDensityIntraNodeSolver extends BaseSolver {
       this.constructorParams
     this.activeSubSolver = new PortfolioSingleIntraNodeSolver({
       ...portfolioParams,
+      enableNegotiatedSearch:
+        this.scaleFactor === 1 &&
+        (portfolioParams.enableNegotiatedSearch ?? true),
       nodeWithPortPoints: scaleNodeWithPortPoints(
         this.nodeWithPortPoints,
         this.scaleFactor,

--- a/lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver.ts
+++ b/lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver.ts
@@ -97,7 +97,8 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
   private getTotalCandidateWork(): number {
     return (this.supervisedSolvers ?? []).reduce(
       (total, { solver }) =>
-        total + (solver instanceof HighDensitySolverA13 ? 0 : solver.iterations),
+        total +
+        (solver instanceof HighDensitySolverA13 ? 0 : solver.iterations),
       0,
     )
   }
@@ -453,7 +454,10 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
     }
 
     if (hyperParameters.HIGH_DENSITY_A13) {
-      const maxSearchIterations = Math.max(1, Math.round(50_000_000 * this.effort))
+      const maxSearchIterations = Math.max(
+        1,
+        Math.round(50_000_000 * this.effort),
+      )
       const solver = new HighDensitySolverA13({
         nodeWithPortPoints: this.nodeWithPortPoints,
         cellSizeMm: 0.1,

--- a/lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver.ts
+++ b/lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver.ts
@@ -1,8 +1,8 @@
 import {
   HighDensitySolverA03 as HighDensityA03Solver,
   HighDensitySolverA01,
-  HighDensitySolverA13,
 } from "@tscircuit/high-density-a01"
+import { HighDensitySolverA13 } from "@tscircuit/high-density-a13"
 import { ConnectivityMap } from "circuit-json-to-connectivity-map"
 import {
   HighDensityIntraNodeRoute,
@@ -50,6 +50,8 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
   connMap?: ConnectivityMap
   effort: number
   adaptiveSearchExpanded = false
+  negotiatedSearchStarted = false
+  readonly enableNegotiatedSearch: boolean
 
   private getSolvedSegmentCount(solver: unknown): number | null {
     const solvedConnectionsMap = (solver as any).solvedConnectionsMap
@@ -121,6 +123,7 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
   constructor(
     opts: ConstructorParameters<typeof CachedIntraNodeRouteSolver>[0] & {
       effort?: number
+      enableNegotiatedSearch?: boolean
     },
   ) {
     super()
@@ -128,6 +131,7 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
     this.connMap = opts.connMap
     this.constructorParams = opts
     this.effort = opts.effort ?? 1
+    this.enableNegotiatedSearch = opts.enableNegotiatedSearch ?? false
     this.MAX_ITERATIONS = 20_000_000 * this.effort
     this.GREEDY_MULTIPLIER = 5
     this.MIN_SUBSTEPS = 100
@@ -146,7 +150,6 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
       // ["closedFormTwoTrace"],
       ["highDensityA01"],
       ["highDensityA03"],
-      ["highDensityA13"],
     ]
   }
 
@@ -386,6 +389,21 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
       !this.getSupervisedSolverWithBestFitness()
     ) {
       this.expandAdaptiveSearch()
+    }
+
+    // Preserve successful route orders from the existing portfolio. Use
+    // negotiated congestion only after those orders are exhausted, before
+    // grow/shrink changes the physical clearance problem.
+    if (
+      this.enableNegotiatedSearch &&
+      this.adaptiveSearchExpanded &&
+      !this.negotiatedSearchStarted &&
+      !this.getSupervisedSolverWithBestFitness()
+    ) {
+      this.negotiatedSearchStarted = true
+      this.addSupervisedCandidate({ HIGH_DENSITY_A13: true, SHUFFLE_SEED: 0 })
+      this.stats.negotiatedSearchStartedAtIteration = this.iterations
+      this.refreshDynamicIterationLimit()
     }
 
     super._step()

--- a/lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver.ts
+++ b/lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver.ts
@@ -1,6 +1,7 @@
 import {
   HighDensitySolverA03 as HighDensityA03Solver,
   HighDensitySolverA01,
+  HighDensitySolverA13,
 } from "@tscircuit/high-density-a01"
 import { ConnectivityMap } from "circuit-json-to-connectivity-map"
 import {
@@ -37,6 +38,7 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
   | SingleTransitionThroughObstacleIntraNodeSolver
   | SingleLayerNoDifferentRootIntersectionsIntraNodeSolver
   | HighDensityA03Solver
+  | HighDensitySolverA13
 > {
   override getSolverName(): string {
     return "PortfolioSingleIntraNodeSolver"
@@ -73,6 +75,18 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
   }
 
   private getCandidateProgress(solver: { progress: number }): number {
+    if (solver instanceof HighDensitySolverA13) {
+      if (solver.solved) return 1
+      const connectionCount = solver.connections.length
+      if (connectionCount === 0) return 0
+      // A complete set of provisional paths still needs congestion negotiation.
+      const routedFraction = solver.routedCount / connectionCount
+      const conflictFreeFraction = Math.max(
+        0,
+        (solver.routedCount - solver.conflictCount) / connectionCount,
+      )
+      return Math.min(0.99, (routedFraction + conflictFreeFraction) / 2)
+    }
     const solvedSegmentCount = this.getSolvedSegmentCount(solver)
     if (solvedSegmentCount !== null) {
       return Math.min(1, solvedSegmentCount / this.getNodeSegmentCount())
@@ -82,7 +96,8 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
 
   private getTotalCandidateWork(): number {
     return (this.supervisedSolvers ?? []).reduce(
-      (total, { solver }) => total + solver.iterations,
+      (total, { solver }) =>
+        total + (solver instanceof HighDensitySolverA13 ? 0 : solver.iterations),
       0,
     )
   }
@@ -94,9 +109,11 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
     // to fail or introducing a wall-clock iteration constant.
     return Math.max(
       1,
-      ...(this.supervisedSolvers ?? []).map(
-        ({ solver }) => solver.MAX_ITERATIONS,
-      ),
+      // A13 negotiates route orders internally. Its larger budget must not
+      // delay expansion of the existing A01 ordering search.
+      ...(this.supervisedSolvers ?? [])
+        .filter(({ solver }) => !(solver instanceof HighDensitySolverA13))
+        .map(({ solver }) => solver.MAX_ITERATIONS),
     )
   }
 
@@ -128,6 +145,7 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
       // ["closedFormTwoTrace"],
       ["highDensityA01"],
       ["highDensityA03"],
+      ["highDensityA13"],
     ]
   }
 
@@ -266,6 +284,10 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
           },
         ],
       },
+      {
+        name: "highDensityA13",
+        possibleValues: [{ HIGH_DENSITY_A13: true, SHUFFLE_SEED: 0 }],
+      },
     ]
   }
 
@@ -372,10 +394,11 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
     }
   }
 
-  computeG(solver: IntraNodeRouteSolver) {
+  computeG(solver: IntraNodeRouteSolver): number {
     if (
       (solver as any) instanceof HighDensitySolverA01 ||
-      (solver as any) instanceof HighDensityA03Solver
+      (solver as any) instanceof HighDensityA03Solver ||
+      (solver as any) instanceof HighDensitySolverA13
     ) {
       return (solver as any).iterations / 1_000_000
     }
@@ -392,7 +415,10 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
     )
   }
 
-  computeH(solver: IntraNodeRouteSolver) {
+  computeH(solver: IntraNodeRouteSolver): number {
+    if (solver instanceof HighDensitySolverA13) {
+      return 1 - this.getCandidateProgress(solver)
+    }
     if (this.adaptiveSearchExpanded) {
       return 1 - this.getCandidateProgress(solver)
     }
@@ -426,6 +452,24 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
       }) as any
     }
 
+    if (hyperParameters.HIGH_DENSITY_A13) {
+      const maxSearchIterations = Math.max(1, Math.round(50_000_000 * this.effort))
+      const solver = new HighDensitySolverA13({
+        nodeWithPortPoints: this.nodeWithPortPoints,
+        cellSizeMm: 0.1,
+        viaDiameter: this.constructorParams.viaDiameter ?? 0.3,
+        viaMinDistFromBorder: (this.constructorParams.viaDiameter ?? 0.3) / 2,
+        traceThickness: this.constructorParams.traceWidth ?? 0.15,
+        traceMargin: 0.1,
+        // One search pop per step keeps portfolio scheduling comparable to A01.
+        stepMultiplier: 1,
+        maxSearchIterations,
+        maxRounds: Math.max(1, Math.round(200 * this.effort)),
+        hyperParameters: { shuffleSeed: hyperParameters.SHUFFLE_SEED ?? 0 },
+      })
+      solver.MAX_ITERATIONS = maxSearchIterations * 2
+      return solver as any
+    }
     if (hyperParameters.HIGH_DENSITY_A01) {
       const solver = new HighDensitySolverA01({
         nodeWithPortPoints: this.nodeWithPortPoints,
@@ -506,7 +550,8 @@ export class PortfolioSingleIntraNodeSolver extends HyperParameterSupervisorSolv
     let routes: HighDensityIntraNodeRoute[]
     if (
       (solver.solver as any) instanceof HighDensitySolverA01 ||
-      (solver.solver as any) instanceof HighDensityA03Solver
+      (solver.solver as any) instanceof HighDensityA03Solver ||
+      (solver.solver as any) instanceof HighDensitySolverA13
     ) {
       routes = (solver.solver as any).getOutput()
     } else {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,8 @@
     "high-density-repair01": "git+https://github.com/tscircuit/high-density-repair01.git#01f9fe901ac6f691c325bb25d993f52d916a98a1",
     "high-density-repair02": "https://codeload.github.com/tscircuit/high-density-repair02/tar.gz/eba02dae55f156990e23fac0108a620c8021f47b",
     "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#5f6c9af547dbb70c8948227011e1769b5dfa16a5",
-    "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#cdfd68a40b35e43c0fbb6f6a7056904617725576",
+    "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d",
+    "@tscircuit/high-density-a13": "git+https://github.com/tscircuit/high-density-a01.git#cdfd68a40b35e43c0fbb6f6a7056904617725576",
     "@tscircuit/high-density-b01": "git+https://github.com/tscircuit/high-density-b01.git#e651cab6c314e7aab6df31fd6067277436f67148"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "high-density-repair01": "git+https://github.com/tscircuit/high-density-repair01.git#01f9fe901ac6f691c325bb25d993f52d916a98a1",
     "high-density-repair02": "https://codeload.github.com/tscircuit/high-density-repair02/tar.gz/eba02dae55f156990e23fac0108a620c8021f47b",
     "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#5f6c9af547dbb70c8948227011e1769b5dfa16a5",
-    "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d",
+    "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#0c95b5fea6ee54f49895a895da41b99847dba143",
     "@tscircuit/high-density-b01": "git+https://github.com/tscircuit/high-density-b01.git#e651cab6c314e7aab6df31fd6067277436f67148"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "high-density-repair01": "git+https://github.com/tscircuit/high-density-repair01.git#01f9fe901ac6f691c325bb25d993f52d916a98a1",
     "high-density-repair02": "https://codeload.github.com/tscircuit/high-density-repair02/tar.gz/eba02dae55f156990e23fac0108a620c8021f47b",
     "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#5f6c9af547dbb70c8948227011e1769b5dfa16a5",
-    "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#0c95b5fea6ee54f49895a895da41b99847dba143",
+    "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#cdfd68a40b35e43c0fbb6f6a7056904617725576",
     "@tscircuit/high-density-b01": "git+https://github.com/tscircuit/high-density-b01.git#e651cab6c314e7aab6df31fd6067277436f67148"
   },
   "dependencies": {

--- a/tests/features/pipeline9-a13-srj18-sample2-drc.test.ts
+++ b/tests/features/pipeline9-a13-srj18-sample2-drc.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/AutoroutingPipelineSolver9_PreloadedTraceGraph"
+import { evaluateRelaxedDrc } from "lib/testing/evaluate-relaxed-drc"
+import { loadScenarioBySampleNumber } from "../../scripts/benchmark/scenarios"
+
+test("Pipeline9 completes SRJ18 sample 2 without A13 repair regressions", async (): Promise<void> => {
+  const { scenario } = await loadScenarioBySampleNumber("srj18", 2)
+  const solver = new AutoroutingPipelineSolver9_PreloadedTraceGraph(
+    structuredClone(scenario),
+    { effort: 1, cacheProvider: null },
+  )
+  solver.solve()
+  expect(solver.failed).toBe(false)
+  expect(solver.solved).toBe(true)
+  expect(
+    evaluateRelaxedDrc({
+      inputSrj: scenario,
+      srjWithPointPairs: solver.srjWithPointPairs!,
+      routedTraces: solver.getOutputSimplifiedPcbTraces(),
+    }).errors,
+  ).toEqual([])
+})

--- a/tests/features/portfolio-a13-provisional-progress.test.ts
+++ b/tests/features/portfolio-a13-provisional-progress.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test"
-import { HighDensitySolverA13 } from "@tscircuit/high-density-a01"
+import { HighDensitySolverA13 } from "@tscircuit/high-density-a13"
 import { PortfolioSingleIntraNodeSolver } from "lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver"
 
 test("A13 provisional routes retain nonzero scheduling cost and respect effort", () => {

--- a/tests/features/portfolio-a13-provisional-progress.test.ts
+++ b/tests/features/portfolio-a13-provisional-progress.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test"
+import { HighDensitySolverA13 } from "@tscircuit/high-density-a01"
+import { PortfolioSingleIntraNodeSolver } from "lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver"
+
+test("A13 provisional routes retain nonzero scheduling cost and respect effort", () => {
+  const portfolio = new PortfolioSingleIntraNodeSolver({
+    nodeWithPortPoints: {
+      capacityMeshNodeId: "a13-provisional-crossing",
+      width: 4,
+      height: 4,
+      center: { x: 0, y: 0 },
+      availableZ: [0],
+      portPoints: [
+        { connectionName: "a", x: -2, y: 0, z: 0 },
+        { connectionName: "a", x: 2, y: 0, z: 0 },
+        { connectionName: "b", x: 0, y: -2, z: 0 },
+        { connectionName: "b", x: 0, y: 2, z: 0 },
+      ],
+    },
+    traceWidth: 0.15,
+    viaDiameter: 0.4,
+    effort: 0.5,
+  })
+  const candidate = portfolio.generateSolver({ HIGH_DENSITY_A13: true })
+  expect(candidate).toBeInstanceOf(HighDensitySolverA13)
+  const a13 = candidate as unknown as HighDensitySolverA13
+  while (a13.round === 0 && !a13.failed) a13.step()
+  expect(a13.failed).toBe(false)
+  expect(a13.routedCount).toBe(2)
+  expect(a13.conflictCount).toBe(2)
+  expect(a13.solved).toBe(false)
+  expect(portfolio.computeH(candidate)).toBeGreaterThan(0)
+  expect(portfolio.computeG(candidate)).toBe(candidate.iterations / 1_000_000)
+  expect(a13.props.maxSearchIterations).toBe(25_000_000)
+  expect(a13.props.maxRounds).toBe(100)
+  expect(a13.props.stepMultiplier).toBe(1)
+  expect(a13.traceThickness).toBe(0.15)
+  expect(a13.viaDiameter).toBe(0.4)
+})

--- a/tests/features/portfolio-a13-retains-successful-routing.test.ts
+++ b/tests/features/portfolio-a13-retains-successful-routing.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test"
+import { getGlobalInMemoryCache } from "lib/cache/setupGlobalCaches"
+import { PortfolioSingleIntraNodeSolver } from "lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver"
+import type { NodeWithPortPoints } from "lib/types/high-density-types"
+import nodeJson from "../fixtures/srj18-sample002-large-node.json"
+
+const node: NodeWithPortPoints = nodeJson
+
+test("enabling A13 preserves a successful existing search and its routes", () => {
+  const params = {
+    nodeWithPortPoints: node,
+    traceWidth: 0.1,
+    viaDiameter: 0.3,
+    obstacleMargin: 0.15,
+    obstacles: [],
+    layerCount: 2,
+    effort: 1,
+  }
+  const original = new PortfolioSingleIntraNodeSolver(structuredClone(params))
+  const enabled = new PortfolioSingleIntraNodeSolver({
+    ...structuredClone(params),
+    enableNegotiatedSearch: true,
+  })
+  getGlobalInMemoryCache().clearCache()
+  original.solve()
+  getGlobalInMemoryCache().clearCache()
+  enabled.solve()
+  expect(original.solved).toBe(true)
+  expect(enabled.solved).toBe(true)
+  expect(enabled.negotiatedSearchStarted).toBe(false)
+  expect(enabled.iterations).toBe(original.iterations)
+  expect(enabled.solvedRoutes).toEqual(original.solvedRoutes)
+})

--- a/tests/features/portfolio-a13-srj18-hard-node.test.ts
+++ b/tests/features/portfolio-a13-srj18-hard-node.test.ts
@@ -1,7 +1,10 @@
 import { expect, test } from "bun:test"
 import { findRouteGeometryViolations } from "@tscircuit/high-density-a01"
 import { PortfolioSingleIntraNodeSolver } from "lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver"
-import node from "../fixtures/a13-srj18-hard-node.json"
+import type { NodeWithPortPoints } from "lib/types/high-density-types"
+import nodeJson from "../fixtures/a13-srj18-hard-node.json"
+
+const node: NodeWithPortPoints = nodeJson
 
 test("the high-density portfolio routes the SRJ18 hard node with A13 at 1x", () => {
   const original = structuredClone(node)
@@ -19,17 +22,23 @@ test("the high-density portfolio routes the SRJ18 hard node with A13 at 1x", () 
   expect(solver.failed).toBe(false)
   expect(solver.winningSolver?.getSolverName()).toBe("HighDensitySolverA13")
   expect(solver.solvedRoutes).toHaveLength(26)
-  expect(findRouteGeometryViolations(solver.solvedRoutes.map((route) => ({
-    ...route,
-    traceThickness: route.traceThickness + 0.1,
-    viaDiameter: route.viaDiameter + 0.1,
-  })))).toEqual([])
+  expect(
+    findRouteGeometryViolations(
+      solver.solvedRoutes.map((route) => ({
+        ...route,
+        traceThickness: route.traceThickness + 0.1,
+        viaDiameter: route.viaDiameter + 0.1,
+      })),
+    ),
+  ).toEqual([])
   for (const route of solver.solvedRoutes) {
     expect(route.traceThickness).toBe(0.1)
     expect(route.viaDiameter).toBe(0.3)
-    expect(route.rootConnectionName).toBe(node.portPoints.find(
-      (point) => point.connectionName === route.connectionName,
-    )!.rootConnectionName)
+    expect(route.rootConnectionName).toBe(
+      node.portPoints.find(
+        (point) => point.connectionName === route.connectionName,
+      )!.rootConnectionName,
+    )
   }
   expect(node).toEqual(original)
 })

--- a/tests/features/portfolio-a13-srj18-hard-node.test.ts
+++ b/tests/features/portfolio-a13-srj18-hard-node.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test"
+import { findRouteGeometryViolations } from "@tscircuit/high-density-a01"
+import { PortfolioSingleIntraNodeSolver } from "lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver"
+import node from "../fixtures/a13-srj18-hard-node.json"
+
+test("the high-density portfolio routes the SRJ18 hard node with A13 at 1x", () => {
+  const original = structuredClone(node)
+  const solver = new PortfolioSingleIntraNodeSolver({
+    nodeWithPortPoints: node,
+    traceWidth: 0.1,
+    viaDiameter: 0.3,
+    obstacleMargin: 0.15,
+    obstacles: [],
+    layerCount: 2,
+    effort: 1,
+  })
+  solver.solve()
+  expect(solver.solved).toBe(true)
+  expect(solver.failed).toBe(false)
+  expect(solver.winningSolver?.getSolverName()).toBe("HighDensitySolverA13")
+  expect(solver.solvedRoutes).toHaveLength(26)
+  expect(findRouteGeometryViolations(solver.solvedRoutes.map((route) => ({
+    ...route,
+    traceThickness: route.traceThickness + 0.1,
+    viaDiameter: route.viaDiameter + 0.1,
+  })))).toEqual([])
+  for (const route of solver.solvedRoutes) {
+    expect(route.traceThickness).toBe(0.1)
+    expect(route.viaDiameter).toBe(0.3)
+    expect(route.rootConnectionName).toBe(node.portPoints.find(
+      (point) => point.connectionName === route.connectionName,
+    )!.rootConnectionName)
+  }
+  expect(node).toEqual(original)
+})

--- a/tests/features/portfolio-a13-srj18-hard-node.test.ts
+++ b/tests/features/portfolio-a13-srj18-hard-node.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test"
-import { findRouteGeometryViolations } from "@tscircuit/high-density-a01"
+import { findRouteGeometryViolations } from "@tscircuit/high-density-a13"
 import { PortfolioSingleIntraNodeSolver } from "lib/solvers/HyperHighDensitySolver/PortfolioSingleIntraNodeSolver"
 import type { NodeWithPortPoints } from "lib/types/high-density-types"
 import nodeJson from "../fixtures/a13-srj18-hard-node.json"
@@ -16,10 +16,17 @@ test("the high-density portfolio routes the SRJ18 hard node with A13 at 1x", () 
     obstacles: [],
     layerCount: 2,
     effort: 1,
+    enableNegotiatedSearch: true,
   })
   solver.solve()
   expect(solver.solved).toBe(true)
   expect(solver.failed).toBe(false)
+  expect(solver.negotiatedSearchStarted).toBe(true)
+  expect(
+    solver.supervisedSolvers!
+      .filter(({ solver: candidate }) => candidate !== solver.winningSolver)
+      .every(({ solver: candidate }) => candidate.failed),
+  ).toBe(true)
   expect(solver.winningSolver?.getSolverName()).toBe("HighDensitySolverA13")
   expect(solver.solvedRoutes).toHaveLength(26)
   expect(

--- a/tests/fixtures/a13-srj18-hard-node.json
+++ b/tests/fixtures/a13-srj18-hard-node.json
@@ -1,0 +1,1002 @@
+{
+  "capacityMeshNodeId": "cmn_4__sub_2_0",
+  "center": {
+    "x": 23.236849999999997,
+    "y": 3.2744666666666653
+  },
+  "width": 12.742499999999993,
+  "height": 10.616666666666667,
+  "portPoints": [
+    {
+      "portPointId": "ce5412_pp5_z0::0",
+      "x": 16.8656,
+      "y": -0.8138666666666672,
+      "z": 0,
+      "connectionName": "source_trace_9__source_net_9_mst47",
+      "rootConnectionName": "connectivity_net106",
+      "nextPortPointId": "ce5463_pp1_z0::0"
+    },
+    {
+      "portPointId": "ce5463_pp1_z0::0",
+      "x": 24.388099999999998,
+      "y": 8.582799999999999,
+      "z": 0,
+      "connectionName": "source_trace_9__source_net_9_mst47",
+      "rootConnectionName": "connectivity_net106",
+      "prevPortPointId": "ce5412_pp5_z0::0"
+    },
+    {
+      "portPointId": "ce5412_pp5_z0::0",
+      "x": 16.8656,
+      "y": -0.8138666666666672,
+      "z": 0,
+      "connectionName": "source_trace_9__source_net_9_mst48",
+      "rootConnectionName": "connectivity_net106",
+      "nextPortPointId": "ce5462_pp0_z0::0"
+    },
+    {
+      "portPointId": "ce5462_pp0_z0::0",
+      "x": 19.7456,
+      "y": 8.582799999999999,
+      "z": 0,
+      "connectionName": "source_trace_9__source_net_9_mst48",
+      "rootConnectionName": "connectivity_net106",
+      "prevPortPointId": "ce5412_pp5_z0::0"
+    },
+    {
+      "portPointId": "ce5417_pp5_z0::0",
+      "x": 16.8656,
+      "y": 3.8228,
+      "z": 0,
+      "connectionName": "source_trace_10__source_net_10_mst31",
+      "rootConnectionName": "connectivity_net105",
+      "nextPortPointId": "ce5465_pp0_z1::1"
+    },
+    {
+      "portPointId": "ce5465_pp0_z1::1",
+      "x": 29.008099999999992,
+      "y": 8.582799999999999,
+      "z": 1,
+      "connectionName": "source_trace_10__source_net_10_mst31",
+      "rootConnectionName": "connectivity_net105",
+      "prevPortPointId": "ce5417_pp5_z0::0"
+    },
+    {
+      "portPointId": "ce5449_pp1_z0::0",
+      "x": 20.051225,
+      "y": -2.0338666666666683,
+      "z": 0,
+      "connectionName": "source_trace_28__source_net_28_mst1",
+      "rootConnectionName": "connectivity_net87",
+      "nextPortPointId": "ce5464_pp4_z0::0"
+    },
+    {
+      "portPointId": "ce5464_pp4_z0::0",
+      "x": 28.1531,
+      "y": 8.582799999999999,
+      "z": 0,
+      "connectionName": "source_trace_28__source_net_28_mst1",
+      "rootConnectionName": "connectivity_net87",
+      "prevPortPointId": "ce5449_pp1_z0::0"
+    },
+    {
+      "portPointId": "ce5414_pp0_z1::1",
+      "x": 16.8656,
+      "y": -1.2205333333333341,
+      "z": 1,
+      "connectionName": "source_trace_27__source_net_27_mst1",
+      "rootConnectionName": "connectivity_net88",
+      "nextPortPointId": "ce5464_pp1_z0::0"
+    },
+    {
+      "portPointId": "ce5464_pp1_z0::0",
+      "x": 26.818099999999998,
+      "y": 8.582799999999999,
+      "z": 0,
+      "connectionName": "source_trace_27__source_net_27_mst1",
+      "rootConnectionName": "connectivity_net88",
+      "prevPortPointId": "ce5414_pp0_z1::1"
+    },
+    {
+      "portPointId": "ce5415_pp1_z0::0",
+      "x": 16.8656,
+      "y": 0.8577999999999999,
+      "z": 0,
+      "connectionName": "source_trace_86__source_net_86_mst1",
+      "rootConnectionName": "connectivity_net42",
+      "nextPortPointId": "ce5468_pp0_z1::1"
+    },
+    {
+      "portPointId": "ce5468_pp0_z1::1",
+      "x": 29.608099999999993,
+      "y": -0.9722000000000015,
+      "z": 1,
+      "connectionName": "source_trace_86__source_net_86_mst1",
+      "rootConnectionName": "connectivity_net42",
+      "prevPortPointId": "ce5415_pp1_z0::0"
+    },
+    {
+      "portPointId": "ce5415_pp4_z0::0",
+      "x": 16.8656,
+      "y": 1.7078,
+      "z": 0,
+      "connectionName": "source_trace_85__source_net_85_mst1",
+      "rootConnectionName": "connectivity_net43",
+      "nextPortPointId": "ce5449_pp4_z0::0"
+    },
+    {
+      "portPointId": "ce5449_pp4_z0::0",
+      "x": 26.422474999999995,
+      "y": -2.0338666666666683,
+      "z": 0,
+      "connectionName": "source_trace_85__source_net_85_mst1",
+      "rootConnectionName": "connectivity_net43",
+      "prevPortPointId": "ce5415_pp4_z0::0"
+    },
+    {
+      "portPointId": "ce5402_pp0_z0::0",
+      "x": 16.8656,
+      "y": 2.5528,
+      "z": 0,
+      "connectionName": "source_trace_84__source_net_84_mst1",
+      "rootConnectionName": "connectivity_net44",
+      "nextPortPointId": "ce5468_pp0_z0::0"
+    },
+    {
+      "portPointId": "ce5468_pp0_z0::0",
+      "x": 29.608099999999993,
+      "y": -1.275533333333335,
+      "z": 0,
+      "connectionName": "source_trace_84__source_net_84_mst1",
+      "rootConnectionName": "connectivity_net44",
+      "prevPortPointId": "ce5402_pp0_z0::0"
+    },
+    {
+      "portPointId": "ce5468_pp7_z0::0",
+      "x": 29.608099999999993,
+      "y": 1.7577999999999987,
+      "z": 0,
+      "connectionName": "source_trace_118__source_net_118",
+      "rootConnectionName": "connectivity_net14",
+      "nextPortPointId": "ce5282_pp4_z0::0"
+    },
+    {
+      "portPointId": "ce5282_pp4_z0::0",
+      "x": 16.8656,
+      "y": 5.9878,
+      "z": 0,
+      "connectionName": "source_trace_118__source_net_118",
+      "rootConnectionName": "connectivity_net14",
+      "prevPortPointId": "ce5468_pp7_z0::0"
+    },
+    {
+      "portPointId": "ce5468_pp5_z0::0",
+      "x": 29.608099999999993,
+      "y": 0.24113333333333165,
+      "z": 0,
+      "connectionName": "source_trace_114__source_net_114",
+      "rootConnectionName": "connectivity_net18",
+      "nextPortPointId": "ce5412_pp0_z0::0"
+    },
+    {
+      "portPointId": "ce5412_pp0_z0::0",
+      "x": 16.8656,
+      "y": -1.627200000000001,
+      "z": 0,
+      "connectionName": "source_trace_114__source_net_114",
+      "rootConnectionName": "connectivity_net18",
+      "prevPortPointId": "ce5468_pp5_z0::0"
+    },
+    {
+      "portPointId": "ce5468_pp6_z1::1",
+      "x": 29.608099999999993,
+      "y": 5.397799999999998,
+      "z": 1,
+      "connectionName": "source_trace_113__source_net_113",
+      "rootConnectionName": "connectivity_net19",
+      "nextPortPointId": "ce5416_pp5_z1::1"
+    },
+    {
+      "portPointId": "ce5416_pp5_z1::1",
+      "x": 16.8656,
+      "y": 1.7078,
+      "z": 1,
+      "connectionName": "source_trace_113__source_net_113",
+      "rootConnectionName": "connectivity_net19",
+      "prevPortPointId": "ce5468_pp6_z1::1"
+    },
+    {
+      "portPointId": "ce5468_pp10_z0::0",
+      "x": 29.608099999999993,
+      "y": 3.2744666666666653,
+      "z": 0,
+      "connectionName": "source_trace_112__source_net_112",
+      "rootConnectionName": "connectivity_net20",
+      "nextPortPointId": "ce5418_pp0_z1::1"
+    },
+    {
+      "portPointId": "ce5418_pp0_z1::1",
+      "x": 16.8656,
+      "y": 3.3977999999999997,
+      "z": 1,
+      "connectionName": "source_trace_112__source_net_112",
+      "rootConnectionName": "connectivity_net20",
+      "prevPortPointId": "ce5468_pp10_z0::0"
+    },
+    {
+      "portPointId": "ce5468_pp12_z0::0",
+      "x": 29.608099999999993,
+      "y": 4.791133333333333,
+      "z": 0,
+      "connectionName": "source_trace_111__source_net_111",
+      "rootConnectionName": "connectivity_net21",
+      "nextPortPointId": "ce5282_pp3_z0::0"
+    },
+    {
+      "portPointId": "ce5282_pp3_z0::0",
+      "x": 16.8656,
+      "y": 5.4618,
+      "z": 0,
+      "connectionName": "source_trace_111__source_net_111",
+      "rootConnectionName": "connectivity_net21",
+      "prevPortPointId": "ce5468_pp12_z0::0"
+    },
+    {
+      "portPointId": "ce5468_pp13_z1::1",
+      "x": 29.608099999999993,
+      "y": 7.521133333333333,
+      "z": 1,
+      "connectionName": "source_trace_110__source_net_110",
+      "rootConnectionName": "connectivity_net22",
+      "nextPortPointId": "ce5282_pp1_z1::1"
+    },
+    {
+      "portPointId": "ce5282_pp1_z1::1",
+      "x": 16.8656,
+      "y": 4.9358,
+      "z": 1,
+      "connectionName": "source_trace_110__source_net_110",
+      "rootConnectionName": "connectivity_net22",
+      "prevPortPointId": "ce5468_pp13_z1::1"
+    },
+    {
+      "portPointId": "ce5468_pp13_z0::0",
+      "x": 29.608099999999993,
+      "y": 6.3077999999999985,
+      "z": 0,
+      "connectionName": "source_trace_109__source_net_109",
+      "rootConnectionName": "connectivity_net23",
+      "nextPortPointId": "ce5282_pp2_z0::0"
+    },
+    {
+      "portPointId": "ce5282_pp2_z0::0",
+      "x": 16.8656,
+      "y": 4.9358,
+      "z": 0,
+      "connectionName": "source_trace_109__source_net_109",
+      "rootConnectionName": "connectivity_net23",
+      "prevPortPointId": "ce5468_pp13_z0::0"
+    },
+    {
+      "portPointId": "ce5464_pp5_z1::1",
+      "x": 27.485599999999998,
+      "y": 8.582799999999999,
+      "z": 1,
+      "connectionName": "source_trace_108__source_net_108",
+      "rootConnectionName": "connectivity_net24",
+      "nextPortPointId": "ce5282_pp4_z1::1"
+    },
+    {
+      "portPointId": "ce5282_pp4_z1::1",
+      "x": 16.8656,
+      "y": 5.9878,
+      "z": 1,
+      "connectionName": "source_trace_108__source_net_108",
+      "rootConnectionName": "connectivity_net24",
+      "prevPortPointId": "ce5464_pp5_z1::1"
+    },
+    {
+      "portPointId": "ce5468_pp14_z0::0",
+      "x": 29.608099999999993,
+      "y": 7.824466666666666,
+      "z": 0,
+      "connectionName": "source_trace_107__source_net_107",
+      "rootConnectionName": "connectivity_net25",
+      "nextPortPointId": "ce5282_pp5_z0::0"
+    },
+    {
+      "portPointId": "ce5282_pp5_z0::0",
+      "x": 16.8656,
+      "y": 6.5138,
+      "z": 0,
+      "connectionName": "source_trace_107__source_net_107",
+      "rootConnectionName": "connectivity_net25",
+      "prevPortPointId": "ce5468_pp14_z0::0"
+    },
+    {
+      "portPointId": "ce5463_pp3_z1::1",
+      "x": 24.388099999999998,
+      "y": 8.582799999999999,
+      "z": 1,
+      "connectionName": "source_trace_106__source_net_106",
+      "rootConnectionName": "connectivity_net26",
+      "nextPortPointId": "ce5282_pp6_z0::0"
+    },
+    {
+      "portPointId": "ce5282_pp6_z0::0",
+      "x": 16.8656,
+      "y": 7.0398,
+      "z": 0,
+      "connectionName": "source_trace_106__source_net_106",
+      "rootConnectionName": "connectivity_net26",
+      "prevPortPointId": "ce5463_pp3_z1::1"
+    },
+    {
+      "portPointId": "ce5462_pp6_z1::1",
+      "x": 21.9056,
+      "y": 8.582799999999999,
+      "z": 1,
+      "connectionName": "source_trace_95__source_net_95",
+      "rootConnectionName": "connectivity_net33",
+      "nextPortPointId": "ce5416_pp4_z1::1"
+    },
+    {
+      "portPointId": "ce5416_pp4_z1::1",
+      "x": 16.8656,
+      "y": 0.8577999999999999,
+      "z": 1,
+      "connectionName": "source_trace_95__source_net_95",
+      "rootConnectionName": "connectivity_net33",
+      "prevPortPointId": "ce5462_pp6_z1::1"
+    },
+    {
+      "portPointId": "ce5449_pp6_z1::1",
+      "x": 25.785349999999994,
+      "y": -2.0338666666666683,
+      "z": 1,
+      "connectionName": "source_trace_62__source_net_62",
+      "rootConnectionName": "connectivity_net56",
+      "nextPortPointId": "ce5418_pp4_z1::1"
+    },
+    {
+      "portPointId": "ce5418_pp4_z1::1",
+      "x": 16.8656,
+      "y": 4.2478,
+      "z": 1,
+      "connectionName": "source_trace_62__source_net_62",
+      "rootConnectionName": "connectivity_net56",
+      "prevPortPointId": "ce5449_pp6_z1::1"
+    },
+    {
+      "portPointId": "ce5449_pp3_z1::1",
+      "x": 18.13985,
+      "y": -2.0338666666666683,
+      "z": 1,
+      "connectionName": "source_trace_61__source_net_61",
+      "rootConnectionName": "connectivity_net57",
+      "nextPortPointId": "ce5282_pp6_z1::1"
+    },
+    {
+      "portPointId": "ce5282_pp6_z1::1",
+      "x": 16.8656,
+      "y": 7.0398,
+      "z": 1,
+      "connectionName": "source_trace_61__source_net_61",
+      "rootConnectionName": "connectivity_net57",
+      "prevPortPointId": "ce5449_pp3_z1::1"
+    },
+    {
+      "portPointId": "ce5449_pp5_z1::1",
+      "x": 23.236849999999997,
+      "y": -2.0338666666666683,
+      "z": 1,
+      "connectionName": "source_trace_60__source_net_60",
+      "rootConnectionName": "connectivity_net58",
+      "nextPortPointId": "ce5282_pp5_z1::1"
+    },
+    {
+      "portPointId": "ce5282_pp5_z1::1",
+      "x": 16.8656,
+      "y": 6.5138,
+      "z": 1,
+      "connectionName": "source_trace_60__source_net_60",
+      "rootConnectionName": "connectivity_net58",
+      "prevPortPointId": "ce5449_pp5_z1::1"
+    },
+    {
+      "portPointId": "ce5449_pp4_z1::1",
+      "x": 20.68835,
+      "y": -2.0338666666666683,
+      "z": 1,
+      "connectionName": "source_trace_59__source_net_59",
+      "rootConnectionName": "connectivity_net59",
+      "nextPortPointId": "ce5282_pp3_z1::1"
+    },
+    {
+      "portPointId": "ce5282_pp3_z1::1",
+      "x": 16.8656,
+      "y": 5.4618,
+      "z": 1,
+      "connectionName": "source_trace_59__source_net_59",
+      "rootConnectionName": "connectivity_net59",
+      "prevPortPointId": "ce5449_pp4_z1::1"
+    },
+    {
+      "portPointId": "ce5449_pp9_z1::1",
+      "x": 28.333849999999995,
+      "y": -2.0338666666666683,
+      "z": 1,
+      "connectionName": "source_trace_58__source_net_58",
+      "rootConnectionName": "connectivity_net60",
+      "nextPortPointId": "ce5462_pp0_z1::1"
+    },
+    {
+      "portPointId": "ce5462_pp0_z1::1",
+      "x": 17.5856,
+      "y": 8.582799999999999,
+      "z": 1,
+      "connectionName": "source_trace_58__source_net_58",
+      "rootConnectionName": "connectivity_net60",
+      "prevPortPointId": "ce5449_pp9_z1::1"
+    },
+    {
+      "portPointId": "ce5468_pp1_z1::1",
+      "x": 29.608099999999993,
+      "y": 1.1511333333333318,
+      "z": 1,
+      "connectionName": "source_trace_57__source_net_57",
+      "rootConnectionName": "connectivity_net61",
+      "nextPortPointId": "ce5462_pp4_z1::1"
+    },
+    {
+      "portPointId": "ce5462_pp4_z1::1",
+      "x": 19.0256,
+      "y": 8.582799999999999,
+      "z": 1,
+      "connectionName": "source_trace_57__source_net_57",
+      "rootConnectionName": "connectivity_net61",
+      "prevPortPointId": "ce5468_pp1_z1::1"
+    },
+    {
+      "portPointId": "ce5468_pp2_z1::1",
+      "x": 29.608099999999993,
+      "y": 3.2744666666666653,
+      "z": 1,
+      "connectionName": "source_trace_56__source_net_56",
+      "rootConnectionName": "connectivity_net62",
+      "nextPortPointId": "ce5462_pp5_z1::1"
+    },
+    {
+      "portPointId": "ce5462_pp5_z1::1",
+      "x": 20.4656,
+      "y": 8.582799999999999,
+      "z": 1,
+      "connectionName": "source_trace_56__source_net_56",
+      "rootConnectionName": "connectivity_net62",
+      "prevPortPointId": "ce5468_pp2_z1::1"
+    }
+  ],
+  "portPointsInPairs": [
+    [
+      {
+        "portPointId": "ce5412_pp5_z0::0",
+        "x": 16.8656,
+        "y": -0.8138666666666672,
+        "z": 0,
+        "connectionName": "source_trace_9__source_net_9_mst47",
+        "rootConnectionName": "connectivity_net106",
+        "nextPortPointId": "ce5463_pp1_z0::0"
+      },
+      {
+        "portPointId": "ce5463_pp1_z0::0",
+        "x": 24.388099999999998,
+        "y": 8.582799999999999,
+        "z": 0,
+        "connectionName": "source_trace_9__source_net_9_mst47",
+        "rootConnectionName": "connectivity_net106",
+        "prevPortPointId": "ce5412_pp5_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce5412_pp5_z0::0",
+        "x": 16.8656,
+        "y": -0.8138666666666672,
+        "z": 0,
+        "connectionName": "source_trace_9__source_net_9_mst48",
+        "rootConnectionName": "connectivity_net106",
+        "nextPortPointId": "ce5462_pp0_z0::0"
+      },
+      {
+        "portPointId": "ce5462_pp0_z0::0",
+        "x": 19.7456,
+        "y": 8.582799999999999,
+        "z": 0,
+        "connectionName": "source_trace_9__source_net_9_mst48",
+        "rootConnectionName": "connectivity_net106",
+        "prevPortPointId": "ce5412_pp5_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce5417_pp5_z0::0",
+        "x": 16.8656,
+        "y": 3.8228,
+        "z": 0,
+        "connectionName": "source_trace_10__source_net_10_mst31",
+        "rootConnectionName": "connectivity_net105",
+        "nextPortPointId": "ce5465_pp0_z1::1"
+      },
+      {
+        "portPointId": "ce5465_pp0_z1::1",
+        "x": 29.008099999999992,
+        "y": 8.582799999999999,
+        "z": 1,
+        "connectionName": "source_trace_10__source_net_10_mst31",
+        "rootConnectionName": "connectivity_net105",
+        "prevPortPointId": "ce5417_pp5_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce5449_pp1_z0::0",
+        "x": 20.051225,
+        "y": -2.0338666666666683,
+        "z": 0,
+        "connectionName": "source_trace_28__source_net_28_mst1",
+        "rootConnectionName": "connectivity_net87",
+        "nextPortPointId": "ce5464_pp4_z0::0"
+      },
+      {
+        "portPointId": "ce5464_pp4_z0::0",
+        "x": 28.1531,
+        "y": 8.582799999999999,
+        "z": 0,
+        "connectionName": "source_trace_28__source_net_28_mst1",
+        "rootConnectionName": "connectivity_net87",
+        "prevPortPointId": "ce5449_pp1_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce5414_pp0_z1::1",
+        "x": 16.8656,
+        "y": -1.2205333333333341,
+        "z": 1,
+        "connectionName": "source_trace_27__source_net_27_mst1",
+        "rootConnectionName": "connectivity_net88",
+        "nextPortPointId": "ce5464_pp1_z0::0"
+      },
+      {
+        "portPointId": "ce5464_pp1_z0::0",
+        "x": 26.818099999999998,
+        "y": 8.582799999999999,
+        "z": 0,
+        "connectionName": "source_trace_27__source_net_27_mst1",
+        "rootConnectionName": "connectivity_net88",
+        "prevPortPointId": "ce5414_pp0_z1::1"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce5415_pp1_z0::0",
+        "x": 16.8656,
+        "y": 0.8577999999999999,
+        "z": 0,
+        "connectionName": "source_trace_86__source_net_86_mst1",
+        "rootConnectionName": "connectivity_net42",
+        "nextPortPointId": "ce5468_pp0_z1::1"
+      },
+      {
+        "portPointId": "ce5468_pp0_z1::1",
+        "x": 29.608099999999993,
+        "y": -0.9722000000000015,
+        "z": 1,
+        "connectionName": "source_trace_86__source_net_86_mst1",
+        "rootConnectionName": "connectivity_net42",
+        "prevPortPointId": "ce5415_pp1_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce5415_pp4_z0::0",
+        "x": 16.8656,
+        "y": 1.7078,
+        "z": 0,
+        "connectionName": "source_trace_85__source_net_85_mst1",
+        "rootConnectionName": "connectivity_net43",
+        "nextPortPointId": "ce5449_pp4_z0::0"
+      },
+      {
+        "portPointId": "ce5449_pp4_z0::0",
+        "x": 26.422474999999995,
+        "y": -2.0338666666666683,
+        "z": 0,
+        "connectionName": "source_trace_85__source_net_85_mst1",
+        "rootConnectionName": "connectivity_net43",
+        "prevPortPointId": "ce5415_pp4_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce5402_pp0_z0::0",
+        "x": 16.8656,
+        "y": 2.5528,
+        "z": 0,
+        "connectionName": "source_trace_84__source_net_84_mst1",
+        "rootConnectionName": "connectivity_net44",
+        "nextPortPointId": "ce5468_pp0_z0::0"
+      },
+      {
+        "portPointId": "ce5468_pp0_z0::0",
+        "x": 29.608099999999993,
+        "y": -1.275533333333335,
+        "z": 0,
+        "connectionName": "source_trace_84__source_net_84_mst1",
+        "rootConnectionName": "connectivity_net44",
+        "prevPortPointId": "ce5402_pp0_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce5468_pp7_z0::0",
+        "x": 29.608099999999993,
+        "y": 1.7577999999999987,
+        "z": 0,
+        "connectionName": "source_trace_118__source_net_118",
+        "rootConnectionName": "connectivity_net14",
+        "nextPortPointId": "ce5282_pp4_z0::0"
+      },
+      {
+        "portPointId": "ce5282_pp4_z0::0",
+        "x": 16.8656,
+        "y": 5.9878,
+        "z": 0,
+        "connectionName": "source_trace_118__source_net_118",
+        "rootConnectionName": "connectivity_net14",
+        "prevPortPointId": "ce5468_pp7_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce5468_pp5_z0::0",
+        "x": 29.608099999999993,
+        "y": 0.24113333333333165,
+        "z": 0,
+        "connectionName": "source_trace_114__source_net_114",
+        "rootConnectionName": "connectivity_net18",
+        "nextPortPointId": "ce5412_pp0_z0::0"
+      },
+      {
+        "portPointId": "ce5412_pp0_z0::0",
+        "x": 16.8656,
+        "y": -1.627200000000001,
+        "z": 0,
+        "connectionName": "source_trace_114__source_net_114",
+        "rootConnectionName": "connectivity_net18",
+        "prevPortPointId": "ce5468_pp5_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce5468_pp6_z1::1",
+        "x": 29.608099999999993,
+        "y": 5.397799999999998,
+        "z": 1,
+        "connectionName": "source_trace_113__source_net_113",
+        "rootConnectionName": "connectivity_net19",
+        "nextPortPointId": "ce5416_pp5_z1::1"
+      },
+      {
+        "portPointId": "ce5416_pp5_z1::1",
+        "x": 16.8656,
+        "y": 1.7078,
+        "z": 1,
+        "connectionName": "source_trace_113__source_net_113",
+        "rootConnectionName": "connectivity_net19",
+        "prevPortPointId": "ce5468_pp6_z1::1"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce5468_pp10_z0::0",
+        "x": 29.608099999999993,
+        "y": 3.2744666666666653,
+        "z": 0,
+        "connectionName": "source_trace_112__source_net_112",
+        "rootConnectionName": "connectivity_net20",
+        "nextPortPointId": "ce5418_pp0_z1::1"
+      },
+      {
+        "portPointId": "ce5418_pp0_z1::1",
+        "x": 16.8656,
+        "y": 3.3977999999999997,
+        "z": 1,
+        "connectionName": "source_trace_112__source_net_112",
+        "rootConnectionName": "connectivity_net20",
+        "prevPortPointId": "ce5468_pp10_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce5468_pp12_z0::0",
+        "x": 29.608099999999993,
+        "y": 4.791133333333333,
+        "z": 0,
+        "connectionName": "source_trace_111__source_net_111",
+        "rootConnectionName": "connectivity_net21",
+        "nextPortPointId": "ce5282_pp3_z0::0"
+      },
+      {
+        "portPointId": "ce5282_pp3_z0::0",
+        "x": 16.8656,
+        "y": 5.4618,
+        "z": 0,
+        "connectionName": "source_trace_111__source_net_111",
+        "rootConnectionName": "connectivity_net21",
+        "prevPortPointId": "ce5468_pp12_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce5468_pp13_z1::1",
+        "x": 29.608099999999993,
+        "y": 7.521133333333333,
+        "z": 1,
+        "connectionName": "source_trace_110__source_net_110",
+        "rootConnectionName": "connectivity_net22",
+        "nextPortPointId": "ce5282_pp1_z1::1"
+      },
+      {
+        "portPointId": "ce5282_pp1_z1::1",
+        "x": 16.8656,
+        "y": 4.9358,
+        "z": 1,
+        "connectionName": "source_trace_110__source_net_110",
+        "rootConnectionName": "connectivity_net22",
+        "prevPortPointId": "ce5468_pp13_z1::1"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce5468_pp13_z0::0",
+        "x": 29.608099999999993,
+        "y": 6.3077999999999985,
+        "z": 0,
+        "connectionName": "source_trace_109__source_net_109",
+        "rootConnectionName": "connectivity_net23",
+        "nextPortPointId": "ce5282_pp2_z0::0"
+      },
+      {
+        "portPointId": "ce5282_pp2_z0::0",
+        "x": 16.8656,
+        "y": 4.9358,
+        "z": 0,
+        "connectionName": "source_trace_109__source_net_109",
+        "rootConnectionName": "connectivity_net23",
+        "prevPortPointId": "ce5468_pp13_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce5464_pp5_z1::1",
+        "x": 27.485599999999998,
+        "y": 8.582799999999999,
+        "z": 1,
+        "connectionName": "source_trace_108__source_net_108",
+        "rootConnectionName": "connectivity_net24",
+        "nextPortPointId": "ce5282_pp4_z1::1"
+      },
+      {
+        "portPointId": "ce5282_pp4_z1::1",
+        "x": 16.8656,
+        "y": 5.9878,
+        "z": 1,
+        "connectionName": "source_trace_108__source_net_108",
+        "rootConnectionName": "connectivity_net24",
+        "prevPortPointId": "ce5464_pp5_z1::1"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce5468_pp14_z0::0",
+        "x": 29.608099999999993,
+        "y": 7.824466666666666,
+        "z": 0,
+        "connectionName": "source_trace_107__source_net_107",
+        "rootConnectionName": "connectivity_net25",
+        "nextPortPointId": "ce5282_pp5_z0::0"
+      },
+      {
+        "portPointId": "ce5282_pp5_z0::0",
+        "x": 16.8656,
+        "y": 6.5138,
+        "z": 0,
+        "connectionName": "source_trace_107__source_net_107",
+        "rootConnectionName": "connectivity_net25",
+        "prevPortPointId": "ce5468_pp14_z0::0"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce5463_pp3_z1::1",
+        "x": 24.388099999999998,
+        "y": 8.582799999999999,
+        "z": 1,
+        "connectionName": "source_trace_106__source_net_106",
+        "rootConnectionName": "connectivity_net26",
+        "nextPortPointId": "ce5282_pp6_z0::0"
+      },
+      {
+        "portPointId": "ce5282_pp6_z0::0",
+        "x": 16.8656,
+        "y": 7.0398,
+        "z": 0,
+        "connectionName": "source_trace_106__source_net_106",
+        "rootConnectionName": "connectivity_net26",
+        "prevPortPointId": "ce5463_pp3_z1::1"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce5462_pp6_z1::1",
+        "x": 21.9056,
+        "y": 8.582799999999999,
+        "z": 1,
+        "connectionName": "source_trace_95__source_net_95",
+        "rootConnectionName": "connectivity_net33",
+        "nextPortPointId": "ce5416_pp4_z1::1"
+      },
+      {
+        "portPointId": "ce5416_pp4_z1::1",
+        "x": 16.8656,
+        "y": 0.8577999999999999,
+        "z": 1,
+        "connectionName": "source_trace_95__source_net_95",
+        "rootConnectionName": "connectivity_net33",
+        "prevPortPointId": "ce5462_pp6_z1::1"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce5449_pp6_z1::1",
+        "x": 25.785349999999994,
+        "y": -2.0338666666666683,
+        "z": 1,
+        "connectionName": "source_trace_62__source_net_62",
+        "rootConnectionName": "connectivity_net56",
+        "nextPortPointId": "ce5418_pp4_z1::1"
+      },
+      {
+        "portPointId": "ce5418_pp4_z1::1",
+        "x": 16.8656,
+        "y": 4.2478,
+        "z": 1,
+        "connectionName": "source_trace_62__source_net_62",
+        "rootConnectionName": "connectivity_net56",
+        "prevPortPointId": "ce5449_pp6_z1::1"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce5449_pp3_z1::1",
+        "x": 18.13985,
+        "y": -2.0338666666666683,
+        "z": 1,
+        "connectionName": "source_trace_61__source_net_61",
+        "rootConnectionName": "connectivity_net57",
+        "nextPortPointId": "ce5282_pp6_z1::1"
+      },
+      {
+        "portPointId": "ce5282_pp6_z1::1",
+        "x": 16.8656,
+        "y": 7.0398,
+        "z": 1,
+        "connectionName": "source_trace_61__source_net_61",
+        "rootConnectionName": "connectivity_net57",
+        "prevPortPointId": "ce5449_pp3_z1::1"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce5449_pp5_z1::1",
+        "x": 23.236849999999997,
+        "y": -2.0338666666666683,
+        "z": 1,
+        "connectionName": "source_trace_60__source_net_60",
+        "rootConnectionName": "connectivity_net58",
+        "nextPortPointId": "ce5282_pp5_z1::1"
+      },
+      {
+        "portPointId": "ce5282_pp5_z1::1",
+        "x": 16.8656,
+        "y": 6.5138,
+        "z": 1,
+        "connectionName": "source_trace_60__source_net_60",
+        "rootConnectionName": "connectivity_net58",
+        "prevPortPointId": "ce5449_pp5_z1::1"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce5449_pp4_z1::1",
+        "x": 20.68835,
+        "y": -2.0338666666666683,
+        "z": 1,
+        "connectionName": "source_trace_59__source_net_59",
+        "rootConnectionName": "connectivity_net59",
+        "nextPortPointId": "ce5282_pp3_z1::1"
+      },
+      {
+        "portPointId": "ce5282_pp3_z1::1",
+        "x": 16.8656,
+        "y": 5.4618,
+        "z": 1,
+        "connectionName": "source_trace_59__source_net_59",
+        "rootConnectionName": "connectivity_net59",
+        "prevPortPointId": "ce5449_pp4_z1::1"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce5449_pp9_z1::1",
+        "x": 28.333849999999995,
+        "y": -2.0338666666666683,
+        "z": 1,
+        "connectionName": "source_trace_58__source_net_58",
+        "rootConnectionName": "connectivity_net60",
+        "nextPortPointId": "ce5462_pp0_z1::1"
+      },
+      {
+        "portPointId": "ce5462_pp0_z1::1",
+        "x": 17.5856,
+        "y": 8.582799999999999,
+        "z": 1,
+        "connectionName": "source_trace_58__source_net_58",
+        "rootConnectionName": "connectivity_net60",
+        "prevPortPointId": "ce5449_pp9_z1::1"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce5468_pp1_z1::1",
+        "x": 29.608099999999993,
+        "y": 1.1511333333333318,
+        "z": 1,
+        "connectionName": "source_trace_57__source_net_57",
+        "rootConnectionName": "connectivity_net61",
+        "nextPortPointId": "ce5462_pp4_z1::1"
+      },
+      {
+        "portPointId": "ce5462_pp4_z1::1",
+        "x": 19.0256,
+        "y": 8.582799999999999,
+        "z": 1,
+        "connectionName": "source_trace_57__source_net_57",
+        "rootConnectionName": "connectivity_net61",
+        "prevPortPointId": "ce5468_pp1_z1::1"
+      }
+    ],
+    [
+      {
+        "portPointId": "ce5468_pp2_z1::1",
+        "x": 29.608099999999993,
+        "y": 3.2744666666666653,
+        "z": 1,
+        "connectionName": "source_trace_56__source_net_56",
+        "rootConnectionName": "connectivity_net62",
+        "nextPortPointId": "ce5462_pp5_z1::1"
+      },
+      {
+        "portPointId": "ce5462_pp5_z1::1",
+        "x": 20.4656,
+        "y": 8.582799999999999,
+        "z": 1,
+        "connectionName": "source_trace_56__source_net_56",
+        "rootConnectionName": "connectivity_net62",
+        "prevPortPointId": "ce5468_pp2_z1::1"
+      }
+    ]
+  ],
+  "availableZ": [0, 1]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
 
     "baseUrl": ".",
     "paths": {
+      "@tscircuit/high-density-a13": ["types/high-density-a13.ts"],
       "lib/*": ["lib/*"],
       "examples/*": ["examples/*"],
       "tests/*": ["tests/*"],

--- a/types/high-density-a13.ts
+++ b/types/high-density-a13.ts
@@ -1,0 +1,4 @@
+// The two git revisions share a package name/version. Keep TypeScript from
+// unifying their entry points and exposing unrelated A01/A03 changes here.
+export { HighDensitySolverA13 } from "../node_modules/@tscircuit/high-density-a13/lib/HighDensitySolverA13/HighDensitySolverA13"
+export { findRouteGeometryViolations } from "../node_modules/@tscircuit/high-density-a13/lib/routeGeometryValidation"


### PR DESCRIPTION
Adds A13 negotiated congestion to the initial high-density solver portfolio so difficult nodes can complete at their original size before grow/shrink expands them. Pins `@tscircuit/high-density-a01` to latest main revision `cdfd68a`, including A13 from PR #114 and the search-cache optimization from https://github.com/tscircuit/high-density-a01/pull/115.

A13 uses one search pop per portfolio step, effort-scaled search/round limits, and conflict-aware progress so a complete set of provisional routes is not treated as completion. Its larger budget does not delay the existing A01 ordering expansion schedule. Winning A13 routes follow the existing root-net restoration and same-net connectivity processing.

Validation:
- Four focused tests pass, including the full portfolio selecting A13 for SRJ18 sample 2 node `cmn_4__sub_2_0` at 1×: 26 connections, zero node geometry violations at 0.1 mm clearance.
- Coverage verifies provisional progress, scheduling cost, supplied copper dimensions, and effort scaling.
- `bun run build` passes.

A same-machine Pipeline9 benchmark on dataset SRJ18 is requested in a PR comment to assess full-board completion, DRC, runtime, and via-count changes against main. The dependency upgrade also includes upstream A01/A03 changes since the previous pin, so the benchmark measures the complete integration.


Initial SRJ18 same-machine result (before the search-cache update): [benchmark comment](https://github.com/tscircuit/tscircuit-autorouter/pull/2513#issuecomment-5612878120). Completion and relaxed DRC pass fall from 13/16 to 12/16, with timeouts increasing from 1 to 2; completed samples have zero DRC issues on both revisions. Median time improves from 94.9s to 76.4s. Sample 2 regresses from a 306.3s DRC-clean solve to a 360s timeout in `pipeline9JointDrcRepairSolver`. Its high-density stage falls from 139.6s to 135.6s and simplification from 37.2s to 21.1s, but recorded joint DRC repair time rises from 96.0s to at least 176.5s before timeout. These timings locate the downstream slowdown; they do not establish its geometry-level cause. The benchmark tested fb9a7a5; the subsequent commit changes only test typing and formatting.

Not ready to merge: CI build/type/format checks pass, but test failures include routing snapshot differences, the existing portfolio exploration-budget assertion, a pre-repair error-type assertion for SRJ18 sample 8 (its final zero-DRC assertion passes), and a Game Boy board mutation-provenance exception. These remain unresolved.


Updated to `cdfd68a` in commit `86f685ed`. All four focused integration tests and the build pass. A fresh SRJ18 Pipeline9 comparison is requested at https://github.com/tscircuit/tscircuit-autorouter/pull/2513#issuecomment-5613196874; results are pending.
