### PR TITLE
benchmark pipeline9 via and trace repair fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "zdwiel-dataset": "git+https://github.com/dwiel/tscircuit-benchmark.git#be36518b5bf51755dae92c230061ab3cf4e3e063",
     "high-density-repair01": "git+https://github.com/tscircuit/high-density-repair01.git#01f9fe901ac6f691c325bb25d993f52d916a98a1",
     "high-density-repair02": "https://codeload.github.com/tscircuit/high-density-repair02/tar.gz/eba02dae55f156990e23fac0108a620c8021f47b",
-    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#05aa2c0e29343e7a2a24cc60bdd9068aab27d3a4",
+    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#2ca0d8d564a1cc3b0c808ed52ea5175dd9b096fb",
     "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d",
     "@tscircuit/high-density-b01": "git+https://github.com/tscircuit/high-density-b01.git#e651cab6c314e7aab6df31fd6067277436f67148"
   },

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "zdwiel-dataset": "git+https://github.com/dwiel/tscircuit-benchmark.git#be36518b5bf51755dae92c230061ab3cf4e3e063",
     "high-density-repair01": "git+https://github.com/tscircuit/high-density-repair01.git#01f9fe901ac6f691c325bb25d993f52d916a98a1",
     "high-density-repair02": "https://codeload.github.com/tscircuit/high-density-repair02/tar.gz/eba02dae55f156990e23fac0108a620c8021f47b",
-    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#5f6c9af547dbb70c8948227011e1769b5dfa16a5",
+    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#05aa2c0e29343e7a2a24cc60bdd9068aab27d3a4",
     "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d",
     "@tscircuit/high-density-b01": "git+https://github.com/tscircuit/high-density-b01.git#e651cab6c314e7aab6df31fd6067277436f67148"
   },


### PR DESCRIPTION
### Motivation
- benchmark the RV1106 repair fixes with Pipeline9 on the same machine.

### Before
- main uses repair03 before the via fixes and trace repair scheduling fix.

### After
- pin repair03 commit `2ca0d8d564a1cc3b0c808ed52ea5175dd9b096fb`, containing only the production changes from repair03 #123, #125, and [#127](https://github.com/tscircuit/high-density-repair03/pull/127) on the exact installed baseline.
- run `/benchmark --dataset 18 --pipeline 9 --same-machine` on all 16 SRJ18 samples, with unchanged effort and clearance thresholds.
