### PR TITLE
use optimized tiny hypergraph for rv1106 routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "recharts": "^2.15.1",
     "tailwind-merge": "^3.2.0",
     "terser": "^5.43.1",
-    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#c1043b3043ddf0c4d841fe5a6d9a515165960911",
+    "tiny-hypergraph": "git+https://github.com/tscircuit/tiny-hypergraph.git#955b57eab916cee41ed7846f3e3b238043228115",
     "tiny-hypergraph-poly": "git+https://github.com/tscircuit/tiny-hypergraph.git#7b93b4c",
     "tsup": "^8.3.6",
     "tscircuit-for-pipeline9-fixtures": "npm:tscircuit@0.0.2467",


### PR DESCRIPTION
### Motivation

Removed from the board-improvement stack: the replay skips path search, so this PR does not demonstrate a board improvement. TinyHypergraph performance should be evaluated separately.

Pin [TinyHypergraph #181](https://github.com/tscircuit/tiny-hypergraph/pull/181) on the shared RV1106 repro. This optimizes blocker search without intentionally changing route selection. The full path-search run reached a solved result with 239 traces and 36 relaxed DRC errors, matching the replay count. Bun reported the 30-minute CLI timeout at the final asynchronous snapshot check, so full-run image equality is not yet verified; the displayed image is the checkpoint replay. Further full-run checking was stopped after downstream CI exposed result differences.

| Before: 36 | After: 36 |
|---|---|
| ![Before](https://raw.githubusercontent.com/tscircuit/tscircuit-autorouter/7de7cb2/tests/repro/__snapshots__/rv1106-routing.snap.svg) | ![After](https://raw.githubusercontent.com/tscircuit/tscircuit-autorouter/9dc93c7/tests/repro/__snapshots__/rv1106-routing.snap.svg) |

