### PR TITLE
use repair03 via merge direction fix for rv1106

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "zdwiel-dataset": "git+https://github.com/dwiel/tscircuit-benchmark.git#be36518b5bf51755dae92c230061ab3cf4e3e063",
     "high-density-repair01": "git+https://github.com/tscircuit/high-density-repair01.git#01f9fe901ac6f691c325bb25d993f52d916a98a1",
     "high-density-repair02": "https://codeload.github.com/tscircuit/high-density-repair02/tar.gz/eba02dae55f156990e23fac0108a620c8021f47b",
-    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#5f6c9af547dbb70c8948227011e1769b5dfa16a5",
+    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#6a08bc09432c51d4d35531a4fe18585237f05a77",
     "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d",
     "@tscircuit/high-density-b01": "git+https://github.com/tscircuit/high-density-b01.git#e651cab6c314e7aab6df31fd6067277436f67148"
   },


### PR DESCRIPTION
### Motivation

Removed from the board-improvement stack: this dependency update did not improve the shared RV1106 snapshot or DRC count.

Pin the autorouter-compatible [repair03 merge-direction fix #128](https://github.com/tscircuit/high-density-repair03/pull/128), preserving the newer pad-clearance implementation. The same RV1106 replay and snapshot remain at 36 relaxed DRC errors; this dependency update alone does not reduce the board's final DRC count.

| Before: 36 | After: 36 |
|---|---|
| ![Before](https://raw.githubusercontent.com/tscircuit/tscircuit-autorouter/9dc93c7/tests/repro/__snapshots__/rv1106-routing.snap.svg) | ![After](https://raw.githubusercontent.com/tscircuit/tscircuit-autorouter/597db33/tests/repro/__snapshots__/rv1106-routing.snap.svg) |

