### PR TITLE
Cache repeated A03 via geometry in Pipeline9

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "high-density-repair01": "git+https://github.com/tscircuit/high-density-repair01.git#01f9fe901ac6f691c325bb25d993f52d916a98a1",
     "high-density-repair02": "https://codeload.github.com/tscircuit/high-density-repair02/tar.gz/eba02dae55f156990e23fac0108a620c8021f47b",
     "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#5f6c9af547dbb70c8948227011e1769b5dfa16a5",
-    "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#c62332eae34847782eefb17f5baf5c2bff7a30b1",
+    "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#b311077ec762f3cdf08092c828a27e5a738434dd",
     "@tscircuit/high-density-a13": "git+https://github.com/tscircuit/high-density-a01.git#c6812cebd44b09f29f2fee929837b313b822f2ae",
     "@tscircuit/high-density-b01": "git+https://github.com/tscircuit/high-density-b01.git#e651cab6c314e7aab6df31fd6067277436f67148"
   },

--- a/package.json
+++ b/package.json
@@ -7,9 +7,7 @@
     "type": "git",
     "url": "https://github.com/tscircuit/tscircuit-autorouter"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "prepublishOnly": "bun run build && bun scripts/check-published-autorouter-version.ts",
     "start": "cosmos",
@@ -104,7 +102,7 @@
     "high-density-repair01": "git+https://github.com/tscircuit/high-density-repair01.git#01f9fe901ac6f691c325bb25d993f52d916a98a1",
     "high-density-repair02": "https://codeload.github.com/tscircuit/high-density-repair02/tar.gz/eba02dae55f156990e23fac0108a620c8021f47b",
     "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#5f6c9af547dbb70c8948227011e1769b5dfa16a5",
-    "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d",
+    "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#c62332eae34847782eefb17f5baf5c2bff7a30b1",
     "@tscircuit/high-density-a13": "git+https://github.com/tscircuit/high-density-a01.git#c6812cebd44b09f29f2fee929837b313b822f2ae",
     "@tscircuit/high-density-b01": "git+https://github.com/tscircuit/high-density-b01.git#e651cab6c314e7aab6df31fd6067277436f67148"
   },

--- a/scripts/benchmark-pipeline9-high-density.ts
+++ b/scripts/benchmark-pipeline9-high-density.ts
@@ -1,0 +1,106 @@
+import { createHash } from "node:crypto"
+import { mkdir, writeFile } from "node:fs/promises"
+import { dirname } from "node:path"
+import { dataset } from "dataset-srj18"
+import { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "../lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/AutoroutingPipelineSolver9_PreloadedTraceGraph"
+import { evaluateRelaxedDrc } from "../lib/testing/evaluate-relaxed-drc"
+import type { SimpleRouteJson } from "../lib/types"
+
+type StageDuration = { stage: string; durationMs: number }
+
+const sampleId = `sample${String(Number(process.argv[2])).padStart(3, "0")}`
+const entry = Object.entries(dataset).find(([key]) => key === sampleId)
+if (!entry) throw new Error(`Unknown sample ${sampleId}`)
+const inputSrj = structuredClone(entry[1]) as SimpleRouteJson
+const inputSha256 = createHash("sha256")
+  .update(JSON.stringify(inputSrj))
+  .digest("hex")
+const outFile = process.argv[3]
+if (!outFile)
+  throw new Error(
+    "Usage: bun scripts/benchmark-pipeline9-high-density.ts <sample number> <report path>",
+  )
+const stages: StageDuration[] = []
+const startedAt = new Date().toISOString()
+const cpuStart = process.cpuUsage()
+const startMs = performance.now()
+const solver = new AutoroutingPipelineSolver9_PreloadedTraceGraph(inputSrj, {
+  effort: 1,
+})
+const constructionDurationMs = performance.now() - startMs
+let thrownError: string | null = null
+try {
+  while (!solver.solved && !solver.failed) {
+    const stageIndex = solver.currentPipelineStepIndex
+    const stage =
+      solver.pipelineDef[stageIndex]?.solverName ?? "pipeline_completion"
+    const stageStartMs = performance.now()
+    try {
+      do {
+        solver.step()
+      } while (
+        !solver.solved &&
+        !solver.failed &&
+        solver.currentPipelineStepIndex === stageIndex
+      )
+    } finally {
+      stages.push({ stage, durationMs: performance.now() - stageStartMs })
+    }
+  }
+} catch (error) {
+  thrownError = String(error)
+}
+const durationMs = performance.now() - startMs
+const cpuUsage = process.cpuUsage(cpuStart)
+const outputSrj = solver.solved ? solver.getOutputSimpleRouteJson() : null
+const drc = solver.solved
+  ? evaluateRelaxedDrc({
+      inputSrj,
+      srjWithPointPairs: solver.srjWithPointPairs ?? inputSrj,
+      routedTraces: solver.getOutputSimplifiedPcbTraces(),
+    })
+  : null
+const report = {
+  sampleId,
+  startedAt,
+  completedAt: new Date().toISOString(),
+  effort: 1,
+  bun: Bun.version,
+  bunRevision: Bun.revision,
+  revision: Bun.spawnSync(["git", "rev-parse", "HEAD"])
+    .stdout.toString()
+    .trim(),
+  inputSha256,
+  outputSha256: outputSrj
+    ? createHash("sha256").update(JSON.stringify(outputSrj)).digest("hex")
+    : null,
+  solved: solver.solved,
+  failed: solver.failed,
+  error: thrownError ?? solver.error,
+  durationMs,
+  constructionDurationMs,
+  stages,
+  iterations: solver.iterations,
+  cpuUserMs: cpuUsage.user / 1000,
+  cpuSystemMs: cpuUsage.system / 1000,
+  peakRssBytes:
+    process.resourceUsage().maxRSS * (process.platform === "darwin" ? 1 : 1024),
+  relaxedDrcErrors: drc?.errors ?? null,
+  vias:
+    outputSrj?.traces?.reduce(
+      (sum, trace) =>
+        sum + trace.route.filter((point) => point.route_type === "via").length,
+      0,
+    ) ?? null,
+  highDensityStats: solver.highDensityRouteSolver?.stats ?? null,
+}
+await mkdir(dirname(outFile), { recursive: true })
+await writeFile(outFile, JSON.stringify(report, null, 2))
+if (outputSrj)
+  await writeFile(
+    `${outFile}.output.json.gz`,
+    Bun.gzipSync(JSON.stringify(outputSrj)),
+  )
+console.log(
+  `${sampleId} solved=${solver.solved} failed=${solver.failed} duration=${(durationMs / 1000).toFixed(3)}s hd=${((stages.find((stage) => stage.stage === "highDensityRouteSolver")?.durationMs ?? 0) / 1000).toFixed(3)}s drc=${drc?.errors.length ?? "not_run"}`,
+)

--- a/tests/a03-occupant-query-isolation.test.ts
+++ b/tests/a03-occupant-query-isolation.test.ts
@@ -1,0 +1,79 @@
+import { expect, test } from "bun:test"
+import {
+  HighDensitySolverA03,
+  type NodeWithPortPoints,
+} from "@tscircuit/high-density-a01"
+
+test("A03 occupancy queries preserve conflict order across layers, edits and stamp rollover", (): void => {
+  const connectionNames = ["active", "sibling", "first", "second"]
+  const nodeWithPortPoints: NodeWithPortPoints = {
+    capacityMeshNodeId: "occupant-query-isolation",
+    center: { x: 0, y: 0 },
+    width: 4,
+    height: 4,
+    availableZ: [0, 1],
+    portPoints: connectionNames.flatMap((connectionName, index) => [
+      {
+        connectionName,
+        rootConnectionName: index < 2 ? "shared-root" : connectionName,
+        x: -1.5,
+        y: index * 0.5 - 1,
+        z: 0,
+      },
+      {
+        connectionName,
+        rootConnectionName: index < 2 ? "shared-root" : connectionName,
+        x: 1.5,
+        y: index * 0.5 - 1,
+        z: 1,
+      },
+    ]),
+  }
+  const solver = new HighDensitySolverA03({
+    nodeWithPortPoints,
+    highResolutionCellSize: 0.25,
+    lowResolutionCellSize: 0.5,
+    highResolutionCellThickness: 2,
+    viaDiameter: 0.3,
+  })
+  solver.setup()
+  expect(solver.failed).toBeFalse()
+  const active = solver["connNameToId"].get("active")!
+  const sibling = solver["connNameToId"].get("sibling")!
+  const first = solver["connNameToId"].get("first")!
+  const second = solver["connNameToId"].get("second")!
+  const occupiedCells = solver["usedCellsFlat"]
+  const sharedCells = solver["sharedCellsFlat"]
+  const cellId = Math.floor(solver.planeSize / 2)
+  const traceOccupants: number[] = []
+
+  // The same connections occur in many cells and on both layers.
+  occupiedCells.fill(first)
+  sharedCells.fill([active, second, sibling, first, second])
+  solver["fillViaOccupants"](cellId, active)
+  expect(solver["_viaOccs"]).toEqual([first, second])
+
+  // A trace query changes both encounter order and the active connection.
+  occupiedCells[0] = second
+  sharedCells[0] = [first, first, active, sibling, second]
+  solver["fillTraceOccupants"](0, first, traceOccupants)
+  expect(traceOccupants).toEqual([second, active, sibling])
+  occupiedCells[0] = first
+  sharedCells[0] = [active, second, sibling, first, second]
+  solver["fillViaOccupants"](cellId, active)
+  expect(solver["_viaOccs"]).toEqual([first, second])
+
+  // Rip-up/replacement between queries must immediately change conflicts.
+  occupiedCells.fill(second)
+  sharedCells.fill(undefined)
+  solver["fillViaOccupants"](cellId, active)
+  expect(solver["_viaOccs"]).toEqual([second])
+
+  solver["occupantQueryStamp"] = 0xffffffff
+  solver["occupantSeenStamp"].fill(1)
+  solver["fillViaOccupants"](cellId, active)
+  expect(solver["_viaOccs"]).toEqual([second])
+  occupiedCells.fill(-1)
+  solver["fillTraceOccupants"](0, active, traceOccupants)
+  expect(traceOccupants).toEqual([])
+})

--- a/tests/a03-occupant-query-isolation.test.ts
+++ b/tests/a03-occupant-query-isolation.test.ts
@@ -1,10 +1,8 @@
 import { expect, test } from "bun:test"
-import {
-  HighDensitySolverA03,
-  type NodeWithPortPoints,
-} from "@tscircuit/high-density-a01"
+import { HighDensitySolverA03 } from "@tscircuit/high-density-a01"
+import type { NodeWithPortPoints } from "@tscircuit/high-density-a01"
 
-test("A03 occupancy queries preserve conflict order across layers, edits and stamp rollover", (): void => {
+test("A03 cached via footprints preserve live conflict order across layers and edits", (): void => {
   const connectionNames = ["active", "sibling", "first", "second"]
   const nodeWithPortPoints: NodeWithPortPoints = {
     capacityMeshNodeId: "occupant-query-isolation",
@@ -69,11 +67,9 @@ test("A03 occupancy queries preserve conflict order across layers, edits and sta
   solver["fillViaOccupants"](cellId, active)
   expect(solver["_viaOccs"]).toEqual([second])
 
-  solver["occupantQueryStamp"] = 0xffffffff
-  solver["occupantSeenStamp"].fill(1)
-  solver["fillViaOccupants"](cellId, active)
-  expect(solver["_viaOccs"]).toEqual([second])
   occupiedCells.fill(-1)
   solver["fillTraceOccupants"](0, active, traceOccupants)
   expect(traceOccupants).toEqual([])
+  solver["fillViaOccupants"](cellId, active)
+  expect(solver["_viaOccs"]).toEqual([])
 })

--- a/tests/a03-via-footprint-geometry.test.ts
+++ b/tests/a03-via-footprint-geometry.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test"
+import { HighDensitySolverA03 } from "@tscircuit/high-density-a01"
+
+test("A03 cached via footprints match circle intersections across fine and coarse grid boundaries", (): void => {
+  const solver = new HighDensitySolverA03({
+    nodeWithPortPoints: {
+      capacityMeshNodeId: "via-footprint-geometry",
+      center: { x: 0.3, y: -0.2 },
+      width: 4,
+      height: 4,
+      availableZ: [0, 1],
+      portPoints: [],
+    },
+    highResolutionCellSize: 0.25,
+    lowResolutionCellSize: 0.5,
+    highResolutionCellThickness: 2,
+    viaDiameter: 0.3,
+    traceThickness: 0.12,
+    traceMargin: 0.1,
+  })
+  solver.setup()
+  expect(solver.failed).toBeFalse()
+  const radius = 0.3 / 2 + 0.12 / 2 + 0.1
+
+  for (let cellId = 0; cellId < solver.planeSize; cellId++) {
+    const cx = solver.cellCenterX[cellId]!
+    const cy = solver.cellCenterY[cellId]!
+    const expectedCellIds: number[] = []
+    for (let candidateId = 0; candidateId < solver.planeSize; candidateId++) {
+      const dx = Math.max(
+        solver.cellMinX[candidateId]! - cx,
+        0,
+        cx - solver.cellMaxX[candidateId]!,
+      )
+      const dy = Math.max(
+        solver.cellMinY[candidateId]! - cy,
+        0,
+        cy - solver.cellMaxY[candidateId]!,
+      )
+      if (dx * dx + dy * dy <= radius * radius) {
+        expectedCellIds.push(candidateId)
+      }
+    }
+    const footprint = solver["getViaFootprintCellIds"](cellId)
+    expect(Array.from(footprint)).toEqual(expectedCellIds)
+    expect(solver["getViaFootprintCellIds"](cellId)).toBe(footprint)
+  }
+})


### PR DESCRIPTION
A03 repeatedly recomputed the same circle-to-grid intersections while collecting conflicts around possible vias. This caches each queried cell’s fixed footprint lazily, preserving encounter order while reading live occupancy on every query. Geometry, active/same-root filtering, duplicate filtering, effort and solver scheduling remain unchanged.

The implementation is in [high-density-a01 #119](https://github.com/tscircuit/high-density-a01/pull/119). This PR pins its identical compatibility backport `b311077ec762f3cdf08092c828a27e5a738434dd` onto the previous dependency revision `9a3a3dbc62d425c0459e6fc2fef7a656b448e9a0`, excluding unrelated upstream changes. A13 retains its existing pin. Two downstream regressions exercise the actual pinned package; the new benchmark entrypoint makes the local measurement reproducible.

**96 fresh-process local runs (16 boards × 3 repetitions × 2 revisions): total median-based time −3.53%, full high-density time −6.28%.** Successful-route time alone improved 1.57%; failed-attempt time improved 6.23%. All 13 successful output JSON hashes, via counts and relaxed DRC results match, and the same three failures persist. No timeout, interruption or sleep affected the cohort. The three paired total savings were 23.675, 25.716 and 24.570 seconds.

The [supported same-machine GitHub benchmark](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/34551143257) also passed: total elapsed −5.18%, recorded high-density time −10.09%, the same 13/16 solved, zero DRC issues/timeouts, identical per-board via counts and 13 identical SVG hashes. It is a separate single-run cohort: the workflow adds legacy obstacle metadata, uses Bun 1.4.2/Linux, and has different timer/output conventions. The local repeated cohort uses raw pinned SRJs and Bun 1.3.9/macOS; these results are not pooled.

All standard CI checks passed on both PRs, including the geometry/live-occupancy regressions and all nine autorouter test shards. **No local tests were run.** All changed supported files were formatted with each repository’s Biome before every push, explicitly including package.json despite its default exclusion. Main remains `109c67baebc709be95fb37df1fdac9b3b74624c5`; measured PR head is `b86a9b871424950247f076033eea6281c299822c`.

Independent of held PR #2532, which was not modified or used as a base. Neither PR is authorized for merging.

<details>
<summary>Full profiling, per-board medians and dispersion, output hashes, stage timings, audit and reproduction</summary>

# SRJ18 Pipeline9 A03 via-footprint cache

Baseline `109c67baebc709be95fb37df1fdac9b3b74624c5`; candidate `b86a9b871424950247f076033eea6281c299822c`.

Canonical PR: https://github.com/tscircuit/high-density-a01/pull/119. Autorouter PR: https://github.com/tscircuit/tscircuit-autorouter/pull/2541. Neither PR is authorized for merging.

The change lazily caches fixed via-footprint cell IDs in A03. It preserves encounter order and reads live occupancy on every query. The same canonical patch is backported onto the previously pinned dependency revision, excluding unrelated upstream changes.

**Measured result: 3.5% lower total routing time and 6.3% lower full high-density time, with 13 identical successful routes and the same 3 failures. Successful-route time alone is 1.6% lower.**

## Repeated uninstrumented results

16 boards × 3 repetitions × 2 revisions, one fresh process at a time, alternating revision order. Dataset SRJ18 `100e8957ce789b5b288e14c476dc83f4efc5214b`, Pipeline9 effort 1, Bun 1.3.9 (`cf6cdbbb`), Apple M1/macOS arm64/8 GB.

| Group | Boards | Total baseline → candidate (s) | Change | HD baseline → candidate (s) | P50 baseline → candidate (s) | P95 baseline → candidate (s) |
|---|---:|---:|---:|---:|---:|---:|
| all | 16 | 702.843 → 678.033 | -3.53% | 391.072 → 366.530 | 29.161 → 28.719 | 136.805 → 126.824 |
| solved | 13 | 407.225 → 400.818 | -1.57% | 163.600 → 157.038 | 21.463 → 21.423 | 68.233 → 66.278 |
| failed | 3 | 295.617 → 277.215 | -6.23% | 227.472 → 209.492 | 90.889 → 87.329 | 136.805 → 126.824 |

Total is the sum of per-board medians. P50 is the median of board medians; P95 is nearest rank `ceil(0.95 × board count)`. Failed attempts are reported separately and do not represent additional solved boards. Three repetitions measure repeatability on this pinned cohort.

## Per-board total latency

Median seconds; brackets show min–max and MAD across repetitions.

| Board | Outcome | Baseline | Candidate | Change |
|---|---|---:|---:|---:|
| sample001 | solved | 9.089 [9.066–9.108; MAD 0.019] | 9.103 [9.079–9.156; MAD 0.024] | +0.15% |
| sample002 | solved | 59.231 [59.099–59.258; MAD 0.026] | 58.517 [58.152–58.842; MAD 0.325] | -1.21% |
| sample003 | solved | 10.014 [9.994–10.025; MAD 0.012] | 9.889 [9.709–9.941; MAD 0.052] | -1.25% |
| sample004 | solved | 33.328 [33.253–33.563; MAD 0.075] | 32.973 [32.772–33.190; MAD 0.201] | -1.07% |
| sample005 | solved | 8.899 [8.833–8.931; MAD 0.032] | 8.855 [8.855–8.857; MAD 0.001] | -0.49% |
| sample006 | failed | 67.924 [67.822–68.102; MAD 0.102] | 63.062 [62.979–63.387; MAD 0.083] | -7.16% |
| sample007 | solved | 13.180 [13.175–13.220; MAD 0.005] | 13.021 [12.983–13.030; MAD 0.009] | -1.21% |
| sample008 | solved | 67.544 [67.282–67.612; MAD 0.068] | 65.672 [65.123–65.790; MAD 0.117] | -2.77% |
| sample009 | solved | 13.312 [13.003–13.335; MAD 0.022] | 12.914 [12.888–12.971; MAD 0.025] | -2.99% |
| sample010 | solved | 13.521 [13.510–13.544; MAD 0.011] | 13.509 [13.457–13.551; MAD 0.043] | -0.09% |
| sample011 | solved | 21.463 [21.432–21.546; MAD 0.031] | 21.423 [21.327–21.454; MAD 0.031] | -0.19% |
| sample012 | solved | 64.418 [64.416–64.519; MAD 0.002] | 64.200 [63.898–64.638; MAD 0.302] | -0.34% |
| sample013 | solved | 68.233 [68.097–68.471; MAD 0.136] | 66.278 [65.972–66.293; MAD 0.016] | -2.87% |
| sample014 | failed | 136.805 [135.659–136.974; MAD 0.169] | 126.824 [126.288–126.954; MAD 0.130] | -7.30% |
| sample015 | failed | 90.889 [90.631–91.192; MAD 0.258] | 87.329 [87.282–87.700; MAD 0.047] | -3.92% |
| sample016 | solved | 24.994 [24.842–25.115; MAD 0.121] | 24.466 [24.412–24.545; MAD 0.054] | -2.11% |

## Full high-density stage

| Board | Baseline | Candidate | Change |
|---|---:|---:|---:|
| sample001 | 2.849 [2.839–2.857; MAD 0.008] | 2.868 [2.865–2.886; MAD 0.003] | +0.66% |
| sample002 | 23.845 [23.833–23.876; MAD 0.012] | 23.056 [22.998–23.060; MAD 0.005] | -3.31% |
| sample003 | 4.535 [4.535–4.546; MAD 0.000] | 4.394 [4.247–4.401; MAD 0.006] | -3.10% |
| sample004 | 13.197 [13.188–13.209; MAD 0.009] | 12.823 [12.738–12.825; MAD 0.002] | -2.84% |
| sample005 | 2.544 [2.497–2.558; MAD 0.014] | 2.540 [2.529–2.554; MAD 0.011] | -0.15% |
| sample006 | 49.995 [49.927–50.007; MAD 0.012] | 44.920 [44.914–45.383; MAD 0.006] | -10.15% |
| sample007 | 5.486 [5.474–5.590; MAD 0.012] | 5.378 [5.359–5.385; MAD 0.007] | -1.98% |
| sample008 | 34.236 [34.094–34.289; MAD 0.053] | 32.437 [31.912–32.452; MAD 0.015] | -5.26% |
| sample009 | 4.234 [4.060–4.311; MAD 0.077] | 3.864 [3.848–3.894; MAD 0.016] | -8.73% |
| sample010 | 3.170 [3.164–3.171; MAD 0.001] | 3.118 [3.090–3.143; MAD 0.025] | -1.64% |
| sample011 | 7.240 [7.218–7.266; MAD 0.022] | 7.062 [7.042–7.126; MAD 0.021] | -2.45% |
| sample012 | 12.315 [12.285–12.360; MAD 0.030] | 12.105 [12.074–12.171; MAD 0.031] | -1.71% |
| sample013 | 37.194 [37.153–37.311; MAD 0.041] | 35.113 [34.950–35.225; MAD 0.113] | -5.60% |
| sample014 | 109.057 [107.969–109.243; MAD 0.186] | 99.070 [98.578–99.211; MAD 0.142] | -9.16% |
| sample015 | 68.420 [67.457–68.533; MAD 0.114] | 65.502 [65.160–65.557; MAD 0.055] | -4.26% |
| sample016 | 12.755 [12.683–12.893; MAD 0.072] | 12.281 [12.270–12.307; MAD 0.011] | -3.72% |

## Routing behavior

Semantic mismatches: 0. Timeouts: 0.

Compared input hash, solved/failed state, failure text, iterations, successful output hash, via count and complete relaxed DRC errors on every paired run.

| Board | Successful output SHA-256 | Vias | Relaxed DRC errors |
|---|---|---:|---:|
| sample001 | fb8df616d5a66b4bff2b897ce68083eb0b33b794dfdf4e49886256de88326a1a | 167 | 0 |
| sample002 | 89fa2b57bf14948e35050c7581e758bbb84662e2724e1955a36036785fa886df | 538 | 0 |
| sample003 | a39a707bda119cc2b57e8897d2021717a0297620e17d50ef49bce9a2a104a682 | 96 | 0 |
| sample004 | 3c304b51d28ea96b4a68c64a334c178f132ced05328fb14843e6104f2c76e7c1 | 136 | 0 |
| sample005 | 7ea015cffe6167eff9f71ad3499880bd4494d51724596c068e1413e9fa2bd570 | 146 | 0 |
| sample006 | not produced (failed) | n/a | not run (failed) |
| sample007 | 382ff7d3668c2a382b8e4c9a6dc4884c3d75de6a4ca548b33bb9a3bb3672ab48 | 224 | 0 |
| sample008 | 6d42c454bfd552fa66a38fbc0f52bfd2b0a3e000e3c8f9ab2c92572d5a83a217 | 299 | 0 |
| sample009 | 3b9390e901f2d6c8fef71aeeac330d6de4cb6a8fcb31c8411acdcd1578ed3f63 | 115 | 0 |
| sample010 | 3f0f36a7e992c1c07aee8c4c7b9e5007ed0e45a673dd60aff89070cae6bbdb61 | 159 | 0 |
| sample011 | 9309f8c039b71daafe244aa04f8a84419d86bf074224b9812da56531232157e2 | 194 | 0 |
| sample012 | e584cb9adddae7a3f918d35ceb4ba3cab5f32e560753ade1675d6c94247a334a | 292 | 0 |
| sample013 | 909a50be322bb9b111028338eeb917016eb3ba479e40c946e7ac0f76e1310472 | 223 | 0 |
| sample014 | not produced (failed) | n/a | not run (failed) |
| sample015 | not produced (failed) | n/a | not run (failed) |
| sample016 | cd4ea73481c2426545ebc2f791ceb9631a23ffba3ea78faceaf9dd05606972e9 | 113 | 0 |

## Paired repetition totals

- all: baseline [701.716533457, 702.815604123, 702.936993542]; candidate [678.041236414, 677.099613957, 678.366697124]; paired candidate-minus-baseline seconds [-23.675297043, -25.715990165999983, -24.570296417999998].
- solved: baseline [407.503358458, 407.02025037299995, 406.94931458400004]; candidate [401.083737289, 399.884840291, 400.733819958]; paired candidate-minus-baseline seconds [-6.419621168999981, -7.135410081999964, -6.215494626000009].
- failed: baseline [294.213174999, 295.79535375, 295.987678958]; candidate [276.957499125, 277.214773666, 277.632877166]; paired candidate-minus-baseline seconds [-17.255675873999962, -18.58058008400002, -18.35480179199999].

## Reproduction and raw evidence

Raw results: `/Users/anassarkiz/tsci/tscircuit-autorouter/tmp/high-density-evidence/full-01`. Summary: `/Users/anassarkiz/tsci/tscircuit-autorouter/tmp/high-density-evidence/full-01/summary.json`. Full methodology: `/Users/anassarkiz/tsci/tscircuit-autorouter/tmp/high-density-evidence/methodology.md`.

Use the committed `scripts/benchmark-pipeline9-high-density.ts <sample number> <report path>` entrypoint in each checkout with Bun. The retained `tmp/compare.py` performs the alternating fresh-process cohort; `tmp/summarize-comparison.py` computes these statistics. Source instrumentation and native CPU profiles are diagnostic only, not used for latency claims.

No local tests ran. Regression execution is through standard GitHub CI. Every push was preceded by formatting all changed supported files with the owning repository’s Biome.

## Construction, preparation and complete stage boundaries

Pipeline construction alone: 0.384585 → 0.385589 seconds (sum of board medians). Nested stage construction and preparation are included in the full stage timings below, including unused candidates.

Each stage is the sum of its per-board medians. These independently computed medians need not sum to the independently computed total median. Small changes outside the target stage are not credited as optimization gains.

| Stage | Baseline seconds | Candidate seconds |
|---|---:|---:|
| preprocessSimpleRouteJsonSolver | 1.395 | 1.394 |
| componentDetectionSolver | 0.035 | 0.035 |
| escapeViaLocationSolver | 0.138 | 0.137 |
| netToPointPairsSolver | 0.612 | 0.614 |
| topologyPlanningSolver | 3.472 | 3.493 |
| topologyMergingSolver | 3.083 | 3.082 |
| nodeDimensionSubdivisionSolver | 0.077 | 0.076 |
| edgeSolver | 0.803 | 0.806 |
| availableSegmentPointSolver | 0.198 | 0.200 |
| necessaryCrampedPortPointSolver | 1.303 | 1.291 |
| preloadedTraceGraphSolver | 0.513 | 0.510 |
| portPointPathingSolver | 117.769 | 117.700 |
| uniformPortDistributionSolver | 9.039 | 9.039 |
| highDensityRouteSolver | 391.072 | 366.530 |
| highDensityForceImproveSolver | 6.866 | 6.882 |
| highDensityRepairSolver | 16.881 | 16.840 |
| highDensityStitchSolver | 1.950 | 1.956 |
| traceSimplificationSolver | 35.919 | 35.712 |
| mutatedPreloadedTraceSimplificationSolver | 0.088 | 0.090 |
| traceWidthSolver | 6.894 | 6.834 |
| globalDrcForceImproveSolver | 19.514 | 19.601 |
| pipeline9JointDrcRepairSolver | 80.426 | 80.702 |
| lengthMatchingPostProcessingSolver | 3.567 | 3.600 |
| powerTraceExpansionSolver | 0.757 | 0.760 |
| pipeline_completion | 0.000 | 0.000 |

## Profiling evidence and attribution limits

Fresh discovery covered all 16 boards with constructor, setup, solver lifecycle, preparation-method and region records. Native CPU profiles cover samples002/006/013/014, including the most expensive high-density board. Detailed instrumentation preserved input/output hashes, outcomes, errors, iterations and relaxed DRC on all 16 boards; the four native baseline runs matched too. All 20 diagnostic comparisons passed.

Source-instrumented spans subtract nested spans to distinguish exclusive from inclusive time. Native inclusive source-family samples overlap; parent and child times must not be added. Hundreds of millions of A01 step calls substantially inflate diagnostic wrapper overhead, so instrumented durations and constructor counts are not treated as production CPU savings. Uninstrumented results above are the speed measurements.

| Native HD source family | Inclusive sampled seconds, four boards |
|---|---:|
| HighDensitySolverA01 | 74.537 |
| HighDensitySolverA03 | 68.154 |
| SingleHighDensityRouteSolver | 52.937 |
| HighDensitySolverA13 | 8.386 |
| PortfolioSingleIntraNodeSolver | 218.539 |
| CachedIntraNodeRouteSolver | 57.679 |

The fresh profiles placed A01 and A03 ahead of the grid solver family. A03 repeatedly enumerated circle neighborhoods and tested cell rectangles in its occupancy query. A stamp-based duplicate-scan experiment was screened and rejected: it saved only about 1% on three boards, and native samples showed much of the cost moving to the replacement checks. The final tree retains the original duplicate filtering and caches only fixed geometry. The initial experiment is preserved separately and is excluded from the final timing cohort.

Preparation was measured rather than inferred from candidate counts. Across all 16 instrumented boards, `initializeSolvers` had 16.457 seconds inclusive, while the nested `initializeCandidateBudget` span had 0.798 seconds inclusive; these overlap. Cached-wrapper constructor self time was 4.940 seconds and cache-key/transform self time was 14.352 seconds in the instrumented run. Native samples placed cached-wrapper own code at only 0.378 seconds across the four CPU-profiled boards. Those differing boundaries and instrumentation effects do not support claiming constructor counts as the main bottleneck.

Most expensive instrumented regions (diagnostic durations, not latency claims):

| Board | Region | Inclusive outer-region seconds | Outcome |
|---|---|---:|---|
| sample014 | cmn_5 | 166.663 | failed |
| sample014 | cmn_44 | 33.257 | solved |
| sample015 | cmn_17 | 32.366 | solved |
| sample006 | topology_merge_4592 | 32.064 | failed |
| sample006 | cmn_15 | 26.991 | solved |
| sample015 | cmn_400 | 19.912 | solved |
| sample002 | cmn_3 | 19.527 | solved |
| sample013 | cmn_37 | 17.845 | solved |

All region records and nested solver records are retained in `discovery/detailed`. The fresh main baseline reaches high-density routing on samples014/015, unlike an earlier profile; older timings are not used as the optimization baseline.

## Measurement audit

All 96 processes completed without timeout, interruption or sleep. The power audit found no sleep event overlapping any run. The observed peak RSS across the complete cohort was 5.200 GiB baseline and 5.019 GiB candidate.

Both installed dependency trees were compared file by file. Only the intended A03 source, its Git-package tag, and the two added regression files differ. The installed candidate source is byte-identical to the canonical compatibility worktree. Canonical and compatibility net patch IDs both equal `4e4957eb61b8cc572b0d11c7e6d32a3fe834f976`.

The three paired total savings were 23.675, 25.716 and 24.570 seconds; successful-board savings were 6.420, 7.135 and 6.215 seconds. This is a repeatable change in this cohort. Most of the total saving comes from faster failed attempts, and small per-board changes near the observed run variability are not presented as independent wins.

## Raw local timing values

Machine-readable six-run-per-board timing values, hashes, outcomes, iterations, vias and DRC are in `full-01/compact-results.json`. Complete reports also retain every stage, process timestamps and CPU/memory measurements.

## Final native CPU corroboration

The final candidate profiles ran serially after the complete latency cohort and audits. They preserve the same outcomes, errors, iterations and output metrics. Native timings below describe attribution, not the repeated uninstrumented speed claim.

| Board | A03 inclusive sampled seconds, baseline → candidate | A01 inclusive sampled seconds, baseline → candidate |
|---|---:|---:|
| sample006 | 21.286 → 15.902 | 12.828 → 13.062 |
| sample014 | 36.333 → 24.743 | 41.752 → 42.510 |

Repeated circle-neighborhood enumeration is no longer a major sampled cost in the candidate. Per-function attribution also changes with JIT inlining; the original duplicate filter remains in the final implementation. Source-family attribution and the full-stage uninstrumented measurements together support the footprint-cache mechanism.

## Supported GitHub same-machine comparison

[Successful workflow, attempt 2](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/34551143257), artifact `same-machine-benchmark-srj18`. Logs verify baseline `109c67baebc709be95fb37df1fdac9b3b74624c5` and candidate `b86a9b871424950247f076033eea6281c299822c`, SRJ18, Pipeline9 effort 1, concurrency 1, 1800-second sample timeout, and Bun 1.4.2 (`744846f84`) for both installs. Both revisions ran sequentially on one Blacksmith ARM runner. The first attempt failed during baseline dependency installation with a GitHub tarball HTTP 504, before any routing; its logs are preserved and it is excluded.

| Group | Boards | Total elapsed baseline → candidate (s) | Change | Recorded HD baseline → candidate (s) |
|---|---:|---:|---:|---:|
| all | 16 | 2280.914 → 2162.860 | -5.18% | 1076.982 → 968.275 |
| solved | 13 | 1319.549 → 1286.636 | -2.49% | 459.677 → 428.794 |
| failed | 3 | 961.365 → 876.224 | -8.86% | 617.306 → 539.481 |

Both revisions solved 13/16 boards, failed on 006/014/015, had zero timeouts and zero relaxed DRC issues, and reported the same per-board via counts. All 13 rendered SVG snapshots are byte-identical by SHA-256. The standard artifact does not supply full route-JSON hashes; those are verified in the local repeated cohort.

This single sequential workflow run is supplemental evidence, not pooled with the repeated local timings. Its elapsed timer starts after construction and its stage timers use the standard internal stage records, unlike the complete outer-stage local timer. Its published P50/P95 use the standard workflow percentile definition, which includes solved and timed-out samples; ordinary failed attempts are excluded. The local P50/P95 definitions above remain authoritative for the repeated cohort.

### Investigated differences between cohorts

The workflow scenario loader adds `effort: 1` and calls `migrateLegacyObstacleCircuitJsonMetadata`, adding Circuit JSON provenance to 178–801 obstacles per board. The local cohort deliberately uses the pinned raw SRJs, matching the fresh diagnostic inputs. The workflow also runs Bun 1.4.2/Linux and counts vias from simplified output traces; local output hashes and via counts use the full output SRJ under Bun 1.3.9/macOS. These are distinct cohorts. Via counts differ between cohorts on samples001/004/011/013/016, and those differences are present equally in each cohort’s baseline and candidate. Input preparation and runtime have not been independently isolated as causes, so cross-cohort route parity is not claimed. Within each controlled revision comparison there are no outcome or via-count differences, with full local JSON hash parity and remote SVG hash parity.

## CI and review status

Canonical dependency commit `702dea6` and compatibility commit `b311077ec762f3cdf08092c828a27e5a738434dd` contain the same net patch. The primary head is `b86a9b871424950247f076033eea6281c299822c`. All standard CI checks passed on both PRs, including both new regressions, all nine autorouter test shards, type checking, formatting and builds. No local tests were executed. Inline review comments were checked on both PRs and none were present. Neither PR was merged.

Final main verification at 2026-09-11 03:00 UTC: `109c67baebc709be95fb37df1fdac9b3b74624c5`, unchanged from the intended baseline.

</details>

<details>
<summary>Machine-readable local repetitions and routing results</summary>

```json
[
  {
    "sample": 1,
    "solved": true,
    "failed": false,
    "error": null,
    "iterations": 271901,
    "inputSha256": "b43bfc493f6305ce51e5a0e470c5625fa28b9c4e5eea9b594f1996eb65cd11b5",
    "outputSha256": "fb8df616d5a66b4bff2b897ce68083eb0b33b794dfdf4e49886256de88326a1a",
    "vias": 167,
    "relaxedDrcErrors": [],
    "baseline": {
      "totalSeconds": [
        9.10806825,
        9.089430708,
        9.065565167
      ],
      "highDensitySeconds": [
        2.8568885830000004,
        2.839034334,
        2.8486442920000004
      ]
    },
    "candidate": {
      "totalSeconds": [
        9.102990875,
        9.155671833,
        9.078511832999999
      ],
      "highDensitySeconds": [
        2.864924834,
        2.886288709,
        2.8675689159999997
      ]
    }
  },
  {
    "sample": 2,
    "solved": true,
    "failed": false,
    "error": null,
    "iterations": 1167719,
    "inputSha256": "f9862e41c3fe278dda8e5f5cf14532fd2de08547cec8d9b30260567f9740cd1f",
    "outputSha256": "89fa2b57bf14948e35050c7581e758bbb84662e2724e1955a36036785fa886df",
    "vias": 538,
    "relaxedDrcErrors": [],
    "baseline": {
      "totalSeconds": [
        59.098808874999996,
        59.2575265,
        59.231212542
      ],
      "highDensitySeconds": [
        23.844501124999997,
        23.832996583,
        23.875862041
      ]
    },
    "candidate": {
      "totalSeconds": [
        58.516762875,
        58.151719625,
        58.841982042000005
      ],
      "highDensitySeconds": [
        22.99805475,
        23.055645583,
        23.060217750000003
      ]
    }
  },
  {
    "sample": 3,
    "solved": true,
    "failed": false,
    "error": null,
    "iterations": 245429,
    "inputSha256": "459bd750ac87c95b3c6c2f3ebafd8c3ce7fa7e97b0e33f193093ceb7c7aecabe",
    "outputSha256": "a39a707bda119cc2b57e8897d2021717a0297620e17d50ef49bce9a2a104a682",
    "vias": 96,
    "relaxedDrcErrors": [],
    "baseline": {
      "totalSeconds": [
        9.994279417,
        10.025429833,
        10.013706125
      ],
      "highDensitySeconds": [
        4.546400166,
        4.534577042,
        4.5348194589999995
      ]
    },
    "candidate": {
      "totalSeconds": [
        9.940871583,
        9.709332416999999,
        9.888693333
      ],
      "highDensitySeconds": [
        4.3942445,
        4.247295415999999,
        4.4006201250000005
      ]
    }
  },
  {
    "sample": 4,
    "solved": true,
    "failed": false,
    "error": null,
    "iterations": 703281,
    "inputSha256": "74b95f6290cae4e60c63b7c9e5cbb6d525f2480f04f3b7c6fa5894a8b1c5af3b",
    "outputSha256": "3c304b51d28ea96b4a68c64a334c178f132ced05328fb14843e6104f2c76e7c1",
    "vias": 136,
    "relaxedDrcErrors": [],
    "baseline": {
      "totalSeconds": [
        33.32797949999999,
        33.562651625,
        33.252580833
      ],
      "highDensitySeconds": [
        13.1975,
        13.188029209,
        13.209144125
      ]
    },
    "candidate": {
      "totalSeconds": [
        32.972884833,
        33.19046975,
        32.771754666
      ],
      "highDensitySeconds": [
        12.824835458999999,
        12.822533458,
        12.737974874999999
      ]
    }
  },
  {
    "sample": 5,
    "solved": true,
    "failed": false,
    "error": null,
    "iterations": 197297,
    "inputSha256": "163c4f981c55246d2b2111aac41a0cfd28e40844b9fa57df6fe7eeacc36e2c47",
    "outputSha256": "7ea015cffe6167eff9f71ad3499880bd4494d51724596c068e1413e9fa2bd570",
    "vias": 146,
    "relaxedDrcErrors": [],
    "baseline": {
      "totalSeconds": [
        8.898704124999998,
        8.832748542000001,
        8.931064875
      ],
      "highDensitySeconds": [
        2.5437361250000006,
        2.496509167,
        2.5577699580000006
      ]
    },
    "candidate": {
      "totalSeconds": [
        8.854545958000001,
        8.855208667,
        8.856722417
      ],
      "highDensitySeconds": [
        2.528918667,
        2.5537550419999997,
        2.5400122499999997
      ]
    }
  },
  {
    "sample": 6,
    "solved": false,
    "failed": true,
    "error": "Pipeline9 primary high-density routing failed: regular high-density routing failed: Failed to solve 1 nodes, topology_merge_4592. err0: GrowShrinkHighDensityIntraNodeSolver cannot route an impossible single-layer crossing.; regional fallback failed: Failed to solve 1 nodes, topology_merge_4592. err0: GrowShrinkHighDensityIntraNodeSolver failed after resizing to 8x. Last error: All solvers failed in hyper solver. Example failures: Not possible to solve problem with given SEGMENTS_PER_POLYLINE (6), atleast 16 vias are required, Not possible to solve problem with given SEGMENTS_PER_POLYLINE (6), atleast 16 vias are required, SingleHighDensityRouteSolver ran out of iterations (MAX_ITERATIONS=10000), SingleHighDensityRouteSolver ran out of iterations (MAX_ITERATIONS=10000), SingleHighDensityRouteSolver ran out of iterations (MAX_ITERATIONS=10000).",
    "iterations": 2683838,
    "inputSha256": "59ce7e76aff227d2b09cd94b53ee45a1c2a273002ea21b4f0843adaa0a727730",
    "outputSha256": null,
    "vias": null,
    "relaxedDrcErrors": null,
    "baseline": {
      "totalSeconds": [
        67.923698375,
        68.10176266600001,
        67.821582541
      ],
      "highDensitySeconds": [
        49.92725725,
        50.00675133299999,
        49.994897916999996
      ]
    },
    "candidate": {
      "totalSeconds": [
        63.387320875,
        63.061632167000006,
        62.978904458
      ],
      "highDensitySeconds": [
        45.383043917,
        44.919875375000004,
        44.914281
      ]
    }
  },
  {
    "sample": 7,
    "solved": true,
    "failed": false,
    "error": null,
    "iterations": 432346,
    "inputSha256": "6013ddc790e332e6834571440f27b6acdc8af13c326bc953ff5e96a0f9e3941f",
    "outputSha256": "382ff7d3668c2a382b8e4c9a6dc4884c3d75de6a4ca548b33bb9a3bb3672ab48",
    "vias": 224,
    "relaxedDrcErrors": [],
    "baseline": {
      "totalSeconds": [
        13.180042625,
        13.220249041999999,
        13.17475725
      ],
      "highDensitySeconds": [
        5.590235000000001,
        5.47389625,
        5.486380958000001
      ]
    },
    "candidate": {
      "totalSeconds": [
        13.020934583,
        13.029720041,
        12.982995083
      ],
      "highDensitySeconds": [
        5.359150291999999,
        5.38526075,
        5.377949207999999
      ]
    }
  },
  {
    "sample": 8,
    "solved": true,
    "failed": false,
    "error": null,
    "iterations": 2594034,
    "inputSha256": "1ae7c5121f86023f265aebaf2f5bae815257fc4adfc28aa995ffc95a24f1f9ec",
    "outputSha256": "6d42c454bfd552fa66a38fbc0f52bfd2b0a3e000e3c8f9ab2c92572d5a83a217",
    "vias": 299,
    "relaxedDrcErrors": [],
    "baseline": {
      "totalSeconds": [
        67.543869791,
        67.28228045799999,
        67.61227924999999
      ],
      "highDensitySeconds": [
        34.236037833,
        34.09443770800001,
        34.289013
      ]
    },
    "candidate": {
      "totalSeconds": [
        65.789966416,
        65.123318542,
        65.67248104100001
      ],
      "highDensitySeconds": [
        32.436871999999994,
        31.912098125000004,
        32.4518115
      ]
    }
  },
  {
    "sample": 9,
    "solved": true,
    "failed": false,
    "error": null,
    "iterations": 325781,
    "inputSha256": "a84142701dd4d50d3b4622e19292f93c9db76dcf419fc7e5ae0ebf1d0c53bf8c",
    "outputSha256": "3b9390e901f2d6c8fef71aeeac330d6de4cb6a8fcb31c8411acdcd1578ed3f63",
    "vias": 115,
    "relaxedDrcErrors": [],
    "baseline": {
      "totalSeconds": [
        13.312191832999998,
        13.002731457999998,
        13.334678
      ],
      "highDensitySeconds": [
        4.234111209,
        4.060497417,
        4.311490834
      ]
    },
    "candidate": {
      "totalSeconds": [
        12.888248375000002,
        12.970597875000001,
        12.913645917
      ],
      "highDensitySeconds": [
        3.864311584,
        3.89351375,
        3.848122333
      ]
    }
  },
  {
    "sample": 10,
    "solved": true,
    "failed": false,
    "error": null,
    "iterations": 345846,
    "inputSha256": "231e9e524de3f7bb8e92cc4d477324771b80b9b7f0bf6dcf6f374a7a8039578e",
    "outputSha256": "3f0f36a7e992c1c07aee8c4c7b9e5007ed0e45a673dd60aff89070cae6bbdb61",
    "vias": 159,
    "relaxedDrcErrors": [],
    "baseline": {
      "totalSeconds": [
        13.509963209000002,
        13.520815,
        13.544161375000002
      ],
      "highDensitySeconds": [
        3.170204,
        3.16375875,
        3.1714895409999992
      ]
    },
    "candidate": {
      "totalSeconds": [
        13.551427083,
        13.508624916,
        13.4567355
      ],
      "highDensitySeconds": [
        3.143305,
        3.1181405840000003,
        3.0901467080000002
      ]
    }
  },
  {
    "sample": 11,
    "solved": true,
    "failed": false,
    "error": null,
    "iterations": 687579,
    "inputSha256": "6bbb716d32ddd006f5533e17b7a53018de6a18b93cfdb51af49a1f5c0471833f",
    "outputSha256": "9309f8c039b71daafe244aa04f8a84419d86bf074224b9812da56531232157e2",
    "vias": 194,
    "relaxedDrcErrors": [],
    "baseline": {
      "totalSeconds": [
        21.545821207999996,
        21.462648665999996,
        21.431927082999998
      ],
      "highDensitySeconds": [
        7.217903334,
        7.239892374999999,
        7.265627959000001
      ]
    },
    "candidate": {
      "totalSeconds": [
        21.422852665999997,
        21.453925458,
        21.327418207999997
      ],
      "highDensitySeconds": [
        7.0623566669999995,
        7.126137333000001,
        7.041506709
      ]
    }
  },
  {
    "sample": 12,
    "solved": true,
    "failed": false,
    "error": null,
    "iterations": 2143961,
    "inputSha256": "6f0a751a8cbe26fd82bec0234a9b2f7209593069d08412bf8d3d8cc58e3b499a",
    "outputSha256": "e584cb9adddae7a3f918d35ceb4ba3cab5f32e560753ade1675d6c94247a334a",
    "vias": 292,
    "relaxedDrcErrors": [],
    "baseline": {
      "totalSeconds": [
        64.519149083,
        64.415756166,
        64.41794533400001
      ],
      "highDensitySeconds": [
        12.314883042000002,
        12.28465725,
        12.360016250000001
      ]
    },
    "candidate": {
      "totalSeconds": [
        64.63797249999999,
        63.897906917,
        64.199859334
      ],
      "highDensitySeconds": [
        12.104897291999999,
        12.073748958,
        12.170561959000002
      ]
    }
  },
  {
    "sample": 13,
    "solved": true,
    "failed": false,
    "error": null,
    "iterations": 2694824,
    "inputSha256": "13d4fede8bd7942211c83dd13f38c271c559dffa7cb910c5a4bec6b751655135",
    "outputSha256": "909a50be322bb9b111028338eeb917016eb3ba479e40c946e7ac0f76e1310472",
    "vias": 223,
    "relaxedDrcErrors": [],
    "baseline": {
      "totalSeconds": [
        68.470947292,
        68.233225917,
        68.096980125
      ],
      "highDensitySeconds": [
        37.310538084,
        37.152648875,
        37.194127417
      ]
    },
    "candidate": {
      "totalSeconds": [
        65.972399917,
        66.293476958,
        66.27751425000001
      ],
      "highDensitySeconds": [
        34.9497775,
        35.22516775,
        35.112596749999994
      ]
    }
  },
  {
    "sample": 14,
    "solved": false,
    "failed": true,
    "error": "Pipeline9 primary high-density routing failed: regular high-density routing failed: Failed to solve 1 nodes, cmn_5. err0: GrowShrinkHighDensityIntraNodeSolver failed after resizing to 8x. Last error: All solvers failed in hyper solver. Example failures: ViaPossibilitiesSolver2 failed with: Exceeded max via count of 5, ViaPossibilitiesSolver2 failed with: Exceeded max via count of 5, CachedIntraNodeRouteSolver ran out of iterations (MAX_ITERATIONS=41569.219381653056), HighDensitySolverA03 ran out of iterations, HighDensitySolverA01 ran out of iterations.; regional fallback failed: Failed to solve 1 nodes, cmn_5. err0: GrowShrinkHighDensityIntraNodeSolver failed after resizing to 8x. Last error: All solvers failed in hyper solver. Example failures: ViaPossibilitiesSolver2 failed with: Exceeded max via count of 5, ViaPossibilitiesSolver2 failed with: Exceeded max via count of 5, CachedIntraNodeRouteSolver ran out of iterations (MAX_ITERATIONS=41569.219381653056), HighDensitySolverA03 ran out of iterations, HighDensitySolverA01 ran out of iterations.",
    "iterations": 4124298,
    "inputSha256": "9a1ea760aab8f9d544dd84790290a95e88ca0dacbbf5338cc9fd4b441cd87f77",
    "outputSha256": null,
    "vias": null,
    "relaxedDrcErrors": null,
    "baseline": {
      "totalSeconds": [
        135.658720833,
        136.804601542,
        136.973690125
      ],
      "highDensitySeconds": [
        107.96911312500002,
        109.05729716599998,
        109.24315066700001
      ]
    },
    "candidate": {
      "totalSeconds": [
        126.28769962499999,
        126.824114666,
        126.95373879200001
      ],
      "highDensitySeconds": [
        98.578368583,
        99.06969362499999,
        99.211209083
      ]
    }
  },
  {
    "sample": 15,
    "solved": false,
    "failed": true,
    "error": "Pipeline9 primary high-density routing failed: regular high-density routing failed: Failed to solve 1 nodes, topology_merge_1553. err0: GrowShrinkHighDensityIntraNodeSolver failed after resizing to 8x. Last error: All solvers failed in hyper solver. Example failures: ViaPossibilitiesSolver2 failed with: Exceeded max via count of 5, ViaPossibilitiesSolver2 failed with: Exceeded max via count of 5, Ran out of candidate nodes to explore, Ran out of candidate nodes to explore, Ran out of candidate nodes to explore.; regional fallback failed: Failed to solve 1 nodes, topology_merge_1553. err0: GrowShrinkHighDensityIntraNodeSolver failed after resizing to 8x. Last error: All solvers failed in hyper solver. Example failures: ViaPossibilitiesSolver2 failed with: Exceeded max via count of 5, ViaPossibilitiesSolver2 failed with: Exceeded max via count of 5, Convergence failure: exceeded MAX_RIPS 200, Convergence failure: exceeded MAX_RIPS 200, Ran out of candidate nodes to explore.",
    "iterations": 2823965,
    "inputSha256": "0abc1ca078a8f23f884f409174ee7068810b9663672373d9609adf520c514be1",
    "outputSha256": null,
    "vias": null,
    "relaxedDrcErrors": null,
    "baseline": {
      "totalSeconds": [
        90.630755791,
        90.88898954199999,
        91.192406292
      ],
      "highDensitySeconds": [
        68.53322275000001,
        68.419596125,
        67.45734437499999
      ]
    },
    "candidate": {
      "totalSeconds": [
        87.28247862500001,
        87.329026833,
        87.700233916
      ],
      "highDensitySeconds": [
        65.5020285,
        65.159851833,
        65.556802084
      ]
    }
  },
  {
    "sample": 16,
    "solved": true,
    "failed": false,
    "error": null,
    "iterations": 622286,
    "inputSha256": "cb9e246f6f0e8ef0f696a9f5f5632b31771e7366cad77dde15c25f971130d9f9",
    "outputSha256": "cd4ea73481c2426545ebc2f791ceb9631a23ffba3ea78faceaf9dd05606972e9",
    "vias": 113,
    "relaxedDrcErrors": [],
    "baseline": {
      "totalSeconds": [
        24.99353325,
        25.114756458,
        24.842456625000004
      ],
      "highDensitySeconds": [
        12.754874792,
        12.892787499999999,
        12.683179958999999
      ]
    },
    "candidate": {
      "totalSeconds": [
        24.411879625,
        24.544867292000003,
        24.465506333999997
      ],
      "highDensitySeconds": [
        12.280832833999998,
        12.307243458999999,
        12.269644167000001
      ]
    }
  }
]
```

</details>
