### PR TITLE
fix: convert MapIterator to Array before map in IntraNodeRouteSolver (#2106)

### DIFF
--- a/lib/solvers/HighDensitySolver/IntraNodeSolver.ts
+++ b/lib/solvers/HighDensitySolver/IntraNodeSolver.ts
@@ -143,13 +143,13 @@ export class IntraNodeRouteSolver extends BaseSolver {
         ],
       ),
     )
-    this.unsolvedConnections = Array.from(
-      unsolvedConnectionsMap.entries().map(([connectionName, points]) => ({
+    this.unsolvedConnections = Array.from(unsolvedConnectionsMap.entries()).map(
+      ([connectionName, points]) => ({
         connectionName,
         rootConnectionName:
           this.rootConnectionNameByConnectionName.get(connectionName),
         points: dedupeConnectionPoints(points),
-      })),
+      }),
     )
     this.rerouteAttemptsByConnection = new Map()
 

--- a/tests/bugs/issue2106-map-iterator-compat.test.ts
+++ b/tests/bugs/issue2106-map-iterator-compat.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "bun:test"
+import { IntraNodeRouteSolver } from "lib/solvers/HighDensitySolver/IntraNodeSolver"
+import type { NodeWithPortPoints } from "lib/types/high-density-types"
+
+test("IntraNodeRouteSolver handles MapIterator without Iterator.prototype.map (issue #2106)", () => {
+  const nodeWithPortPoints: NodeWithPortPoints = {
+    capacityMeshNodeId: "node1",
+    center: { x: 0, y: 0 },
+    width: 10,
+    height: 10,
+    portPoints: [
+      {
+        connectionName: "net1",
+        rootConnectionName: "root_net1",
+        x: 0,
+        y: 0,
+        z: 0,
+      },
+      {
+        connectionName: "net1",
+        rootConnectionName: "root_net1",
+        x: 2,
+        y: 2,
+        z: 0,
+      },
+    ],
+  }
+
+  // Find Iterator / MapIterator prototype chain
+  const mapEntries = new Map().entries()
+  const mapIteratorProto = Object.getPrototypeOf(mapEntries)
+  const iteratorProto = Object.getPrototypeOf(mapIteratorProto)
+
+  const originalMapIteratorMap = (mapIteratorProto as any).map
+  const originalIteratorMap = (iteratorProto as any)?.map
+
+  try {
+    delete (mapIteratorProto as any).map
+    if (iteratorProto) {
+      delete (iteratorProto as any).map
+    }
+
+    const solver = new IntraNodeRouteSolver({
+      nodeWithPortPoints,
+    })
+
+    expect(solver.unsolvedConnections).toHaveLength(1)
+    expect(solver.unsolvedConnections[0].connectionName).toBe("net1")
+    expect(solver.unsolvedConnections[0].rootConnectionName).toBe("root_net1")
+    expect(solver.unsolvedConnections[0].points).toHaveLength(2)
+  } finally {
+    if (originalMapIteratorMap) {
+      ;(mapIteratorProto as any).map = originalMapIteratorMap
+    }
+    if (originalIteratorMap && iteratorProto) {
+      ;(iteratorProto as any).map = originalIteratorMap
+    }
+  }
+})


### PR DESCRIPTION
Closes #2106

## Problem
In `lib/solvers/HighDensitySolver/IntraNodeSolver.ts:146-153`, `this.unsolvedConnections` called `.map(...)` directly on `unsolvedConnectionsMap.entries()` due to a misplaced parenthesis in `Array.from(...)`:
```ts
this.unsolvedConnections = Array.from(
  unsolvedConnectionsMap.entries().map(([connectionName, points]) => ({
    connectionName,
    rootConnectionName:
      this.rootConnectionNameByConnectionName.get(connectionName),
    points: dedupeConnectionPoints(points),
  })),
)
```
Because `unsolvedConnectionsMap.entries()` returns a `MapIterator`, calling `.map()` directly throws a fatal runtime `TypeError: o2.entries().map is not a function` in production bundle runtimes and JS environments that do not support Iterator Helpers (as reported in #2106 for `<board#104 />`).

## Solution
- Converted `unsolvedConnectionsMap.entries()` to an Array via `Array.from(unsolvedConnectionsMap.entries()).map(...)`, matching the pattern used in line 139 for `originalConnectionPointsByName`.
- Added unit regression test in `tests/bugs/issue2106-map-iterator-compat.test.ts` that explicitly deletes `map` from the iterator prototype chain to verify `IntraNodeRouteSolver` initializes and parses connections properly across all environments.

## Verification
- `tests/bugs/issue2106-map-iterator-compat.test.ts`: **1 pass, 0 fail** (reproduces and catches the TypeError without the fix; passes with the fix)
- `bun x tsc --noEmit`: **Clean (exit code 0)**
- `bun run build`: **Clean (exit code 0)**
- `bun scripts/check-no-string-id-hacks.ts`: **Clean**
