### PR TITLE
Reject high-density route searches with blocked fixed targets

### DIFF
--- a/lib/solvers/HighDensitySolver/SingleHighDensityRouteSolver.ts
+++ b/lib/solvers/HighDensitySolver/SingleHighDensityRouteSolver.ts
@@ -741,6 +741,33 @@ export class SingleHighDensityRouteSolver extends BaseSolver {
   }
 
   _step() {
+    if (this.iterations === 1 && this.NEARBY_SEGMENT_CLEARANCE > 0) {
+      // Every accepted final segment ends at B on B.z. If B is already
+      // inside a fixed foreign segment's clearance, no search path can pass
+      // doesPathToParentIntersectObstacle's final-segment check.
+      // Check on the first step so subclass hyperparameters are initialized.
+      const clearance = this.NEARBY_SEGMENT_CLEARANCE
+      const segments = this.obstacleSegmentsByLayer.get(this.B.z)
+      const nearbySegmentIds = this.obstacleSegmentIndexByLayer
+        .get(this.B.z)
+        ?.search(
+          this.B.x - clearance,
+          this.B.y - clearance,
+          this.B.x + clearance,
+          this.B.y + clearance,
+        )
+      if (segments && nearbySegmentIds) {
+        for (const segmentId of nearbySegmentIds) {
+          const segment = segments[segmentId]!
+          if (pointToSegmentDistance(this.B, segment.A, segment.B) < clearance) {
+            this.failed = true
+            this.error = `Target for ${this.connectionName} on layer ${this.B.z} is inside fixed obstacle segment clearance`
+            return
+          }
+        }
+      }
+    }
+
     let currentNode = this.candidates.dequeue()
     let currentNodeKey = currentNode ? this.getNodeKey(currentNode) : undefined
 

--- a/lib/solvers/HighDensitySolver/SingleHighDensityRouteSolver.ts
+++ b/lib/solvers/HighDensitySolver/SingleHighDensityRouteSolver.ts
@@ -759,7 +759,9 @@ export class SingleHighDensityRouteSolver extends BaseSolver {
       if (segments && nearbySegmentIds) {
         for (const segmentId of nearbySegmentIds) {
           const segment = segments[segmentId]!
-          if (pointToSegmentDistance(this.B, segment.A, segment.B) < clearance) {
+          if (
+            pointToSegmentDistance(this.B, segment.A, segment.B) < clearance
+          ) {
             this.failed = true
             this.error = `Target for ${this.connectionName} on layer ${this.B.z} is inside fixed obstacle segment clearance`
             return

--- a/tests/solvers/single-route-blocked-target-clearance-boundary.test.ts
+++ b/tests/solvers/single-route-blocked-target-clearance-boundary.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test"
+import { SingleHighDensityRouteSolver6_VertHorzLayer_FutureCost } from "lib/solvers/HighDensitySolver/SingleHighDensityRouteSolver6_VertHorzLayer_FutureCost"
+
+test("early rejection uses strict final-segment clearance configured before search", () => {
+  for (const clearance of [0, 0.25, 0.25001]) {
+    const solver = new SingleHighDensityRouteSolver6_VertHorzLayer_FutureCost({
+      connectionName: "target",
+      A: { x: 1, y: 1, z: 0 },
+      B: { x: 8, y: 8, z: 0 },
+      bounds: { minX: 0, minY: 0, maxX: 10, maxY: 10 },
+      minDistBetweenEnteringPoints: 0.1,
+      captureSearchDebug: false,
+      obstacleRoutes: [{
+        connectionName: "obstacle",
+        traceThickness: 0.15,
+        viaDiameter: 0.3,
+        route: [{ x: 7, y: 8.25, z: 0 }, { x: 9, y: 8.25, z: 0 }],
+        vias: [],
+      }],
+      nearbySegmentClearance: 0.5,
+    })
+    solver.NEARBY_SEGMENT_CLEARANCE = clearance
+    solver.step()
+    expect(solver.failed).toBe(clearance > 0.25)
+    expect(solver.exploredNodes.size).toBe(clearance > 0.25 ? 0 : 1)
+  }
+})

--- a/tests/solvers/single-route-blocked-target-clearance-boundary.test.ts
+++ b/tests/solvers/single-route-blocked-target-clearance-boundary.test.ts
@@ -10,13 +10,18 @@ test("early rejection uses strict final-segment clearance configured before sear
       bounds: { minX: 0, minY: 0, maxX: 10, maxY: 10 },
       minDistBetweenEnteringPoints: 0.1,
       captureSearchDebug: false,
-      obstacleRoutes: [{
-        connectionName: "obstacle",
-        traceThickness: 0.15,
-        viaDiameter: 0.3,
-        route: [{ x: 7, y: 8.25, z: 0 }, { x: 9, y: 8.25, z: 0 }],
-        vias: [],
-      }],
+      obstacleRoutes: [
+        {
+          connectionName: "obstacle",
+          traceThickness: 0.15,
+          viaDiameter: 0.3,
+          route: [
+            { x: 7, y: 8.25, z: 0 },
+            { x: 9, y: 8.25, z: 0 },
+          ],
+          vias: [],
+        },
+      ],
       nearbySegmentClearance: 0.5,
     })
     solver.NEARBY_SEGMENT_CLEARANCE = clearance

--- a/tests/solvers/single-route-blocked-target-connected-and-layer.test.ts
+++ b/tests/solvers/single-route-blocked-target-connected-and-layer.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "bun:test"
+import { ConnectivityMap } from "circuit-json-to-connectivity-map"
+import { SingleHighDensityRouteSolver } from "lib/solvers/HighDensitySolver/SingleHighDensityRouteSolver"
+import { SingleHighDensityRouteSolver6_VertHorzLayer_FutureCost } from "lib/solvers/HighDensitySolver/SingleHighDensityRouteSolver6_VertHorzLayer_FutureCost"
+
+test("connected and other-layer traces do not block targets", () => {
+  for (const Solver of [
+    SingleHighDensityRouteSolver,
+    SingleHighDensityRouteSolver6_VertHorzLayer_FutureCost,
+  ]) {
+    for (const connected of [false, true]) {
+      const z = connected ? 0 : 1
+      const solver = new Solver({
+        connectionName: "target",
+        A: { x: 1, y: 1, z: 0 },
+        B: { x: 8, y: 8, z: 0 },
+        bounds: { minX: 0, minY: 0, maxX: 10, maxY: 10 },
+        minDistBetweenEnteringPoints: 0.1,
+        captureSearchDebug: false,
+        obstacleRoutes: [
+          {
+            connectionName: "obstacle",
+            traceThickness: 0.15,
+            viaDiameter: 0.3,
+            route: [
+              { x: 7, y: 8, z },
+              { x: 9, y: 8, z },
+            ],
+            vias: [],
+          },
+        ],
+        connMap: new ConnectivityMap(
+          connected
+            ? { sameNet: ["target", "obstacle"] }
+            : { targetNet: ["target"], obstacleNet: ["obstacle"] },
+        ),
+      })
+      solver.solve()
+      expect(solver.failed).toBe(false)
+      expect(solver.solved).toBe(true)
+    }
+  }
+})

--- a/tests/solvers/single-route-blocked-target.test.ts
+++ b/tests/solvers/single-route-blocked-target.test.ts
@@ -14,13 +14,18 @@ test("a target inside fixed trace clearance fails before exploring candidates", 
       bounds: { minX: 0, minY: 0, maxX: 10, maxY: 10 },
       minDistBetweenEnteringPoints: 0.1,
       captureSearchDebug: false,
-      obstacleRoutes: [{
-        connectionName: "obstacle",
-        traceThickness: 0.15,
-        viaDiameter: 0.3,
-        route: [{ x: 7, y: 8, z: 0 }, { x: 9, y: 8, z: 0 }],
-        vias: [],
-      }],
+      obstacleRoutes: [
+        {
+          connectionName: "obstacle",
+          traceThickness: 0.15,
+          viaDiameter: 0.3,
+          route: [
+            { x: 7, y: 8, z: 0 },
+            { x: 9, y: 8, z: 0 },
+          ],
+          vias: [],
+        },
+      ],
     })
     solver.solve()
     expect(solver.failed).toBe(true)

--- a/tests/solvers/single-route-blocked-target.test.ts
+++ b/tests/solvers/single-route-blocked-target.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test"
+import { SingleHighDensityRouteSolver } from "lib/solvers/HighDensitySolver/SingleHighDensityRouteSolver"
+import { SingleHighDensityRouteSolver6_VertHorzLayer_FutureCost } from "lib/solvers/HighDensitySolver/SingleHighDensityRouteSolver6_VertHorzLayer_FutureCost"
+
+test("a target inside fixed trace clearance fails before exploring candidates", () => {
+  for (const Solver of [
+    SingleHighDensityRouteSolver,
+    SingleHighDensityRouteSolver6_VertHorzLayer_FutureCost,
+  ]) {
+    const solver = new Solver({
+      connectionName: "target",
+      A: { x: 1, y: 1, z: 0 },
+      B: { x: 8, y: 8, z: 0 },
+      bounds: { minX: 0, minY: 0, maxX: 10, maxY: 10 },
+      minDistBetweenEnteringPoints: 0.1,
+      captureSearchDebug: false,
+      obstacleRoutes: [{
+        connectionName: "obstacle",
+        traceThickness: 0.15,
+        viaDiameter: 0.3,
+        route: [{ x: 7, y: 8, z: 0 }, { x: 9, y: 8, z: 0 }],
+        vias: [],
+      }],
+    })
+    solver.solve()
+    expect(solver.failed).toBe(true)
+    expect(solver.solved).toBe(false)
+    expect(solver.iterations).toBe(1)
+    expect(solver.exploredNodes.size).toBe(0)
+    expect(solver.error).toContain("inside fixed obstacle segment clearance")
+  }
+})


### PR DESCRIPTION
A single-route high-density search can exhaust 10,001 iterations even when its fixed target is inside an unrelated, fixed trace's clearance. Reject that attempt on its first search step, before exploring candidates, using the existing destination-layer segment index and `NEARBY_SEGMENT_CLEARANCE`.

Every accepted final segment ends at B on B.z. Its distance to an obstacle segment cannot exceed B's distance to that segment. If the latter is already strictly below the existing final-segment clearance, `doesPathToParentIntersectObstacle` will reject every possible arrival. Connected traces are excluded by the existing index, other layers are excluded, and equality remains allowed. The check runs after subclass initialization and fails the individual attempt; it does not declare the whole region impossible or change routing budgets.

### Local validation

- Bun 1.4.1 (`4661e494f`), Apple M3 Pro/macOS arm64, main `109c67baebc709be95fb37df1fdac9b3b74624c5`, original A01 dependency pin. No cache patch is included in this PR.
- 24 tests passed across 14 files, including both single-route variants, the three new regressions, Pipeline9 high-density tests, and grow/shrink tests. 528 assertions.
- `bun run build` passed, including declaration generation.
- SRJ18 sample002 still solves with zero relaxed DRC errors and identical output SHA-256 `5c852ef1d769c7e28c58819ade3cf49ec8be2d505ec09fcb2aceef2c73e47027`.
- SRJ18 sample006 still fails at `topology_merge_4592` with the same error. Pipeline iterations decrease from 2,683,838 to 2,682,116. This does not solve the board.

### Measured scope of the improvement

A diagnostic replay of the full sample006 run found the same 920 blocked-target searches before and after the change. None solved in the baseline.

| Blocked-target work | Main | PR |
| --- | ---: | ---: |
| Search steps across those attempts | 174,766 | 920 |
| Time inside those attempts' `_step` calls | 860.045 ms | 0.704 ms |
| Explored candidates in the focused impossible-target reproducer | 10,420 / 10,460 | 0 / 0 |
| Reproducer iterations, both variants | 10,001 | 1 |

For the focused reproducer, five measured solves after one warm-up gave median constructor-plus-solve times of 17.966 → 0.017 ms (base solver) and 24.897 → 0.009 ms (future-cost solver).

The 0.86 seconds accounted for only about 1.1% of high-density time in the instrumented baseline. **No full-board wall-clock speedup is claimed for this PR.** Other CPU-heavy processes were running during the later full-board measurements; even unchanged stages varied substantially. These timings describe the bounded optimization, not a solution to the largest A01/A03 search costs.

### Related A03 cache investigation

The cache is already implemented by AnasSarkiz in [high-density-a01 #119](https://github.com/tscircuit/high-density-a01/pull/119) and integrated in [autorouter #2541](https://github.com/tscircuit/tscircuit-autorouter/pull/2541). Independently replaying sample006's captured `cmn_15` directly through A03, in six fresh alternating processes, confirmed median 1.419 → 1.156 seconds (18.5% faster), with identical 252,076 iterations and convergence failure in every run. Both cache geometry/live-occupancy tests passed locally.

Twelve separate full-board cache runs (samples006/002 × three repetitions × two revisions) preserved all outcomes, iteration counts, sample002 output hashes and DRC results. Sample006's observed total median was 84.273 → 81.665 seconds (3.1% lower); the full-board effect size remains sensitive to background load. The cache and this early-exit change were measured separately.

A blanket minimum-distance rejection of region ports is deliberately not included: several close-port regions currently solve, and A03 has explicit segment-end overlap exceptions. The existing impossible-single-layer-crossing and polyline via-count checks already reject their respective strategies early.
