### PR TITLE
Reproduce Pipeline 9 through-via obstacle policy gap

### DIFF
--- a/tests/repro/pipeline9-through-via-policy.test.ts
+++ b/tests/repro/pipeline9-through-via-policy.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test"
+import { getPipeline9FixedRouteObstacles } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9FixedRouteCopper"
+import type { PreloadedHighDensityRoute } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/convertPreloadedTraceToHdRoutes"
+
+test.failing(
+  "Pipeline9 keeps a preloaded top-to-inner2 via clear on bottom when blind vias are disabled",
+  (): void => {
+    const preloadedThroughVia: PreloadedHighDensityRoute = {
+      connectionName: "preloaded-via",
+      rootConnectionName: "preloaded-via",
+      preloadedTraceIndex: 0,
+      preloadedRouteIndex: 0,
+      traceThickness: 0.15,
+      viaDiameter: 0.45,
+      route: [
+        { x: 0, y: 0, z: 0 },
+        { x: 0, y: 0, z: 2 },
+      ],
+      vias: [{ x: 0, y: 0 }],
+    }
+
+    const fixedObstacles = getPipeline9FixedRouteObstacles({
+      fixedObstacleRoutes: [preloadedThroughVia],
+      layerCount: 4,
+    })
+
+    // Blind and buried vias are disabled by default. The physical via must
+    // therefore block all board copper layers, including bottom (z3).
+    expect(fixedObstacles).toEqual([
+      expect.objectContaining({
+        center: { x: 0, y: 0 },
+        width: 0.45,
+        height: 0.45,
+        layers: ["top", "inner1", "inner2", "bottom"],
+      }),
+    ])
+  },
+)


### PR DESCRIPTION
## Reproduction

Adds a focused expected-failure test for Pipeline 9 fixed preloaded copper. On a four-layer board where blind and buried vias are disabled, a preloaded route transitioning from top to inner2 must occupy bottom as a through-via.

Current Pipeline 9 fixed-obstacle generation derives the obstacle layers solely from the transition endpoints (top, inner1, inner2), omitting bottom. A parent or new bottom-layer route can therefore be planned through physical through-hole copper.

This PR intentionally contains only the reproducer. The Repair03 reproducer is separate; fixes will follow in separate PRs.