### PR TITLE
Fix Pipeline9 through-via policy

### DIFF
--- a/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/Pipeline9NetworkedHighDensitySolver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/Pipeline9NetworkedHighDensitySolver.ts
@@ -183,6 +183,7 @@ export class Pipeline9NetworkedHighDensitySolver extends Pipeline9HighDensitySol
       boardGeometry: this.boardGeometry,
       regionalObstacles: regionalInput.obstacles,
       layerCount: this.layerCount,
+      allowBlindAndBuriedVias: this.allowBlindAndBuriedVias,
       nodePf: this.nodePfById.get(node.capacityMeshNodeId) ?? null,
     }
   }

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9NetworkedTypes.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/pipeline9NetworkedTypes.ts
@@ -30,6 +30,7 @@ export type Pipeline9NetworkedHighDensityNodeInput = {
   boardGeometry?: HighDensityBoardGeometry
   regionalObstacles: Obstacle[]
   layerCount: number
+  allowBlindAndBuriedVias?: boolean
   nodePf: number | null
 }
 

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/solvePipeline9NetworkedHighDensityNode.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_Networked/solvePipeline9NetworkedHighDensityNode.ts
@@ -120,6 +120,7 @@ export function solvePipeline9NetworkedHighDensityNode(
     },
     obstacles: input.regionalObstacles,
     layerCount: input.layerCount,
+    allowBlindAndBuriedVias: input.allowBlindAndBuriedVias,
   })
   regionalSolver.solve()
   if (regionalSolver.solved) {

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/AutoroutingPipelineSolver9_PreloadedTraceGraph.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/AutoroutingPipelineSolver9_PreloadedTraceGraph.ts
@@ -622,6 +622,7 @@ export class AutoroutingPipelineSolver9_PreloadedTraceGraph extends BaseSolver {
             colorMap: cms.colorMap,
             obstacles: cms.srj.obstacles,
             layerCount: cms.srj.layerCount,
+            allowBlindAndBuriedVias: cms.srj.allowBlindAndBuriedVias,
             viaDiameter: cms.viaDiameter,
             traceWidth: cms.minTraceWidth,
             obstacleMargin: cms.srj.defaultObstacleMargin ?? 0.15,

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9HighDensitySolver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9HighDensitySolver.ts
@@ -40,6 +40,7 @@ export type Pipeline9HighDensitySolverParams = {
   obstacles: Obstacle[]
   boardGeometry?: HighDensityBoardGeometry
   layerCount: number
+  allowBlindAndBuriedVias?: boolean
   viaDiameter: number
   traceWidth: number
   obstacleMargin: number
@@ -384,6 +385,7 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
   readonly obstacles: Obstacle[]
   readonly boardGeometry?: HighDensityBoardGeometry
   readonly layerCount: number
+  readonly allowBlindAndBuriedVias: boolean
   readonly viaDiameter: number
   readonly traceWidth: number
   readonly obstacleMargin: number
@@ -418,6 +420,7 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
     this.obstacles = params.obstacles
     this.boardGeometry = params.boardGeometry
     this.layerCount = params.layerCount
+    this.allowBlindAndBuriedVias = params.allowBlindAndBuriedVias ?? false
     this.viaDiameter = params.viaDiameter
     this.traceWidth = params.traceWidth
     this.obstacleMargin = params.obstacleMargin
@@ -558,6 +561,7 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
     const fixedRouteObstacles = getPipeline9FixedRouteObstacles({
       fixedObstacleRoutes: this.activeFallbackFixedObstacleRoutes,
       layerCount: this.layerCount,
+      allowBlindAndBuriedVias: this.allowBlindAndBuriedVias,
     })
     this.activeFallbackSolver = new Pipeline9RegionalFallbackSolver({
       nodeWithPortPoints: fallbackProblem.nodeWithPortPoints,
@@ -573,6 +577,7 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
       movablePreloadedConnectionNames: movableFixedRouteConnectionNames,
       viaToPadClearance: this.viaToPadClearance,
       layerCount: this.layerCount,
+      allowBlindAndBuriedVias: this.allowBlindAndBuriedVias,
     })
     if (promotedFixedRouteConnectionNames.size === 0) {
       this.stats.fallbackNodeCount =
@@ -683,6 +688,8 @@ export class Pipeline9HighDensitySolver extends BaseSolver {
             left: candidateRoute,
             right: fixedRoute,
             clearance: this.obstacleMargin,
+            layerCount: this.layerCount,
+            allowBlindAndBuriedVias: this.allowBlindAndBuriedVias,
             leftBounds: candidateBounds,
           })
         ) {

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9RegionalFallbackSolver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9RegionalFallbackSolver.ts
@@ -172,8 +172,7 @@ export class Pipeline9RegionalFallbackSolver extends BaseSolver {
       boardObstacles,
       connMap: this.params.connMap,
       layerCount: this.params.layerCount,
-      allowBlindAndBuriedVias:
-        this.params.allowBlindAndBuriedVias ?? false,
+      allowBlindAndBuriedVias: this.params.allowBlindAndBuriedVias ?? false,
       viaToPadClearance,
     })
     if (hasViaConflict) {

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9RegionalFallbackSolver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/Pipeline9RegionalFallbackSolver.ts
@@ -13,7 +13,10 @@ import type {
 import type { Obstacle } from "lib/types/srj-types"
 import { mapLayerNameToZ } from "lib/utils/mapLayerNameToZ"
 import { materializePipeline9HdRouteVias } from "./materializePipeline9HdRouteVias"
-import { getPipeline9RouteCopperGeometry } from "./pipeline9FixedRouteCopper"
+import {
+  getPipeline9RouteCopperGeometry,
+  getPipeline9ViaSpanZLayers,
+} from "./pipeline9FixedRouteCopper"
 
 type Pipeline9RegionalFallbackSolverParams = {
   nodeWithPortPoints: NodeWithPortPoints
@@ -31,6 +34,7 @@ type Pipeline9RegionalFallbackSolverParams = {
   movablePreloadedConnectionNames?: ReadonlySet<string>
   viaToPadClearance?: number
   layerCount: number
+  allowBlindAndBuriedVias?: boolean
 }
 
 type RegionalFallbackPhase = "route" | "improve" | "repair" | "done"
@@ -68,6 +72,7 @@ const hasPreloadedViaToBoardObstacleConflict = ({
   boardObstacles,
   connMap,
   layerCount,
+  allowBlindAndBuriedVias,
   viaToPadClearance,
 }: {
   routes: HighDensityRoute[]
@@ -75,6 +80,7 @@ const hasPreloadedViaToBoardObstacleConflict = ({
   boardObstacles: Obstacle[]
   connMap: ConnectivityMap
   layerCount: number
+  allowBlindAndBuriedVias: boolean
   viaToPadClearance: number
 }): boolean =>
   routes.some((route) => {
@@ -86,7 +92,12 @@ const hasPreloadedViaToBoardObstacleConflict = ({
       boardObstacles.some((obstacle) => {
         if (isObstacleConnectedToRoute(obstacle, route, connMap)) return false
         const obstacleZLayers = getObstacleZLayers(obstacle, layerCount)
-        if (!obstacleZLayers.some((z) => z >= via.minZ && z <= via.maxZ)) {
+        const viaZLayers = getPipeline9ViaSpanZLayers({
+          via,
+          layerCount,
+          allowBlindAndBuriedVias,
+        })
+        if (!obstacleZLayers.some((z) => viaZLayers.includes(z))) {
           return false
         }
         return (
@@ -161,6 +172,8 @@ export class Pipeline9RegionalFallbackSolver extends BaseSolver {
       boardObstacles,
       connMap: this.params.connMap,
       layerCount: this.params.layerCount,
+      allowBlindAndBuriedVias:
+        this.params.allowBlindAndBuriedVias ?? false,
       viaToPadClearance,
     })
     if (hasViaConflict) {

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/PreloadedTraceGraphSolver.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/PreloadedTraceGraphSolver.ts
@@ -31,7 +31,11 @@ const getLayersBetween = (
   fromLayer: string,
   toLayer: string,
   layerCount: number,
+  allowBlindAndBuriedVias = false,
 ): number[] => {
+  if (!allowBlindAndBuriedVias) {
+    return Array.from({ length: layerCount }, (_, z) => z)
+  }
   const fromZ = mapLayerNameToZ(fromLayer, layerCount)
   const toZ = mapLayerNameToZ(toLayer, layerCount)
   return Array.from(
@@ -71,6 +75,7 @@ const getPreloadedTracePrimitives = (
             routePoint.from_layer,
             routePoint.to_layer,
             srj.layerCount,
+            srj.allowBlindAndBuriedVias,
           ),
           start: routePoint,
           end: routePoint,
@@ -86,6 +91,7 @@ const getPreloadedTracePrimitives = (
             routePoint.from_layer,
             routePoint.to_layer,
             srj.layerCount,
+            srj.allowBlindAndBuriedVias,
           ),
           start: routePoint.start,
           end: routePoint.end,

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/applyPipeline9RegionalB01Repairs.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/applyPipeline9RegionalB01Repairs.ts
@@ -324,12 +324,16 @@ const candidateConflictsWithFixedRoutes = ({
   obstacleMargin,
   connMap,
   candidateBounds,
+  layerCount,
+  allowBlindAndBuriedVias,
 }: {
   candidateRoutes: HighDensityRoute[]
   fixedObstacleRoutes: PreloadedHighDensityRoute[]
   obstacleMargin: number
   connMap: ConnectivityMap
   candidateBounds?: Bounds
+  layerCount: number
+  allowBlindAndBuriedVias?: boolean
 }): boolean => {
   for (const candidateRoute of candidateRoutes) {
     for (const fixedRoute of fixedObstacleRoutes) {
@@ -341,6 +345,8 @@ const candidateConflictsWithFixedRoutes = ({
           left: candidateRoute,
           right: fixedRoute,
           clearance: obstacleMargin,
+          layerCount,
+          allowBlindAndBuriedVias,
           leftBounds: candidateBounds,
         })
       ) {
@@ -419,6 +425,7 @@ const getRegionalCandidate = ({
     colorMap,
     obstacles: srj.obstacles,
     layerCount: srj.layerCount,
+    allowBlindAndBuriedVias: srj.allowBlindAndBuriedVias,
     viaDiameter,
     traceWidth,
     obstacleMargin,
@@ -517,6 +524,7 @@ const getRegularRegionalCandidate = ({
   const fixedRouteObstacles = getPipeline9FixedRouteObstacles({
     fixedObstacleRoutes: localFixedObstacleRoutes,
     layerCount: srj.layerCount,
+    allowBlindAndBuriedVias: srj.allowBlindAndBuriedVias,
   })
   const solver = new Pipeline9RegionalFallbackSolver({
     nodeWithPortPoints: problem.nodeWithPortPoints,
@@ -528,6 +536,7 @@ const getRegularRegionalCandidate = ({
     effort,
     obstacles: [...srj.obstacles, ...fixedRouteObstacles],
     layerCount: srj.layerCount,
+    allowBlindAndBuriedVias: srj.allowBlindAndBuriedVias,
   })
   solver.solve()
   if (!solver.solved || solver.failed) return undefined
@@ -567,6 +576,8 @@ const getRegularRegionalCandidate = ({
       obstacleMargin,
       connMap,
       candidateBounds,
+      layerCount: srj.layerCount,
+      allowBlindAndBuriedVias: srj.allowBlindAndBuriedVias,
     })
   ) {
     return undefined

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9FixedRouteCopper.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9FixedRouteCopper.ts
@@ -154,9 +154,11 @@ export const getPipeline9AxisAlignedWireApproximations = (
 export const getPipeline9FixedRouteObstacles = ({
   fixedObstacleRoutes,
   layerCount,
+  allowBlindAndBuriedVias = false,
 }: {
   fixedObstacleRoutes: PreloadedHighDensityRoute[]
   layerCount: number
+  allowBlindAndBuriedVias?: boolean
 }): Obstacle[] => {
   return fixedObstacleRoutes.flatMap((route, routeIndex) => {
     const connectedTo = [route.connectionName, route.rootConnectionName].filter(
@@ -184,11 +186,11 @@ export const getPipeline9FixedRouteObstacles = ({
         (via, viaIndex): Obstacle => ({
           obstacleId: `pipeline9_fixed_obstacle_${routeIndex}_via_${viaIndex}`,
           type: "rect",
-          layers: Array.from(
-            { length: via.maxZ - via.minZ + 1 },
-            (_, layerOffset) =>
-              mapZToLayerName(via.minZ + layerOffset, layerCount),
-          ),
+          layers: getPipeline9ViaSpanZLayers({
+            via,
+            layerCount,
+            allowBlindAndBuriedVias,
+          }).map((z) => mapZToLayerName(z, layerCount)),
           center: via.center,
           width: via.diameter,
           height: via.diameter,
@@ -197,6 +199,20 @@ export const getPipeline9FixedRouteObstacles = ({
       ),
     ]
   })
+}
+
+export const getPipeline9ViaSpanZLayers = ({
+  via,
+  layerCount,
+  allowBlindAndBuriedVias,
+}: {
+  via: Pipeline9RouteViaSpan
+  layerCount: number
+  allowBlindAndBuriedVias: boolean
+}): number[] => {
+  const minZ = allowBlindAndBuriedVias ? via.minZ : 0
+  const maxZ = allowBlindAndBuriedVias ? via.maxZ : layerCount - 1
+  return Array.from({ length: maxZ - minZ + 1 }, (_, z) => minZ + z)
 }
 
 export const arePipeline9RoutesOnSameNet = (
@@ -260,11 +276,15 @@ export const doPipeline9RoutesHaveCopperConflict = ({
   left,
   right,
   clearance,
+  layerCount,
+  allowBlindAndBuriedVias = false,
   leftBounds,
 }: {
   left: HighDensityRoute
   right: HighDensityRoute
   clearance: number
+  layerCount: number
+  allowBlindAndBuriedVias?: boolean
   leftBounds?: Pipeline9Bounds
 }): boolean => {
   const leftGeometry = getPipeline9RouteCopperGeometry(left)
@@ -296,7 +316,15 @@ export const doPipeline9RoutesHaveCopperConflict = ({
       }
     }
     for (const rightVia of rightGeometry.viaSpans) {
-      if (leftWire.z < rightVia.minZ || leftWire.z > rightVia.maxZ) continue
+      if (
+        !getPipeline9ViaSpanZLayers({
+          via: rightVia,
+          layerCount,
+          allowBlindAndBuriedVias,
+        }).includes(leftWire.z)
+      ) {
+        continue
+      }
       const requiredClearance =
         leftWire.width / 2 + rightVia.diameter / 2 + clearance
       if (
@@ -313,7 +341,15 @@ export const doPipeline9RoutesHaveCopperConflict = ({
   }
   for (const leftVia of leftVias) {
     for (const rightWire of rightGeometry.wireSegments) {
-      if (rightWire.z < leftVia.minZ || rightWire.z > leftVia.maxZ) continue
+      if (
+        !getPipeline9ViaSpanZLayers({
+          via: leftVia,
+          layerCount,
+          allowBlindAndBuriedVias,
+        }).includes(rightWire.z)
+      ) {
+        continue
+      }
       const requiredClearance =
         leftVia.diameter / 2 + rightWire.width / 2 + clearance
       if (
@@ -328,7 +364,17 @@ export const doPipeline9RoutesHaveCopperConflict = ({
       }
     }
     for (const rightVia of rightGeometry.viaSpans) {
-      if (leftVia.minZ > rightVia.maxZ || rightVia.minZ > leftVia.maxZ) continue
+      const leftZLayers = getPipeline9ViaSpanZLayers({
+        via: leftVia,
+        layerCount,
+        allowBlindAndBuriedVias,
+      })
+      const rightZLayers = getPipeline9ViaSpanZLayers({
+        via: rightVia,
+        layerCount,
+        allowBlindAndBuriedVias,
+      })
+      if (!leftZLayers.some((z) => rightZLayers.includes(z))) continue
       const requiredClearance =
         leftVia.diameter / 2 + rightVia.diameter / 2 + clearance
       if (

--- a/lib/types/srj-types.ts
+++ b/lib/types/srj-types.ts
@@ -53,6 +53,11 @@ export type JumperType = "1206x4" | "0603"
 
 export interface SimpleRouteJson {
   layerCount: number
+  /**
+   * Enables blind and buried vias. When omitted or false, generated vias
+   * occupy every copper layer in the board stackup.
+   */
+  allowBlindAndBuriedVias?: boolean
   minTraceWidth: number
   nominalTraceWidth?: number
   /** @deprecated Use `min_via_pad_diameter` / `minViaPadDiameter` instead. */

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "zdwiel-dataset": "git+https://github.com/dwiel/tscircuit-benchmark.git#be36518b5bf51755dae92c230061ab3cf4e3e063",
     "high-density-repair01": "git+https://github.com/tscircuit/high-density-repair01.git#01f9fe901ac6f691c325bb25d993f52d916a98a1",
     "high-density-repair02": "https://codeload.github.com/tscircuit/high-density-repair02/tar.gz/eba02dae55f156990e23fac0108a620c8021f47b",
-    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#5f6c9af547dbb70c8948227011e1769b5dfa16a5",
+    "high-density-repair03": "git+https://github.com/Abse2001/high-density-repair03.git#97ef741",
     "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d",
     "@tscircuit/high-density-a13": "git+https://github.com/tscircuit/high-density-a01.git#c6812cebd44b09f29f2fee929837b313b822f2ae",
     "@tscircuit/high-density-b01": "git+https://github.com/tscircuit/high-density-b01.git#e651cab6c314e7aab6df31fd6067277436f67148"

--- a/tests/features/pipeline9-regional-fallback-new-layer-fixed-copper.test.ts
+++ b/tests/features/pipeline9-regional-fallback-new-layer-fixed-copper.test.ts
@@ -86,6 +86,7 @@ test("Pipeline9 promotes only fixed copper that blocks an all-layer fallback", (
         left: route,
         right: updatedFixedRoute,
         clearance: 0.15,
+        layerCount: 2,
       }),
     ),
   ).toBeFalse()

--- a/tests/repro/pipeline9-through-via-policy.test.ts
+++ b/tests/repro/pipeline9-through-via-policy.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test"
 import { getPipeline9FixedRouteObstacles } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9FixedRouteCopper"
 import type { PreloadedHighDensityRoute } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/convertPreloadedTraceToHdRoutes"
 
-test.failing(
+test(
   "Pipeline9 keeps a preloaded top-to-inner2 via clear on bottom when blind vias are disabled",
   (): void => {
     const preloadedThroughVia: PreloadedHighDensityRoute = {
@@ -32,6 +32,24 @@ test.failing(
         width: 0.45,
         height: 0.45,
         layers: ["top", "inner1", "inner2", "bottom"],
+      }),
+    ])
+
+    const fixedObstaclesWithBlindViasEnabled =
+      getPipeline9FixedRouteObstacles({
+        fixedObstacleRoutes: [preloadedThroughVia],
+        layerCount: 4,
+        allowBlindAndBuriedVias: true,
+      })
+
+    // The explicit opt-in preserves the endpoint span for an actual blind
+    // via: top through inner2, excluding bottom.
+    expect(fixedObstaclesWithBlindViasEnabled).toEqual([
+      expect.objectContaining({
+        center: { x: 0, y: 0 },
+        width: 0.45,
+        height: 0.45,
+        layers: ["top", "inner1", "inner2"],
       }),
     ])
   },

--- a/tests/repro/pipeline9-through-via-policy.test.ts
+++ b/tests/repro/pipeline9-through-via-policy.test.ts
@@ -2,55 +2,51 @@ import { expect, test } from "bun:test"
 import { getPipeline9FixedRouteObstacles } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9FixedRouteCopper"
 import type { PreloadedHighDensityRoute } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/convertPreloadedTraceToHdRoutes"
 
-test(
-  "Pipeline9 keeps a preloaded top-to-inner2 via clear on bottom when blind vias are disabled",
-  (): void => {
-    const preloadedThroughVia: PreloadedHighDensityRoute = {
-      connectionName: "preloaded-via",
-      rootConnectionName: "preloaded-via",
-      preloadedTraceIndex: 0,
-      preloadedRouteIndex: 0,
-      traceThickness: 0.15,
-      viaDiameter: 0.45,
-      route: [
-        { x: 0, y: 0, z: 0 },
-        { x: 0, y: 0, z: 2 },
-      ],
-      vias: [{ x: 0, y: 0 }],
-    }
+test("Pipeline9 keeps a preloaded top-to-inner2 via clear on bottom when blind vias are disabled", (): void => {
+  const preloadedThroughVia: PreloadedHighDensityRoute = {
+    connectionName: "preloaded-via",
+    rootConnectionName: "preloaded-via",
+    preloadedTraceIndex: 0,
+    preloadedRouteIndex: 0,
+    traceThickness: 0.15,
+    viaDiameter: 0.45,
+    route: [
+      { x: 0, y: 0, z: 0 },
+      { x: 0, y: 0, z: 2 },
+    ],
+    vias: [{ x: 0, y: 0 }],
+  }
 
-    const fixedObstacles = getPipeline9FixedRouteObstacles({
-      fixedObstacleRoutes: [preloadedThroughVia],
-      layerCount: 4,
-    })
+  const fixedObstacles = getPipeline9FixedRouteObstacles({
+    fixedObstacleRoutes: [preloadedThroughVia],
+    layerCount: 4,
+  })
 
-    // Blind and buried vias are disabled by default. The physical via must
-    // therefore block all board copper layers, including bottom (z3).
-    expect(fixedObstacles).toEqual([
-      expect.objectContaining({
-        center: { x: 0, y: 0 },
-        width: 0.45,
-        height: 0.45,
-        layers: ["top", "inner1", "inner2", "bottom"],
-      }),
-    ])
+  // Blind and buried vias are disabled by default. The physical via must
+  // therefore block all board copper layers, including bottom (z3).
+  expect(fixedObstacles).toEqual([
+    expect.objectContaining({
+      center: { x: 0, y: 0 },
+      width: 0.45,
+      height: 0.45,
+      layers: ["top", "inner1", "inner2", "bottom"],
+    }),
+  ])
 
-    const fixedObstaclesWithBlindViasEnabled =
-      getPipeline9FixedRouteObstacles({
-        fixedObstacleRoutes: [preloadedThroughVia],
-        layerCount: 4,
-        allowBlindAndBuriedVias: true,
-      })
+  const fixedObstaclesWithBlindViasEnabled = getPipeline9FixedRouteObstacles({
+    fixedObstacleRoutes: [preloadedThroughVia],
+    layerCount: 4,
+    allowBlindAndBuriedVias: true,
+  })
 
-    // The explicit opt-in preserves the endpoint span for an actual blind
-    // via: top through inner2, excluding bottom.
-    expect(fixedObstaclesWithBlindViasEnabled).toEqual([
-      expect.objectContaining({
-        center: { x: 0, y: 0 },
-        width: 0.45,
-        height: 0.45,
-        layers: ["top", "inner1", "inner2"],
-      }),
-    ])
-  },
-)
+  // The explicit opt-in preserves the endpoint span for an actual blind
+  // via: top through inner2, excluding bottom.
+  expect(fixedObstaclesWithBlindViasEnabled).toEqual([
+    expect.objectContaining({
+      center: { x: 0, y: 0 },
+      width: 0.45,
+      height: 0.45,
+      layers: ["top", "inner1", "inner2"],
+    }),
+  ])
+})

--- a/tests/repro/pipeline9-through-via-policy.test.ts
+++ b/tests/repro/pipeline9-through-via-policy.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test"
+import { getPipeline9FixedRouteObstacles } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/pipeline9FixedRouteCopper"
+import type { PreloadedHighDensityRoute } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/convertPreloadedTraceToHdRoutes"
+
+test.failing(
+  "Pipeline9 keeps a preloaded top-to-inner2 via clear on bottom when blind vias are disabled",
+  (): void => {
+    const preloadedThroughVia: PreloadedHighDensityRoute = {
+      connectionName: "preloaded-via",
+      rootConnectionName: "preloaded-via",
+      preloadedTraceIndex: 0,
+      preloadedRouteIndex: 0,
+      traceThickness: 0.15,
+      viaDiameter: 0.45,
+      route: [
+        { x: 0, y: 0, z: 0 },
+        { x: 0, y: 0, z: 2 },
+      ],
+      vias: [{ x: 0, y: 0 }],
+    }
+
+    const fixedObstacles = getPipeline9FixedRouteObstacles({
+      fixedObstacleRoutes: [preloadedThroughVia],
+      layerCount: 4,
+    })
+
+    // Blind and buried vias are disabled by default. The physical via must
+    // therefore block all board copper layers, including bottom (z3).
+    expect(fixedObstacles).toEqual([
+      expect.objectContaining({
+        center: { x: 0, y: 0 },
+        width: 0.45,
+        height: 0.45,
+        layers: ["top", "inner1", "inner2", "bottom"],
+      }),
+    ])
+  },
+)


### PR DESCRIPTION
## Summary
- makes Pipeline9 treat vias as through-board by default when blind and buried vias are disabled
- preserves endpoint-only spans when the SRJ explicitly enables blind and buried vias
- updates high-density-repair03 to the Repair03 through-via DRC fix at 97ef741

## Reproduction
The focused repro was opened first in #2555. This PR includes that test as a passing regression after the fix.

## Validation
- bunx tsc --noEmit
- focused Pipeline9 policy, fixed-copper fallback, regional fallback, and preloaded-trace tests