### PR TITLE
test: reproduce Pipeline9 default through-via routing

### DIFF
--- a/tests/repro/__snapshots__/pipeline9-default-via-is-through-hole-visual.snap.svg
+++ b/tests/repro/__snapshots__/pipeline9-default-via-is-through-hole-visual.snap.svg
@@ -1,0 +1,44 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="white"/><g><polyline data-points="-3,0 -0.7599522326072499,0 -0.5762016272675846,0.1837506053396652 -0.203,0.205 0.203,0.205 0.608,0.205 0.4138259407742878,0.205 2.795,0.205 3,0" data-type="line" data-label="" points="40,320 249.0711249566567,320 266.22118145502543,302.84994350163123 301.05333333333334,300.8666666666667 338.94666666666666,300.8666666666667 376.74666666666667,300.8666666666667 358.62375447226685,300.8666666666667 580.8666666666667,300.8666666666667 600,320" fill="none" stroke="rgba(0,0,255,0.5)" stroke-linejoin="round" stroke-width="9.333333333333334" stroke-dasharray="0.2 0.2"/></g><circle data-type="circle" data-label="" data-x="0" data-y="0" cx="320" cy="320" r="21" fill="blue" stroke="none" stroke-width="0.010714285714285714"/><g id="crosshair" style="display: none"><line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5"/><line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5"/><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text></g><script><![CDATA[
+              document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+                const svg = e.currentTarget;
+                const rect = svg.getBoundingClientRect();
+                const x = e.clientX - rect.left;
+                const y = e.clientY - rect.top;
+                const crosshair = svg.getElementById('crosshair');
+                const h = svg.getElementById('crosshair-h');
+                const v = svg.getElementById('crosshair-v');
+                const coords = svg.getElementById('coordinates');
+
+                crosshair.style.display = 'block';
+                h.setAttribute('x1', '0');
+                h.setAttribute('x2', '640');
+                h.setAttribute('y1', y);
+                h.setAttribute('y2', y);
+                v.setAttribute('x1', x);
+                v.setAttribute('x2', x);
+                v.setAttribute('y1', '0');
+                v.setAttribute('y2', '640');
+
+                // Calculate real coordinates using inverse transformation
+                const matrix = {"a":93.33333333333333,"c":0,"e":320,"b":0,"d":-93.33333333333333,"f":320};
+                // Manually invert and apply the affine transform
+                // Since we only use translate and scale, we can directly compute:
+                // x' = (x - tx) / sx
+                // y' = (y - ty) / sy
+                const sx = matrix.a;
+                const sy = matrix.d;
+                const tx = matrix.e;
+                const ty = matrix.f;
+                const realPoint = {
+                  x: (x - tx) / sx,
+                  y: (y - ty) / sy // Flip y back since we used negative scale
+                }
+
+                coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+                coords.setAttribute('x', (x + 5).toString());
+                coords.setAttribute('y', (y - 5).toString());
+              });
+              document.currentScript.parentElement.addEventListener('mouseleave', () => {
+                document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+              });
+            ]]></script><g data-testid="relaxed-drc-summary"><rect x="12" y="12" width="300" height="44" rx="6" fill="white" stroke="#b91c1c"/><text x="24" y="40" font-family="Arial, sans-serif" font-size="20" font-weight="600" fill="#b91c1c">Relaxed DRC errors: 5</text></g></svg>

--- a/tests/repro/pipeline9-default-via-is-through-hole-visual.test.ts
+++ b/tests/repro/pipeline9-default-via-is-through-hole-visual.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "bun:test"
+import { AutoroutingPipelineSolver9_PreloadedTraceGraph } from "lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/AutoroutingPipelineSolver9_PreloadedTraceGraph"
+import { getBugReportSnapshotSvg } from "lib/testing/getBugReportSnapshotSvg"
+import type { SimpleRouteJson } from "lib/types"
+
+test("Pipeline9 routes across a preloaded default via's missing bottom obstacle", (): void => {
+  const inputSrj: SimpleRouteJson = {
+    layerCount: 4,
+    minTraceWidth: 0.1,
+    minViaPadDiameter: 0.45,
+    minViaHoleDiameter: 0.3,
+    minTraceToPadEdgeClearance: 0.25,
+    bounds: { minX: -4, maxX: 4, minY: -2, maxY: 2 },
+    obstacles: [],
+    connections: [
+      {
+        name: "bottom-trace",
+        pointsToConnect: [
+          { x: -3, y: 0, layer: "bottom", pointId: "left" },
+          { x: 3, y: 0, layer: "bottom", pointId: "right" },
+        ],
+      },
+    ],
+    traces: [
+      {
+        type: "pcb_trace",
+        pcb_trace_id: "preloaded-transition",
+        connection_name: "preloaded-transition",
+        route: [
+          { route_type: "wire", x: 0, y: -1, width: 0.1, layer: "top" },
+          {
+            route_type: "via",
+            x: 0,
+            y: 0,
+            from_layer: "top",
+            to_layer: "inner2",
+            via_diameter: 0.45,
+            via_hole_diameter: 0.3,
+          },
+          {
+            route_type: "wire",
+            x: 0,
+            y: 1,
+            width: 0.1,
+            layer: "inner2",
+          },
+        ],
+      },
+    ],
+  }
+  const solver = new AutoroutingPipelineSolver9_PreloadedTraceGraph(inputSrj, {
+    cacheProvider: null,
+    effort: 0.1,
+  })
+
+  solver.solve()
+
+  expect(solver.solved).toBeTrue()
+  expect(solver.failed).toBeFalse()
+  expect(
+    getBugReportSnapshotSvg({
+      inputSrj,
+      srjWithPointPairs: solver.srjWithPointPairs!,
+      routedTraces: solver.getOutputSimplifiedPcbTraces(),
+    }),
+  ).toMatchSvgSnapshot(import.meta.path)
+})


### PR DESCRIPTION
Pipeline 9 reserves a preloaded top-to-inner2 via on only top, inner1, and inner2. When blind and buried vias are disabled, the physical through-hole via also occupies bottom, so a different net must not route through its bottom-layer copper.

This PR contains one repro test and one SVG snapshot. The test runs Pipeline 9 on a four-layer input with a preloaded via and a new bottom-layer connection. It generates the snapshot from the solver's output using the repository's `getBugReportSnapshotSvg` helper. The snapshot records the current behavior for review; this PR contains no routing fix or dependency changes.

### Explanation

The diagram below explains the missing obstacle layer. It is an explanatory diagram, not an autorouter routing result, and is linked from an earlier commit so it is not included in this PR's file changes.

![Current Pipeline 9 fixed-obstacle geometry](https://raw.githubusercontent.com/tscircuit/tscircuit-autorouter/50036879df4ec643097b3207e9a16a4aa92c51b5/docs/visuals/pipeline9-default-through-via-obstacle-span.svg)

The test-generated autorouter snapshot is in `tests/repro/__snapshots__/pipeline9-default-via-is-through-hole-visual.snap.svg`.
