### PR TITLE
Connect same-region connections from degenerate HD routes

### DIFF
--- a/lib/utils/convertHdRouteToSimplifiedRoute.ts
+++ b/lib/utils/convertHdRouteToSimplifiedRoute.ts
@@ -366,8 +366,56 @@ export const convertHdRouteToSimplifiedRoute = (
     }
   }
 
+  // Same-region connection fallback. When both endpoints of a connection fall
+  // in a single capacity node, no region boundary is crossed. Terminal ports
+  // are filtered out of the HD node graph, so the HD solver can return a
+  // degenerate single-point route and leave the net unconnected. Emit the
+  // direct intra-node segment between the two endpoints so the connection is
+  // actually made.
+  let route = result
+  const distinctWireXy = new Set(
+    route
+      .filter((seg) => seg.route_type === "wire")
+      .map((seg) => `${(seg as { x: number }).x},${(seg as { y: number }).y}`),
+  )
+  const cps = opts.connectionPoints
+  if (cps && cps.length >= 2 && distinctWireXy.size < 2) {
+    const a = cps[0]
+    const b = cps[cps.length - 1]
+    if (
+      isSingleLayerConnectionPoint(a) &&
+      isSingleLayerConnectionPoint(b) &&
+      (a.x !== b.x || a.y !== b.y)
+    ) {
+      const width = hdRoute.traceThickness
+      if (a.layer === b.layer) {
+        route = [
+          { route_type: "wire", x: a.x, y: a.y, width, layer: a.layer },
+          { route_type: "wire", x: b.x, y: b.y, width, layer: b.layer },
+        ]
+      } else {
+        route = [
+          { route_type: "wire", x: a.x, y: a.y, width, layer: a.layer },
+          { route_type: "wire", x: b.x, y: b.y, width, layer: a.layer },
+          {
+            route_type: "via",
+            x: b.x,
+            y: b.y,
+            from_layer: a.layer,
+            to_layer: b.layer,
+            via_diameter: hdRoute.viaDiameter,
+            ...(opts.defaultViaHoleDiameter !== undefined
+              ? { via_hole_diameter: opts.defaultViaHoleDiameter }
+              : {}),
+          },
+          { route_type: "wire", x: b.x, y: b.y, width, layer: b.layer },
+        ]
+      }
+    }
+  }
+
   return attachTerminalViasToSimplifiedRoute({
-    route: result,
+    route,
     hdRoute,
     layerCount,
     connectionPoints: opts.connectionPoints,

--- a/tests/utils/convertHdRouteToSimplifiedRoute.test.ts
+++ b/tests/utils/convertHdRouteToSimplifiedRoute.test.ts
@@ -1,7 +1,7 @@
-import { expect, test, describe } from "bun:test"
-import { convertHdRouteToSimplifiedRoute } from "../../lib/utils/convertHdRouteToSimplifiedRoute"
+import { describe, expect, test } from "bun:test"
 import type { ConnectionPoint } from "../../lib/types"
 import { HighDensityIntraNodeRoute } from "../../lib/types/high-density-types"
+import { convertHdRouteToSimplifiedRoute } from "../../lib/utils/convertHdRouteToSimplifiedRoute"
 
 describe("convertHdRouteToSimplifiedRoute", () => {
   test("converts a simple single layer route correctly", () => {
@@ -210,7 +210,7 @@ describe("convertHdRouteToSimplifiedRoute", () => {
     }
 
     const result = convertHdRouteToSimplifiedRoute(input, 2)
-    expect(result).toMatchInlineSnapshot(`[]`)
+    expect(result).toMatchInlineSnapshot("[]")
   })
 
   test("correctly ignores via data when actual z-level change doesn't have a matching via", () => {
@@ -427,5 +427,28 @@ describe("convertHdRouteToSimplifiedRoute", () => {
         },
       ]
     `)
+  })
+
+  test("completes a degenerate same-region route from the connection endpoints", () => {
+    const input: HighDensityIntraNodeRoute = {
+      connectionName: "same-region",
+      traceThickness: 0.15,
+      viaDiameter: 0.6,
+      route: [{ x: -4.92, y: 4.4, z: 0 }],
+      vias: [],
+    }
+    const connectionPoints: ConnectionPoint[] = [
+      { x: -4.92, y: 5.2, layer: "top" },
+      { x: -4.92, y: 4.4, layer: "top" },
+    ]
+
+    const result = convertHdRouteToSimplifiedRoute(input, 2, {
+      connectionPoints,
+    })
+
+    expect(result).toEqual([
+      { route_type: "wire", x: -4.92, y: 5.2, width: 0.15, layer: "top" },
+      { route_type: "wire", x: -4.92, y: 4.4, width: 0.15, layer: "top" },
+    ])
   })
 })


### PR DESCRIPTION
Replaces stale-bot-closed #1530.

When both endpoints of a connection sit in one capacity node, terminal ports are dropped from the HD node graph and the solver can return a single-point route. The net is then left open. Fall back to a direct segment between the connection endpoints (with a via if the layers differ).