### PR TITLE
fix: align SimpleRouteJson with core and enforce exclusive point layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,21 @@ interface Obstacle {
 
 interface SimpleRouteConnection {
   name: string
-  pointsToConnect: Array<{ x: number; y: number; layer: string }>
+  pointsToConnect: Array<SingleLayerConnectionPoint | MultiLayerConnectionPoint>
+}
+
+type SingleLayerConnectionPoint = {
+  x: number
+  y: number
+  layer: string
+  layers?: never
+}
+
+type MultiLayerConnectionPoint = {
+  x: number
+  y: number
+  layers: string[]
+  layer?: never
 }
 
 interface SimpleRouteBus {
@@ -117,6 +131,13 @@ interface DifferentialPair {
   maxUncoupledLength?: number // Maximum uncoupled length in millimeters
 }
 ```
+
+Connection points use exactly one representation: `layer` for a fixed routing
+layer, or `layers` for a terminal accessible on multiple routing layers. Never
+include both fields. The optional `never` properties enforce this distinction
+in TypeScript; they are not JSON fields to emit. For multilayer points, the first
+entry is the primary layer. Obstacle and via `layers` arrays describe their
+physical copper span and are separate from the connection-point representation.
 
 `maxLengthSkew` records the maximum permitted routed-length difference for the
 bus. Bus metadata is preserved in the output so routing implementations can

--- a/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/getTerminalLayerIndicesByPcbPortId.ts
+++ b/lib/autorouter-pipelines/AutoroutingPipeline9_PreloadedTraceGraph/getTerminalLayerIndicesByPcbPortId.ts
@@ -1,3 +1,4 @@
+import { getConnectionPointLayers } from "lib/utils/connection-point-utils"
 import type { Obstacle, SimpleRouteConnection } from "lib/types"
 import { mapLayerNameToZ } from "lib/utils/mapLayerNameToZ"
 
@@ -27,7 +28,7 @@ export const getTerminalLayerIndicesByPcbPortId = (
       if (!point.pcb_port_id) continue
       const terminalLayerIndices =
         terminalLayerIndicesByPcbPortId.get(point.pcb_port_id) ?? new Set()
-      const layerNames = "layers" in point ? point.layers : [point.layer]
+      const layerNames = getConnectionPointLayers(point)
       for (const layerName of layerNames) {
         terminalLayerIndices.add(mapLayerNameToZ(layerName, layerCount))
       }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -105,6 +105,7 @@ export type {
   MultiLayerConnectionPoint,
   Obstacle,
   SimpleRouteBus,
+  SimpleRouteBusTermination,
   SimpleRouteConnection,
   SimpleRouteJson,
   SimplifiedPcbTrace,

--- a/lib/solvers/PortPointPathingSolver/hgportpointpathingsolver/checkIfConnectionPointIsInRegion.ts
+++ b/lib/solvers/PortPointPathingSolver/hgportpointpathingsolver/checkIfConnectionPointIsInRegion.ts
@@ -1,3 +1,4 @@
+import { getConnectionPointLayers } from "lib/utils/connection-point-utils"
 import { pointToBoxDistance } from "@tscircuit/math-utils"
 import type { ConnectionPoint } from "lib/types"
 import { mapLayerNameToZ } from "lib/utils/mapLayerNameToZ"
@@ -18,8 +19,7 @@ export function checkIfConnectionPointIsInRegion(params: {
     pointToBoxDistance(params.point, params.region.d) <=
     CONNECTION_POINT_REGION_TOLERANCE
   ) {
-    const layers =
-      "layers" in params.point ? params.point.layers : [params.point.layer]
+    const layers = getConnectionPointLayers(params.point)
     const intLayers = layers.map((layer) => {
       return mapLayerNameToZ(layer, params.layerCount)
     })

--- a/lib/solvers/PortPointPathingSolver/hgportpointpathingsolver/get-connection-point-z-layers.ts
+++ b/lib/solvers/PortPointPathingSolver/hgportpointpathingsolver/get-connection-point-z-layers.ts
@@ -1,3 +1,4 @@
+import { getConnectionPointLayers } from "lib/utils/connection-point-utils"
 import type { ConnectionPoint } from "lib/types"
 import { mapLayerNameToZ } from "lib/utils/mapLayerNameToZ"
 
@@ -10,7 +11,7 @@ export function getConnectionPointZLayers({
   point,
   layerCount,
 }: GetConnectionPointZLayersParams): number[] {
-  const layerNames = "layers" in point ? point.layers : [point.layer]
+  const layerNames = getConnectionPointLayers(point)
   const zLayers = layerNames.map((layerName) =>
     mapLayerNameToZ(layerName, layerCount),
   )

--- a/lib/types/srj-types.ts
+++ b/lib/types/srj-types.ts
@@ -21,7 +21,6 @@ export type SingleLayerConnectionPoint = {
   x: number
   y: number
   layer: string
-  layers?: string[]
   pointId?: PointId
   pcb_port_id?: string
   /** Stable semantic selector for the source port, e.g. `U1.USB_DM`. */

--- a/lib/types/srj-types.ts
+++ b/lib/types/srj-types.ts
@@ -17,20 +17,26 @@ export type TerminalViaHint = {
   toLayer: string
   viaDiameter?: number
 }
+/** A terminal on one routing layer. Never carries a `layers` array. */
 export type SingleLayerConnectionPoint = {
   x: number
   y: number
   layer: string
+  /** Forbids mixed single-layer/multilayer objects, including structural assignments. */
+  layers?: never
   pointId?: PointId
   pcb_port_id?: string
   /** Stable semantic selector for the source port, e.g. `U1.USB_DM`. */
   port_selector?: string
   terminalVia?: TerminalViaHint
 }
+/** A terminal accessible on multiple routing layers. Never carries `layer`. */
 export type MultiLayerConnectionPoint = {
   x: number
   y: number
   layers: string[]
+  /** Use SingleLayerConnectionPoint when the routing layer is fixed. */
+  layer?: never
   pointId?: PointId
   busId?: BusId
   pcb_port_id?: string

--- a/lib/types/srj-types.ts
+++ b/lib/types/srj-types.ts
@@ -21,8 +21,11 @@ export type SingleLayerConnectionPoint = {
   x: number
   y: number
   layer: string
+  layers?: string[]
   pointId?: PointId
   pcb_port_id?: string
+  /** Stable semantic selector for the source port, e.g. `U1.USB_DM`. */
+  port_selector?: string
   terminalVia?: TerminalViaHint
 }
 export type MultiLayerConnectionPoint = {
@@ -32,6 +35,8 @@ export type MultiLayerConnectionPoint = {
   pointId?: PointId
   busId?: BusId
   pcb_port_id?: string
+  /** Stable semantic selector for the source port, e.g. `U1.USB_DM`. */
+  port_selector?: string
 }
 export type ConnectionPoint =
   | SingleLayerConnectionPoint
@@ -53,6 +58,8 @@ export type JumperType = "1206x4" | "0603"
 
 export interface SimpleRouteJson {
   layerCount: number
+  /** Whether autorouters may use vias that do not span the full board stack. */
+  allowBlindAndBuriedVias?: boolean
   minTraceWidth: number
   nominalTraceWidth?: number
   /** @deprecated Use `min_via_pad_diameter` / `minViaPadDiameter` instead. */
@@ -65,6 +72,9 @@ export interface SimpleRouteJson {
   minTraceToPadEdgeClearance?: number
   minBoardEdgeClearance?: number
   minViaEdgeToPadEdgeClearance?: number
+  minViaHoleEdgeToViaHoleEdgeClearance?: number
+  minPlatedHoleDrillEdgeToDrillEdgeClearance?: number
+  minPadEdgeToPadEdgeClearance?: number
   obstacles: Obstacle[]
   connections: Array<SimpleRouteConnection>
   differentialPairs?: Array<DifferentialPair>
@@ -93,22 +103,39 @@ export interface DifferentialPair {
   maxUncoupledLength?: number
 }
 
+export type SimpleRouteBusTermination =
+  | { type: "boundary" }
+  | { type: "plane"; layer: string }
+
 export interface SimpleRouteBus {
   busId: BusId
+  name?: string
   /** SimpleRouteJson connection names belonging to this bus, in bus order. */
   connectionNames: string[]
+  /** Downstream routing hints that guide fanout exits without replacing endpoints. */
+  connectionExitTargets?: Readonly<
+    Record<string, { x: number; y: number; layer?: string }>
+  >
   /** Maximum permitted routed-length difference in millimeters. */
   maxLengthSkew?: number
   /** Resolved copper width in millimeters for members without an override. */
   traceWidth?: number
   /** Layers on which this bus may be routed, including its terminal layers. */
   allowedLayers?: string[]
+  /** Highest-priority fanout layer for this bus. */
+  preferredLayer?: string
+  /** Additional preferred fanout layers for this bus, in priority order. */
+  preferredLayers?: string[]
+  termination?: SimpleRouteBusTermination
 }
 
 export interface Obstacle {
   obstacleId?: string
   /** Optional source component identifier associated with this obstacle. */
   componentId?: string
+  /** True when this obstacle replaces one completed fanout source footprint. */
+  isFanoutSourceKeepout?: boolean
+  shape?: "circle"
   /**
    * Optional Circuit JSON provenance carried through SRJ.
    * Routing algorithms must not use this field.
@@ -133,6 +160,8 @@ export interface Obstacle {
 
 export interface SimpleRouteConnection {
   name: string
+  routingPcbGroupId?: string
+  source_trace_id?: string
   rootConnectionName?: RootConnectionName
   mergedConnectionNames?: string[]
   __rootConnectionNames?: string[]
@@ -140,6 +169,8 @@ export interface SimpleRouteConnection {
   netConnectionName?: string
   __netConnectionName?: string
   nominalTraceWidth?: number
+  /** @deprecated Use `nominalTraceWidth` instead. */
+  width?: number
   pointsToConnect: Array<ConnectionPoint>
 
   /** @deprecated DO NOT USE **/
@@ -169,6 +200,8 @@ export interface SimplifiedPcbTrace {
         y: number
         to_layer: string
         from_layer: string
+        /** Physical copper layers occupied by the drilled barrel. */
+        layers?: string[]
         via_diameter?: number
         via_hole_diameter?: number
       }

--- a/lib/utils/addApproximatingRectsToSrj.ts
+++ b/lib/utils/addApproximatingRectsToSrj.ts
@@ -1,3 +1,4 @@
+import { getConnectionPointLayers } from "./connection-point-utils"
 import { CONNECTION_REGION_SIZE } from "@tscircuit/fixed-via-hypergraph-solver/lib/FixedViaHypergraphSolver/via-graph-generator/createConnectionRegion"
 import {
   distance as calculateDistance,
@@ -86,9 +87,6 @@ interface Rect {
   width: number
   height: number
 }
-
-const getConnectionPointLayers = (point: ConnectionPoint): string[] =>
-  "layers" in point ? point.layers : [point.layer]
 
 const isPointInsideObstacle = (point: ConnectionPoint, obstacle: Obstacle) => {
   if (

--- a/lib/utils/connection-point-utils.ts
+++ b/lib/utils/connection-point-utils.ts
@@ -8,13 +8,13 @@ import type {
 export function isMultiLayerConnectionPoint(
   point: ConnectionPoint,
 ): point is MultiLayerConnectionPoint {
-  return "layers" in point && Array.isArray((point as any).layers)
+  return !("layer" in point) && Array.isArray(point.layers)
 }
 
 export function isSingleLayerConnectionPoint(
   point: ConnectionPoint,
 ): point is SingleLayerConnectionPoint {
-  return "layer" in point && typeof (point as any).layer === "string"
+  return !("layers" in point) && typeof point.layer === "string"
 }
 
 /**
@@ -22,10 +22,7 @@ export function isSingleLayerConnectionPoint(
  * For MultiLayerConnectionPoint, returns the first layer as default.
  */
 export function getConnectionPointLayer(point: ConnectionPoint): string {
-  if (isMultiLayerConnectionPoint(point)) {
-    return point.layers[0]
-  }
-  return point.layer
+  return getConnectionPointLayers(point)[0]
 }
 
 /**
@@ -36,5 +33,8 @@ export function getConnectionPointLayers(point: ConnectionPoint): string[] {
   if (isMultiLayerConnectionPoint(point)) {
     return point.layers
   }
-  return [point.layer]
+  if (isSingleLayerConnectionPoint(point)) {
+    return [point.layer]
+  }
+  throw new Error("Connection point must specify either layer or layers, never both")
 }

--- a/lib/utils/connection-point-utils.ts
+++ b/lib/utils/connection-point-utils.ts
@@ -36,5 +36,7 @@ export function getConnectionPointLayers(point: ConnectionPoint): string[] {
   if (isSingleLayerConnectionPoint(point)) {
     return [point.layer]
   }
-  throw new Error("Connection point must specify either layer or layers, never both")
+  throw new Error(
+    "Connection point must specify either layer or layers, never both",
+  )
 }

--- a/lib/utils/getConnectivityMapFromSimpleRouteJson.ts
+++ b/lib/utils/getConnectivityMapFromSimpleRouteJson.ts
@@ -23,12 +23,10 @@ export const getConnectivityMapFromSimpleRouteJson = (srj: SimpleRouteJson) => {
       connMap.addConnections([
         [
           connection.name,
-          `${pointHash(point)}:${
-            getConnectionPointLayers(point)
-              .map((layer) => mapLayerNameToZ(layer, srj.layerCount))
-              .sort()
-              .join("-")
-          }`,
+          `${pointHash(point)}:${getConnectionPointLayers(point)
+            .map((layer) => mapLayerNameToZ(layer, srj.layerCount))
+            .sort()
+            .join("-")}`,
         ],
       ])
       if ("pcb_port_id" in point && point.pcb_port_id) {

--- a/lib/utils/getConnectivityMapFromSimpleRouteJson.ts
+++ b/lib/utils/getConnectivityMapFromSimpleRouteJson.ts
@@ -1,3 +1,4 @@
+import { getConnectionPointLayers } from "./connection-point-utils"
 import { SimpleRouteJson } from "lib/types"
 import { ConnectivityMap } from "circuit-json-to-connectivity-map"
 import { mapLayerNameToZ } from "./mapLayerNameToZ"
@@ -23,12 +24,10 @@ export const getConnectivityMapFromSimpleRouteJson = (srj: SimpleRouteJson) => {
         [
           connection.name,
           `${pointHash(point)}:${
-            "layers" in point
-              ? point.layers
-                  .map((l) => mapLayerNameToZ(l, srj.layerCount))
-                  .sort()
-                  .join("-")
-              : mapLayerNameToZ(point.layer, srj.layerCount)
+            getConnectionPointLayers(point)
+              .map((layer) => mapLayerNameToZ(layer, srj.layerCount))
+              .sort()
+              .join("-")
           }`,
         ],
       ])

--- a/lib/utils/getLayerFromPoint.ts
+++ b/lib/utils/getLayerFromPoint.ts
@@ -1,14 +1,12 @@
-/**
- * Returns the first layer name from a point that may have `layer` or `layers`.
- */
+import type { ConnectionPoint } from "lib/types"
+import { getConnectionPointLayer } from "./connection-point-utils"
+
+/** Returns the primary routing layer of a connection point, if present. */
 export function getLayerFromPoint({
   point,
 }: {
-  point: { layer?: string; layers?: string[] } | null | undefined
+  point: ConnectionPoint | null | undefined
 }): string | undefined {
   if (!point) return undefined
-  if ("layers" in point && Array.isArray(point.layers)) {
-    return point.layers[0]
-  }
-  return point.layer
+  return getConnectionPointLayer(point)
 }

--- a/lib/utils/getPointKey.ts
+++ b/lib/utils/getPointKey.ts
@@ -1,8 +1,5 @@
 import { ConnectionPoint, PointKey } from "lib/types"
-import {
-  isMultiLayerConnectionPoint,
-  isSingleLayerConnectionPoint,
-} from "./connection-point-utils"
+import { getConnectionPointLayers } from "./connection-point-utils"
 
 /**
  * Generates a unique string key for a ConnectionPoint,
@@ -13,15 +10,7 @@ export function getPointKey(connectionPoint: ConnectionPoint): PointKey {
     return connectionPoint.pointId
   }
 
-  let layerKey = ""
-  if (isSingleLayerConnectionPoint(connectionPoint)) {
-    layerKey = connectionPoint.layer
-  } else if (
-    isMultiLayerConnectionPoint(connectionPoint) &&
-    connectionPoint.layers
-  ) {
-    layerKey = connectionPoint.layers.sort().join("-") // Sort layers for consistent key
-  }
+  const layerKey = [...getConnectionPointLayers(connectionPoint)].sort().join("-")
 
   // Using toFixed(4) for precision in coordinate-based keys
   return `${connectionPoint.x.toFixed(4)},${connectionPoint.y.toFixed(4)},${layerKey}`

--- a/lib/utils/getPointKey.ts
+++ b/lib/utils/getPointKey.ts
@@ -10,7 +10,9 @@ export function getPointKey(connectionPoint: ConnectionPoint): PointKey {
     return connectionPoint.pointId
   }
 
-  const layerKey = [...getConnectionPointLayers(connectionPoint)].sort().join("-")
+  const layerKey = [...getConnectionPointLayers(connectionPoint)]
+    .sort()
+    .join("-")
 
   // Using toFixed(4) for precision in coordinate-based keys
   return `${connectionPoint.x.toFixed(4)},${connectionPoint.y.toFixed(4)},${layerKey}`

--- a/tests/features/simple-route-json-bus-types.test.ts
+++ b/tests/features/simple-route-json-bus-types.test.ts
@@ -5,13 +5,26 @@ import type { SimpleRouteJson } from "lib"
 test("preserves SimpleRouteJson bus metadata during preprocessing", () => {
   const srj: SimpleRouteJson = {
     layerCount: 2,
+    allowBlindAndBuriedVias: true,
     minTraceWidth: 0.1,
+    minViaHoleEdgeToViaHoleEdgeClearance: 0.2,
+    minPlatedHoleDrillEdgeToDrillEdgeClearance: 0.25,
+    minPadEdgeToPadEdgeClearance: 0.1,
     obstacles: [],
     connections: [
       {
         name: "data0",
+        routingPcbGroupId: "pcb_group_1",
+        source_trace_id: "source_trace_1",
+        width: 0.12,
         pointsToConnect: [
-          { x: -1, y: 0, layer: "top" },
+          {
+            x: -1,
+            y: 0,
+            layer: "top",
+            layers: ["top", "bottom"],
+            port_selector: "U1.DATA0",
+          },
           { x: 1, y: 0, layer: "top" },
         ],
       },
@@ -26,10 +39,18 @@ test("preserves SimpleRouteJson bus metadata during preprocessing", () => {
     buses: [
       {
         busId: "data",
+        name: "Data bus",
         connectionNames: ["data0", "data1"],
+        connectionExitTargets: {
+          data0: { x: 1, y: 0, layer: "top" },
+          data1: { x: 1, y: 1 },
+        },
         maxLengthSkew: 0.1,
         traceWidth: 0.12,
         allowedLayers: ["top"],
+        preferredLayer: "top",
+        preferredLayers: ["bottom"],
+        termination: { type: "plane", layer: "bottom" },
       },
     ],
     differentialPairs: [
@@ -46,6 +67,12 @@ test("preserves SimpleRouteJson bus metadata during preprocessing", () => {
 
   solver.solve()
 
+  const output = solver.getOutputSimpleRouteJson()
+  expect(output.allowBlindAndBuriedVias).toBe(true)
+  expect(output.minViaHoleEdgeToViaHoleEdgeClearance).toBe(0.2)
+  expect(output.minPlatedHoleDrillEdgeToDrillEdgeClearance).toBe(0.25)
+  expect(output.minPadEdgeToPadEdgeClearance).toBe(0.1)
+  expect(output.connections).toEqual(srj.connections)
   expect(solver.getOutputSimpleRouteJson().buses).toEqual(srj.buses)
   expect(solver.getOutputSimpleRouteJson().differentialPairs).toEqual(
     srj.differentialPairs,

--- a/tests/features/simple-route-json-bus-types.test.ts
+++ b/tests/features/simple-route-json-bus-types.test.ts
@@ -22,7 +22,6 @@ test("preserves SimpleRouteJson bus metadata during preprocessing", () => {
             x: -1,
             y: 0,
             layer: "top",
-            layers: ["top", "bottom"],
             port_selector: "U1.DATA0",
           },
           { x: 1, y: 0, layer: "top" },

--- a/tests/utils/connection-point-utils.test.ts
+++ b/tests/utils/connection-point-utils.test.ts
@@ -14,13 +14,23 @@ import { getPointKey } from "../../lib/utils/getPointKey"
 
 type Assert<T extends true> = T
 type MixedPoint = { x: number; y: number; layer: string; layers: string[] }
-type RejectMixedSingle = Assert<MixedPoint extends SingleLayerConnectionPoint ? false : true>
-type RejectMixedMulti = Assert<MixedPoint extends MultiLayerConnectionPoint ? false : true>
-type RejectMixedUnion = Assert<MixedPoint extends ConnectionPoint ? false : true>
+type RejectMixedSingle = Assert<
+  MixedPoint extends SingleLayerConnectionPoint ? false : true
+>
+type RejectMixedMulti = Assert<
+  MixedPoint extends MultiLayerConnectionPoint ? false : true
+>
+type RejectMixedUnion = Assert<
+  MixedPoint extends ConnectionPoint ? false : true
+>
 
 test("single-layer and multilayer points are exclusive and use consistent layer helpers", () => {
   const single: SingleLayerConnectionPoint = { x: 0, y: 0, layer: "top" }
-  const multi: MultiLayerConnectionPoint = { x: 0, y: 0, layers: ["top", "bottom"] }
+  const multi: MultiLayerConnectionPoint = {
+    x: 0,
+    y: 0,
+    layers: ["top", "bottom"],
+  }
   expect(isSingleLayerConnectionPoint(single)).toBe(true)
   expect(isMultiLayerConnectionPoint(single)).toBe(false)
   expect(isSingleLayerConnectionPoint(multi)).toBe(false)

--- a/tests/utils/connection-point-utils.test.ts
+++ b/tests/utils/connection-point-utils.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "bun:test"
+import type {
+  ConnectionPoint,
+  SingleLayerConnectionPoint,
+  MultiLayerConnectionPoint,
+} from "../../lib/types/srj-types"
+import {
+  getConnectionPointLayer,
+  getConnectionPointLayers,
+  isSingleLayerConnectionPoint,
+  isMultiLayerConnectionPoint,
+} from "../../lib/utils/connection-point-utils"
+import { getPointKey } from "../../lib/utils/getPointKey"
+
+type Assert<T extends true> = T
+type MixedPoint = { x: number; y: number; layer: string; layers: string[] }
+type RejectMixedSingle = Assert<MixedPoint extends SingleLayerConnectionPoint ? false : true>
+type RejectMixedMulti = Assert<MixedPoint extends MultiLayerConnectionPoint ? false : true>
+type RejectMixedUnion = Assert<MixedPoint extends ConnectionPoint ? false : true>
+
+test("single-layer and multilayer points are exclusive and use consistent layer helpers", () => {
+  const single: SingleLayerConnectionPoint = { x: 0, y: 0, layer: "top" }
+  const multi: MultiLayerConnectionPoint = { x: 0, y: 0, layers: ["top", "bottom"] }
+  expect(isSingleLayerConnectionPoint(single)).toBe(true)
+  expect(isMultiLayerConnectionPoint(single)).toBe(false)
+  expect(isSingleLayerConnectionPoint(multi)).toBe(false)
+  expect(isMultiLayerConnectionPoint(multi)).toBe(true)
+  expect(getConnectionPointLayers(single)).toEqual(["top"])
+  expect(getConnectionPointLayers(multi)).toEqual(["top", "bottom"])
+  expect(getConnectionPointLayer(single)).toBe("top")
+  expect(getConnectionPointLayer(multi)).toBe("top")
+  expect(getPointKey(multi)).toBe("0.0000,0.0000,bottom-top")
+  expect(getConnectionPointLayer(multi)).toBe("top")
+
+  // JSON inputs can bypass the static contract; do not silently choose a field.
+  const mixed = { ...single, layers: ["bottom"] } as unknown as ConnectionPoint
+  expect(isSingleLayerConnectionPoint(mixed)).toBe(false)
+  expect(isMultiLayerConnectionPoint(mixed)).toBe(false)
+  expect(() => getConnectionPointLayers(mixed)).toThrow("never both")
+  expect(() => getConnectionPointLayer(mixed)).toThrow("never both")
+  expect(() => getPointKey(mixed)).toThrow("never both")
+})


### PR DESCRIPTION
Adds the SimpleRouteJson properties missing from core and makes single-layer and multilayer connection points mutually exclusive. A single-layer point has `layer`; a multilayer point has `layers`. Optional `never` members reject mixed objects even through structural assignment and are not fields to emit in JSON.

Connection-point guards now reject mixed shapes, and shared layer accessors throw instead of choosing conflicting representations. Connectivity, region checks, obstacle approximation, and terminal-layer lookup use the same helpers. Point-key generation sorts a copy so it cannot change a multilayer point's primary layer.

Also adds core's clearance settings, bus exit/termination preferences, connection provenance and port selectors, obstacle shape/fanout metadata, and physical via layers. Obstacle and via layer arrays retain their separate meaning.

Companion core PR: https://github.com/tscircuit/core/pull/3917

Validation:
- Full `tsc --noEmit`, including compile-time checks rejecting mixed point shapes
- `bun run build`, including declarations
- Five focused tests pass: connection-point helpers, SRJ metadata preprocessing, connectivity, terminal-layer indices, and multilayer routing
- `git diff --check`

Local validation reused dependencies from an existing autorouter checkout.
