### PR TITLE
fix: retain best Repair03 portfolio candidate

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "zdwiel-dataset": "git+https://github.com/dwiel/tscircuit-benchmark.git#be36518b5bf51755dae92c230061ab3cf4e3e063",
     "high-density-repair01": "git+https://github.com/tscircuit/high-density-repair01.git#01f9fe901ac6f691c325bb25d993f52d916a98a1",
     "high-density-repair02": "https://codeload.github.com/tscircuit/high-density-repair02/tar.gz/eba02dae55f156990e23fac0108a620c8021f47b",
-    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#5f6c9af547dbb70c8948227011e1769b5dfa16a5",
+    "high-density-repair03": "git+https://github.com/Abse2001/high-density-repair03.git#867d64f93cd6fd772b7928bf42ccbc319e3b3093",
     "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d",
     "@tscircuit/high-density-a13": "git+https://github.com/tscircuit/high-density-a01.git#c6812cebd44b09f29f2fee929837b313b822f2ae",
     "@tscircuit/high-density-b01": "git+https://github.com/tscircuit/high-density-b01.git#e651cab6c314e7aab6df31fd6067277436f67148"


### PR DESCRIPTION
## Summary

Update only the immutable Repair03 dependency to include [high-density-repair03 #134](https://github.com/tscircuit/high-density-repair03/pull/134), rebased onto the exact Repair03 baseline currently used by autorouter main.

The repair portfolio can accept a better safe-layer result, then start its broad search again from the original input and accidentally replace the accepted result with a worse/tied later candidate. #134 preserves the accepted candidate and uses the existing comparison rule to select the winner. Search stages, iteration limits, electrical endpoints, trace widths, and via dimensions are unchanged.

This comparison deliberately excludes the separate Core DRC alignment work, the new copper-width port, detector changes, feature flags, and Game Boy-specific logic. The pinned Repair03 integration adapts its test to an unchanged captured native USB phase input, avoiding unrelated fixture dependencies; production code is exactly #134.

## Verification

- Repair03's focused candidate-retention regression and TypeScript checks.
- Autorouter typecheck, build, and full tests/snapshots run in ordinary PR CI.
- Pipeline 9 same-machine benchmarks requested through PR comments for dataset01, srj18, srj19, srj20, srj21, and srj23. Current `/benchmark-all` covers only the first two; four additional native benchmark comments cover the remainder.

Benchmark results are pending; no claim of zero DRCs or regression-free routing is made until the reports complete.
