### PR TITLE
Update Repair03 actual via-diameter repair (#133 + #134)

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "zdwiel-dataset": "git+https://github.com/dwiel/tscircuit-benchmark.git#be36518b5bf51755dae92c230061ab3cf4e3e063",
     "high-density-repair01": "git+https://github.com/tscircuit/high-density-repair01.git#01f9fe901ac6f691c325bb25d993f52d916a98a1",
     "high-density-repair02": "https://codeload.github.com/tscircuit/high-density-repair02/tar.gz/eba02dae55f156990e23fac0108a620c8021f47b",
-    "high-density-repair03": "git+https://github.com/tscircuit/high-density-repair03.git#5f6c9af547dbb70c8948227011e1769b5dfa16a5",
+    "high-density-repair03": "git+https://github.com/Abse2001/high-density-repair03.git#691fd64daaa2f1983989196d1d04c313ccabb0cf",
     "@tscircuit/high-density-a01": "git+https://github.com/tscircuit/high-density-a01.git#9a3a3d",
     "@tscircuit/high-density-a13": "git+https://github.com/tscircuit/high-density-a01.git#c6812cebd44b09f29f2fee929837b313b822f2ae",
     "@tscircuit/high-density-b01": "git+https://github.com/tscircuit/high-density-b01.git#e651cab6c314e7aab6df31fd6067277436f67148"


### PR DESCRIPTION
Fresh dataset01 and SRJ18 benchmarks were requested on 13 September 2026 at 17:03 UTC by [this slash-command comment](https://github.com/tscircuit/tscircuit-autorouter/pull/2566#issuecomment-5654725847). Both are running: [dataset01](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/34770454595) and [SRJ18](https://github.com/tscircuit/tscircuit-autorouter/actions/runs/34770455631). A 20-minute scheduled check will report the results. The completed comparison table below is from the earlier September 12 runs against the same main and PR hashes; it is not the result of this fresh request.

Broad pad repulsion calculates via-to-pad separation using the actual via diameter. A 0.8 mm via on a board with a 0.3 mm minimum diameter previously remained 0.05 mm from a foreign pad despite a required 0.1 mm clearance; the corrected candidate meets the required clearance.

This dependency-only update integrates [Repair03 #133](https://github.com/tscircuit/high-density-repair03/pull/133) and its merged prerequisite [#134](https://github.com/tscircuit/high-density-repair03/pull/134). #134 preserves an already accepted repair candidate when later broad exploration only ties it.

Repair03 #133's reviewed head is `0f7796026320372bfa9bdd538c1a4b760e3b9393`. The compatible integration pin is [`691fd64daaa2f1983989196d1d04c313ccabb0cf`](https://github.com/Abse2001/high-density-repair03/commit/691fd64daaa2f1983989196d1d04c313ccabb0cf), based on the autorouter's existing `5f6c9af` dependency. That baseline already includes the actual-trace-width correction and other terminal/via/board-edge safeguards absent from Repair03 main. The integration preserves them and ports the remaining via-radius correction; the new via hunk matches #133. It does not pin #133's entire branch directly.

Focused tests independently reproduced both native-main failures: trace clearance 0.09 mm and via clearance 0.05 mm, versus 0.1 mm required. All three #133 regressions/control checks pass afterward (20 assertions). On the compatible integration, three controls pass and the via regression fails before the via correction; all four pass afterward (47 assertions). Repair03 typecheck passes. Autorouter build, typecheck, all nine test shards and the other required PR checks pass.

The requested benchmark coverage is **dataset01 and srj18**. Benchmarks must be invoked through a slash-command comment on this PR. The existing [command comment](https://github.com/tscircuit/tscircuit-autorouter/pull/2566#issuecomment-5649133417) is:

```
/benchmark-all --pipeline 9 --same-machine --concurrency 4
```

As documented by the PR bot, this command selects only dataset01 and srj18. Both comparisons have completed for current main `5d53fdd36f32cedd6ee5c80a6aebd47105a69e8c` versus this PR's `c76770a40b028fbf1e36abf0ec4f7a5bbeb3d6d2`. Each dataset ran both revisions sequentially on one 8-vCPU Blacksmith runner, with four workers and 1x effort.

| Dataset | Scenarios | Completion, main → PR | Relaxed DRC pass, main → PR | DRC issues, main → PR | Timeouts, main → PR | P50 time delta | P95 time delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| [dataset01](https://github.com/tscircuit/tscircuit-autorouter/pull/2566#issuecomment-5649136754) | 85 | 85/85 → 85/85 | 85/85 → 85/85 | 0 → 0 | 0 → 0 | -2.84% | +2.91% |
| [srj18](https://github.com/tscircuit/tscircuit-autorouter/pull/2566#issuecomment-5649136774) | 16 | 13/16 → 13/16 | 13/16 → 13/16 | 0 → 0 | 1 → 1 | +3.24% | +1.86% |

The downloaded raw reports contain **101 matched scenarios** in the requested datasets, with **0 routing outcome improvements and 0 routing outcome regressions**. Every individual sample has unchanged solve/timeout status, relaxed DRC result, DRC issue count and via count. Solved-sample trace counts also match. Existing failures and the one timeout remain unchanged; DRC issues remain zero across solved samples. Timeout progress diagnostics vary without changing its outcome.

Timing is mixed: dataset01 P50 is 2.84% faster and P95 2.91% slower; srj18 P50 is 3.24% slower, P90 3.64% slower and P95 1.86% slower. These single paired runs do not establish a speed improvement or prove the timing increases are caused by this dependency change.

SRJ22 is optional, but is not supported by the benchmark dataset selector at the current controller revision. No substitute dataset is required. Earlier srj19/srj21/srj23 runs are supplementary evidence outside the requested scope. The cancelled srj20 run is also outside this scope and does not leave the requested benchmark coverage incomplete.

The review supports the copper-size correctness fix, with no measured routing regressions in the requested datasets and no demonstrated general routing improvement. The benchmark's relaxed DRC results are not a zero-Core-DRC claim. This PR changes only the dependency pin; it introduces no checker, clearance-default, search-budget, endpoint, trace-width or via-dimension changes.
